### PR TITLE
Create a new package @cardano-sdk/in-memory-key-manager

### DIFF
--- a/packages/blockfrost/src/blockfrostProvider.ts
+++ b/packages/blockfrost/src/blockfrostProvider.ts
@@ -15,7 +15,7 @@ export const blockfrostProvider = (options: Options): CardanoProvider => {
 
   const submitTx: CardanoProvider['submitTx'] = async (signedTransaction) => {
     try {
-      const hash = await blockfrost.txSubmit(signedTransaction);
+      const hash = await blockfrost.txSubmit(signedTransaction.to_bytes());
 
       return !!hash;
     } catch {

--- a/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
+++ b/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
@@ -27,7 +27,9 @@ export const cardanoGraphqlDbSyncProvider = (uri: string): CardanoProvider => {
       type Response = TransactionSubmitResponse;
       type Variables = { transaction: string };
 
-      const response = await client.request<Response, Variables>(mutation, { transaction: signedTransaction });
+      const response = await client.request<Response, Variables>(mutation, {
+        transaction: Buffer.from(signedTransaction.to_bytes()).toString('hex')
+      });
 
       return !!response.hash;
     } catch {

--- a/packages/cardano-serialization-lib/package.json
+++ b/packages/cardano-serialization-lib/package.json
@@ -25,6 +25,7 @@
     "shx": "^0.3.3"
   },
   "dependencies": {
+    "@cardano-ogmios/schema": "^4.0.0-beta.6",
     "@cardano-sdk/core": "0.1.0", 
     "@emurgo/cardano-serialization-lib-browser": "^8.0.0",
     "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
     "shx": "^0.3.3"
   },
   "dependencies": {
-    "@cardano-ogmios/schema": "^4.0.0-beta.6"
+    "@cardano-ogmios/schema": "^4.0.0-beta.6",
+    "@emurgo/cardano-serialization-lib-nodejs": "8.0.0"
   }
 }

--- a/packages/core/src/Cardano/ChainSettings.ts
+++ b/packages/core/src/Cardano/ChainSettings.ts
@@ -1,0 +1,4 @@
+export enum ChainSettings {
+  mainnet = 'mainnet',
+  testnet = 'testnet'
+}

--- a/packages/core/src/Cardano/index.ts
+++ b/packages/core/src/Cardano/index.ts
@@ -1,0 +1,1 @@
+export { ChainSettings } from './ChainSettings';

--- a/packages/core/src/Provider/CardanoProvider.ts
+++ b/packages/core/src/Provider/CardanoProvider.ts
@@ -1,3 +1,5 @@
+// Importing types from cardano-serialization-lib-browser will cause TypeScript errors.
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
 import Cardano, { ProtocolParametersAlonzo } from '@cardano-ogmios/schema';
 import { Tx } from '../Transaction';
 
@@ -16,7 +18,7 @@ export type ProtocolParametersRequiredByWallet = Pick<
 
 export interface CardanoProvider {
   /** @param signedTransaction signed and serialized cbor */
-  submitTx: (signedTransaction: string) => Promise<boolean>;
+  submitTx: (tx: CardanoSerializationLib.Transaction) => Promise<boolean>;
   utxoDelegationAndRewards: (
     addresses: Cardano.Address[],
     stakeKeyHash: Cardano.Hash16

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * as Asset from './Asset';
+export * as Cardano from './Cardano';
 export * from './Genesis';
 export * from './Provider';
 export * from './Transaction';

--- a/packages/in-memory-key-manager/.gitignore
+++ b/packages/in-memory-key-manager/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/in-memory-key-manager/README.md
+++ b/packages/in-memory-key-manager/README.md
@@ -1,0 +1,1 @@
+# Cardano JS SDK | in-memory-key-manager

--- a/packages/in-memory-key-manager/package.json
+++ b/packages/in-memory-key-manager/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@cardano-sdk/in-memory-key-manager",
+  "version": "0.1.0",
+  "description": "",
+  "engines": {
+    "node": "^14"
+  },
+  "bin": "dist/index.js",
+  "main": "dist/index.js",
+  "repository": "https://github.com/input-output-hk/cardano-js-sdk/packages/in-memory-key-manager",
+  "author": "James Sweetland",
+  "license": "MPL-2.0",
+  "scripts": {
+    "build": "tsc --build ./src",
+    "cleanup": "shx rm -rf dist node_modules",
+    "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
+    "test": "jest -c ./test/jest.config.js"
+  },
+  "devDependencies": {
+    "shx": "^0.3.3"
+  },
+  "dependencies": {
+    "@cardano-sdk/cardano-serialization-lib": "0.1.0",
+    "@cardano-sdk/wallet": "0.1.0",
+    "bip39": "^3.0.4"
+  }
+}

--- a/packages/in-memory-key-manager/src/.eslintrc.js
+++ b/packages/in-memory-key-manager/src/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "extends": ["../../../.eslintrc.js"],
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": __dirname
+  }
+}

--- a/packages/in-memory-key-manager/src/InMemoryKey.ts
+++ b/packages/in-memory-key-manager/src/InMemoryKey.ts
@@ -1,0 +1,54 @@
+// Importing types from cardano-serialization-lib-browser will cause TypeScript errors.
+import * as bip39 from 'bip39';
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { KeyManagement } from '@cardano-sdk/wallet';
+import { harden } from './util';
+
+/**
+ *
+ */
+export const createInMemoryKeyManager = ({
+  password,
+  accountIndex,
+  mnemonic
+}: {
+  password: string;
+  accountIndex?: number;
+  mnemonic: string;
+}): KeyManagement.KeyManager => {
+  if (!accountIndex) {
+    accountIndex = 0;
+  }
+
+  const validMnemonic = bip39.validateMnemonic(mnemonic);
+  if (!validMnemonic) throw new KeyManagement.errors.InvalidMnemonic();
+
+  const entropy = bip39.mnemonicToEntropy(mnemonic);
+  const account = CardanoSerializationLib.Bip32PrivateKey.from_bip39_entropy(
+    Buffer.from(entropy, 'hex'),
+    Buffer.from(password)
+  )
+    .derive(harden(1852))
+    .derive(harden(1815))
+    .derive(harden(accountIndex));
+
+  const privateParentKey = account.derive(0).derive(0);
+  const publicParentKey = privateParentKey.to_public().to_raw_key();
+
+  return {
+    signMessage: async (_addressType, _signingIndex, message) => ({
+      publicKey: publicParentKey.toString(),
+      signature: `Signature for ${message} is not implemented yet`
+    }),
+    signTransaction: async (txHash: CardanoSerializationLib.TransactionHash) => {
+      const witnessSet = CardanoSerializationLib.TransactionWitnessSet.new();
+      const vkeyWitnesses = CardanoSerializationLib.Vkeywitnesses.new();
+      const vkeyWitness = CardanoSerializationLib.make_vkey_witness(txHash, privateParentKey.to_raw_key());
+      vkeyWitnesses.add(vkeyWitness);
+      witnessSet.set_vkeys(vkeyWitnesses);
+      return witnessSet;
+    },
+    publicKey: account.to_public().to_raw_key(),
+    publicParentKey
+  };
+};

--- a/packages/in-memory-key-manager/src/index.ts
+++ b/packages/in-memory-key-manager/src/index.ts
@@ -1,0 +1,2 @@
+export * from './InMemoryKey';
+export * as util from './util';

--- a/packages/in-memory-key-manager/src/tsconfig.json
+++ b/packages/in-memory-key-manager/src/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "."
   },
   "references": [
-    { "path": "../../cardano-serialization-lib/src" },
-    { "path": "../../core/src" }
+    { "path": "../../core/src" },
+    { "path": "../../wallet/src" }
   ]
 }

