### PR TITLE
Feature/cardano serialization lib translations

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -64,5 +64,5 @@ jobs:
     - name: 📤 Upload Golden Test Generator exe - macOS
       uses: actions/upload-artifact@v2
       with:
-        name: cardano-ogmios-repl-macos
+        name: golden-test-generator-macos
         path: packages/golden-test-generator/build/golden-test-generator-macos

--- a/packages/cardano-serialization-lib/.gitignore
+++ b/packages/cardano-serialization-lib/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/cardano-serialization-lib/README.md
+++ b/packages/cardano-serialization-lib/README.md
@@ -1,0 +1,5 @@
+# Cardano JS SDK | cardano-serialization-lib
+
+This package contains the integration with [cardano-serialization-lib].
+
+[cardano-serialization-lib]: https://github.com/Emurgo/cardano-serialization-lib

--- a/packages/cardano-serialization-lib/package.json
+++ b/packages/cardano-serialization-lib/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@cardano-sdk/cardano-serialization-lib",
+  "version": "0.1.0",
+  "description": "Integration with cardano-serialization-lib",
+  "engines": {
+    "node": "^14"
+  },
+  "main": "dist/index.js",
+  "repository": "https://github.com/input-output-hk/cardano-js-sdk/packages/cardano-serialization-lib",
+  "contributors": [
+    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
+    "James Sweetland"
+  ],
+  "license": "MPL-2.0",
+  "scripts": {
+    "build": "tsc --build ./src",
+    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "cleanup": "shx rm -rf dist node_modules",
+    "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
+    "test": "jest -c ./test/jest.config.js",
+    "test:debug": "DEBUG=true yarn test"
+  },
+  "devDependencies": {
+    "mock-browser": "^0.92.14",
+    "shx": "^0.3.3"
+  },
+  "dependencies": {
+    "@emurgo/cardano-serialization-lib-browser": "^8.0.0",
+    "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
+    "ts-custom-error": "^3.2.0",
+    "ts-log": "^2.2.3"
+  }
+}

--- a/packages/cardano-serialization-lib/package.json
+++ b/packages/cardano-serialization-lib/package.json
@@ -25,6 +25,7 @@
     "shx": "^0.3.3"
   },
   "dependencies": {
+    "@cardano-sdk/core": "0.1.0", 
     "@emurgo/cardano-serialization-lib-browser": "^8.0.0",
     "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
     "ts-custom-error": "^3.2.0",

--- a/packages/cardano-serialization-lib/src/.eslintrc.js
+++ b/packages/cardano-serialization-lib/src/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "extends": ["../../../.eslintrc.js"],
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": __dirname
+  }
+}

--- a/packages/cardano-serialization-lib/src/OgmiosToCardanoWasm.ts
+++ b/packages/cardano-serialization-lib/src/OgmiosToCardanoWasm.ts
@@ -1,0 +1,42 @@
+import CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
+import OgmiosSchema from '@cardano-ogmios/schema';
+import { Asset } from '@cardano-sdk/core';
+
+export const OgmiosToCardanoWasm = {
+  txIn: (ogmios: OgmiosSchema.TxIn): CardanoWasm.TransactionInput =>
+    CardanoWasm.TransactionInput.new(
+      CardanoWasm.TransactionHash.from_bytes(Buffer.from(ogmios.txId, 'hex')),
+      ogmios.index
+    ),
+  txOut: (ogmios: OgmiosSchema.TxOut): CardanoWasm.TransactionOutput =>
+    CardanoWasm.TransactionOutput.new(
+      CardanoWasm.Address.from_bech32(ogmios.address),
+      OgmiosToCardanoWasm.value(ogmios.value)
+    ),
+  utxo: (ogmios: OgmiosSchema.Utxo): CardanoWasm.TransactionUnspentOutput[] =>
+    ogmios.map((item) =>
+      CardanoWasm.TransactionUnspentOutput.new(OgmiosToCardanoWasm.txIn(item[0]), OgmiosToCardanoWasm.txOut(item[1]))
+    ),
+  value: (ogmios: OgmiosSchema.Value): CardanoWasm.Value => {
+    const value = CardanoWasm.Value.new(CardanoWasm.BigNum.from_str(ogmios.coins.toString()));
+    const assets = Object.entries(ogmios.assets);
+    if (assets.length === 0) {
+      return value;
+    }
+    const multiAsset = CardanoWasm.MultiAsset.new();
+    const policies = [...new Set(assets.map(([assetId]) => Asset.util.policyIdFromAssetId(assetId)))];
+    for (const policy of policies) {
+      const policyAssets = assets.filter(([assetId]) => Asset.util.policyIdFromAssetId(assetId) === policy);
+      const wasmAssets = CardanoWasm.Assets.new();
+      for (const [assetId, assetQuantity] of policyAssets) {
+        wasmAssets.insert(
+          CardanoWasm.AssetName.new(Buffer.from(Asset.util.assetNameFromAssetId(assetId), 'hex')),
+          CardanoWasm.BigNum.from_str(assetQuantity.toString())
+        );
+      }
+      multiAsset.insert(CardanoWasm.ScriptHash.from_bytes(Buffer.from(policy, 'hex')), wasmAssets);
+    }
+    value.set_multiasset(multiAsset);
+    return value;
+  }
+};

