### PR TITLE
fix(cardano-graphql-db-sync): typescript types of graphql responses

### DIFF
--- a/packages/cardano-graphql-db-sync/src/utils.ts
+++ b/packages/cardano-graphql-db-sync/src/utils.ts
@@ -1,0 +1,24 @@
+import { Schema as Cardano } from '@cardano-ogmios/client';
+import { Tx } from '@cardano-sdk/core';
+
+type GraphqlTransaction = {
+  hash: Cardano.Hash16;
+  inputs: { txHash: Cardano.Hash16; sourceTxIndex: number }[];
+  outputs: {
+    address: Cardano.Address;
+    value: string;
+    tokens: { asset: { assetId: string }; quantity: string }[];
+  }[];
+};
+export const graphqlTransactionsToCardanoTxs = (transactions: GraphqlTransaction[]): Tx[] =>
+  transactions.map((tx) => ({
+    hash: tx.hash,
+    inputs: tx.inputs.map((index) => ({ txId: index.txHash, index: index.sourceTxIndex })),
+    outputs: tx.outputs.map((output) => {
+      const assets: Cardano.Value['assets'] = {};
+
+      for (const token of output.tokens) assets[token.asset.assetId] = BigInt(token.quantity);
+
+      return { address: output.address, value: { coins: Number(output.value), assets } };
+    })
+  }));

--- a/packages/cardano-graphql-db-sync/test/cardanoGraphqlDbSyncProvider.test.ts
+++ b/packages/cardano-graphql-db-sync/test/cardanoGraphqlDbSyncProvider.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable max-len */
 
 import { GraphQLClient } from 'graphql-request';
+import { Schema as Cardano } from '@cardano-ogmios/client';
+import { Tx } from '@cardano-sdk/core';
 import { cardanoGraphqlDbSyncProvider } from '../src';
 jest.mock('graphql-request');
 
