### PR TITLE
Refactor/cardano serialization lib package improvements

### DIFF
--- a/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
+++ b/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
@@ -14,4 +14,4 @@ export const isNodeJs = (): boolean => {
  * Dynamically loads the browser library.
  */
 export const loadCardanoSerializationLib = async (): Promise<typeof CardanoSerializationLibNodeJs> =>
-  isNodeJs() ? CardanoSerializationLibNodeJs : await import('@emurgo/cardano-serialization-lib-nodejs');
+  isNodeJs() ? CardanoSerializationLibNodeJs : await import('@emurgo/cardano-serialization-lib-browser');

--- a/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
+++ b/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
@@ -8,10 +8,12 @@ export const isNodeJs = (): boolean => {
   }
 };
 
+export type CardanoSerializationLib = typeof CardanoSerializationLibNodeJs;
+
 /**
  * Loads the environment-specific library.
  * The type of each complete library is the same, so one is statically imported for the return type.
  * Dynamically loads the browser library.
  */
-export const loadCardanoSerializationLib = async (): Promise<typeof CardanoSerializationLibNodeJs> =>
+export const loadCardanoSerializationLib = async (): Promise<CardanoSerializationLib> =>
   isNodeJs() ? CardanoSerializationLibNodeJs : await import('@emurgo/cardano-serialization-lib-browser');


### PR DESCRIPTION
# Context
A fix and improvement is staged in https://github.com/input-output-hk/cardano-js-sdk/pull/84, which is dependent but out of scope. I need access to the changes in another branch.

# Proposed Solution
Cherry-picked https://github.com/input-output-hk/cardano-js-sdk/pull/84/commits/04d48c05edfe5c62a97992b19c2132bbcff203df and https://github.com/input-output-hk/cardano-js-sdk/pull/84/commits/b2f9d4aee96e502aae11e829e54f349f93c43a94

# Important Changes Introduced
Dependent packages should import the type `CardanoSerializationLib`