### PR TITLE
chore(cardano-serialization-lib): dynamic import for @emurgo/cardano-serialization-lib-nodejs

### DIFF
--- a/packages/cardano-serialization-lib/src/index.ts
+++ b/packages/cardano-serialization-lib/src/index.ts
@@ -1,1 +1,2 @@
 export * from './loadCardanoSerializationLib';
+export * from './OgmiosToCardanoWasm';

--- a/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
+++ b/packages/cardano-serialization-lib/src/loadCardanoSerializationLib.ts
@@ -1,5 +1,3 @@
-import CardanoSerializationLibNodeJs from '@emurgo/cardano-serialization-lib-nodejs';
-
 export const isNodeJs = (): boolean => {
   try {
     return !!process;
@@ -8,12 +6,11 @@ export const isNodeJs = (): boolean => {
   }
 };
 
-export type CardanoSerializationLib = typeof CardanoSerializationLibNodeJs;
+export type CardanoSerializationLib = typeof import('@emurgo/cardano-serialization-lib-nodejs');
 
 /**
- * Loads the environment-specific library.
- * The type of each complete library is the same, so one is statically imported for the return type.
- * Dynamically loads the browser library.
+ * Dynamically loads the environment-specific library.
+ * The type of each complete library is the same.
  */
-export const loadCardanoSerializationLib = async (): Promise<CardanoSerializationLib> =>
-  isNodeJs() ? CardanoSerializationLibNodeJs : await import('@emurgo/cardano-serialization-lib-browser');
+export const loadCardanoSerializationLib = (): Promise<CardanoSerializationLib> =>
+  isNodeJs() ? import('@emurgo/cardano-serialization-lib-nodejs') : import('@emurgo/cardano-serialization-lib-browser');


### PR DESCRIPTION
# Context

`package.json` of `@emurgo/cardano-serialization-lib-nodejs` doesn't have a `browser` field, which means it will be bundled for browser builds when used with webpack.

# Proposed Solution

Dynamic import

# Important Changes Introduced

Re-export OgmiosToCardanoWasm from cardano-serialization-lib package main