--- a/packages/in-memory-key-manager/src/util.ts
+++ b/packages/in-memory-key-manager/src/util.ts
@@ -1,0 +1,13 @@
+import * as bip39 from 'bip39';
+
+/**
+ * A wrapper around the bip39 package function, with default strength applied to produce 24 words
+ */
+export const generateMnemonic = (strength = 256) => bip39.generateMnemonic(strength);
+
+/**
+ * A wrapper around the bip39 package function
+ */
+export const validateMnemonic = bip39.validateMnemonic;
+
+export const harden = (num: number): number => 0x80_00_00_00 + num;

--- a/packages/in-memory-key-manager/test/.eslintrc.js
+++ b/packages/in-memory-key-manager/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    "extends": ["../../../test/.eslintrc.js"],
+    "parserOptions": {
+        "project": "./tsconfig.json",
+        "tsconfigRootDir": __dirname
+    }
+}

--- a/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
+++ b/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
@@ -1,0 +1,33 @@
+import { createInMemoryKeyManager } from '@src/InMemoryKey';
+import { util } from '@src/.';
+import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { KeyManagement } from '@cardano-sdk/wallet';
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+
+describe('InMemoryKeyManager', () => {
+  let keyManager: KeyManagement.KeyManager;
+  let cardanoWasm: typeof CardanoSerializationLib;
+
+  beforeEach(async () => {
+    cardanoWasm = await loadCardanoSerializationLib();
+    const mnemonic = util.generateMnemonic();
+    keyManager = createInMemoryKeyManager({
+      mnemonic,
+      password: '123'
+    });
+    expect(keyManager.publicKey).toBeInstanceOf(CardanoSerializationLib.PublicKey);
+  });
+
+  test('initial state publicKey', async () => {
+    expect(keyManager.publicKey).toBeDefined();
+    expect(keyManager.publicParentKey).toBeDefined();
+  });
+
+  test('signTransaction', async () => {
+    const txHash = cardanoWasm.TransactionHash.from_bytes(
+      Buffer.from('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec', 'hex')
+    );
+    const witnessSet = await keyManager.signTransaction(txHash);
+    expect(witnessSet).toBeInstanceOf(CardanoSerializationLib.TransactionWitnessSet);
+  });
+});

