### PR TITLE
fix(in-memory-key-manager): add missing yarn script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs": "typedoc --packages .",
     "cleanup": "yarn workspaces run cleanup && shx rm -rf node_modules",
     "lint": "yarn workspaces run lint",
-    "tsc": "yarn workspaces run tsc",
+    "tscNoEmit": "yarn workspaces run tscNoEmit",
     "prepare": "husky install",
     "pre-commit": "lint-staged",
     "mainnet:up": "DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker-compose -p sdk-mainnet up",
@@ -28,7 +28,7 @@
   "lint-staged": {
     "*(apps/**/*.{js,ts}|packages/!(*golden-test-generator)/**/*.{js,ts})": [
       "yarn lint",
-      "yarn tsc"
+      "yarn tscNoEmit"
     ]
   },
   "repository": {

--- a/packages/blockfrost/package.json
+++ b/packages/blockfrost/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
-    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./test/jest.config.js"

--- a/packages/cardano-graphql-db-sync/package.json
+++ b/packages/cardano-graphql-db-sync/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
-    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./test/jest.config.js"

--- a/packages/cardano-serialization-lib/package.json
+++ b/packages/cardano-serialization-lib/package.json
@@ -14,7 +14,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
-    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./test/jest.config.js",

--- a/packages/cip30/package.json
+++ b/packages/cip30/package.json
@@ -14,7 +14,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
-    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./test/jest.config.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
-    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "shx echo No tests in this package"

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -12,7 +12,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
-    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "dev": "API_PORT=3000 OGMIOS_HOST=localhost OGMIOS_PORT=1337 ts-node-dev ./src/index.ts",
     "lint": "shx echo linting disabled in this package temporarily",

--- a/packages/in-memory-key-manager/package.json
+++ b/packages/in-memory-key-manager/package.json
@@ -12,6 +12,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./test/jest.config.js"

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -15,7 +15,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "which tsc",
-    "tsc": "shx echo typescript --noEmit command not implemented yet",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "shx echo No tests in this package",


### PR DESCRIPTION
# Context
With a package missing the `tsc` script, the pre-commit hook was calling the global executable and failing the pre-commit operation. Thanks for debugging @mkazlauskas 

# Proposed Solution
Adds the missing script, and renames to avoid this in future.

