### PR TITLE
fix(cip2): change token bundle size constraint arg to CSL.MultiAsset

### DIFF
--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -264,7 +264,9 @@ export const computeChangeAndAdjustForFee = async ({
 
   const change = changeBundles.map((bundle) => valueQuantitiesToValue(bundle, csl));
   for (const value of change) {
-    if (tokenBundleSizeExceedsLimit(value)) {
+    const multiasset = value.multiasset();
+    if (!multiasset) continue;
+    if (tokenBundleSizeExceedsLimit(multiasset)) {
       // Algorithm could be improved to attempt to rebalance the bundles
       throw new InputSelectionError(InputSelectionFailure.UtxoFullyDepleted);
     }

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -48,7 +48,7 @@ export type EstimateTxFee = (selectionSkeleton: SelectionSkeleton) => Promise<bi
 /**
  * @returns true if token bundle size exceeds it's maximum size limit.
  */
-export type TokenBundleSizeExceedsLimit = (tokenBundle: CSL.Value) => boolean;
+export type TokenBundleSizeExceedsLimit = (tokenBundle: CSL.MultiAsset) => boolean;
 
 /**
  * @returns minimum lovelace amount in a UTxO

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -135,8 +135,8 @@ describe('RoundRobinRandomImprove', () => {
       it('Change bundle size exceeds constraint', async () => {
         await testInputSelectionFailureMode({
           getAlgorithm: getRoundRobinRandomImprove,
-          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 2_000_000n })],
-          createOutputs: (utils) => [utils.createOutput({ coins: 1_000_000n })],
+          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 2_000_000n, assets: { [TSLA_Asset]: 1000n } })],
+          createOutputs: (utils) => [utils.createOutput({ coins: 1_000_000n, assets: { [TSLA_Asset]: 500n } })],
           constraints: {
             ...NO_CONSTRAINTS,
             tokenBundleSizeExceedsLimit: () => true


### PR DESCRIPTION
# Context

Input selection constraint for token bundle size takes in an entire `Value` (including coin), but coin quantity is not relevant.

# Proposed Solution

Use `CSL.MultiAsset` instead

# Important Changes Introduced