--- a/packages/in-memory-key-manager/test/jest.config.js
+++ b/packages/in-memory-key-manager/test/jest.config.js
@@ -1,0 +1,11 @@
+const { pathsToModuleNameMapper } = require('ts-jest/utils')
+const { compilerOptions } = require('./tsconfig')
+
+module.exports = {
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
+  preset: 'ts-jest',
+  transform: {
+    "^.+\\.test.ts?$": "ts-jest"
+  },
+  testTimeout: 120000
+}

--- a/packages/in-memory-key-manager/test/tsconfig.json
+++ b/packages/in-memory-key-manager/test/tsconfig.json
@@ -8,6 +8,6 @@
   },
   "references": [
     { "path": "../src" },
-    { "path": "../../core/src" }
+    { "path": "../../wallet/src" }
   ]
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -22,6 +22,11 @@
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {
+    "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
     "shx": "^0.3.3"
+  },
+  "dependencies": {
+    "@cardano-ogmios/schema": "^4.0.0-beta.6",
+    "@cardano-sdk/cardano-serialization-lib": "0.1.0"
   }
 }

--- a/packages/wallet/src/Address.ts
+++ b/packages/wallet/src/Address.ts
@@ -1,0 +1,12 @@
+/** internal = change address & external = receipt address */
+export enum AddressType {
+  internal = 'Internal',
+  external = 'External'
+}
+
+export interface Address {
+  address: string;
+  index: number;
+  type: AddressType;
+  accountIndex: number;
+}

--- a/packages/wallet/src/KeyManagement/KeyManager.ts
+++ b/packages/wallet/src/KeyManagement/KeyManager.ts
@@ -1,0 +1,15 @@
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { Address } from '../';
+
+export interface KeyManager {
+  signMessage: (
+    addressType: Address.AddressType,
+    signingIndex: number,
+    message: string
+  ) => Promise<{ publicKey: string; signature: string }>;
+  publicKey: CardanoSerializationLib.PublicKey;
+  publicParentKey: CardanoSerializationLib.PublicKey;
+  signTransaction: (
+    txHash: CardanoSerializationLib.TransactionHash
+  ) => Promise<CardanoSerializationLib.TransactionWitnessSet>;
+}

