### PR TITLE
Refactor/window injection

### DIFF
--- a/packages/cip30/README.md
+++ b/packages/cip30/README.md
@@ -1,1 +1,6 @@
 # Cardano JS SDK | CIP30
+This package implements concepts from the draft specification being developed in [CIP-0030]. The 
+package defines TypeScript types and interfaces, as well as a class to implement allow list 
+persistence.
+
+[CIP-0030]: https://github.com/cardano-foundation/CIPs/pull/88

--- a/packages/cip30/src/Wallet/WalletPublic.ts
+++ b/packages/cip30/src/Wallet/WalletPublic.ts
@@ -1,7 +1,3 @@
-import { Enable, IsEnabled, WalletProperties } from './Wallet';
+import { Wallet } from './Wallet';
 
-export interface WalletPublic extends WalletProperties {
-  enable: Enable;
-
-  isEnabled: IsEnabled;
-}
+export type WalletPublic = Pick<Wallet, 'enable' | 'isEnabled' | 'name' | 'version'>;

--- a/packages/cip30/src/injectWindow.ts
+++ b/packages/cip30/src/injectWindow.ts
@@ -1,0 +1,34 @@
+import { Wallet, WalletPublic } from './Wallet';
+import { dummyLogger, Logger } from 'ts-log';
+
+export type WindowMaybeWithCardano = Window & { cardano?: { [k: string]: WalletPublic } };
+
+export const injectWindow = (window: WindowMaybeWithCardano, wallet: Wallet, logger: Logger = dummyLogger): void => {
+  if (!window.cardano) {
+    logger.debug(
+      {
+        module: 'injectWindow',
+        wallet: { name: wallet.name, version: wallet.version }
+      },
+      'Creating cardano global scope'
+    );
+    window.cardano = {};
+  } else {
+    logger.debug(
+      {
+        module: 'injectWindow',
+        wallet: { name: wallet.name, version: wallet.version }
+      },
+      'Cardano global scope exists'
+    );
+  }
+  window.cardano[wallet.name] = window.cardano[wallet.name] || wallet.getPublicApi(window);
+  logger.debug(
+    {
+      module: 'injectWindow',
+      wallet: { name: wallet.name, version: wallet.version },
+      windowCardano: window.cardano
+    },
+    'Injected'
+  );
+};

--- a/packages/cip30/test/injectWindow.test.ts
+++ b/packages/cip30/test/injectWindow.test.ts
@@ -1,0 +1,45 @@
+import { mocks } from 'mock-browser';
+import { Wallet } from '@src/Wallet';
+import { api, properties, requestAccess } from './testWallet';
+import { injectWindow, WindowMaybeWithCardano } from '@src/injectWindow';
+
+describe('injectWindow', () => {
+  let wallet: Wallet;
+  let window: ReturnType<typeof mocks.MockBrowser>;
+
+  beforeEach(() => {
+    wallet = new Wallet(properties, api, requestAccess, { persistAllowList: false });
+    window = mocks.MockBrowser.createWindow();
+  });
+
+  it('creates the cardano scope when not exists, and injects the wallet public API into it', async () => {
+    expect(window.cardano).not.toBeDefined();
+    injectWindow(window, wallet);
+    expect(window.cardano).toBeDefined();
+    expect(window.cardano[properties.name].name).toBe(properties.name);
+    expect(await window.cardano[properties.name].isEnabled()).toBe(false);
+    await window.cardano[properties.name].enable();
+    expect(await window.cardano[properties.name].isEnabled()).toBe(true);
+  });
+
+  describe('existing cardano object', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let anotherObj: any;
+
+    beforeEach(() => {
+      anotherObj = { could: 'be', anything: 'here' };
+      expect(window.cardano).not.toBeDefined();
+      window.cardano = {} as WindowMaybeWithCardano;
+      window.cardano['another-obj'] = anotherObj;
+      expect(window.cardano).toBeDefined();
+    });
+
+    it('injects the wallet public API into the existing cardano scope', () => {
+      expect(window.cardano).toBeDefined();
+      injectWindow(window, wallet);
+      expect(window.cardano[properties.name].name).toBe(properties.name);
+      expect(Object.keys(window.cardano[properties.name])).toEqual(['name', 'version', 'enable', 'isEnabled']);
+      expect(window.cardano['another-obj']).toBe(anotherObj);
+    });
+  });
+});

--- a/packages/cip30/test/testWallet.ts
+++ b/packages/cip30/test/testWallet.ts
@@ -1,0 +1,22 @@
+import { RequestAccess, WalletApi } from '@src/Wallet';
+
+export const api = <WalletApi>{
+  getUtxos: async (_amount) => [
+    [
+      { txId: '123456', index: 0 },
+      { address: 'asdf', value: { coins: 100, assets: {} } }
+    ]
+  ],
+  getBalance: async () => '100',
+  getUsedAddresses: async () => ['used-address-1', 'used-address-2', 'used-address-3'],
+  getUnusedAddresses: async () => ['unused-address-1', 'unused-address-2', 'unused-address-3'],
+  getChangeAddress: async () => 'change-address',
+  getRewardAddresses: async () => ['reward-address-1', 'reward-address-2'],
+  signTx: async (_tx) => 'signedTransaction',
+  signData: async (_addr, _sig) => 'signedData',
+  submitTx: async (_tx) => 'transactionId'
+};
+
+export const properties = { name: 'test-wallet', version: '0.1.0' };
+
+export const requestAccess: RequestAccess = async () => true;


### PR DESCRIPTION
# Context
_See commit messages_

# Proposed Solution
:pushpin: **refactor(cip30): lift window injection behaviour out of class**
In hindsight my direction to do this inside the class (and particularly
the constructor) was wrong, when we can simply use a function and keep
the concerns of modifying window state separate. I suspect we'll end
up refactoring this further once the allow list is improved, but for
now this is an isolated change that includes more testing.

:pushpin: **refactor(cip30): pick properties from the Wallet for WalletPublic**

:pushpin: **docs(cip30): add short intro to package README**

# Important Changes Introduced