--- a/packages/cardano-serialization-lib/src/index.ts
+++ b/packages/cardano-serialization-lib/src/index.ts
@@ -1,0 +1,1 @@
+export * from './loadCardanoSerializationLib';

--- a/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
+++ b/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
@@ -1,0 +1,17 @@
+import CardanoSerializationLibNodeJs from '@emurgo/cardano-serialization-lib-nodejs';
+
+export const isNodeJs = (): boolean => {
+  try {
+    return !!process;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Loads the environment-specific library.
+ * The type of each complete library is the same, so one is statically imported for the return type.
+ * Dynamically loads the browser library.
+ */
+export const loadCardanoSerializationLib = async (): Promise<typeof CardanoSerializationLibNodeJs> =>
+  isNodeJs() ? CardanoSerializationLibNodeJs : await import('@emurgo/cardano-serialization-lib-nodejs');

--- a/packages/cardano-serialization-lib/src/tsconfig.json
+++ b/packages/cardano-serialization-lib/src/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/",
+    "rootDir": "."
+  }
+}

--- a/packages/cardano-serialization-lib/src/tsconfig.json
+++ b/packages/cardano-serialization-lib/src/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "outDir": "../dist/",
     "rootDir": "."
-  }
+  },
+  "references": [{ "path": "../../core/src" }]
 }

--- a/packages/cardano-serialization-lib/test/.eslintrc.js
+++ b/packages/cardano-serialization-lib/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "extends": ["../../../test/.eslintrc.js"],
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": __dirname
+  }
+}