--- a/packages/wallet/src/KeyManagement/errors/InvalidMnemonic.ts
+++ b/packages/wallet/src/KeyManagement/errors/InvalidMnemonic.ts
@@ -1,0 +1,9 @@
+import { CustomError } from 'ts-custom-error';
+
+export class InvalidMnemonic extends CustomError {
+  constructor() {
+    super();
+    this.message = 'Invalid Mnemonic';
+    this.name = 'InvalidMnemonic';
+  }
+}

--- a/packages/wallet/src/KeyManagement/errors/index.ts
+++ b/packages/wallet/src/KeyManagement/errors/index.ts
@@ -1,0 +1,1 @@
+export { InvalidMnemonic } from './InvalidMnemonic';

--- a/packages/wallet/src/KeyManagement/index.ts
+++ b/packages/wallet/src/KeyManagement/index.ts
@@ -1,0 +1,4 @@
+import { KeyManager } from './KeyManager';
+import * as errors from './errors';
+
+export { errors, KeyManager };

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -1,0 +1,2 @@
+export * as Address from './Address';
+export * as KeyManagement from './KeyManagement';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,6 +1515,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.1.tgz#70cedfda26af7a2ca073fdcc9beb2fff4aa693f8"
   integrity sha512-hBOx4SUlEPKwRi6PrXuTGw1z6lz0fjsibcWCM378YxsSu/6+C30L6CR49zIBKHiwNWCYIcOLjg4OHKZaFeLAug==
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
 "@types/node@^11.9.4":
   version "11.15.54"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.54.tgz#59ed60e7b0d56905a654292e8d73275034eb6283"
@@ -2228,6 +2233,16 @@ binjumper@^0.1.4:
   resolved "https://registry.yarnpkg.com/binjumper/-/binjumper-0.1.4.tgz#4acc0566832714bd6508af6d666bd9e5e21fc7f8"
   integrity sha512-Gdxhj+U295tIM6cO4bJO1jsvSjBVHNpj2o/OwW7pqDEtaqF6KdOxjtbo93jMMKAkP7+u09+bV8DhSqjIv4qR3w==
 
+bip39@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
+  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
+  dependencies:
+    "@types/node" "11.11.6"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
+
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -2466,6 +2481,14 @@ ci-info@^3.1.1, ci-info@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
   integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
+
+cipher-base@^1.0.1, cipher-base@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
@@ -2731,6 +2754,29 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+create-hash@^1.1.0, create-hash@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+create-hmac@^1.1.4:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
+  dependencies:
+    cipher-base "^1.0.3"
+    create-hash "^1.1.0"
+    inherits "^2.0.1"
+    ripemd160 "^2.0.0"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -4060,6 +4106,15 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hash-base@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -5668,6 +5723,15 @@ matcher@^3.0.0:
   dependencies:
     escape-string-regexp "^4.0.0"
 
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
+
 meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
@@ -6351,6 +6415,17 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pbkdf2@^3.0.9:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
 peek-stream@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/peek-stream/-/peek-stream-1.1.3.tgz#3b35d84b7ccbbd262fff31dc10da56856ead6d67"
@@ -6665,6 +6740,13 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+randombytes@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+  dependencies:
+    safe-buffer "^5.1.0"
+
 rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -6892,6 +6974,14 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+ripemd160@^2.0.0, ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
 roarr@^2.15.3:
   version "2.15.4"
   resolved "https://registry.yarnpkg.com/roarr/-/roarr-2.15.4.tgz#f5fe795b7b838ccfe35dc608e0282b9eba2e7afd"
@@ -6923,7 +7013,7 @@ rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.7:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -6995,6 +7085,14 @@ set-immediate-shim@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
   integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
+
+sha.js@^2.4.0, sha.js@^2.4.8:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
# Context

- ADP-1103

# Proposed Solution

This PR does two things:

1. Hoist the KeyManager interface and custom errors from the prototype into the core package.
2. Create a new package @cardano-sdk/in-memory-key-manager and hoist the InMemoryKeyManager implementation from the prototype.

