### PR TITLE
feat(core|blockfrost): modify utxo method on provider to return delegations & rewards

### DIFF
--- a/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
+++ b/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
@@ -35,53 +35,9 @@ export const cardanoGraphqlDbSyncProvider = (uri: string): CardanoProvider => {
     }
   };
 
-  const utxo: CardanoProvider['utxo'] = async (addresses) => {
-    const query = gql`
-      query ($addresses: [String]!) {
-        utxos(where: { address: { _in: $addresses } }) {
-          transaction {
-            hash
-          }
-          index
-          address
-          value # coins
-          tokens {
-            asset {
-              assetId # asset key
-            }
-            quantity
-          }
-        }
-      }
-    `;
-
-    type Utxo = {
-      transaction: { hash: Cardano.Hash16 };
-      index: number;
-      address: Cardano.Address;
-      value: string;
-      tokens: {
-        asset: {
-          assetId: string;
-        };
-        quantity: string;
-      }[];
-    };
-    type Response = { utxos: Utxo[] };
-    type Variables = { addresses: string[] };
-
-    const response = await client.request<Response, Variables>(query, { addresses });
-
-    return response.utxos.map((uxto) => {
-      const assets: Cardano.Value['assets'] = {};
-
-      for (const t of uxto.tokens) assets[t.asset.assetId] = BigInt(t.quantity);
-
-      return [
-        { txId: uxto.transaction.hash, index: uxto.index },
-        { address: uxto.address, value: { coins: Number(uxto.value), assets } }
-      ];
-    });
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const utxoDelegationAndRewards: CardanoProvider['utxoDelegationAndRewards'] = async () => {
+    throw new Error('Not implemented yet.');
   };
 
   const queryTransactionsByAddresses: CardanoProvider['queryTransactionsByAddresses'] = async (addresses) => {
@@ -170,7 +126,7 @@ export const cardanoGraphqlDbSyncProvider = (uri: string): CardanoProvider => {
 
   return {
     submitTx,
-    utxo,
+    utxoDelegationAndRewards,
     queryTransactionsByAddresses,
     queryTransactionsByHashes
   };

--- a/packages/cardano-graphql-db-sync/test/cardanoGraphqlDbSyncProvider.test.ts
+++ b/packages/cardano-graphql-db-sync/test/cardanoGraphqlDbSyncProvider.test.ts
@@ -1,85 +1,12 @@
 /* eslint-disable max-len */
 
 import { GraphQLClient } from 'graphql-request';
-import { Schema as Cardano } from '@cardano-ogmios/client';
 import { Tx } from '@cardano-sdk/core';
 import { cardanoGraphqlDbSyncProvider } from '../src';
 jest.mock('graphql-request');
 
 describe('cardanoGraphqlDbSyncProvider', () => {
   const uri = 'http://someurl.com';
-
-  test('utxo', async () => {
-    const mockedResponse = {
-      utxos: [
-        {
-          transaction: {
-            hash: '6f04f2cd96b609b8d5675f89fe53159bab859fb1d62bb56c6001ccf58d9ac128'
-          },
-          index: 0,
-          address:
-            'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
-          value: '1097647',
-          tokens: []
-        },
-        {
-          transaction: {
-            hash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5'
-          },
-          index: 0,
-          address:
-            'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
-          value: '50928877',
-          tokens: [
-            {
-              asset: {
-                assetId: 'b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237'
-              },
-              quantity: '1'
-            }
-          ]
-        }
-      ]
-    };
-    GraphQLClient.prototype.request = jest.fn().mockResolvedValue(mockedResponse);
-    const client = cardanoGraphqlDbSyncProvider(uri);
-
-    const response = await client.utxo([
-      'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
-    ]);
-
-    expect(response).toHaveLength(2);
-
-    expect(response[0]).toHaveLength(2);
-    expect(response[0][0]).toMatchObject<Cardano.TxIn>({
-      txId: '6f04f2cd96b609b8d5675f89fe53159bab859fb1d62bb56c6001ccf58d9ac128',
-      index: 0
-    });
-    expect(response[0][1]).toMatchObject<Cardano.TxOut>({
-      address:
-        'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
-      value: {
-        coins: 1_097_647,
-        assets: {}
-      }
-    });
-
-    expect(response[1]).toHaveLength(2);
-    expect(response[1][0]).toMatchObject<Cardano.TxIn>({
-      txId: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
-      index: 0
-    });
-    expect(response[1][1]).toMatchObject<Cardano.TxOut>({
-      address:
-        'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
-      value: {
-        coins: 50_928_877,
-        assets: {
-          b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237: BigInt(1)
-        }
-      }
-    });
-  });
 
   test('queryTransactionsByAddresses', async () => {
     const mockedResponse = {

--- a/packages/core/src/Provider/CardanoProvider.ts
+++ b/packages/core/src/Provider/CardanoProvider.ts
@@ -4,7 +4,10 @@ import { Tx } from '../Transaction';
 export interface CardanoProvider {
   /** @param signedTransaction signed and serialized cbor */
   submitTx: (signedTransaction: string) => Promise<boolean>;
-  utxo: (addresses: Cardano.Address[]) => Promise<Cardano.Utxo>;
+  utxoDelegationAndRewards: (
+    addresses: Cardano.Address[],
+    stakeKeyHash: Cardano.Hash16
+  ) => Promise<{ utxo: Cardano.Utxo; delegationAndRewards: Cardano.DelegationsAndRewards }>;
   queryTransactionsByAddresses: (addresses: Cardano.Address[]) => Promise<Tx[]>;
   queryTransactionsByHashes: (hashes: Cardano.Hash16[]) => Promise<Tx[]>;
 }


### PR DESCRIPTION
# Context

The light wallet will need to fetch delegations & rewards & they are usually fetched together with uxtos.

# Proposed Solution

Modify `Provider.utxo` to `Provider.utxoDelegationAndRewards` to return delegations & rewards along side utxos.

# Important Changes Introduced

- `Provider.utxo` no longer exists.