--- a/packages/cardano-serialization-lib/test/OgmiosToCardanoWasm.test.ts
+++ b/packages/cardano-serialization-lib/test/OgmiosToCardanoWasm.test.ts
@@ -1,0 +1,25 @@
+import CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
+import { OgmiosToCardanoWasm } from '@src/OgmiosToCardanoWasm';
+import * as OgmiosSchema from '@cardano-ogmios/schema';
+
+const txIn: OgmiosSchema.TxIn = { txId: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5', index: 0 };
+const txOut: OgmiosSchema.TxOut = {
+  address:
+    'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+  value: { coins: 10, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
+};
+
+describe('OgmiosToCardanoWasm', () => {
+  test('txIn', () => {
+    expect(OgmiosToCardanoWasm.txIn(txIn)).toBeInstanceOf(CardanoWasm.TransactionInput);
+  });
+  test('txOut', () => {
+    expect(OgmiosToCardanoWasm.txOut(txOut)).toBeInstanceOf(CardanoWasm.TransactionOutput);
+  });
+  test('utxo', () => {
+    expect(OgmiosToCardanoWasm.utxo([[txIn, txOut]])[0]).toBeInstanceOf(CardanoWasm.TransactionUnspentOutput);
+  });
+  test('value', () => {
+    expect(OgmiosToCardanoWasm.value(txOut.value)).toBeInstanceOf(CardanoWasm.Value);
+  });
+});

--- a/packages/cardano-serialization-lib/test/jest.config.js
+++ b/packages/cardano-serialization-lib/test/jest.config.js
@@ -1,0 +1,11 @@
+const { pathsToModuleNameMapper } = require('ts-jest/utils')
+const { compilerOptions } = require('./tsconfig')
+
+module.exports = {
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
+  preset: 'ts-jest',
+  transform: {
+    "^.+\\.test.ts?$": "ts-jest"
+  },
+  testTimeout: 120000
+}

--- a/packages/cardano-serialization-lib/test/loadLibrary.test.ts
+++ b/packages/cardano-serialization-lib/test/loadLibrary.test.ts
@@ -1,0 +1,8 @@
+import { loadCardanoSerializationLib } from '@src/loadCardanoSerializationLib';
+
+describe('loadLibrary', () => {
+  it('loads the appropriate library in Node.js', async () => {
+    const cardanoSerializationLib = await loadCardanoSerializationLib();
+    expect(cardanoSerializationLib.TransactionInput).toBeDefined();
+  });
+});

--- a/packages/cardano-serialization-lib/test/tsconfig.json
+++ b/packages/cardano-serialization-lib/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@src/*": ["../src/*"]
+    }
+  },
+  "references": [{ "path": "../src" }]
+}

--- a/packages/core/src/Asset/index.ts
+++ b/packages/core/src/Asset/index.ts
@@ -1,0 +1,1 @@
+export * as util from './util';

--- a/packages/core/src/Asset/util.ts
+++ b/packages/core/src/Asset/util.ts
@@ -1,0 +1,3 @@
+export const policyIdFromAssetId = (assetId: string): string => assetId.slice(0, 56);
+
+export const assetNameFromAssetId = (assetId: string): string => assetId.slice(56);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
+export * as Asset from './Asset';
 export * from './Genesis';
 export * from './Provider';

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,10 +661,20 @@
   resolved "https://registry.yarnpkg.com/@deepcode/dcignore/-/dcignore-1.0.2.tgz#39e4a3df7dde8811925330506e4bb3fbf3c288d8"
   integrity sha512-DPgxtHuJwBORpqRkPXzzOT+uoPRVJmaN7LR+pmeL6DQM90kj6G6GFUH1i/YpRH8NbML8ZGEDwB9f9u4UwD2pzg==
 
+"@emurgo/cardano-serialization-lib-browser@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-8.0.0.tgz#b938890b035222d8514030410aa2bfe52e6098a0"
+  integrity sha512-JoYF8LfnELddD9oGVhrEZ6j1PPvXladT80XVGCGmwBARag/iNNUYZEZwklGPf5YBztX26Xzj2zAK0/4hK407Eg==
+
 "@emurgo/cardano-serialization-lib-nodejs@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-7.1.0.tgz#657ce11655d29560c2e302b616dc0fe86c4d2920"
   integrity sha512-ogAUL23kJLDdc5nfRGBMhx/84aq0hnmEJea6VNozm3vnTYPsE1tmdvcYAmoRvsn+k745/E89ToSYBrjwnuZZpg==
+
+"@emurgo/cardano-serialization-lib-nodejs@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-8.0.0.tgz#9666c4fe4afc08df53cb4a9d12c19fe91112e9b5"
+  integrity sha512-GHN1w1B//JwLRKr3/VE5xTGpY3Nof0FnZ6pMvxYaZ8LbXHlW7vfcqzz/5cEc2m1oyULzdCPQm8/8u5I9VTvJlg==
 
 "@es-joy/jsdoccomment@0.10.7":
   version "0.10.7"


### PR DESCRIPTION
# Context
We need a way to easily move between our base types (Ogmios) and the format required for transaction construction.

# Proposed Solution
:pushpin: **feature(cardano-serialization-lib): add basic package and loader based on environment**

:pushpin: **feature(cardano-serialization-lib): add Ogmios to CardanoWasm translator**
The SDK uses Ogmios types as it's base, however easily converting to CardanoWasm instances is required for transaction construction and to convert between formats.

# Important Changes Introduced
:pushpin: **ci: fixup copy/paste error in naming**