@@ -49,31 +51,31 @@ describe('cardanoGraphqlDbSyncProvider', () => {
     expect(response).toHaveLength(2);
 
     expect(response[0]).toHaveLength(2);
-    expect(response[0][0]).toMatchObject({
+    expect(response[0][0]).toMatchObject<Cardano.TxIn>({
       txId: '6f04f2cd96b609b8d5675f89fe53159bab859fb1d62bb56c6001ccf58d9ac128',
       index: 0
     });
-    expect(response[0][1]).toMatchObject({
+    expect(response[0][1]).toMatchObject<Cardano.TxOut>({
       address:
         'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
       value: {
-        coins: '1097647',
+        coins: 1_097_647,
         assets: {}
       }
     });
 
     expect(response[1]).toHaveLength(2);
-    expect(response[1][0]).toMatchObject({
+    expect(response[1][0]).toMatchObject<Cardano.TxIn>({
       txId: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
       index: 0
     });
-    expect(response[1][1]).toMatchObject({
+    expect(response[1][1]).toMatchObject<Cardano.TxOut>({
       address:
         'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
       value: {
-        coins: '50928877',
+        coins: 50_928_877,
         assets: {
-          b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237: '1'
+          b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237: BigInt(1)
         }
       }
     });
@@ -94,12 +96,21 @@ describe('cardanoGraphqlDbSyncProvider', () => {
             {
               address:
                 'addr_test1qzhj44x8qdyj8uzzk98h85wmwjaxwfelnsce78y2823n67klx3h666clw83vu7askvacnvtlh0megn8ue60afer83hfseeq9q7',
-              value: '1000000000'
+              value: '1000000000',
+              tokens: [
+                {
+                  asset: {
+                    assetId: 'b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237'
+                  },
+                  quantity: '1'
+                }
+              ]
             },
             {
               address:
                 'addr_test1qz7xvvc30qghk00sfpzcfhsw3s2nyn7my0r8hq8c2jj47zsxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flkns6sjg2v',
-              value: '9515281005985'
+              value: '9515281005985',
+              tokens: []
             }
           ]
         },
@@ -115,11 +126,13 @@ describe('cardanoGraphqlDbSyncProvider', () => {
             {
               address:
                 'addr_test1qp5ckv784ddzn2tstt4y5c9kex3wnuza6kuz0jc66q8ezcsxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flknsyqaf7l',
-              value: '9514280838416'
+              value: '9514280838416',
+              tokens: []
             },
             {
               address: 'addr_test1vrdkagyspkmt96k6z87rnt9dzzy8mlcex7awjymm8wx434q837u24',
-              value: '1000000000'
+              value: '1000000000',
+              tokens: []
             }
           ]
         }
@@ -134,7 +147,7 @@ describe('cardanoGraphqlDbSyncProvider', () => {
 
     expect(response).toHaveLength(2);
 
-    expect(response[0]).toMatchObject({
+    expect(response[0]).toMatchObject<Tx>({
       hash: '886206542d63b23a047864021fbfccf291d78e47c1e59bd4c75fbc67b248c5e8',
       inputs: [
         {
@@ -146,12 +159,17 @@ describe('cardanoGraphqlDbSyncProvider', () => {
         {
           address:
             'addr_test1qzhj44x8qdyj8uzzk98h85wmwjaxwfelnsce78y2823n67klx3h666clw83vu7askvacnvtlh0megn8ue60afer83hfseeq9q7',
-          value: '1000000000'
+          value: {
+            coins: 1_000_000_000,
+            assets: {
+              b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237: BigInt('1')
+            }
+          }
         },
         {
           address:
             'addr_test1qz7xvvc30qghk00sfpzcfhsw3s2nyn7my0r8hq8c2jj47zsxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flkns6sjg2v',
-          value: '9515281005985'
+          value: { coins: 9_515_281_005_985, assets: {} }
         }
       ]
     });
@@ -172,12 +190,21 @@ describe('cardanoGraphqlDbSyncProvider', () => {
             {
               address:
                 'addr_test1qzhj44x8qdyj8uzzk98h85wmwjaxwfelnsce78y2823n67klx3h666clw83vu7askvacnvtlh0megn8ue60afer83hfseeq9q7',
-              value: '1000000000'
+              value: '1000000000',
+              tokens: [
+                {
+                  asset: {
+                    assetId: 'b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237'
+                  },
+                  quantity: '1'
+                }
+              ]
             },
             {
               address:
                 'addr_test1qz7xvvc30qghk00sfpzcfhsw3s2nyn7my0r8hq8c2jj47zsxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flkns6sjg2v',
-              value: '9515281005985'
+              value: '9515281005985',
+              tokens: []
             }
           ]
         }
@@ -192,7 +219,7 @@ describe('cardanoGraphqlDbSyncProvider', () => {
     ]);
 
     expect(response).toHaveLength(1);
-    expect(response[0]).toMatchObject({
+    expect(response[0]).toMatchObject<Tx>({
       hash: '886206542d63b23a047864021fbfccf291d78e47c1e59bd4c75fbc67b248c5e8',
       inputs: [
         {
@@ -204,12 +231,17 @@ describe('cardanoGraphqlDbSyncProvider', () => {
         {
           address:
             'addr_test1qzhj44x8qdyj8uzzk98h85wmwjaxwfelnsce78y2823n67klx3h666clw83vu7askvacnvtlh0megn8ue60afer83hfseeq9q7',
-          value: '1000000000'
+          value: {
+            coins: 1_000_000_000,
+            assets: {
+              b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237: BigInt('1')
+            }
+          }
         },
         {
           address:
             'addr_test1qz7xvvc30qghk00sfpzcfhsw3s2nyn7my0r8hq8c2jj47zsxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flkns6sjg2v',
-          value: '9515281005985'
+          value: { coins: 9_515_281_005_985, assets: {} }
         }
       ]
     });


### PR DESCRIPTION
# Context

- cardano-graphql-db-sync

# Proposed Solution

This PR fixes the incorrect typescript types of the graphql responses and includes the related logic to map the response into the format inline with the `CardanoProvider` interface.