### PR TITLE
Feature/ UTxO repository and single-address wallet

### DIFF
--- a/packages/blockfrost/src/BlockfrostToOgmios.ts
+++ b/packages/blockfrost/src/BlockfrostToOgmios.ts
@@ -1,6 +1,6 @@
 import { Responses } from '@blockfrost/blockfrost-js';
 import * as OgmiosSchema from '@cardano-ogmios/schema';
-import { ProtocolParametersRequiredByWallet, Tx } from '@cardano-sdk/core';
+import { ProtocolParametersRequiredByWallet, Transaction } from '@cardano-sdk/core';
 
 type Unpacked<T> = T extends (infer U)[] ? U : T;
 type BlockfrostAddressUtxoContent = Responses['address_utxo_content'];
@@ -41,7 +41,7 @@ export const BlockfrostToOgmios = {
   outputs: (outputs: BlockfrostOutputs): OgmiosSchema.TxOut[] =>
     outputs.map((output) => BlockfrostToOgmios.txOut(output)),
 
-  txContentUtxo: (blockfrost: Responses['tx_content_utxo']): Tx => ({
+  txContentUtxo: (blockfrost: Responses['tx_content_utxo']): Transaction.WithHash => ({
     hash: blockfrost.hash,
     inputs: BlockfrostToOgmios.inputs(blockfrost.inputs),
     outputs: BlockfrostToOgmios.outputs(blockfrost.outputs)

--- a/packages/blockfrost/test/blockfrostProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostProvider.test.ts
@@ -3,7 +3,7 @@
 import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
 import { blockfrostProvider } from '../src';
 import { Schema as Cardano } from '@cardano-ogmios/client';
-import { Tx } from '@cardano-sdk/core';
+import { Transaction } from '@cardano-sdk/core';
 jest.mock('@blockfrost/blockfrost-js');
 
 describe('blockfrostProvider', () => {
@@ -165,7 +165,7 @@ describe('blockfrostProvider', () => {
     ]);
 
     expect(response).toHaveLength(1);
-    expect(response[0]).toMatchObject<Tx>({
+    expect(response[0]).toMatchObject<Transaction.WithHash>({
       hash: '4123d70f66414cc921f6ffc29a899aafc7137a99a0fd453d6b200863ef5702d6',
       inputs: [
         {
@@ -253,7 +253,7 @@ describe('blockfrostProvider', () => {
     ]);
 
     expect(response).toHaveLength(1);
-    expect(response[0]).toMatchObject<Tx>({
+    expect(response[0]).toMatchObject<Transaction.WithHash>({
       hash: '4123d70f66414cc921f6ffc29a899aafc7137a99a0fd453d6b200863ef5702d6',
       inputs: [
         {

--- a/packages/cardano-graphql-db-sync/src/CardanoGraphqlToOgmios.ts
+++ b/packages/cardano-graphql-db-sync/src/CardanoGraphqlToOgmios.ts
@@ -1,5 +1,5 @@
 import { Schema as Cardano } from '@cardano-ogmios/client';
-import { ProtocolParametersRequiredByWallet, Tx } from '@cardano-sdk/core';
+import { ProtocolParametersRequiredByWallet, Transaction } from '@cardano-sdk/core';
 import { Block } from '@cardano-graphql/client-ts';
 
 type GraphqlTransaction = {
@@ -31,7 +31,7 @@ export type GraphqlCurrentWalletProtocolParameters = {
 export type CardanoGraphQlTip = Pick<Block, 'hash' | 'number' | 'slotNo'>;
 
 export const CardanoGraphqlToOgmios = {
-  graphqlTransactionsToCardanoTxs: (transactions: GraphqlTransaction[]): Tx[] =>
+  graphqlTransactionsToCardanoTxs: (transactions: GraphqlTransaction[]): Transaction.WithHash[] =>
     transactions.map((tx) => ({
       hash: tx.hash,
       inputs: tx.inputs.map((index) => ({ txId: index.txHash, index: index.sourceTxIndex })),

--- a/packages/cardano-graphql-db-sync/test/cardanoGraphqlDbSyncProvider.test.ts
+++ b/packages/cardano-graphql-db-sync/test/cardanoGraphqlDbSyncProvider.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 
 import { GraphQLClient } from 'graphql-request';
-import { ProtocolParametersRequiredByWallet, Tx } from '@cardano-sdk/core';
+import { ProtocolParametersRequiredByWallet, Transaction } from '@cardano-sdk/core';
 import { cardanoGraphqlDbSyncProvider } from '../src';
 import { Schema as Cardano } from '@cardano-ogmios/client';
 jest.mock('graphql-request');
@@ -75,7 +75,7 @@ describe('cardanoGraphqlDbSyncProvider', () => {
 
     expect(response).toHaveLength(2);
 
-    expect(response[0]).toMatchObject<Tx>({
+    expect(response[0]).toMatchObject<Transaction.WithHash>({
       hash: '886206542d63b23a047864021fbfccf291d78e47c1e59bd4c75fbc67b248c5e8',
       inputs: [
         {
@@ -147,7 +147,7 @@ describe('cardanoGraphqlDbSyncProvider', () => {
     ]);
 
     expect(response).toHaveLength(1);
-    expect(response[0]).toMatchObject<Tx>({
+    expect(response[0]).toMatchObject<Transaction.WithHash>({
       hash: '886206542d63b23a047864021fbfccf291d78e47c1e59bd4c75fbc67b248c5e8',
       inputs: [
         {

--- a/packages/cip2/src/util.ts
+++ b/packages/cip2/src/util.ts
@@ -1,5 +1,5 @@
 // TODO: move these utils to either core package.
-// Current impelmentation of OgmiosToCardanoWasm.value() uses number instead of bigint for lovelace.
+// Current impelmentation of ogmiosToCsl.value() uses number instead of bigint for lovelace.
 // These utils should be moved after CSL is updated to use bigint.
 import { CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { Asset, Ogmios } from '@cardano-sdk/core';
@@ -41,8 +41,8 @@ export const valueToValueQuantities = (value: CSL.Value): ValueQuantities => {
   return result;
 };
 
-// This is equivalent to OgmiosToCardanoWasm.value(), so they should be merged.
-// Note that current implementation of OgmiosToCardanoWasm
+// This is equivalent to ogmiosToCsl.value(), so they should be merged.
+// Note that current implementation of ogmiosToCsl
 // imports nodejs version of CSL, so it cannot be used in browser.
 export const valueQuantitiesToValue = ({ coins, assets }: ValueQuantities, csl: CardanoSerializationLib): CSL.Value => {
   const value = csl.Value.new(csl.BigNum.from_str(coins.toString()));

--- a/packages/cip2/src/util.ts
+++ b/packages/cip2/src/util.ts
@@ -1,5 +1,5 @@
 // TODO: move these utils to either core package.
-// Current impelmentation of ogmiosToCsl.value() uses number instead of bigint for lovelace.
+// Current implementation of ogmiosToCsl.value() uses number instead of bigint for lovelace.
 // These utils should be moved after CSL is updated to use bigint.
 import { CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { Asset, Ogmios } from '@cardano-sdk/core';
@@ -42,8 +42,6 @@ export const valueToValueQuantities = (value: CSL.Value): ValueQuantities => {
 };
 
 // This is equivalent to ogmiosToCsl.value(), so they should be merged.
-// Note that current implementation of ogmiosToCsl
-// imports nodejs version of CSL, so it cannot be used in browser.
 export const valueQuantitiesToValue = ({ coins, assets }: ValueQuantities, csl: CardanoSerializationLib): CSL.Value => {
   const value = csl.Value.new(csl.BigNum.from_str(coins.toString()));
   if (!assets) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@cardano-ogmios/schema": "^4.0.0-beta.6",
-    "@emurgo/cardano-serialization-lib-nodejs": "8.0.0",
+    "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
     "buffer": "^6.0.3"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@cardano-ogmios/schema": "^4.0.0-beta.6",
-    "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
     "buffer": "^6.0.3"
   }
 }

--- a/packages/core/src/Asset/util.ts
+++ b/packages/core/src/Asset/util.ts
@@ -1,5 +1,4 @@
-import { CardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
-import { AssetName, ScriptHash } from '@emurgo/cardano-serialization-lib-nodejs';
+import { CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { Buffer } from 'buffer';
 
 export const policyIdFromAssetId = (assetId: string): string => assetId.slice(0, 56);
@@ -8,7 +7,7 @@ export const assetNameFromAssetId = (assetId: string): string => assetId.slice(5
 /**
  * @returns {string} concatenated hex-encoded policy id and asset name
  */
-export const createAssetId = (scriptHash: ScriptHash, assetName: AssetName): string =>
+export const createAssetId = (scriptHash: CSL.ScriptHash, assetName: CSL.AssetName): string =>
   Buffer.from(scriptHash.to_bytes()).toString('hex') + Buffer.from(assetName.name()).toString('hex');
 
 export const parseAssetId = (assetId: string, csl: CardanoSerializationLib) => {

--- a/packages/core/src/Cardano/ChainSettings.ts
+++ b/packages/core/src/Cardano/ChainSettings.ts
@@ -1,4 +1,0 @@
-export enum ChainSettings {
-  mainnet = 'mainnet',
-  testnet = 'testnet'
-}

--- a/packages/core/src/Cardano/NetworkId.ts
+++ b/packages/core/src/Cardano/NetworkId.ts
@@ -1,0 +1,4 @@
+export enum NetworkId {
+  mainnet = 1,
+  testnet = 0
+}

--- a/packages/core/src/Cardano/index.ts
+++ b/packages/core/src/Cardano/index.ts
@@ -1,2 +1,2 @@
-export { ChainSettings } from './ChainSettings';
+export { NetworkId } from './NetworkId';
 export * as util from './util';

--- a/packages/core/src/Ogmios/OgmiosToCardanoWasm.ts
+++ b/packages/core/src/Ogmios/OgmiosToCardanoWasm.ts
@@ -19,7 +19,7 @@ export const OgmiosToCardanoWasm = {
     ),
   value: (ogmios: OgmiosSchema.Value): CardanoWasm.Value => {
     const value = CardanoWasm.Value.new(CardanoWasm.BigNum.from_str(ogmios.coins.toString()));
-    const assets = Object.entries(ogmios.assets);
+    const assets = ogmios.assets !== undefined ? Object.entries(ogmios.assets) : [];
     if (assets.length === 0) {
       return value;
     }

--- a/packages/core/src/Ogmios/OgmiosToCardanoWasm.ts
+++ b/packages/core/src/Ogmios/OgmiosToCardanoWasm.ts
@@ -1,40 +1,34 @@
-import CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
+import { CSL } from '@cardano-sdk/cardano-serialization-lib';
 import OgmiosSchema from '@cardano-ogmios/schema';
 import * as Asset from '../Asset';
 
 export const OgmiosToCardanoWasm = {
-  txIn: (ogmios: OgmiosSchema.TxIn): CardanoWasm.TransactionInput =>
-    CardanoWasm.TransactionInput.new(
-      CardanoWasm.TransactionHash.from_bytes(Buffer.from(ogmios.txId, 'hex')),
-      ogmios.index
-    ),
-  txOut: (ogmios: OgmiosSchema.TxOut): CardanoWasm.TransactionOutput =>
-    CardanoWasm.TransactionOutput.new(
-      CardanoWasm.Address.from_bech32(ogmios.address),
-      OgmiosToCardanoWasm.value(ogmios.value)
-    ),
-  utxo: (ogmios: OgmiosSchema.Utxo): CardanoWasm.TransactionUnspentOutput[] =>
+  txIn: (ogmios: OgmiosSchema.TxIn): CSL.TransactionInput =>
+    CSL.TransactionInput.new(CSL.TransactionHash.from_bytes(Buffer.from(ogmios.txId, 'hex')), ogmios.index),
+  txOut: (ogmios: OgmiosSchema.TxOut): CSL.TransactionOutput =>
+    CSL.TransactionOutput.new(CSL.Address.from_bech32(ogmios.address), OgmiosToCardanoWasm.value(ogmios.value)),
+  utxo: (ogmios: OgmiosSchema.Utxo): CSL.TransactionUnspentOutput[] =>
     ogmios.map((item) =>
-      CardanoWasm.TransactionUnspentOutput.new(OgmiosToCardanoWasm.txIn(item[0]), OgmiosToCardanoWasm.txOut(item[1]))
+      CSL.TransactionUnspentOutput.new(OgmiosToCardanoWasm.txIn(item[0]), OgmiosToCardanoWasm.txOut(item[1]))
     ),
-  value: (ogmios: OgmiosSchema.Value): CardanoWasm.Value => {
-    const value = CardanoWasm.Value.new(CardanoWasm.BigNum.from_str(ogmios.coins.toString()));
+  value: (ogmios: OgmiosSchema.Value): CSL.Value => {
+    const value = CSL.Value.new(CSL.BigNum.from_str(ogmios.coins.toString()));
     const assets = ogmios.assets !== undefined ? Object.entries(ogmios.assets) : [];
     if (assets.length === 0) {
       return value;
     }
-    const multiAsset = CardanoWasm.MultiAsset.new();
+    const multiAsset = CSL.MultiAsset.new();
     const policies = [...new Set(assets.map(([assetId]) => Asset.util.policyIdFromAssetId(assetId)))];
     for (const policy of policies) {
       const policyAssets = assets.filter(([assetId]) => Asset.util.policyIdFromAssetId(assetId) === policy);
-      const wasmAssets = CardanoWasm.Assets.new();
+      const wasmAssets = CSL.Assets.new();
       for (const [assetId, assetQuantity] of policyAssets) {
         wasmAssets.insert(
-          CardanoWasm.AssetName.new(Buffer.from(Asset.util.assetNameFromAssetId(assetId), 'hex')),
-          CardanoWasm.BigNum.from_str(assetQuantity.toString())
+          CSL.AssetName.new(Buffer.from(Asset.util.assetNameFromAssetId(assetId), 'hex')),
+          CSL.BigNum.from_str(assetQuantity.toString())
         );
       }
-      multiAsset.insert(CardanoWasm.ScriptHash.from_bytes(Buffer.from(policy, 'hex')), wasmAssets);
+      multiAsset.insert(CSL.ScriptHash.from_bytes(Buffer.from(policy, 'hex')), wasmAssets);
     }
     value.set_multiasset(multiAsset);
     return value;

--- a/packages/core/src/Ogmios/index.ts
+++ b/packages/core/src/Ogmios/index.ts
@@ -1,2 +1,2 @@
-export * from './OgmiosToCardanoWasm';
+export * from './ogmiosToCsl';
 export * as util from './util';

--- a/packages/core/src/Ogmios/ogmiosToCsl.ts
+++ b/packages/core/src/Ogmios/ogmiosToCsl.ts
@@ -1,34 +1,36 @@
-import { CSL } from '@cardano-sdk/cardano-serialization-lib';
+import { CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import OgmiosSchema from '@cardano-ogmios/schema';
 import * as Asset from '../Asset';
 
-export const ogmiosToCsl = {
+export const ogmiosToCsl = (csl: CardanoSerializationLib) => ({
   txIn: (ogmios: OgmiosSchema.TxIn): CSL.TransactionInput =>
-    CSL.TransactionInput.new(CSL.TransactionHash.from_bytes(Buffer.from(ogmios.txId, 'hex')), ogmios.index),
+    csl.TransactionInput.new(csl.TransactionHash.from_bytes(Buffer.from(ogmios.txId, 'hex')), ogmios.index),
   txOut: (ogmios: OgmiosSchema.TxOut): CSL.TransactionOutput =>
-    CSL.TransactionOutput.new(CSL.Address.from_bech32(ogmios.address), ogmiosToCsl.value(ogmios.value)),
+    csl.TransactionOutput.new(csl.Address.from_bech32(ogmios.address), ogmiosToCsl(csl).value(ogmios.value)),
   utxo: (ogmios: OgmiosSchema.Utxo): CSL.TransactionUnspentOutput[] =>
-    ogmios.map((item) => CSL.TransactionUnspentOutput.new(ogmiosToCsl.txIn(item[0]), ogmiosToCsl.txOut(item[1]))),
+    ogmios.map((item) =>
+      csl.TransactionUnspentOutput.new(ogmiosToCsl(csl).txIn(item[0]), ogmiosToCsl(csl).txOut(item[1]))
+    ),
   value: (ogmios: OgmiosSchema.Value): CSL.Value => {
-    const value = CSL.Value.new(CSL.BigNum.from_str(ogmios.coins.toString()));
+    const value = csl.Value.new(csl.BigNum.from_str(ogmios.coins.toString()));
     const assets = ogmios.assets !== undefined ? Object.entries(ogmios.assets) : [];
     if (assets.length === 0) {
       return value;
     }
-    const multiAsset = CSL.MultiAsset.new();
+    const multiAsset = csl.MultiAsset.new();
     const policies = [...new Set(assets.map(([assetId]) => Asset.util.policyIdFromAssetId(assetId)))];
     for (const policy of policies) {
       const policyAssets = assets.filter(([assetId]) => Asset.util.policyIdFromAssetId(assetId) === policy);
-      const wasmAssets = CSL.Assets.new();
+      const wasmAssets = csl.Assets.new();
       for (const [assetId, assetQuantity] of policyAssets) {
         wasmAssets.insert(
-          CSL.AssetName.new(Buffer.from(Asset.util.assetNameFromAssetId(assetId), 'hex')),
-          CSL.BigNum.from_str(assetQuantity.toString())
+          csl.AssetName.new(Buffer.from(Asset.util.assetNameFromAssetId(assetId), 'hex')),
+          csl.BigNum.from_str(assetQuantity.toString())
         );
       }
-      multiAsset.insert(CSL.ScriptHash.from_bytes(Buffer.from(policy, 'hex')), wasmAssets);
+      multiAsset.insert(csl.ScriptHash.from_bytes(Buffer.from(policy, 'hex')), wasmAssets);
     }
     value.set_multiasset(multiAsset);
     return value;
   }
-};
+});

--- a/packages/core/src/Ogmios/ogmiosToCsl.ts
+++ b/packages/core/src/Ogmios/ogmiosToCsl.ts
@@ -2,15 +2,13 @@ import { CSL } from '@cardano-sdk/cardano-serialization-lib';
 import OgmiosSchema from '@cardano-ogmios/schema';
 import * as Asset from '../Asset';
 
-export const OgmiosToCardanoWasm = {
+export const ogmiosToCsl = {
   txIn: (ogmios: OgmiosSchema.TxIn): CSL.TransactionInput =>
     CSL.TransactionInput.new(CSL.TransactionHash.from_bytes(Buffer.from(ogmios.txId, 'hex')), ogmios.index),
   txOut: (ogmios: OgmiosSchema.TxOut): CSL.TransactionOutput =>
-    CSL.TransactionOutput.new(CSL.Address.from_bech32(ogmios.address), OgmiosToCardanoWasm.value(ogmios.value)),
+    CSL.TransactionOutput.new(CSL.Address.from_bech32(ogmios.address), ogmiosToCsl.value(ogmios.value)),
   utxo: (ogmios: OgmiosSchema.Utxo): CSL.TransactionUnspentOutput[] =>
-    ogmios.map((item) =>
-      CSL.TransactionUnspentOutput.new(OgmiosToCardanoWasm.txIn(item[0]), OgmiosToCardanoWasm.txOut(item[1]))
-    ),
+    ogmios.map((item) => CSL.TransactionUnspentOutput.new(ogmiosToCsl.txIn(item[0]), ogmiosToCsl.txOut(item[1]))),
   value: (ogmios: OgmiosSchema.Value): CSL.Value => {
     const value = CSL.Value.new(CSL.BigNum.from_str(ogmios.coins.toString()));
     const assets = ogmios.assets !== undefined ? Object.entries(ogmios.assets) : [];

--- a/packages/core/src/Provider/CardanoProvider.ts
+++ b/packages/core/src/Provider/CardanoProvider.ts
@@ -1,7 +1,7 @@
 // Importing types from cardano-serialization-lib-browser will cause TypeScript errors.
 import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
 import Cardano, { ProtocolParametersAlonzo } from '@cardano-ogmios/schema';
-import { Tx } from '../Transaction';
+import { Transaction } from '../';
 
 export type ProtocolParametersRequiredByWallet = Pick<
   ProtocolParametersAlonzo,
@@ -25,7 +25,7 @@ export interface CardanoProvider {
     addresses: Cardano.Address[],
     stakeKeyHash: Cardano.Hash16
   ) => Promise<{ utxo: Cardano.Utxo; delegationAndRewards: Cardano.DelegationsAndRewards }>;
-  queryTransactionsByAddresses: (addresses: Cardano.Address[]) => Promise<Tx[]>;
-  queryTransactionsByHashes: (hashes: Cardano.Hash16[]) => Promise<Tx[]>;
+  queryTransactionsByAddresses: (addresses: Cardano.Address[]) => Promise<Transaction.WithHash[]>;
+  queryTransactionsByHashes: (hashes: Cardano.Hash16[]) => Promise<Transaction.WithHash[]>;
   currentWalletProtocolParameters: () => Promise<ProtocolParametersRequiredByWallet>;
 }

--- a/packages/core/src/Provider/CardanoProvider.ts
+++ b/packages/core/src/Provider/CardanoProvider.ts
@@ -1,5 +1,4 @@
-// Importing types from cardano-serialization-lib-browser will cause TypeScript errors.
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { CSL } from '@cardano-sdk/cardano-serialization-lib';
 import Cardano, { ProtocolParametersAlonzo } from '@cardano-ogmios/schema';
 import { Transaction } from '../';
 
@@ -20,7 +19,7 @@ export type ProtocolParametersRequiredByWallet = Pick<
 export interface CardanoProvider {
   ledgerTip: () => Promise<Cardano.Tip>;
   /** @param signedTransaction signed and serialized cbor */
-  submitTx: (tx: CardanoSerializationLib.Transaction) => Promise<boolean>;
+  submitTx: (tx: CSL.Transaction) => Promise<boolean>;
   utxoDelegationAndRewards: (
     addresses: Cardano.Address[],
     stakeKeyHash: Cardano.Hash16

--- a/packages/core/src/Transaction/Tx.ts
+++ b/packages/core/src/Transaction/Tx.ts
@@ -1,3 +1,0 @@
-import OgmiosSchema from '@cardano-ogmios/schema';
-
-export type Tx = { hash: OgmiosSchema.Hash16 } & OgmiosSchema.Tx;

--- a/packages/core/src/Transaction/ValidityInterval.ts
+++ b/packages/core/src/Transaction/ValidityInterval.ts
@@ -1,0 +1,6 @@
+import { Slot } from '@cardano-ogmios/schema';
+
+export interface ValidityInterval {
+  invalidBefore?: Slot;
+  invalidHereafter?: Slot;
+}

--- a/packages/core/src/Transaction/WithHash.ts
+++ b/packages/core/src/Transaction/WithHash.ts
@@ -1,0 +1,3 @@
+import OgmiosSchema from '@cardano-ogmios/schema';
+
+export type WithHash = { hash: OgmiosSchema.Hash16 } & OgmiosSchema.Tx;

--- a/packages/core/src/Transaction/index.ts
+++ b/packages/core/src/Transaction/index.ts
@@ -1,1 +1,2 @@
+export * from './ValidityInterval';
 export * from './WithHash';

--- a/packages/core/src/Transaction/index.ts
+++ b/packages/core/src/Transaction/index.ts
@@ -1,1 +1,1 @@
-export * from './Tx';
+export * from './WithHash';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,5 +3,5 @@ export * as Cardano from './Cardano';
 export * as Ogmios from './Ogmios';
 export * from './Genesis';
 export * from './Provider';
-export * from './Transaction';
+export * as Transaction from './Transaction';
 export * from './util';

--- a/packages/core/test/Ogmios/OgmiosToCardanoWasm.test.ts
+++ b/packages/core/test/Ogmios/OgmiosToCardanoWasm.test.ts
@@ -1,4 +1,4 @@
-import CardanoWasm from '@emurgo/cardano-serialization-lib-nodejs';
+import { CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { OgmiosToCardanoWasm } from '../../src/Ogmios';
 import * as OgmiosSchema from '@cardano-ogmios/schema';
 
@@ -11,15 +11,15 @@ const txOut: OgmiosSchema.TxOut = {
 
 describe('OgmiosToCardanoWasm', () => {
   test('txIn', () => {
-    expect(OgmiosToCardanoWasm.txIn(txIn)).toBeInstanceOf(CardanoWasm.TransactionInput);
+    expect(OgmiosToCardanoWasm.txIn(txIn)).toBeInstanceOf(CSL.TransactionInput);
   });
   test('txOut', () => {
-    expect(OgmiosToCardanoWasm.txOut(txOut)).toBeInstanceOf(CardanoWasm.TransactionOutput);
+    expect(OgmiosToCardanoWasm.txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
   });
   test('utxo', () => {
-    expect(OgmiosToCardanoWasm.utxo([[txIn, txOut]])[0]).toBeInstanceOf(CardanoWasm.TransactionUnspentOutput);
+    expect(OgmiosToCardanoWasm.utxo([[txIn, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);
   });
   test('value', () => {
-    expect(OgmiosToCardanoWasm.value(txOut.value)).toBeInstanceOf(CardanoWasm.Value);
+    expect(OgmiosToCardanoWasm.value(txOut.value)).toBeInstanceOf(CSL.Value);
   });
 });

--- a/packages/core/test/Ogmios/ogmiosToCsl.test.ts
+++ b/packages/core/test/Ogmios/ogmiosToCsl.test.ts
@@ -1,5 +1,5 @@
 import { CSL } from '@cardano-sdk/cardano-serialization-lib';
-import { OgmiosToCardanoWasm } from '../../src/Ogmios';
+import { ogmiosToCsl } from '../../src/Ogmios';
 import * as OgmiosSchema from '@cardano-ogmios/schema';
 
 const txIn: OgmiosSchema.TxIn = { txId: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5', index: 0 };
@@ -9,17 +9,17 @@ const txOut: OgmiosSchema.TxOut = {
   value: { coins: 10, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
 };
 
-describe('OgmiosToCardanoWasm', () => {
+describe('ogmiosToCsl', () => {
   test('txIn', () => {
-    expect(OgmiosToCardanoWasm.txIn(txIn)).toBeInstanceOf(CSL.TransactionInput);
+    expect(ogmiosToCsl.txIn(txIn)).toBeInstanceOf(CSL.TransactionInput);
   });
   test('txOut', () => {
-    expect(OgmiosToCardanoWasm.txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
+    expect(ogmiosToCsl.txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
   });
   test('utxo', () => {
-    expect(OgmiosToCardanoWasm.utxo([[txIn, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);
+    expect(ogmiosToCsl.utxo([[txIn, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);
   });
   test('value', () => {
-    expect(OgmiosToCardanoWasm.value(txOut.value)).toBeInstanceOf(CSL.Value);
+    expect(ogmiosToCsl.value(txOut.value)).toBeInstanceOf(CSL.Value);
   });
 });

--- a/packages/core/test/Ogmios/ogmiosToCsl.test.ts
+++ b/packages/core/test/Ogmios/ogmiosToCsl.test.ts
@@ -1,4 +1,4 @@
-import { CSL } from '@cardano-sdk/cardano-serialization-lib';
+import { CardanoSerializationLib, CSL, loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
 import { ogmiosToCsl } from '../../src/Ogmios';
 import * as OgmiosSchema from '@cardano-ogmios/schema';
 
@@ -10,16 +10,20 @@ const txOut: OgmiosSchema.TxOut = {
 };
 
 describe('ogmiosToCsl', () => {
+  let csl: CardanoSerializationLib;
+  beforeAll(async () => {
+    csl = await loadCardanoSerializationLib();
+  });
   test('txIn', () => {
-    expect(ogmiosToCsl.txIn(txIn)).toBeInstanceOf(CSL.TransactionInput);
+    expect(ogmiosToCsl(csl).txIn(txIn)).toBeInstanceOf(CSL.TransactionInput);
   });
   test('txOut', () => {
-    expect(ogmiosToCsl.txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
+    expect(ogmiosToCsl(csl).txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
   });
   test('utxo', () => {
-    expect(ogmiosToCsl.utxo([[txIn, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);
+    expect(ogmiosToCsl(csl).utxo([[txIn, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);
   });
   test('value', () => {
-    expect(ogmiosToCsl.value(txOut.value)).toBeInstanceOf(CSL.Value);
+    expect(ogmiosToCsl(csl).value(txOut.value)).toBeInstanceOf(CSL.Value);
   });
 });

--- a/packages/core/test/Ogmios/ogmiosToCsl.test.ts
+++ b/packages/core/test/Ogmios/ogmiosToCsl.test.ts
@@ -1,4 +1,4 @@
-import { CardanoSerializationLib, CSL, loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { CardanoSerializationLib, loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
 import { ogmiosToCsl } from '../../src/Ogmios';
 import * as OgmiosSchema from '@cardano-ogmios/schema';
 
@@ -15,15 +15,15 @@ describe('ogmiosToCsl', () => {
     csl = await loadCardanoSerializationLib();
   });
   test('txIn', () => {
-    expect(ogmiosToCsl(csl).txIn(txIn)).toBeInstanceOf(CSL.TransactionInput);
+    expect(ogmiosToCsl(csl).txIn(txIn)).toBeInstanceOf(csl.TransactionInput);
   });
   test('txOut', () => {
-    expect(ogmiosToCsl(csl).txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
+    expect(ogmiosToCsl(csl).txOut(txOut)).toBeInstanceOf(csl.TransactionOutput);
   });
   test('utxo', () => {
-    expect(ogmiosToCsl(csl).utxo([[txIn, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);
+    expect(ogmiosToCsl(csl).utxo([[txIn, txOut]])[0]).toBeInstanceOf(csl.TransactionUnspentOutput);
   });
   test('value', () => {
-    expect(ogmiosToCsl(csl).value(txOut.value)).toBeInstanceOf(CSL.Value);
+    expect(ogmiosToCsl(csl).value(txOut.value)).toBeInstanceOf(csl.Value);
   });
 });

--- a/packages/in-memory-key-manager/package.json
+++ b/packages/in-memory-key-manager/package.json
@@ -18,10 +18,10 @@
     "test": "jest -c ./test/jest.config.js"
   },
   "devDependencies": {
+    "@cardano-sdk/cardano-serialization-lib": "0.1.0",
     "shx": "^0.3.3"
   },
   "dependencies": {
-    "@cardano-sdk/cardano-serialization-lib": "0.1.0",
     "@cardano-sdk/wallet": "0.1.0",
     "bip39": "^3.0.4"
   }

--- a/packages/in-memory-key-manager/package.json
+++ b/packages/in-memory-key-manager/package.json
@@ -22,6 +22,7 @@
     "shx": "^0.3.3"
   },
   "dependencies": {
+    "@cardano-sdk/core": "0.1.0",
     "@cardano-sdk/wallet": "0.1.0",
     "bip39": "^3.0.4"
   }

--- a/packages/in-memory-key-manager/src/InMemoryKey.ts
+++ b/packages/in-memory-key-manager/src/InMemoryKey.ts
@@ -3,6 +3,7 @@ import * as bip39 from 'bip39';
 import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
 import { KeyManagement } from '@cardano-sdk/wallet';
 import { harden } from './util';
+import { Cardano } from '@cardano-sdk/core';
 
 /**
  *
@@ -10,11 +11,13 @@ import { harden } from './util';
 export const createInMemoryKeyManager = ({
   password,
   accountIndex,
-  mnemonic
+  mnemonic,
+  networkId
 }: {
   password: string;
   accountIndex?: number;
   mnemonic: string;
+  networkId: Cardano.NetworkId;
 }): KeyManagement.KeyManager => {
   if (!accountIndex) {
     accountIndex = 0;
@@ -24,7 +27,7 @@ export const createInMemoryKeyManager = ({
   if (!validMnemonic) throw new KeyManagement.errors.InvalidMnemonic();
 
   const entropy = bip39.mnemonicToEntropy(mnemonic);
-  const account = CardanoSerializationLib.Bip32PrivateKey.from_bip39_entropy(
+  const accountPrivateKey = CardanoSerializationLib.Bip32PrivateKey.from_bip39_entropy(
     Buffer.from(entropy, 'hex'),
     Buffer.from(password)
   )
@@ -32,10 +35,22 @@ export const createInMemoryKeyManager = ({
     .derive(harden(1815))
     .derive(harden(accountIndex));
 
-  const privateParentKey = account.derive(0).derive(0);
-  const publicParentKey = privateParentKey.to_public().to_raw_key();
+  const privateParentKey = accountPrivateKey.derive(0).derive(0);
+  const publicParentKey = privateParentKey.to_public();
+  const publicKey = accountPrivateKey.to_public();
+  const stakeKey = publicKey.derive(2).derive(0);
 
   return {
+    deriveAddress: (addressIndex, index) => {
+      const utxoPubKey = publicKey.derive(index).derive(addressIndex);
+      const baseAddr = CardanoSerializationLib.BaseAddress.new(
+        networkId,
+        CardanoSerializationLib.StakeCredential.from_keyhash(utxoPubKey.to_raw_key().hash()),
+        CardanoSerializationLib.StakeCredential.from_keyhash(stakeKey.to_raw_key().hash())
+      );
+
+      return baseAddr.to_address().to_bech32();
+    },
     signMessage: async (_addressType, _signingIndex, message) => ({
       publicKey: publicParentKey.toString(),
       signature: `Signature for ${message} is not implemented yet`
@@ -48,7 +63,8 @@ export const createInMemoryKeyManager = ({
       witnessSet.set_vkeys(vkeyWitnesses);
       return witnessSet;
     },
-    publicKey: account.to_public().to_raw_key(),
-    publicParentKey
+    stakeKey: stakeKey.to_raw_key(),
+    publicKey: publicKey.to_raw_key(),
+    publicParentKey: publicParentKey.to_raw_key()
   };
 };

--- a/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
+++ b/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
@@ -1,23 +1,23 @@
 import { createInMemoryKeyManager } from '@src/InMemoryKey';
 import { util } from '@src/.';
-import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { CardanoSerializationLib, CSL, loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
 import { Cardano } from '@cardano-sdk/core';
 import { KeyManagement } from '@cardano-sdk/wallet';
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
 
 describe('InMemoryKeyManager', () => {
   let keyManager: KeyManagement.KeyManager;
-  let cardanoWasm: typeof CardanoSerializationLib;
+  let csl: CardanoSerializationLib;
 
   beforeEach(async () => {
-    cardanoWasm = await loadCardanoSerializationLib();
+    csl = await loadCardanoSerializationLib();
     const mnemonic = util.generateMnemonic();
     keyManager = createInMemoryKeyManager({
+      csl,
       mnemonic,
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });
-    expect(keyManager.publicKey).toBeInstanceOf(CardanoSerializationLib.PublicKey);
+    expect(keyManager.publicKey).toBeInstanceOf(CSL.PublicKey);
   });
 
   test('initial state publicKey', async () => {
@@ -32,10 +32,10 @@ describe('InMemoryKeyManager', () => {
   });
 
   test('signTransaction', async () => {
-    const txHash = cardanoWasm.TransactionHash.from_bytes(
+    const txHash = csl.TransactionHash.from_bytes(
       Buffer.from('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec', 'hex')
     );
     const witnessSet = await keyManager.signTransaction(txHash);
-    expect(witnessSet).toBeInstanceOf(CardanoSerializationLib.TransactionWitnessSet);
+    expect(witnessSet).toBeInstanceOf(CSL.TransactionWitnessSet);
   });
 });

--- a/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
+++ b/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
@@ -1,6 +1,6 @@
 import { createInMemoryKeyManager } from '@src/InMemoryKey';
 import { util } from '@src/.';
-import { CardanoSerializationLib, CSL, loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { CardanoSerializationLib, loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
 import { Cardano } from '@cardano-sdk/core';
 import { KeyManagement } from '@cardano-sdk/wallet';
 
@@ -17,7 +17,7 @@ describe('InMemoryKeyManager', () => {
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });
-    expect(keyManager.publicKey).toBeInstanceOf(CSL.PublicKey);
+    expect(keyManager.publicKey).toBeInstanceOf(csl.PublicKey);
   });
 
   test('initial state publicKey', async () => {
@@ -36,6 +36,6 @@ describe('InMemoryKeyManager', () => {
       Buffer.from('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec', 'hex')
     );
     const witnessSet = await keyManager.signTransaction(txHash);
-    expect(witnessSet).toBeInstanceOf(CSL.TransactionWitnessSet);
+    expect(witnessSet).toBeInstanceOf(csl.TransactionWitnessSet);
   });
 });

--- a/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
+++ b/packages/in-memory-key-manager/test/InMemoryKeyManager.test.ts
@@ -1,6 +1,7 @@
 import { createInMemoryKeyManager } from '@src/InMemoryKey';
 import { util } from '@src/.';
 import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { Cardano } from '@cardano-sdk/core';
 import { KeyManagement } from '@cardano-sdk/wallet';
 import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
 
@@ -13,6 +14,7 @@ describe('InMemoryKeyManager', () => {
     const mnemonic = util.generateMnemonic();
     keyManager = createInMemoryKeyManager({
       mnemonic,
+      networkId: Cardano.NetworkId.testnet,
       password: '123'
     });
     expect(keyManager.publicKey).toBeInstanceOf(CardanoSerializationLib.PublicKey);
@@ -20,6 +22,12 @@ describe('InMemoryKeyManager', () => {
 
   test('initial state publicKey', async () => {
     expect(keyManager.publicKey).toBeDefined();
+    expect(keyManager.publicParentKey).toBeDefined();
+  });
+
+  test('deriveAddress', async () => {
+    const address = await keyManager.deriveAddress(0, 0);
+    expect(address).toBeDefined();
     expect(keyManager.publicParentKey).toBeDefined();
   });
 

--- a/packages/in-memory-key-manager/test/tsconfig.json
+++ b/packages/in-memory-key-manager/test/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "references": [
     { "path": "../src" },
+    { "path": "../../core/src" },
     { "path": "../../wallet/src" }
   ]
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -14,7 +14,7 @@
   ],
   "license": "MPL-2.0",
   "scripts": {
-    "build": "which tsc",
+    "build": "tsc --build ./src",
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -30,7 +30,6 @@
     "@cardano-sdk/cardano-serialization-lib": "0.1.0",
     "@cardano-sdk/cip2": "0.1.0",
     "@cardano-sdk/core": "0.1.0",
-    "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
     "ts-log": "^2.2.3"
   }
 }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -18,15 +18,19 @@
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
-    "test": "shx echo No tests in this package",
+    "test": "jest -c ./test/jest.config.js",
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {
-    "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
+    "@cardano-sdk/in-memory-key-manager": "0.1.0",
     "shx": "^0.3.3"
   },
   "dependencies": {
     "@cardano-ogmios/schema": "^4.0.0-beta.6",
-    "@cardano-sdk/cardano-serialization-lib": "0.1.0"
+    "@cardano-sdk/cardano-serialization-lib": "0.1.0",
+    "@cardano-sdk/cip2": "0.1.0",
+    "@cardano-sdk/core": "0.1.0",
+    "@emurgo/cardano-serialization-lib-nodejs": "^8.0.0",
+    "ts-log": "^2.2.3"
   }
 }

--- a/packages/wallet/src/InMemoryUtxoRepository.ts
+++ b/packages/wallet/src/InMemoryUtxoRepository.ts
@@ -3,7 +3,7 @@ import { UtxoRepository } from './UtxoRepository';
 import { CardanoProvider, Ogmios } from '@cardano-sdk/core';
 import { dummyLogger, Logger } from 'ts-log';
 import { InputSelector, SelectionConstraints, SelectionResult } from '@cardano-sdk/cip2';
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { KeyManager } from './KeyManagement';
 
 export class InMemoryUtxoRepository implements UtxoRepository {
@@ -47,7 +47,7 @@ export class InMemoryUtxoRepository implements UtxoRepository {
   }
 
   public async selectInputs(
-    outputs: CardanoSerializationLib.TransactionOutputs,
+    outputs: CSL.TransactionOutputs,
     constraints: SelectionConstraints
   ): Promise<SelectionResult> {
     if (this.#utxoSet.size === 0) {

--- a/packages/wallet/src/InMemoryUtxoRepository.ts
+++ b/packages/wallet/src/InMemoryUtxoRepository.ts
@@ -63,7 +63,7 @@ export class InMemoryUtxoRepository implements UtxoRepository {
       await this.sync();
     }
     return this.#inputSelector.select({
-      utxo: Ogmios.ogmiosToCsl(this.#csl).utxo([...this.#utxoSet.values()]),
+      utxo: Ogmios.ogmiosToCsl(this.#csl).utxo(this.allUtxos),
       outputs,
       constraints
     });

--- a/packages/wallet/src/InMemoryUtxoRepository.ts
+++ b/packages/wallet/src/InMemoryUtxoRepository.ts
@@ -1,0 +1,75 @@
+import Schema, { TxIn, TxOut } from '@cardano-ogmios/schema';
+import { UtxoRepository } from './UtxoRepository';
+import { CardanoProvider, Ogmios } from '@cardano-sdk/core';
+import { dummyLogger, Logger } from 'ts-log';
+import { InputSelector, SelectionConstraints, SelectionResult } from '@cardano-sdk/cip2';
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { KeyManager } from './KeyManagement';
+
+export class InMemoryUtxoRepository implements UtxoRepository {
+  #delegationAndRewards: Schema.DelegationsAndRewards;
+  #inputSelector: InputSelector;
+  #keyManager: KeyManager;
+  #logger: Logger;
+  #provider: CardanoProvider;
+  #utxoSet: Set<[TxIn, TxOut]>;
+
+  constructor(provider: CardanoProvider, keyManager: KeyManager, inputSelector: InputSelector, logger?: Logger) {
+    this.#logger = logger ?? dummyLogger;
+    this.#provider = provider;
+    this.#utxoSet = new Set();
+    this.#delegationAndRewards = { rewards: null, delegate: null };
+    this.#inputSelector = inputSelector;
+    this.#keyManager = keyManager;
+  }
+
+  public async sync(): Promise<void> {
+    this.#logger.debug('Syncing InMemoryUtxoRepository');
+    const result = await this.#provider.utxoDelegationAndRewards(
+      [this.#keyManager.deriveAddress(1, 0)],
+      Buffer.from(this.#keyManager.stakeKey.hash().to_bytes()).toString('hex')
+    );
+    this.#logger.trace(result);
+    for (const utxo of result.utxo) {
+      if (!this.#utxoSet.has(utxo)) {
+        this.#utxoSet.add(utxo);
+        this.#logger.debug('New UTxO', utxo);
+      }
+    }
+    if (this.#delegationAndRewards.delegate !== result.delegationAndRewards.delegate) {
+      this.#delegationAndRewards.delegate = result.delegationAndRewards.delegate;
+      this.#logger.debug('Delegation stored', result.delegationAndRewards.delegate);
+    }
+    if (this.#delegationAndRewards.rewards !== result.delegationAndRewards.rewards) {
+      this.#delegationAndRewards.rewards = result.delegationAndRewards.rewards;
+      this.#logger.debug('Rewards balance stored', result.delegationAndRewards.rewards);
+    }
+  }
+
+  public async selectInputs(
+    outputs: CardanoSerializationLib.TransactionOutputs,
+    constraints: SelectionConstraints
+  ): Promise<SelectionResult> {
+    if (this.#utxoSet.size === 0) {
+      this.#logger.debug('Local UTxO set is empty. Syncing...');
+      await this.sync();
+    }
+    return this.#inputSelector.select({
+      utxo: Ogmios.OgmiosToCardanoWasm.utxo([...this.#utxoSet.values()]),
+      outputs,
+      constraints
+    });
+  }
+
+  public get allUtxos(): Schema.Utxo {
+    return [...this.#utxoSet.values()];
+  }
+
+  public get rewards(): Schema.Lovelace {
+    return this.#delegationAndRewards.rewards;
+  }
+
+  public get delegation(): Schema.PoolId {
+    return this.#delegationAndRewards.delegate;
+  }
+}

--- a/packages/wallet/src/InMemoryUtxoRepository.ts
+++ b/packages/wallet/src/InMemoryUtxoRepository.ts
@@ -55,7 +55,7 @@ export class InMemoryUtxoRepository implements UtxoRepository {
       await this.sync();
     }
     return this.#inputSelector.select({
-      utxo: Ogmios.OgmiosToCardanoWasm.utxo([...this.#utxoSet.values()]),
+      utxo: Ogmios.ogmiosToCsl.utxo([...this.#utxoSet.values()]),
       outputs,
       constraints
     });

--- a/packages/wallet/src/KeyManagement/KeyManager.ts
+++ b/packages/wallet/src/KeyManagement/KeyManager.ts
@@ -1,4 +1,4 @@
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { Address } from '../';
 
 export interface KeyManager {
@@ -8,10 +8,8 @@ export interface KeyManager {
     signingIndex: number,
     message: string
   ) => Promise<{ publicKey: string; signature: string }>;
-  publicKey: CardanoSerializationLib.PublicKey;
-  publicParentKey: CardanoSerializationLib.PublicKey;
-  signTransaction: (
-    txHash: CardanoSerializationLib.TransactionHash
-  ) => Promise<CardanoSerializationLib.TransactionWitnessSet>;
-  stakeKey: CardanoSerializationLib.PublicKey;
+  publicKey: CSL.PublicKey;
+  publicParentKey: CSL.PublicKey;
+  signTransaction: (txHash: CSL.TransactionHash) => Promise<CSL.TransactionWitnessSet>;
+  stakeKey: CSL.PublicKey;
 }

--- a/packages/wallet/src/KeyManagement/KeyManager.ts
+++ b/packages/wallet/src/KeyManagement/KeyManager.ts
@@ -2,6 +2,7 @@ import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
 import { Address } from '../';
 
 export interface KeyManager {
+  deriveAddress: (addressIndex: number, index: 0 | 1) => string;
   signMessage: (
     addressType: Address.AddressType,
     signingIndex: number,
@@ -12,4 +13,5 @@ export interface KeyManager {
   signTransaction: (
     txHash: CardanoSerializationLib.TransactionHash
   ) => Promise<CardanoSerializationLib.TransactionWitnessSet>;
+  stakeKey: CardanoSerializationLib.PublicKey;
 }

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -41,7 +41,7 @@ export const createSingleAddressWallet = async (
       const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
       const txOutputs = csl.TransactionOutputs.new();
       for (const output of props.outputs) {
-        txOutputs.add(Ogmios.ogmiosToCsl.txOut(output));
+        txOutputs.add(Ogmios.ogmiosToCsl(csl).txOut(output));
       }
       const inputSelectionResult = await utxoRepository.selectInputs(txOutputs, {
         computeMinimumCost: async ({ utxo, outputs, change }) => {

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -1,0 +1,101 @@
+import Schema from '@cardano-ogmios/schema';
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { CardanoProvider, Ogmios, Transaction } from '@cardano-sdk/core';
+import { createTransactionInternals, KeyManagement, TxInternals, UtxoRepository } from './';
+import { dummyLogger, Logger } from 'ts-log';
+
+export type InitializeTxProps = {
+  outputs: Schema.TxOut[];
+  options?: {
+    validityInterval?: Transaction.ValidityInterval;
+  };
+};
+
+export interface SingleAddressWallet {
+  address: Schema.Address;
+  initializeTx: (props: InitializeTxProps) => Promise<TxInternals>;
+  signTx: (
+    body: CardanoSerializationLib.TransactionBody,
+    hash: CardanoSerializationLib.TransactionHash
+  ) => Promise<CardanoSerializationLib.Transaction>;
+  submitTx: (tx: CardanoSerializationLib.Transaction) => Promise<boolean>;
+}
+
+const ensureValidityInterval = (
+  currentSlot: number,
+  validityInterval?: Transaction.ValidityInterval
+): Transaction.ValidityInterval =>
+  // Todo: Based this on slot duration, to equal 2hrs
+  ({ invalidHereafter: currentSlot + 3600, ...validityInterval });
+
+export const createSingleAddressWallet = async (
+  CSL: typeof CardanoSerializationLib,
+  provider: CardanoProvider,
+  keyManager: KeyManagement.KeyManager,
+  utxoRepository: UtxoRepository,
+  logger: Logger = dummyLogger
+): Promise<SingleAddressWallet> => {
+  const address = keyManager.deriveAddress(0, 0);
+  const protocolParameters = await provider.currentWalletProtocolParameters();
+  return {
+    address,
+    initializeTx: async (props) => {
+      const tip = await provider.ledgerTip();
+      const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
+      const txOutputs = CSL.TransactionOutputs.new();
+      for (const output of props.outputs) {
+        txOutputs.add(Ogmios.OgmiosToCardanoWasm.txOut(output));
+      }
+      const inputSelectionResult = await utxoRepository.selectInputs(txOutputs, {
+        computeMinimumCost: async ({ utxo, outputs, change }) => {
+          const transactionInternals = await createTransactionInternals(CSL, {
+            changeAddress: address,
+            inputSelection: {
+              outputs,
+              inputs: utxo,
+              change,
+              fee: 0n
+            },
+            validityInterval
+          });
+          const witnessSet = await keyManager.signTransaction(transactionInternals.hash);
+          const tx = CSL.Transaction.new(transactionInternals.body, witnessSet);
+          return BigInt(
+            CSL.min_fee(
+              tx,
+              CSL.LinearFee.new(
+                CSL.BigNum.from_str(protocolParameters.minFeeCoefficient.toString()),
+                CSL.BigNum.from_str(protocolParameters.minFeeConstant.toString())
+              )
+            ).to_str()
+          );
+        },
+        tokenBundleSizeExceedsLimit: (tokenBundle) => {
+          logger.debug('SelectionConstraint: tokenBundleSizeExceedsLimit', tokenBundle);
+          // Todo: Replace with real implementation
+          return false;
+        },
+        computeMinimumCoinQuantity: (assetQuantities) => {
+          logger.debug('SelectionConstraint: computeMinimumCoinQuantity', assetQuantities);
+          // Todo: Replace with real implementation
+          return 1_000_000n;
+        },
+        computeSelectionLimit: async (selectionSkeleton) => {
+          logger.debug('SelectionConstraint: computeSelectionLimit', selectionSkeleton);
+          // Todo: Replace with real implementation
+          return 5;
+        }
+      });
+      return createTransactionInternals(CSL, {
+        changeAddress: address,
+        inputSelection: inputSelectionResult.selection,
+        validityInterval
+      });
+    },
+    signTx: async (body, hash) => {
+      const witnessSet = await keyManager.signTransaction(hash);
+      return CSL.Transaction.new(body, witnessSet);
+    },
+    submitTx: async (tx) => provider.submitTx(tx)
+  };
+};

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -41,7 +41,7 @@ export const createSingleAddressWallet = async (
       const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
       const txOutputs = csl.TransactionOutputs.new();
       for (const output of props.outputs) {
-        txOutputs.add(Ogmios.OgmiosToCardanoWasm.txOut(output));
+        txOutputs.add(Ogmios.ogmiosToCsl.txOut(output));
       }
       const inputSelectionResult = await utxoRepository.selectInputs(txOutputs, {
         computeMinimumCost: async ({ utxo, outputs, change }) => {

--- a/packages/wallet/src/UtxoRepository.ts
+++ b/packages/wallet/src/UtxoRepository.ts
@@ -1,0 +1,14 @@
+import Schema from '@cardano-ogmios/schema';
+import { SelectionConstraints, SelectionResult } from '@cardano-sdk/cip2';
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+
+export interface UtxoRepository {
+  allUtxos: Schema.Utxo;
+  rewards: Schema.Lovelace;
+  delegation: Schema.PoolId;
+  sync: () => Promise<void>;
+  selectInputs: (
+    outputs: CardanoSerializationLib.TransactionOutputs,
+    constraints: SelectionConstraints
+  ) => Promise<SelectionResult>;
+}

--- a/packages/wallet/src/UtxoRepository.ts
+++ b/packages/wallet/src/UtxoRepository.ts
@@ -1,14 +1,11 @@
 import Schema from '@cardano-ogmios/schema';
 import { SelectionConstraints, SelectionResult } from '@cardano-sdk/cip2';
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { CSL } from '@cardano-sdk/cardano-serialization-lib';
 
 export interface UtxoRepository {
   allUtxos: Schema.Utxo;
   rewards: Schema.Lovelace;
   delegation: Schema.PoolId;
   sync: () => Promise<void>;
-  selectInputs: (
-    outputs: CardanoSerializationLib.TransactionOutputs,
-    constraints: SelectionConstraints
-  ) => Promise<SelectionResult>;
+  selectInputs: (outputs: CSL.TransactionOutputs, constraints: SelectionConstraints) => Promise<SelectionResult>;
 }

--- a/packages/wallet/src/createTransactionInternals.ts
+++ b/packages/wallet/src/createTransactionInternals.ts
@@ -1,11 +1,10 @@
-// Importing types from cardano-serialization-lib-browser will cause TypeScript errors.
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { SelectionResult } from '@cardano-sdk/cip2';
 import { Transaction } from '@cardano-sdk/core';
 
 export type TxInternals = {
-  hash: CardanoSerializationLib.TransactionHash;
-  body: CardanoSerializationLib.TransactionBody;
+  hash: CSL.TransactionHash;
+  body: CSL.TransactionBody;
 };
 
 export type CreateTxInternalsProps = {
@@ -15,17 +14,17 @@ export type CreateTxInternalsProps = {
 };
 
 export const createTransactionInternals = async (
-  cardanoSerializationLib: typeof CardanoSerializationLib,
+  csl: CardanoSerializationLib,
   props: CreateTxInternalsProps
 ): Promise<TxInternals> => {
-  const inputs = cardanoSerializationLib.TransactionInputs.new();
+  const inputs = csl.TransactionInputs.new();
   for (const utxo of props.inputSelection.inputs) {
     inputs.add(utxo.input());
   }
-  const body = cardanoSerializationLib.TransactionBody.new(
+  const body = csl.TransactionBody.new(
     inputs,
     props.inputSelection.outputs,
-    cardanoSerializationLib.BigNum.from_str(props.inputSelection.fee.toString()),
+    csl.BigNum.from_str(props.inputSelection.fee.toString()),
     props.validityInterval.invalidHereafter
   );
   if (props.validityInterval.invalidBefore !== undefined) {
@@ -33,6 +32,6 @@ export const createTransactionInternals = async (
   }
   return {
     body,
-    hash: cardanoSerializationLib.hash_transaction(body)
+    hash: csl.hash_transaction(body)
   };
 };

--- a/packages/wallet/src/createTransactionInternals.ts
+++ b/packages/wallet/src/createTransactionInternals.ts
@@ -1,0 +1,38 @@
+// Importing types from cardano-serialization-lib-browser will cause TypeScript errors.
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { SelectionResult } from '@cardano-sdk/cip2';
+import { Transaction } from '@cardano-sdk/core';
+
+export type TxInternals = {
+  hash: CardanoSerializationLib.TransactionHash;
+  body: CardanoSerializationLib.TransactionBody;
+};
+
+export type CreateTxInternalsProps = {
+  changeAddress: string;
+  inputSelection: SelectionResult['selection'];
+  validityInterval: Transaction.ValidityInterval;
+};
+
+export const createTransactionInternals = async (
+  cardanoSerializationLib: typeof CardanoSerializationLib,
+  props: CreateTxInternalsProps
+): Promise<TxInternals> => {
+  const inputs = cardanoSerializationLib.TransactionInputs.new();
+  for (const utxo of props.inputSelection.inputs) {
+    inputs.add(utxo.input());
+  }
+  const body = cardanoSerializationLib.TransactionBody.new(
+    inputs,
+    props.inputSelection.outputs,
+    cardanoSerializationLib.BigNum.from_str(props.inputSelection.fee.toString()),
+    props.validityInterval.invalidHereafter
+  );
+  if (props.validityInterval.invalidBefore !== undefined) {
+    body.set_validity_start_interval(props.validityInterval.invalidBefore);
+  }
+  return {
+    body,
+    hash: cardanoSerializationLib.hash_transaction(body)
+  };
+};

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -1,4 +1,5 @@
 export * as Address from './Address';
+export * from './createTransactionInternals';
 export * from './InMemoryUtxoRepository';
 export * as KeyManagement from './KeyManagement';
 export * from './UtxoRepository';

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -2,4 +2,5 @@ export * as Address from './Address';
 export * from './createTransactionInternals';
 export * from './InMemoryUtxoRepository';
 export * as KeyManagement from './KeyManagement';
+export * from './SingleAddressWallet';
 export * from './UtxoRepository';

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -1,2 +1,4 @@
 export * as Address from './Address';
+export * from './InMemoryUtxoRepository';
 export * as KeyManagement from './KeyManagement';
+export * from './UtxoRepository';

--- a/packages/wallet/src/tsconfig.json
+++ b/packages/wallet/src/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "references": [
     { "path": "../../cardano-serialization-lib/src" },
+    { "path": "../../cip2/src" },
     { "path": "../../core/src" }
   ]
 }

--- a/packages/wallet/test/InMemoryUtxoRepository.test.ts
+++ b/packages/wallet/test/InMemoryUtxoRepository.test.ts
@@ -2,8 +2,7 @@ import { CardanoProvider, Ogmios } from '@cardano-sdk/core';
 import { UtxoRepository } from '@src/UtxoRepository';
 import { InMemoryUtxoRepository } from '@src/InMemoryUtxoRepository';
 import { roundRobinRandomImprove, InputSelector } from '@cardano-sdk/cip2';
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
-import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { loadCardanoSerializationLib, CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { providerStub, delegate, rewards } from './ProviderStub';
 import { createInMemoryKeyManager, util } from '@cardano-sdk/in-memory-key-manager';
 import { NO_CONSTRAINTS } from './util';
@@ -18,7 +17,7 @@ const addresses = [
 //   { txId: '08fc1f8af3abbc8fc1f8a466e6e754833a08a62a059bf059bf5483a8a66e6e74', index: 0 }
 // ];
 
-const outputs = CardanoSerializationLib.TransactionOutputs.new();
+const outputs = CSL.TransactionOutputs.new();
 
 outputs.add(
   Ogmios.OgmiosToCardanoWasm.txOut({
@@ -39,12 +38,12 @@ describe('InMemoryUtxoRepository', () => {
   let utxoRepository: UtxoRepository;
   let provider: CardanoProvider;
   let inputSelector: InputSelector;
-  let cardanoSerializationLib: typeof CardanoSerializationLib;
+  let csl: CardanoSerializationLib;
 
   beforeEach(async () => {
     provider = providerStub();
-    cardanoSerializationLib = await loadCardanoSerializationLib();
-    inputSelector = roundRobinRandomImprove(cardanoSerializationLib);
+    csl = await loadCardanoSerializationLib();
+    inputSelector = roundRobinRandomImprove(csl);
     const keyManager = createInMemoryKeyManager({
       mnemonic: util.generateMnemonic(),
       networkId: 0,

--- a/packages/wallet/test/InMemoryUtxoRepository.test.ts
+++ b/packages/wallet/test/InMemoryUtxoRepository.test.ts
@@ -45,6 +45,7 @@ describe('InMemoryUtxoRepository', () => {
     csl = await loadCardanoSerializationLib();
     inputSelector = roundRobinRandomImprove(csl);
     const keyManager = createInMemoryKeyManager({
+      csl,
       mnemonic: util.generateMnemonic(),
       networkId: 0,
       password: '123'

--- a/packages/wallet/test/InMemoryUtxoRepository.test.ts
+++ b/packages/wallet/test/InMemoryUtxoRepository.test.ts
@@ -20,14 +20,14 @@ const addresses = [
 const outputs = CSL.TransactionOutputs.new();
 
 outputs.add(
-  Ogmios.OgmiosToCardanoWasm.txOut({
+  Ogmios.ogmiosToCsl.txOut({
     address: addresses[0],
     // value: { coins: 4_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
     value: { coins: 4_000_000 }
   })
 );
 outputs.add(
-  Ogmios.OgmiosToCardanoWasm.txOut({
+  Ogmios.ogmiosToCsl.txOut({
     address: addresses[0],
     // value: { coins: 2_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
     value: { coins: 2_000_000 }

--- a/packages/wallet/test/InMemoryUtxoRepository.test.ts
+++ b/packages/wallet/test/InMemoryUtxoRepository.test.ts
@@ -10,35 +10,13 @@ import { NO_CONSTRAINTS } from './util';
 const addresses = [
   'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
 ];
-// const stakeKeyHash = 'stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d';
-
-// const txIn: OgmiosSchema.TxIn[] = [
-//   { txId: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5', index: 0 },
-//   { txId: '08fc1f8af3abbc8fc1f8a466e6e754833a08a62a059bf059bf5483a8a66e6e74', index: 0 }
-// ];
-
-const outputs = CSL.TransactionOutputs.new();
-
-outputs.add(
-  Ogmios.ogmiosToCsl.txOut({
-    address: addresses[0],
-    // value: { coins: 4_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
-    value: { coins: 4_000_000 }
-  })
-);
-outputs.add(
-  Ogmios.ogmiosToCsl.txOut({
-    address: addresses[0],
-    // value: { coins: 2_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
-    value: { coins: 2_000_000 }
-  })
-);
 
 describe('InMemoryUtxoRepository', () => {
   let utxoRepository: UtxoRepository;
   let provider: CardanoProvider;
   let inputSelector: InputSelector;
   let csl: CardanoSerializationLib;
+  let outputs: CSL.TransactionOutputs;
 
   beforeEach(async () => {
     provider = providerStub();
@@ -50,7 +28,20 @@ describe('InMemoryUtxoRepository', () => {
       networkId: 0,
       password: '123'
     });
-    utxoRepository = new InMemoryUtxoRepository(provider, keyManager, inputSelector);
+    outputs = csl.TransactionOutputs.new();
+    outputs.add(
+      Ogmios.ogmiosToCsl(csl).txOut({
+        address: addresses[0],
+        value: { coins: 4_000_000 }
+      })
+    );
+    outputs.add(
+      Ogmios.ogmiosToCsl(csl).txOut({
+        address: addresses[0],
+        value: { coins: 2_000_000 }
+      })
+    );
+    utxoRepository = new InMemoryUtxoRepository(csl, provider, keyManager, inputSelector);
   });
 
   test('constructed state', async () => {

--- a/packages/wallet/test/InMemoryUtxoRepository.test.ts
+++ b/packages/wallet/test/InMemoryUtxoRepository.test.ts
@@ -1,0 +1,80 @@
+import { CardanoProvider, Ogmios } from '@cardano-sdk/core';
+import { UtxoRepository } from '@src/UtxoRepository';
+import { InMemoryUtxoRepository } from '@src/InMemoryUtxoRepository';
+import { roundRobinRandomImprove, InputSelector } from '@cardano-sdk/cip2';
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { providerStub, delegate, rewards } from './ProviderStub';
+import { createInMemoryKeyManager, util } from '@cardano-sdk/in-memory-key-manager';
+import { NO_CONSTRAINTS } from './util';
+
+const addresses = [
+  'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+];
+// const stakeKeyHash = 'stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d';
+
+// const txIn: OgmiosSchema.TxIn[] = [
+//   { txId: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5', index: 0 },
+//   { txId: '08fc1f8af3abbc8fc1f8a466e6e754833a08a62a059bf059bf5483a8a66e6e74', index: 0 }
+// ];
+
+const outputs = CardanoSerializationLib.TransactionOutputs.new();
+
+outputs.add(
+  Ogmios.OgmiosToCardanoWasm.txOut({
+    address: addresses[0],
+    // value: { coins: 4_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
+    value: { coins: 4_000_000 }
+  })
+);
+outputs.add(
+  Ogmios.OgmiosToCardanoWasm.txOut({
+    address: addresses[0],
+    // value: { coins: 2_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
+    value: { coins: 2_000_000 }
+  })
+);
+
+describe('InMemoryUtxoRepository', () => {
+  let utxoRepository: UtxoRepository;
+  let provider: CardanoProvider;
+  let inputSelector: InputSelector;
+  let cardanoSerializationLib: typeof CardanoSerializationLib;
+
+  beforeEach(async () => {
+    provider = providerStub();
+    cardanoSerializationLib = await loadCardanoSerializationLib();
+    inputSelector = roundRobinRandomImprove(cardanoSerializationLib);
+    const keyManager = createInMemoryKeyManager({
+      mnemonic: util.generateMnemonic(),
+      networkId: 0,
+      password: '123'
+    });
+    utxoRepository = new InMemoryUtxoRepository(provider, keyManager, inputSelector);
+  });
+
+  test('constructed state', async () => {
+    await expect(utxoRepository.allUtxos.length).toBe(0);
+    await expect(utxoRepository.rewards).toBe(null);
+    await expect(utxoRepository.delegation).toBe(null);
+  });
+
+  test('sync', async () => {
+    await utxoRepository.sync();
+    await expect(utxoRepository.allUtxos.length).toBe(3);
+    await expect(utxoRepository.rewards).toBe(rewards);
+    await expect(utxoRepository.delegation).toBe(delegate);
+  });
+
+  describe('selectInputs', () => {
+    it('can be called without explicitly syncing', async () => {
+      const result = await utxoRepository.selectInputs(outputs, NO_CONSTRAINTS);
+      await expect(utxoRepository.allUtxos.length).toBe(3);
+      await expect(utxoRepository.rewards).toBe(rewards);
+      await expect(utxoRepository.delegation).toBe(delegate);
+      await expect(result.selection.inputs.length).toBeGreaterThan(0);
+      await expect(result.selection.outputs).toBe(outputs);
+      await expect(result.selection.change.length).toBe(2);
+    });
+  });
+});

--- a/packages/wallet/test/ProviderStub.ts
+++ b/packages/wallet/test/ProviderStub.ts
@@ -1,0 +1,120 @@
+/* eslint-disable max-len */
+import { CardanoProvider } from '@cardano-sdk/core';
+import * as Schema from '@cardano-ogmios/schema';
+
+export const stakeKeyHash = 'stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d';
+
+export const utxo: Schema.Utxo = [
+  [
+    {
+      txId: 'bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0',
+      index: 1
+    },
+    {
+      address:
+        'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
+      value: {
+        coins: 4_027_026_465
+      },
+      datum: null
+    }
+  ],
+  [
+    {
+      txId: 'c7c0973c6bbf1a04a9f306da7814b4fa564db649bf48b0bd93c273bd03143547',
+      index: 0
+    },
+    {
+      address:
+        'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g',
+      value: {
+        coins: 3_289_566
+      },
+      datum: null
+    }
+  ],
+  [
+    {
+      txId: 'ea1517b8c36fea3148df9aa1f49bbee66ff59a5092331a67bd8b3c427e1d79d7',
+      index: 2
+    },
+    {
+      address:
+        'addr_test1qqydn46r6mhge0kfpqmt36m6q43knzsd9ga32n96m89px3nuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qypp3m9',
+      value: {
+        coins: 9_825_963
+      },
+      datum: null
+    }
+  ]
+];
+
+export const delegate = 'pool185g59xpqzt7gf0ljr8v8f3akl95qnmardf2f8auwr3ffx7atjj5';
+export const rewards = 33_333;
+
+/**
+ * Provider stub for testing
+ *
+ * @returns {CardanoProvider} CardanoProvider
+ */
+
+export const providerStub = (): CardanoProvider => ({
+  ledgerTip: async () => ({
+    blockNo: 1_111_111,
+    hash: '10d64cc11e9b20e15b6c46aa7b1fed11246f437e62225655a30ea47bf8cc22d0',
+    slot: 37_834_496
+  }),
+  submitTx: async () => true,
+  utxoDelegationAndRewards: async () => {
+    const delegationAndRewards = {
+      delegate,
+      rewards
+    };
+
+    return { utxo, delegationAndRewards };
+  },
+  queryTransactionsByAddresses: async () =>
+    Promise.resolve([
+      {
+        hash: 'ea1517b8c36fea3148df9aa1f49bbee66ff59a5092331a67bd8b3c427e1d79d7',
+        inputs: [
+          {
+            txId: 'bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0',
+            index: 0
+          }
+        ],
+        outputs: [
+          {
+            address:
+              'addr_test1qpfhhfy2qgls50r9u4yh0l7z67xpg0a5rrhkmvzcuqrd0znuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q9gw0lz',
+            value: { coins: 5_000_000 }
+          },
+          {
+            address:
+              'addr_test1qplfzem2xsc29wxysf8wkdqrm4s4mmncd40qnjq9sk84l3tuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q52ukj5',
+            value: { coins: 5_000_000 }
+          },
+          {
+            address:
+              'addr_test1qqydn46r6mhge0kfpqmt36m6q43knzsd9ga32n96m89px3nuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qypp3m9',
+            value: { coins: 9_825_963 }
+          }
+        ]
+      }
+    ]),
+  queryTransactionsByHashes: async () => {
+    throw new Error('Not implemented yet');
+  },
+  currentWalletProtocolParameters: async () => ({
+    minFeeCoefficient: 44,
+    minFeeConstant: 155_381,
+    stakeKeyDeposit: 2_000_000,
+    poolDeposit: 500_000_000,
+    protocolVersion: { major: 5, minor: 0 },
+    minPoolCost: 340_000_000,
+    maxTxSize: 16_384,
+    maxValueSize: 1000,
+    maxCollateralInputs: 1,
+    coinsPerUtxoWord: 34_482
+  })
+});

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable max-len */
+
+// All types should be imported from cardano-serialization-lib-nodejs.
+// Importing from cardano-serialization-lib-browser will cause TypeScript errors.
+// Do not create objects from direct imports of serialization lib, use @cardano-sdk/cardano-serialization-lib.
+
+import { createSingleAddressWallet, SingleAddressWallet } from '@src/SingleAddressWallet';
+import * as KeyManagement from '@src/KeyManagement';
+import { Cardano, CardanoProvider } from '@cardano-sdk/core';
+import { createInMemoryKeyManager, util } from '@cardano-sdk/in-memory-key-manager';
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { InMemoryUtxoRepository } from '@src/InMemoryUtxoRepository';
+import { UtxoRepository } from '@src/UtxoRepository';
+import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/cip2';
+import { providerStub } from './ProviderStub';
+
+describe('Wallet', () => {
+  let CSL: typeof CardanoSerializationLib;
+  let inputSelector: InputSelector;
+  let keyManager: KeyManagement.KeyManager;
+  let provider: CardanoProvider;
+  let utxoRepository: UtxoRepository;
+
+  beforeEach(async () => {
+    CSL = await loadCardanoSerializationLib();
+    keyManager = createInMemoryKeyManager({
+      mnemonic: util.generateMnemonic(),
+      networkId: Cardano.NetworkId.testnet,
+      password: '123'
+    });
+    provider = providerStub();
+    inputSelector = roundRobinRandomImprove(CSL);
+    utxoRepository = new InMemoryUtxoRepository(provider, keyManager, inputSelector);
+  });
+
+  test('createWallet', async () => {
+    const wallet = await createSingleAddressWallet(CSL, provider, keyManager, utxoRepository);
+    expect(wallet.address).toBeDefined();
+    expect(typeof wallet.initializeTx).toBe('function');
+    expect(typeof wallet.signTx).toBe('function');
+  });
+
+  describe('wallet behaviour', () => {
+    let wallet: SingleAddressWallet;
+    const props = {
+      outputs: [
+        {
+          address:
+            'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w',
+          value: { coins: 11_111_111 }
+        }
+      ]
+    };
+
+    beforeEach(async () => {
+      wallet = await createSingleAddressWallet(CSL, provider, keyManager, utxoRepository);
+    });
+
+    test('initializeTx', async () => {
+      const txInternals = await wallet.initializeTx(props);
+      expect(txInternals.body).toBeInstanceOf(CSL.TransactionBody);
+      expect(txInternals.hash).toBeInstanceOf(CSL.TransactionHash);
+    });
+
+    test('signTx', async () => {
+      const { body, hash } = await wallet.initializeTx(props);
+      const tx = await wallet.signTx(body, hash);
+      await expect(tx.body().outputs().len()).toBe(1);
+      await expect(tx.body().inputs().len()).toBeGreaterThan(0);
+    });
+
+    test('submitTx', async () => {
+      const { body, hash } = await wallet.initializeTx(props);
+      const tx = await wallet.signTx(body, hash);
+      const result = await wallet.submitTx(tx);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -27,7 +27,7 @@ describe('Wallet', () => {
     });
     provider = providerStub();
     inputSelector = roundRobinRandomImprove(csl);
-    utxoRepository = new InMemoryUtxoRepository(provider, keyManager, inputSelector);
+    utxoRepository = new InMemoryUtxoRepository(csl, provider, keyManager, inputSelector);
   });
 
   test('createWallet', async () => {

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -1,41 +1,36 @@
 /* eslint-disable max-len */
 
-// All types should be imported from cardano-serialization-lib-nodejs.
-// Importing from cardano-serialization-lib-browser will cause TypeScript errors.
-// Do not create objects from direct imports of serialization lib, use @cardano-sdk/cardano-serialization-lib.
-
 import { createSingleAddressWallet, SingleAddressWallet } from '@src/SingleAddressWallet';
 import * as KeyManagement from '@src/KeyManagement';
 import { Cardano, CardanoProvider } from '@cardano-sdk/core';
 import { createInMemoryKeyManager, util } from '@cardano-sdk/in-memory-key-manager';
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
-import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { loadCardanoSerializationLib, CardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
 import { InMemoryUtxoRepository } from '@src/InMemoryUtxoRepository';
 import { UtxoRepository } from '@src/UtxoRepository';
 import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/cip2';
 import { providerStub } from './ProviderStub';
 
 describe('Wallet', () => {
-  let CSL: typeof CardanoSerializationLib;
+  let csl: CardanoSerializationLib;
   let inputSelector: InputSelector;
   let keyManager: KeyManagement.KeyManager;
   let provider: CardanoProvider;
   let utxoRepository: UtxoRepository;
 
   beforeEach(async () => {
-    CSL = await loadCardanoSerializationLib();
+    csl = await loadCardanoSerializationLib();
     keyManager = createInMemoryKeyManager({
       mnemonic: util.generateMnemonic(),
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });
     provider = providerStub();
-    inputSelector = roundRobinRandomImprove(CSL);
+    inputSelector = roundRobinRandomImprove(csl);
     utxoRepository = new InMemoryUtxoRepository(provider, keyManager, inputSelector);
   });
 
   test('createWallet', async () => {
-    const wallet = await createSingleAddressWallet(CSL, provider, keyManager, utxoRepository);
+    const wallet = await createSingleAddressWallet(csl, provider, keyManager, utxoRepository);
     expect(wallet.address).toBeDefined();
     expect(typeof wallet.initializeTx).toBe('function');
     expect(typeof wallet.signTx).toBe('function');
@@ -54,13 +49,13 @@ describe('Wallet', () => {
     };
 
     beforeEach(async () => {
-      wallet = await createSingleAddressWallet(CSL, provider, keyManager, utxoRepository);
+      wallet = await createSingleAddressWallet(csl, provider, keyManager, utxoRepository);
     });
 
     test('initializeTx', async () => {
       const txInternals = await wallet.initializeTx(props);
-      expect(txInternals.body).toBeInstanceOf(CSL.TransactionBody);
-      expect(txInternals.hash).toBeInstanceOf(CSL.TransactionHash);
+      expect(txInternals.body).toBeInstanceOf(csl.TransactionBody);
+      expect(txInternals.hash).toBeInstanceOf(csl.TransactionHash);
     });
 
     test('signTx', async () => {

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -20,6 +20,7 @@ describe('Wallet', () => {
   beforeEach(async () => {
     csl = await loadCardanoSerializationLib();
     keyManager = createInMemoryKeyManager({
+      csl,
       mnemonic: util.generateMnemonic(),
       networkId: Cardano.NetworkId.testnet,
       password: '123'

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -11,28 +11,12 @@ import { NO_CONSTRAINTS } from './util';
 const address =
   'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g';
 
-const outputs = CSL.TransactionOutputs.new();
-
-outputs.add(
-  Ogmios.ogmiosToCsl.txOut({
-    address,
-    // value: { coins: 4_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
-    value: { coins: 4_000_000 }
-  })
-);
-outputs.add(
-  Ogmios.ogmiosToCsl.txOut({
-    address,
-    // value: { coins: 2_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
-    value: { coins: 2_000_000 }
-  })
-);
-
 describe('createTransactionInternals', () => {
   let csl: CardanoSerializationLib;
   let provider: CardanoProvider;
   let inputSelector: InputSelector;
   let utxoRepository: UtxoRepository;
+  let outputs: CSL.TransactionOutputs;
 
   beforeEach(async () => {
     csl = await loadCardanoSerializationLib();
@@ -44,7 +28,21 @@ describe('createTransactionInternals', () => {
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });
-    utxoRepository = new InMemoryUtxoRepository(provider, keyManager, inputSelector);
+    outputs = CSL.TransactionOutputs.new();
+
+    outputs.add(
+      Ogmios.ogmiosToCsl(csl).txOut({
+        address,
+        value: { coins: 4_000_000 }
+      })
+    );
+    outputs.add(
+      Ogmios.ogmiosToCsl(csl).txOut({
+        address,
+        value: { coins: 2_000_000 }
+      })
+    );
+    utxoRepository = new InMemoryUtxoRepository(csl, provider, keyManager, inputSelector);
   });
 
   test('simple transaction', async () => {

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -14,14 +14,14 @@ const address =
 const outputs = CSL.TransactionOutputs.new();
 
 outputs.add(
-  Ogmios.OgmiosToCardanoWasm.txOut({
+  Ogmios.ogmiosToCsl.txOut({
     address,
     // value: { coins: 4_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
     value: { coins: 4_000_000 }
   })
 );
 outputs.add(
-  Ogmios.OgmiosToCardanoWasm.txOut({
+  Ogmios.ogmiosToCsl.txOut({
     address,
     // value: { coins: 2_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
     value: { coins: 2_000_000 }

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -1,0 +1,66 @@
+// All types should be imported from cardano-serialization-lib-nodejs.
+// Importing from cardano-serialization-lib-browser will cause TypeScript errors.
+// Do not create objects from direct imports of serialization lib, use @cardano-sdk/cardano-serialization-lib.
+import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
+import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { createTransactionInternals } from '@src/createTransactionInternals';
+import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/cip2';
+import { Cardano, CardanoProvider, Ogmios } from '@cardano-sdk/core';
+import { providerStub } from './ProviderStub';
+import { UtxoRepository } from '@src/UtxoRepository';
+import { InMemoryUtxoRepository } from '@src/InMemoryUtxoRepository';
+import { createInMemoryKeyManager, util } from '@cardano-sdk/in-memory-key-manager';
+import { NO_CONSTRAINTS } from './util';
+
+const address =
+  'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g';
+
+const outputs = CardanoSerializationLib.TransactionOutputs.new();
+
+outputs.add(
+  Ogmios.OgmiosToCardanoWasm.txOut({
+    address,
+    // value: { coins: 4_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
+    value: { coins: 4_000_000 }
+  })
+);
+outputs.add(
+  Ogmios.OgmiosToCardanoWasm.txOut({
+    address,
+    // value: { coins: 2_000_000, assets: { '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740': 20n } }
+    value: { coins: 2_000_000 }
+  })
+);
+
+describe('createTransactionInternals', () => {
+  let CSL: typeof CardanoSerializationLib;
+  let provider: CardanoProvider;
+  let inputSelector: InputSelector;
+  let utxoRepository: UtxoRepository;
+
+  beforeEach(async () => {
+    CSL = await loadCardanoSerializationLib();
+    provider = providerStub();
+    inputSelector = roundRobinRandomImprove(CSL);
+    const keyManager = createInMemoryKeyManager({
+      mnemonic: util.generateMnemonic(),
+      networkId: Cardano.NetworkId.testnet,
+      password: '123'
+    });
+    utxoRepository = new InMemoryUtxoRepository(provider, keyManager, inputSelector);
+  });
+
+  test('simple transaction', async () => {
+    const result = await utxoRepository.selectInputs(outputs, NO_CONSTRAINTS);
+    const ledgerTip = await provider.ledgerTip();
+    const { body, hash } = await createTransactionInternals(CSL, {
+      changeAddress: 'addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpsqe70et',
+      inputSelection: result.selection,
+      validityInterval: {
+        invalidHereafter: ledgerTip.slot + 3600
+      }
+    });
+    expect(body).toBeInstanceOf(CardanoSerializationLib.TransactionBody);
+    expect(hash).toBeInstanceOf(CardanoSerializationLib.TransactionHash);
+  });
+});

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -39,6 +39,7 @@ describe('createTransactionInternals', () => {
     provider = providerStub();
     inputSelector = roundRobinRandomImprove(csl);
     const keyManager = createInMemoryKeyManager({
+      csl,
       mnemonic: util.generateMnemonic(),
       networkId: Cardano.NetworkId.testnet,
       password: '123'

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -1,8 +1,4 @@
-// All types should be imported from cardano-serialization-lib-nodejs.
-// Importing from cardano-serialization-lib-browser will cause TypeScript errors.
-// Do not create objects from direct imports of serialization lib, use @cardano-sdk/cardano-serialization-lib.
-import CardanoSerializationLib from '@emurgo/cardano-serialization-lib-nodejs';
-import { loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { loadCardanoSerializationLib, CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { createTransactionInternals } from '@src/createTransactionInternals';
 import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/cip2';
 import { Cardano, CardanoProvider, Ogmios } from '@cardano-sdk/core';
@@ -15,7 +11,7 @@ import { NO_CONSTRAINTS } from './util';
 const address =
   'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g';
 
-const outputs = CardanoSerializationLib.TransactionOutputs.new();
+const outputs = CSL.TransactionOutputs.new();
 
 outputs.add(
   Ogmios.OgmiosToCardanoWasm.txOut({
@@ -33,15 +29,15 @@ outputs.add(
 );
 
 describe('createTransactionInternals', () => {
-  let CSL: typeof CardanoSerializationLib;
+  let csl: CardanoSerializationLib;
   let provider: CardanoProvider;
   let inputSelector: InputSelector;
   let utxoRepository: UtxoRepository;
 
   beforeEach(async () => {
-    CSL = await loadCardanoSerializationLib();
+    csl = await loadCardanoSerializationLib();
     provider = providerStub();
-    inputSelector = roundRobinRandomImprove(CSL);
+    inputSelector = roundRobinRandomImprove(csl);
     const keyManager = createInMemoryKeyManager({
       mnemonic: util.generateMnemonic(),
       networkId: Cardano.NetworkId.testnet,
@@ -53,14 +49,14 @@ describe('createTransactionInternals', () => {
   test('simple transaction', async () => {
     const result = await utxoRepository.selectInputs(outputs, NO_CONSTRAINTS);
     const ledgerTip = await provider.ledgerTip();
-    const { body, hash } = await createTransactionInternals(CSL, {
+    const { body, hash } = await createTransactionInternals(csl, {
       changeAddress: 'addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpsqe70et',
       inputSelection: result.selection,
       validityInterval: {
         invalidHereafter: ledgerTip.slot + 3600
       }
     });
-    expect(body).toBeInstanceOf(CardanoSerializationLib.TransactionBody);
-    expect(hash).toBeInstanceOf(CardanoSerializationLib.TransactionHash);
+    expect(body).toBeInstanceOf(csl.TransactionBody);
+    expect(hash).toBeInstanceOf(csl.TransactionHash);
   });
 });

--- a/packages/wallet/test/jest.config.js
+++ b/packages/wallet/test/jest.config.js
@@ -2,6 +2,7 @@ const { pathsToModuleNameMapper } = require('ts-jest/utils')
 const { compilerOptions } = require('./tsconfig')
 
 module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
   preset: 'ts-jest',
   transform: {

--- a/packages/wallet/test/jest.setup.js
+++ b/packages/wallet/test/jest.setup.js
@@ -1,0 +1,4 @@
+// TODO: jest environment is not happy with 'lodash-es' exports.
+// I think using non-es-module 'lodash' in 'dependencies' is too heavy.
+// eslint-disable-next-line unicorn/prefer-module
+jest.mock('lodash-es', () => require('lodash'));

--- a/packages/wallet/test/tsconfig.json
+++ b/packages/wallet/test/tsconfig.json
@@ -7,6 +7,9 @@
     }
   },
   "references": [
-    { "path": "../src" }
+    { "path": "../src" },
+    { "path": "../../cip2/src" },
+    { "path": "../../core/src" },
+    { "path": "../../in-memory-key-manager/src" }
   ]
 }

--- a/packages/wallet/test/util.ts
+++ b/packages/wallet/test/util.ts
@@ -1,5 +1,6 @@
 import { SelectionConstraints } from '@cardano-sdk/cip2';
 
+// Todo: Hoist to util-dev package
 export const NO_CONSTRAINTS: SelectionConstraints = {
   computeMinimumCoinQuantity: () => 1_000_000n,
   computeMinimumCost: async () => 170_000n,

--- a/packages/wallet/test/util.ts
+++ b/packages/wallet/test/util.ts
@@ -1,0 +1,8 @@
+import { SelectionConstraints } from '@cardano-sdk/cip2';
+
+export const NO_CONSTRAINTS: SelectionConstraints = {
+  computeMinimumCoinQuantity: () => 1_000_000n,
+  computeMinimumCost: async () => 170_000n,
+  computeSelectionLimit: async () => 5,
+  tokenBundleSizeExceedsLimit: () => false
+};

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -2,5 +2,12 @@
 
 set -euo pipefail
 
+npm pack --cwd ./packages/blockfrost && \
+npm pack --cwd ./packages/cardano-graphql-db-sync && \
+npm pack --cwd ./packages/cardano-serialization-lib && \
+npm pack --cwd ./packages/cip2 && \
+npm pack --cwd ./packages/cip30 && \
 npm pack --cwd ./packages/core && \
-npm pack --cwd ./packages/golden-test-generator
+npm pack --cwd ./packages/golden-test-generator && \
+npm pack --cwd ./packages/in-memory-key-manager && \
+npm pack --cwd ./packages/wallet

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,5 +2,12 @@
 
 set -euo pipefail
 
+npm publish --cwd ./packages/blockfrost && \
+npm publish --cwd ./packages/cardano-graphql-db-sync && \
+npm publish --cwd ./packages/cardano-serialization-lib && \
+npm publish --cwd ./packages/cip2 && \
+npm publish --cwd ./packages/cip30 && \
 npm publish --cwd ./packages/core && \
-npm publish --cwd ./packages/golden-test-generator
+npm publish --cwd ./packages/golden-test-generator && \
+npm publish --cwd ./packages/in-memory-key-manager && \
+npm publish --cwd ./packages/wallet

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,7 +672,7 @@
   resolved "https://registry.yarnpkg.com/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-8.0.0.tgz#b938890b035222d8514030410aa2bfe52e6098a0"
   integrity sha512-JoYF8LfnELddD9oGVhrEZ6j1PPvXladT80XVGCGmwBARag/iNNUYZEZwklGPf5YBztX26Xzj2zAK0/4hK407Eg==
 
-"@emurgo/cardano-serialization-lib-nodejs@8.0.0", "@emurgo/cardano-serialization-lib-nodejs@^8.0.0":
+"@emurgo/cardano-serialization-lib-nodejs@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-8.0.0.tgz#9666c4fe4afc08df53cb4a9d12c19fe91112e9b5"
   integrity sha512-GHN1w1B//JwLRKr3/VE5xTGpY3Nof0FnZ6pMvxYaZ8LbXHlW7vfcqzz/5cEc2m1oyULzdCPQm8/8u5I9VTvJlg==


### PR DESCRIPTION
# Context
We need to provide a single-address wallet that utilises the `CardanoProvider` to access information and submit transactions to the network.

# Proposed Solution
- A UTxO repository interface and in-memory implementation
- Helper function to create transaction internals (currently very limited to achieve simple payment transactions)
- Extend the key manager interface to include required behaviour and properties.
- This implementation uses hard-coded return values for the selection constraints,
to be replaced by a later scope of work.

# Important Changes Introduced
- This PR also cleans up the `cardano-serialization-lib` dependencies, so that only `@cardano-sdk/cardano-serialization-lib` depends on the Emurgo package, and makes the `InMemoryKeyManager` isomorphic.
