### PR TITLE
test(cip2): generate selection constraints and assert failure properties

### DIFF
--- a/packages/cip2/README.md
+++ b/packages/cip2/README.md
@@ -41,7 +41,7 @@ const demo = async ({ coinsPerUtxoWord }: ProtocolParametersAlonzo): Promise<Sel
 
 Input selection is tested with property-based tests using [fast-check], as well as a few regular example-based tests.
 
-See [code coverage report]. Due to nature of property-based tests, code coverage report is slightly different on each build.
+Due to nature of property-based tests, code coverage report is slightly different on each build.
 
 RoundRobinRandomImprove has 100% code coverage when using high `numRuns` option (e.g. 100_000).
 
@@ -50,4 +50,3 @@ Note that to run it with high `numRuns` you need to increase _Jest_ and _fast-ch
 [cip-0002]: https://cips.cardano.org/cips/cip2/
 [random-improve]: https://cips.cardano.org/cips/cip2/#randomimprove
 [fast-check]: https://github.com/dubzzz/fast-check
-[code coverage report]: https://input-output-hk.github.io/cardano-js-sdk/coverage/cip2

--- a/packages/cip2/README.md
+++ b/packages/cip2/README.md
@@ -37,5 +37,17 @@ const demo = async ({ coinsPerUtxoWord }: ProtocolParametersAlonzo): Promise<Sel
 };
 ```
 
+## Tests
+
+Input selection is tested with property-based tests using [fast-check], as well as a few regular example-based tests.
+
+See [code coverage report]. Due to nature of property-based tests, code coverage report is slightly different on each build.
+
+RoundRobinRandomImprove has 100% code coverage when using high `numRuns` option (e.g. 100_000).
+
+Note that to run it with high `numRuns` you need to increase _Jest_ and _fast-check_ timeout.
+
 [cip-0002]: https://cips.cardano.org/cips/cip2/
 [random-improve]: https://cips.cardano.org/cips/cip2/#randomimprove
+[fast-check]: https://github.com/dubzzz/fast-check
+[code coverage report]: https://input-output-hk.github.io/cardano-js-sdk/coverage/cip2

--- a/packages/cip2/jest.config.js
+++ b/packages/cip2/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
   transform: {
     "^.+\\.test.ts?$": "ts-jest"
   },
-  testTimeout: 120000
+  testTimeout: process.env.CI ? 120000 : 12000,
 }

--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -84,25 +84,23 @@ const createBundlePerOutput = (
 ) => {
   let totalCoinBundled = 0n;
   const totalAssetsBundled: Record<string, bigint> = {};
-  const bundles = outputsWithTotals
-    .map(({ totals: outputTotals }) => {
-      const coins = coinTotalRequested > 0n ? (coinChangeTotal * outputTotals.coins) / coinTotalRequested : 0n;
-      totalCoinBundled += coins;
-      if (!outputTotals.assets) {
-        return { coins };
-      }
-      const assets: AssetQuantities = {};
-      for (const assetId of Object.keys(outputTotals.assets)) {
-        const outputAmount = outputTotals.assets[assetId] || 0n;
-        const { selected, requested } = assetTotals[assetId];
-        const assetChangeTotal = selected - requested;
-        const assetChange = (assetChangeTotal * outputAmount) / selected;
-        totalAssetsBundled[assetId] = (totalAssetsBundled[assetId] || 0n) + assetChange;
-        assets[assetId] = assetChange;
-      }
-      return { coins, assets };
-    })
-    .filter(({ coins, assets }) => coins > 0n || (assets && Object.keys(assets).length > 0));
+  const bundles = outputsWithTotals.map(({ totals: outputTotals }) => {
+    const coins = coinTotalRequested > 0n ? (coinChangeTotal * outputTotals.coins) / coinTotalRequested : 0n;
+    totalCoinBundled += coins;
+    if (!outputTotals.assets) {
+      return { coins };
+    }
+    const assets: AssetQuantities = {};
+    for (const assetId of Object.keys(outputTotals.assets)) {
+      const outputAmount = outputTotals.assets[assetId];
+      const { selected, requested } = assetTotals[assetId];
+      const assetChangeTotal = selected - requested;
+      const assetChange = (assetChangeTotal * outputAmount) / selected;
+      totalAssetsBundled[assetId] = (totalAssetsBundled[assetId] || 0n) + assetChange;
+      assets[assetId] = assetChange;
+    }
+    return { coins, assets };
+  });
   return { totalCoinBundled, bundles, totalAssetsBundled };
 };
 
@@ -147,8 +145,7 @@ const computeRequestedAssetChangeBundles = (
     const assetTotal = assetTotals[assetId];
     const assetLost = assetTotal.selected - assetTotal.requested - totalAssetsBundled[assetId];
     if (assetLost > 0n) {
-      const anyBundle = bundles.find(({ assets }) => assets?.[assetId]) || bundles[0];
-      anyBundle.assets ||= {};
+      const anyBundle = bundles.find(({ assets }) => typeof assets?.[assetId] === 'bigint');
       anyBundle.assets[assetId] = (anyBundle.assets[assetId] || 0n) + assetLost;
     }
   }
@@ -175,9 +172,6 @@ const coalesceChangeBundlesForMinCoinRequirement = (
   changeBundles: ValueQuantities[],
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity
 ): ValueQuantities[] | undefined => {
-  if (changeBundles.length === 0) {
-    return changeBundles;
-  }
   let sortedBundles = orderBy(changeBundles, ({ coins }) => coins, 'desc');
   const satisfiesMinCoinRequirement = (valueQuantities: ValueQuantities) =>
     valueQuantities.coins >= computeMinimumCoinQuantity(valueQuantitiesToValue(valueQuantities, csl).multiasset());
@@ -196,6 +190,8 @@ const coalesceChangeBundlesForMinCoinRequirement = (
     // eslint-disable-next-line consistent-return
     return undefined;
   }
+  // TODO: remove empty bundles
+  // eslint-disable-next-line consistent-return
   return sortedBundles;
 };
 
@@ -279,7 +275,6 @@ export const computeChangeAndAdjustForFee = async ({
 
   if (getCoinQuantity(changeBundles.map((totals) => ({ totals }))) < fee) {
     if (utxoRemaining.length === 0) {
-      // This is not tested
       throw new InputSelectionError(InputSelectionFailure.UtxoBalanceInsufficient);
     }
     // Recompute change and fee with an extra selected UTxO

--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -190,9 +190,9 @@ const coalesceChangeBundlesForMinCoinRequirement = (
     // eslint-disable-next-line consistent-return
     return undefined;
   }
-  // TODO: remove empty bundles
+  // Filter empty bundles
   // eslint-disable-next-line consistent-return
-  return sortedBundles;
+  return sortedBundles.filter((bundle) => bundle.coins > 0n || Object.keys(bundle.assets || {}).length > 0);
 };
 
 const computeChangeBundles = (

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -1,237 +1,175 @@
 import { roundRobinRandomImprove } from '../src/RoundRobinRandomImprove';
-import { InputSelector, SelectionConstraints } from '../src/types';
 import {
-  TestUtils,
+  assertInputSelectionProperties,
+  assertFailureProperties,
   createCslTestUtils,
-  containsUtxo,
+  generateSelectionParams,
+  NO_CONSTRAINTS,
+  PXL_Asset,
+  testInputSelectionFailureMode,
+  toConstraints,
   TSLA_Asset,
-  AllAssets,
-  generateValidUtxoAndOutputs
+  testInputSelectionProperties
 } from './util';
 import { InputSelectionError, InputSelectionFailure } from '../src/InputSelectionError';
-import { loadCardanoSerializationLib, CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
+import { loadCardanoSerializationLib, CardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
 import fc from 'fast-check';
 
 const getRoundRobinRandomImprove = (csl: CardanoSerializationLib) => roundRobinRandomImprove(csl);
 
-const NO_CONSTRAINTS: SelectionConstraints = {
-  computeMinimumCoinQuantity: () => 0n,
-  tokenBundleSizeExceedsLimit: () => false,
-  computeMinimumCost: async () => 0n,
-  computeSelectionLimit: async () => Number.POSITIVE_INFINITY
-};
-
-interface InputSelectionFailureModeTestParams {
-  /**
-   * Test subject (Input Selection algorithm under test)
-   */
-  getAlgorithm: (SerializationLib: CardanoSerializationLib) => InputSelector;
-  /**
-   * Available UTxO
-   */
-  createUtxo: (utils: TestUtils) => CSL.TransactionUnspentOutput[];
-  /**
-   * Transaction outputs
-   */
-  createOutputs: (utils: TestUtils) => CSL.TransactionOutput[];
-  /**
-   * Input selection constraints passed to the algorithm.
-   */
-  constraints: SelectionConstraints;
-  /**
-   * Error that should be thrown
-   */
-  expectedError: InputSelectionFailure;
-}
-
-/**
- * Run input selection and assert that implementation throws error of specific failure.
- */
-const testInputSelectionFailureMode = async ({
-  getAlgorithm,
-  createUtxo,
-  createOutputs,
-  expectedError,
-  constraints
-}: InputSelectionFailureModeTestParams) => {
-  const SerializationLib = await loadCardanoSerializationLib();
-  const utils = createCslTestUtils(SerializationLib);
-  const utxo = createUtxo(utils);
-  const outputs = createOutputs(utils);
-  const algorithm = getAlgorithm(SerializationLib);
-  await expect(algorithm.select({ utxo, outputs: utils.createOutputsObj(outputs), constraints })).rejects.toThrowError(
-    new InputSelectionError(expectedError)
-  );
-};
-
 describe('RoundRobinRandomImprove', () => {
-  describe('Failure Modes', () => {
-    describe('UtxoBalanceInsufficient', () => {
-      it('Coin (Outputs>UTxO)', async () => {
-        await testInputSelectionFailureMode({
+  describe('Examples', () => {
+    describe('Properties', () => {
+      it('No change', async () => {
+        await testInputSelectionProperties({
           getAlgorithm: getRoundRobinRandomImprove,
-          createUtxo: (utils) => [
-            utils.createUnspentTxOutput({ coins: 3_000_000n, assets: {} }),
-            utils.createUnspentTxOutput({ coins: 10_000_000n, assets: {} })
-          ],
-          createOutputs: (utils) => [
-            utils.createOutput({ coins: 12_000_000n, assets: {} }),
-            utils.createOutput({ coins: 2_000_000n, assets: {} })
-          ],
-          constraints: NO_CONSTRAINTS,
-          expectedError: InputSelectionFailure.UtxoBalanceInsufficient
-        });
-      });
-      it('Coin (Outputs+Fee>UTxO)', async () => {
-        await testInputSelectionFailureMode({
-          getAlgorithm: getRoundRobinRandomImprove,
-          createUtxo: (utils) => [
-            utils.createUnspentTxOutput({ coins: 4_910_000n, assets: {} }),
-            utils.createUnspentTxOutput({ coins: 5_000_000n, assets: {} })
-          ],
-          createOutputs: (utils) => [utils.createOutput({ coins: 10_000_000n, assets: {} })],
-          constraints: {
-            ...NO_CONSTRAINTS,
-            computeMinimumCost: async () => 100_000n
-          },
-          expectedError: InputSelectionFailure.UtxoBalanceInsufficient
-        });
-      });
-      it('Asset', async () => {
-        await testInputSelectionFailureMode({
-          getAlgorithm: getRoundRobinRandomImprove,
-          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 10_000_000n, assets: { [TSLA_Asset]: 7000n } })],
-          createOutputs: (utils) => [utils.createOutput({ coins: 5_000_000n, assets: { [TSLA_Asset]: 7001n } })],
-          constraints: NO_CONSTRAINTS,
-          expectedError: InputSelectionFailure.UtxoBalanceInsufficient
-        });
-      });
-      it('No UTxO', async () => {
-        await testInputSelectionFailureMode({
-          getAlgorithm: getRoundRobinRandomImprove,
-          createUtxo: () => [],
-          createOutputs: (utils) => [utils.createOutput({ coins: 5_000_000n })],
-          constraints: NO_CONSTRAINTS,
-          expectedError: InputSelectionFailure.UtxoBalanceInsufficient
+          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 3_000_000n, assets: {} })],
+          createOutputs: (utils) => [utils.createOutput({ coins: 3_000_000n, assets: {} })],
+          mockConstraints: NO_CONSTRAINTS
         });
       });
     });
-    describe('UTxO Fully Depleted', () => {
-      it('Change bundle value is less than constrained', async () => {
+    describe('Failure Modes', () => {
+      describe('UtxoBalanceInsufficient', () => {
+        it('Coin (Outputs>UTxO)', async () => {
+          await testInputSelectionFailureMode({
+            getAlgorithm: getRoundRobinRandomImprove,
+            createUtxo: (utils) => [
+              utils.createUnspentTxOutput({ coins: 3_000_000n, assets: {} }),
+              utils.createUnspentTxOutput({ coins: 10_000_000n, assets: {} })
+            ],
+            createOutputs: (utils) => [
+              utils.createOutput({ coins: 12_000_000n, assets: {} }),
+              utils.createOutput({ coins: 2_000_000n, assets: {} })
+            ],
+            mockConstraints: NO_CONSTRAINTS,
+            expectedError: InputSelectionFailure.UtxoBalanceInsufficient
+          });
+        });
+        it('Coin (Outputs+Fee>UTxO)', async () => {
+          await testInputSelectionFailureMode({
+            getAlgorithm: getRoundRobinRandomImprove,
+            createUtxo: (utils) => [
+              utils.createUnspentTxOutput({ coins: 4_910_000n, assets: {} }),
+              utils.createUnspentTxOutput({ coins: 5_000_000n, assets: {} })
+            ],
+            createOutputs: (utils) => [utils.createOutput({ coins: 10_000_000n, assets: {} })],
+            mockConstraints: {
+              ...NO_CONSTRAINTS,
+              minimumCost: 100_000n
+            },
+            expectedError: InputSelectionFailure.UtxoBalanceInsufficient
+          });
+        });
+        it('Asset', async () => {
+          await testInputSelectionFailureMode({
+            getAlgorithm: getRoundRobinRandomImprove,
+            createUtxo: (utils) => [
+              utils.createUnspentTxOutput({ coins: 10_000_000n, assets: { [TSLA_Asset]: 7000n } })
+            ],
+            createOutputs: (utils) => [utils.createOutput({ coins: 5_000_000n, assets: { [TSLA_Asset]: 7001n } })],
+            mockConstraints: NO_CONSTRAINTS,
+            expectedError: InputSelectionFailure.UtxoBalanceInsufficient
+          });
+        });
+        it('No UTxO', async () => {
+          await testInputSelectionFailureMode({
+            getAlgorithm: getRoundRobinRandomImprove,
+            createUtxo: () => [],
+            createOutputs: (utils) => [utils.createOutput({ coins: 5_000_000n })],
+            mockConstraints: NO_CONSTRAINTS,
+            expectedError: InputSelectionFailure.UtxoBalanceInsufficient
+          });
+        });
+      });
+      describe('UTxO Fully Depleted', () => {
+        it('Change bundle value is less than constrained', async () => {
+          await testInputSelectionFailureMode({
+            getAlgorithm: getRoundRobinRandomImprove,
+            createUtxo: (utils) => [
+              utils.createUnspentTxOutput({ coins: 1_000_000n }),
+              utils.createUnspentTxOutput({ coins: 2_000_000n })
+            ],
+            createOutputs: (utils) => [utils.createOutput({ coins: 2_999_999n })],
+            mockConstraints: {
+              ...NO_CONSTRAINTS,
+              minimumCoinQuantity: 2n
+            },
+            expectedError: InputSelectionFailure.UtxoFullyDepleted
+          });
+        });
+        it('Change bundle size exceeds constraint', async () => {
+          await testInputSelectionFailureMode({
+            getAlgorithm: getRoundRobinRandomImprove,
+            createUtxo: (utils) => [
+              utils.createUnspentTxOutput({ coins: 2_000_000n, assets: { [TSLA_Asset]: 1000n, [PXL_Asset]: 1000n } })
+            ],
+            createOutputs: (utils) => [
+              utils.createOutput({ coins: 1_000_000n, assets: { [TSLA_Asset]: 500n, [PXL_Asset]: 500n } })
+            ],
+            mockConstraints: {
+              ...NO_CONSTRAINTS,
+              maxTokenBundleSize: 1
+            },
+            expectedError: InputSelectionFailure.UtxoFullyDepleted
+          });
+        });
+      });
+      it('Maximum Input Count Exceeded', async () => {
         await testInputSelectionFailureMode({
           getAlgorithm: getRoundRobinRandomImprove,
           createUtxo: (utils) => [
-            utils.createUnspentTxOutput({ coins: 1_000_000n }),
-            utils.createUnspentTxOutput({ coins: 2_000_000n })
+            utils.createUnspentTxOutput({ coins: 2_000_000n }),
+            utils.createUnspentTxOutput({ coins: 2_000_000n }),
+            utils.createUnspentTxOutput({ coins: 3_000_000n })
           ],
-          createOutputs: (utils) => [utils.createOutput({ coins: 2_999_999n })],
-          constraints: {
+          createOutputs: (utils) => [utils.createOutput({ coins: 6_000_000n })],
+          mockConstraints: {
             ...NO_CONSTRAINTS,
-            computeMinimumCoinQuantity: () => 2n
+            selectionLimit: 2
           },
-          expectedError: InputSelectionFailure.UtxoFullyDepleted
+          expectedError: InputSelectionFailure.MaximumInputCountExceeded
         });
       });
-      it('Change bundle size exceeds constraint', async () => {
-        await testInputSelectionFailureMode({
-          getAlgorithm: getRoundRobinRandomImprove,
-          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 2_000_000n, assets: { [TSLA_Asset]: 1000n } })],
-          createOutputs: (utils) => [utils.createOutput({ coins: 1_000_000n, assets: { [TSLA_Asset]: 500n } })],
-          constraints: {
-            ...NO_CONSTRAINTS,
-            tokenBundleSizeExceedsLimit: () => true
-          },
-          expectedError: InputSelectionFailure.UtxoFullyDepleted
-        });
-      });
+      // "UTxO Not Fragmented Enough" doesn't apply for this algorithm
     });
-    it('Maximum Input Count Exceeded', async () => {
-      await testInputSelectionFailureMode({
-        getAlgorithm: getRoundRobinRandomImprove,
-        createUtxo: (utils) => [
-          utils.createUnspentTxOutput({ coins: 2_000_000n }),
-          utils.createUnspentTxOutput({ coins: 2_000_000n }),
-          utils.createUnspentTxOutput({ coins: 3_000_000n })
-        ],
-        createOutputs: (utils) => [utils.createOutput({ coins: 6_000_000n })],
-        constraints: {
-          ...NO_CONSTRAINTS,
-          computeSelectionLimit: async () => 2
-        },
-        expectedError: InputSelectionFailure.MaximumInputCountExceeded
-      });
-    });
-    // "UTxO Not Fragmented Enough" doesn't apply for this algorithm
   });
-  it('Properties', async () => {
+  it('fast-check', async () => {
     const csl = await loadCardanoSerializationLib();
     const utils = createCslTestUtils(csl);
     const algorithm = getRoundRobinRandomImprove(csl);
 
-    const constraints = {
-      ...NO_CONSTRAINTS,
-      computeMinimumCoinQuantity: () => 34_482n * 29n
-    };
-
     await fc.assert(
-      fc.asyncProperty(
-        generateValidUtxoAndOutputs(constraints.computeMinimumCoinQuantity()),
-        async ({ utxoAmounts, outputsAmounts }) => {
-          // Run input selection
-          const utxo = utxoAmounts.map((valueQuantities) => utils.createUnspentTxOutput(valueQuantities));
-          const outputs = outputsAmounts.map((valueQuantities) => utils.createOutput(valueQuantities));
-          const outputsObj = utils.createOutputsObj(outputs);
+      fc.asyncProperty(generateSelectionParams(), async ({ utxoAmounts, outputsAmounts, constraints }) => {
+        // Run input selection
+        const utxo = utxoAmounts.map((valueQuantities) => utils.createUnspentTxOutput(valueQuantities));
+        const outputs = outputsAmounts.map((valueQuantities) => utils.createOutput(valueQuantities));
+        const outputsObj = utils.createOutputsObj(outputs);
+
+        try {
           const results = await algorithm.select({
             utxo,
             outputs: outputsObj,
-            constraints
+            constraints: toConstraints(constraints)
           });
-
-          const vSelected = utils.getTotalInputAmounts(results);
-          const vRequested = utils.getTotalOutputAmounts(outputs);
-
-          // Coverage of Payments
-          expect(vSelected.coins).toBeGreaterThanOrEqual(vRequested.coins);
-          for (const assetName of AllAssets) {
-            expect(vSelected.assets?.[assetName] || 0n).toBeGreaterThanOrEqual(vRequested.assets?.[assetName] || 0n);
-          }
-
-          // Correctness of Change
-          const vChange = utils.getTotalChangeAmounts(results);
-          expect(vSelected.coins).toEqual(vRequested.coins + vChange.coins);
-          for (const assetName of AllAssets) {
-            expect(vSelected.assets?.[assetName] || 0n).toEqual(
-              (vRequested.assets?.[assetName] || 0n) + (vChange.assets?.[assetName] || 0n)
-            );
-          }
-
-          // Conservation of UTxO
-          for (const utxoEntry of utxo) {
-            const isInInputSelectionInputsSet = containsUtxo(results.selection.inputs, utxoEntry);
-            const isInRemainingUtxoSet = containsUtxo(results.remainingUTxO, utxoEntry);
-            expect(isInInputSelectionInputsSet || isInRemainingUtxoSet).toBe(true);
-            expect(isInInputSelectionInputsSet).not.toEqual(isInRemainingUtxoSet);
-          }
-
-          // Conservation of Outputs
-          // If this is used to test other algorithms refactor this
-          // to clone outputs before and do deepEquals to assert it wasn't mutated
-          expect(results.selection.outputs).toEqual(outputsObj);
-
-          // Min UTxO coin requirement for change
-          const minUtxo = constraints.computeMinimumCoinQuantity();
-          for (const value of results.selection.change) {
-            expect(BigInt(value.coin().to_str())).toBeGreaterThanOrEqual(minUtxo);
+          assertInputSelectionProperties({ utils, results, outputs, utxo, outputsObj, constraints });
+        } catch (error) {
+          if (error instanceof InputSelectionError) {
+            assertFailureProperties({ error, utxoAmounts, outputsAmounts, constraints });
+          } else {
+            throw error;
           }
         }
-      ),
+      }),
       {
         interruptAfterTimeLimit: 100_000,
         markInterruptAsFailure: true,
+        // endOnFailure: true,
+        // seed: 895_642_751,
+        // eslint-disable-next-line max-len
+        // path: '8:3:1:2:1:2:2:1:5:1:1:6:2:4:4:1:7:1:4:1:4:1:3:1:1:3:1:1:1:1:13:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:16:12:12:14:14:11:11:13:11:12:11:14:12:11:12:11:14:13:11:11:14:11:11:11:12:13:11:12:11:15:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:15:14:14:16:0:4:1:11:1:1:10:1:1:1:1:2:2:2:2:3:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:3:4:3:3:5:1:1',
+        // numRuns: 1
         numRuns: 500
-        // To rerun failed test:
-        // seed: number
-        // path: string
       }
     );
   });

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -5,10 +5,10 @@ import {
   createCslTestUtils,
   generateSelectionParams,
   NO_CONSTRAINTS,
-  PXL_Asset,
-  testInputSelectionFailureMode,
   toConstraints,
+  PXL_Asset,
   TSLA_Asset,
+  testInputSelectionFailureMode,
   testInputSelectionProperties
 } from './util';
 import { InputSelectionError, InputSelectionFailure } from '../src/InputSelectionError';
@@ -23,8 +23,8 @@ describe('RoundRobinRandomImprove', () => {
       it('No change', async () => {
         await testInputSelectionProperties({
           getAlgorithm: getRoundRobinRandomImprove,
-          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 3_000_000n, assets: {} })],
-          createOutputs: (utils) => [utils.createOutput({ coins: 3_000_000n, assets: {} })],
+          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 3_000_000n })],
+          createOutputs: (utils) => [utils.createOutput({ coins: 3_000_000n })],
           mockConstraints: NO_CONSTRAINTS
         });
       });
@@ -35,12 +35,12 @@ describe('RoundRobinRandomImprove', () => {
           await testInputSelectionFailureMode({
             getAlgorithm: getRoundRobinRandomImprove,
             createUtxo: (utils) => [
-              utils.createUnspentTxOutput({ coins: 3_000_000n, assets: {} }),
-              utils.createUnspentTxOutput({ coins: 10_000_000n, assets: {} })
+              utils.createUnspentTxOutput({ coins: 3_000_000n }),
+              utils.createUnspentTxOutput({ coins: 10_000_000n })
             ],
             createOutputs: (utils) => [
-              utils.createOutput({ coins: 12_000_000n, assets: {} }),
-              utils.createOutput({ coins: 2_000_000n, assets: {} })
+              utils.createOutput({ coins: 12_000_000n }),
+              utils.createOutput({ coins: 2_000_000n })
             ],
             mockConstraints: NO_CONSTRAINTS,
             expectedError: InputSelectionFailure.UtxoBalanceInsufficient
@@ -50,10 +50,10 @@ describe('RoundRobinRandomImprove', () => {
           await testInputSelectionFailureMode({
             getAlgorithm: getRoundRobinRandomImprove,
             createUtxo: (utils) => [
-              utils.createUnspentTxOutput({ coins: 4_910_000n, assets: {} }),
-              utils.createUnspentTxOutput({ coins: 5_000_000n, assets: {} })
+              utils.createUnspentTxOutput({ coins: 4_910_000n }),
+              utils.createUnspentTxOutput({ coins: 5_000_000n })
             ],
-            createOutputs: (utils) => [utils.createOutput({ coins: 10_000_000n, assets: {} })],
+            createOutputs: (utils) => [utils.createOutput({ coins: 10_000_000n })],
             mockConstraints: {
               ...NO_CONSTRAINTS,
               minimumCost: 100_000n
@@ -164,12 +164,9 @@ describe('RoundRobinRandomImprove', () => {
       {
         interruptAfterTimeLimit: 100_000,
         markInterruptAsFailure: true,
-        // endOnFailure: true,
-        // seed: 895_642_751,
-        // eslint-disable-next-line max-len
-        // path: '8:3:1:2:1:2:2:1:5:1:1:6:2:4:4:1:7:1:4:1:4:1:3:1:1:3:1:1:1:1:13:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:7:16:12:12:14:14:11:11:13:11:12:11:14:12:11:12:11:14:13:11:11:14:11:11:11:12:13:11:12:11:15:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:14:15:14:14:16:0:4:1:11:1:1:10:1:1:1:1:2:2:2:2:3:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:2:3:4:3:3:5:1:1',
-        // numRuns: 1
-        numRuns: 500
+        // Review: we probably want to use low numRuns in development and high numRuns in CI.
+        // 500 is too low when generating constraints. 1000 is fine, but leaves a few untested paths.
+        numRuns: 1000
       }
     );
   });

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -50,13 +50,13 @@ describe('RoundRobinRandomImprove', () => {
           await testInputSelectionFailureMode({
             getAlgorithm: getRoundRobinRandomImprove,
             createUtxo: (utils) => [
-              utils.createUnspentTxOutput({ coins: 4_910_000n }),
+              utils.createUnspentTxOutput({ coins: 4_000_000n }),
               utils.createUnspentTxOutput({ coins: 5_000_000n })
             ],
-            createOutputs: (utils) => [utils.createOutput({ coins: 10_000_000n })],
+            createOutputs: (utils) => [utils.createOutput({ coins: 9_000_000n })],
             mockConstraints: {
               ...NO_CONSTRAINTS,
-              minimumCost: 100_000n
+              minimumCost: 1n
             },
             expectedError: InputSelectionFailure.UtxoBalanceInsufficient
           });
@@ -160,14 +160,7 @@ describe('RoundRobinRandomImprove', () => {
             throw error;
           }
         }
-      }),
-      {
-        interruptAfterTimeLimit: 100_000,
-        markInterruptAsFailure: true,
-        // Review: we probably want to use low numRuns in development and high numRuns in CI.
-        // 500 is too low when generating constraints. 1000 is fine, but leaves a few untested paths.
-        numRuns: 1000
-      }
+      })
     );
   });
 });

--- a/packages/cip2/test/jest.setup.js
+++ b/packages/cip2/test/jest.setup.js
@@ -1,4 +1,14 @@
+/* eslint-disable unicorn/prefer-module */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
 // TODO: jest environment is not happy with 'lodash-es' exports.
 // I think using non-es-module 'lodash' in 'dependencies' is too heavy.
 // eslint-disable-next-line unicorn/prefer-module
 jest.mock('lodash-es', () => require('lodash'));
+
+const { testTimeout } = require('../jest.config');
+require('fast-check').configureGlobal({
+  interruptAfterTimeLimit: testTimeout * 0.7,
+  numRuns: testTimeout / 50,
+  markInterruptAsFailure: true
+});

--- a/packages/cip2/test/util/constraints.ts
+++ b/packages/cip2/test/util/constraints.ts
@@ -1,0 +1,22 @@
+import { SelectionConstraints } from '../../src/types';
+
+export interface MockSelectionConstraints {
+  minimumCoinQuantity: bigint;
+  minimumCost: bigint;
+  maxTokenBundleSize: number;
+  selectionLimit: number;
+}
+
+export const NO_CONSTRAINTS: MockSelectionConstraints = {
+  minimumCoinQuantity: 0n,
+  maxTokenBundleSize: Number.POSITIVE_INFINITY,
+  minimumCost: 0n,
+  selectionLimit: Number.POSITIVE_INFINITY
+};
+
+export const toConstraints = (constraints: MockSelectionConstraints): SelectionConstraints => ({
+  computeMinimumCoinQuantity: () => constraints.minimumCoinQuantity,
+  computeMinimumCost: async () => constraints.minimumCost,
+  computeSelectionLimit: async () => constraints.selectionLimit,
+  tokenBundleSizeExceedsLimit: (multiasset) => multiasset.len() > constraints.maxTokenBundleSize
+});

--- a/packages/cip2/test/util/index.ts
+++ b/packages/cip2/test/util/index.ts
@@ -1,0 +1,4 @@
+export * from './util';
+export * from './constraints';
+export * from './properties';
+export * from './tests';

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -1,0 +1,156 @@
+import { AllAssets, containsUtxo, TestUtils } from './util';
+import { SelectionResult } from '../../src/types';
+import { CSL } from '@cardano-sdk/cardano-serialization-lib';
+import { InputSelectionError, InputSelectionFailure } from '../../src/InputSelectionError';
+import { AssetQuantities, ValueQuantities } from '../../src/util';
+import { Ogmios } from '@cardano-sdk/core';
+import fc, { Arbitrary } from 'fast-check';
+import { MockSelectionConstraints } from './constraints';
+
+export const assertInputSelectionProperties = ({
+  utils,
+  results,
+  outputs,
+  utxo,
+  outputsObj,
+  constraints
+}: {
+  utils: TestUtils;
+  results: SelectionResult;
+  outputs: CSL.TransactionOutput[];
+  utxo: CSL.TransactionUnspentOutput[];
+  outputsObj: CSL.TransactionOutputs;
+  constraints: MockSelectionConstraints;
+}) => {
+  const vSelected = utils.getTotalInputAmounts(results);
+  const vRequested = utils.getTotalOutputAmounts(outputs);
+
+  // Coverage of Payments
+  expect(vSelected.coins).toBeGreaterThanOrEqual(vRequested.coins);
+  for (const assetName of AllAssets) {
+    expect(vSelected.assets?.[assetName] || 0n).toBeGreaterThanOrEqual(vRequested.assets?.[assetName] || 0n);
+  }
+
+  // Correctness of Change
+  const vChange = utils.getTotalChangeAmounts(results);
+  expect(vSelected.coins).toEqual(vRequested.coins + vChange.coins);
+  for (const assetName of AllAssets) {
+    expect(vSelected.assets?.[assetName] || 0n).toEqual(
+      (vRequested.assets?.[assetName] || 0n) + (vChange.assets?.[assetName] || 0n)
+    );
+  }
+
+  // Conservation of UTxO
+  for (const utxoEntry of utxo) {
+    const isInInputSelectionInputsSet = containsUtxo(results.selection.inputs, utxoEntry);
+    const isInRemainingUtxoSet = containsUtxo(results.remainingUTxO, utxoEntry);
+    expect(isInInputSelectionInputsSet || isInRemainingUtxoSet).toBe(true);
+    expect(isInInputSelectionInputsSet).not.toEqual(isInRemainingUtxoSet);
+  }
+
+  // Conservation of Outputs
+  // If this is used to test other algorithms refactor this
+  // to clone outputs before and do deepEquals to assert it wasn't mutated
+  expect(results.selection.outputs).toEqual(outputsObj);
+
+  // Min UTxO coin requirement for change
+  const minUtxo = constraints.minimumCoinQuantity;
+  for (const value of results.selection.change) {
+    expect(BigInt(value.coin().to_str())).toBeGreaterThanOrEqual(minUtxo);
+  }
+};
+
+export const assertFailureProperties = ({
+  error,
+  constraints,
+  utxoAmounts,
+  outputsAmounts
+}: {
+  error: InputSelectionError;
+  utxoAmounts: ValueQuantities[];
+  outputsAmounts: ValueQuantities[];
+  constraints: MockSelectionConstraints;
+}) => {
+  const utxoTotals = Ogmios.util.coalesceValueQuantities(...utxoAmounts);
+  const outputsTotals = Ogmios.util.coalesceValueQuantities(...outputsAmounts);
+  switch (error.failure) {
+    case InputSelectionFailure.UtxoBalanceInsufficient: {
+      const insufficientCoin = utxoTotals.coins < outputsTotals.coins + constraints.minimumCost;
+      const insufficientAsset =
+        outputsTotals.assets &&
+        Object.keys(outputsTotals.assets).some(
+          (assetId) => (utxoTotals.assets?.[assetId] || 0n) < outputsTotals.assets[assetId]
+        );
+      expect(insufficientCoin || insufficientAsset).toBe(true);
+      return;
+    }
+    case InputSelectionFailure.UtxoFullyDepleted: {
+      const numUtxoAssets = Object.keys(utxoTotals.assets || {}).length;
+      const bundleSizePotentiallyTooLarge = numUtxoAssets > constraints.maxTokenBundleSize;
+      const minimumCoinQuantityNotMet = utxoTotals.coins - outputsTotals.coins < constraints.minimumCoinQuantity;
+      expect(bundleSizePotentiallyTooLarge || minimumCoinQuantityNotMet).toBe(true);
+      return;
+    }
+    case InputSelectionFailure.MaximumInputCountExceeded: {
+      // Not a great test, but an algorithm might select all utxo.
+      // Complemented with example-based tests.
+      expect(utxoAmounts.length).toBeGreaterThan(constraints.selectionLimit);
+      return;
+    }
+  }
+  throw error;
+};
+
+/**
+ * @returns {Arbitrary} fast-check arbitrary that generates valid sets of UTxO and outputs for input selection.
+ */
+export const generateSelectionParams = (() => {
+  const MAX_U64 = 18_446_744_073_709_551_615n;
+
+  /**
+   * Generate random amount of coin and assets.
+   */
+  const arrayOfCoinAndAssets = () =>
+    fc
+      .array(
+        fc.record<ValueQuantities>({
+          coins: fc.bigUint(MAX_U64),
+          assets: fc.oneof(
+            fc
+              .set(fc.oneof(...AllAssets.map((asset) => fc.constant(asset))))
+              .chain((assets) =>
+                fc.tuple(...assets.map((asset) => fc.bigUint(MAX_U64).map((amount) => ({ asset, amount }))))
+              )
+              .map((assets) =>
+                assets.reduce((quantities, { amount, asset }) => {
+                  quantities[asset] = amount;
+                  return quantities;
+                }, {} as AssetQuantities)
+              ),
+            fc.constant(void 0)
+          )
+        }),
+        { maxLength: 11 }
+      )
+      .filter((values) => {
+        // sum of coin or any asset can't exceed MAX_U64
+        const { coins, assets } = Ogmios.util.coalesceValueQuantities(...values);
+        return coins <= MAX_U64 && (!assets || Object.values(assets).every((quantity) => quantity <= MAX_U64));
+      });
+
+  return (): Arbitrary<{
+    utxoAmounts: ValueQuantities[];
+    outputsAmounts: ValueQuantities[];
+    constraints: MockSelectionConstraints;
+  }> =>
+    fc.record({
+      utxoAmounts: arrayOfCoinAndAssets(),
+      outputsAmounts: arrayOfCoinAndAssets(),
+      constraints: fc.record<MockSelectionConstraints>({
+        maxTokenBundleSize: fc.nat(AllAssets.length),
+        minimumCoinQuantity: fc.oneof(...[0n, 1n, 34_482n * 29n, 9_999_991n].map((n) => fc.constant(n))),
+        minimumCost: fc.oneof(...[0n, 1n, 200_000n, 2_000_003n].map((n) => fc.constant(n))),
+        selectionLimit: fc.oneof(...[0, 1, 2, 7, 30, Number.MAX_SAFE_INTEGER].map((n) => fc.constant(n)))
+      })
+    });
+})();

--- a/packages/cip2/test/util/tests.ts
+++ b/packages/cip2/test/util/tests.ts
@@ -1,0 +1,71 @@
+import { CardanoSerializationLib, CSL, loadCardanoSerializationLib } from '@cardano-sdk/cardano-serialization-lib';
+import { createCslTestUtils, TestUtils } from './util';
+import { InputSelector } from '../../src/types';
+import { InputSelectionError, InputSelectionFailure } from '../../src/InputSelectionError';
+import { MockSelectionConstraints, toConstraints } from './constraints';
+import { assertInputSelectionProperties } from './properties';
+
+export interface InputSelectionPropertiesTestParams {
+  /**
+   * Test subject (Input Selection algorithm under test)
+   */
+  getAlgorithm: (SerializationLib: CardanoSerializationLib) => InputSelector;
+  /**
+   * Available UTxO
+   */
+  createUtxo: (utils: TestUtils) => CSL.TransactionUnspentOutput[];
+  /**
+   * Transaction outputs
+   */
+  createOutputs: (utils: TestUtils) => CSL.TransactionOutput[];
+  /**
+   * Input selection constraints passed to the algorithm.
+   */
+  mockConstraints: MockSelectionConstraints;
+}
+
+export interface InputSelectionFailureModeTestParams extends InputSelectionPropertiesTestParams {
+  /**
+   * Error that should be thrown
+   */
+  expectedError: InputSelectionFailure;
+}
+
+/**
+ * Run input selection and assert that implementation throws error of specific failure.
+ */
+export const testInputSelectionFailureMode = async ({
+  getAlgorithm,
+  createUtxo,
+  createOutputs,
+  expectedError,
+  mockConstraints
+}: InputSelectionFailureModeTestParams) => {
+  const SerializationLib = await loadCardanoSerializationLib();
+  const utils = createCslTestUtils(SerializationLib);
+  const utxo = createUtxo(utils);
+  const outputs = createOutputs(utils);
+  const algorithm = getAlgorithm(SerializationLib);
+  await expect(
+    algorithm.select({ utxo, outputs: utils.createOutputsObj(outputs), constraints: toConstraints(mockConstraints) })
+  ).rejects.toThrowError(new InputSelectionError(expectedError));
+};
+
+/**
+ * Run input selection and assert properties
+ */
+export const testInputSelectionProperties = async ({
+  getAlgorithm,
+  createUtxo,
+  createOutputs,
+  mockConstraints
+}: InputSelectionPropertiesTestParams) => {
+  const SerializationLib = await loadCardanoSerializationLib();
+  const utils = createCslTestUtils(SerializationLib);
+  const utxo = createUtxo(utils);
+  const outputs = createOutputs(utils);
+  const outputsObj = utils.createOutputsObj(outputs);
+  const algorithm = getAlgorithm(SerializationLib);
+  const results = await algorithm.select({ utxo, outputs: outputsObj, constraints: toConstraints(mockConstraints) });
+  assertInputSelectionProperties({ utils, results, outputs, outputsObj, constraints: mockConstraints, utxo });
+};

--- a/packages/cip2/test/util/util.ts
+++ b/packages/cip2/test/util/util.ts
@@ -3,103 +3,13 @@
 // And some of them to a new 'dev-util' package.
 import { CardanoSerializationLib, CSL } from '@cardano-sdk/cardano-serialization-lib';
 import { Ogmios } from '@cardano-sdk/core';
-import { SelectionResult } from '../src/types';
-import { ValueQuantities, AssetQuantities, valueToValueQuantities, valueQuantitiesToValue } from '../src/util';
-import fc, { Arbitrary } from 'fast-check';
-
-export interface TxAssets {
-  key: CSL.ScriptHash;
-  value: CSL.Assets;
-}
+import { SelectionResult } from '../../src/types';
+import { ValueQuantities, valueToValueQuantities, valueQuantitiesToValue } from '../../src/util';
 
 export const TSLA_Asset = '659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41';
 export const PXL_Asset = '1ec85dcee27f2d90ec1f9a1e4ce74a667dc9be8b184463223f9c960150584c';
 export const Unit_Asset = 'a5425bd7bc4182325188af2340415827a73f845846c165d9e14c5aed556e6974';
 export const AllAssets = [TSLA_Asset, PXL_Asset, Unit_Asset];
-
-/**
- * @returns {Arbitrary} fast-check arbitrary that generates valid sets of UTxO and outputs for input selection.
- */
-export const generateValidUtxoAndOutputs = (() => {
-  const MAX_U64 = 18_446_744_073_709_551_615n;
-
-  type GetAssetAmount = (asset: string) => bigint;
-
-  /**
-   * @returns {boolean} true if sum of every token amount doesn't exceed provided values.
-   */
-  const doesntExceedAmounts = (
-    quantities: ValueQuantities[],
-    maxCoin = MAX_U64,
-    getAssetMax: GetAssetAmount
-  ): boolean => {
-    const totals = Ogmios.util.coalesceValueQuantities(...quantities);
-    if (totals.coins > maxCoin) {
-      return false;
-    }
-    if (!totals.assets) {
-      return true;
-    }
-    return Object.keys(totals.assets).every((key) => totals.assets[key] <= getAssetMax(key));
-  };
-
-  /**
-   * Generate random amount of coin and assets.
-   */
-  const coinAndAssets = (minUtxoValue: bigint, maxCoin: bigint, getAssetMax: GetAssetAmount) =>
-    fc
-      .tuple(
-        fc.bigInt(minUtxoValue, maxCoin),
-        fc
-          .set(fc.oneof(...AllAssets.map((asset) => fc.constant(asset))))
-          .chain((assets) =>
-            fc.tuple(...assets.map((asset) => fc.bigUint(getAssetMax(asset)).map((amount) => ({ asset, amount }))))
-          )
-          .map((assets) =>
-            assets
-              .filter(({ amount }) => amount > 0n)
-              .reduce((quantities, { amount, asset }) => {
-                quantities[asset] = amount;
-                return quantities;
-              }, {} as AssetQuantities)
-          )
-      )
-      .map(([coins, assets]): ValueQuantities => ({ coins, assets }));
-
-  /**
-   * Generate an array of random quantities of coin and assets.
-   */
-  const arrayOfCoinAndAssets = (minUtxoValue: bigint, maxCoin = MAX_U64, getAssetMax: GetAssetAmount = () => MAX_U64) =>
-    fc
-      .array(coinAndAssets(minUtxoValue, maxCoin, getAssetMax))
-      // Verify that sum of all array items doesn't exceed limit quantities
-      .filter((results) => doesntExceedAmounts(results, maxCoin, getAssetMax));
-
-  return (
-    // TODO: when working on improving tests,
-    // create MockSelectionConstraints type, where functions don't need any args
-    // and pass the entire object to create this arbitrary
-    minUtxoValue: bigint
-  ): Arbitrary<{
-    utxoAmounts: ValueQuantities[];
-    outputsAmounts: ValueQuantities[];
-  }> =>
-    arrayOfCoinAndAssets(minUtxoValue).chain((utxoAmounts) => {
-      // Generate outputs with quantities not exceeding utxo quantities.
-      // Testing balance insufficient and other failures in example-based tests.
-      if (utxoAmounts.length === 0) {
-        return fc.constant({ utxoAmounts, outputsAmounts: [] });
-      }
-      const utxoTotals = Ogmios.util.coalesceValueQuantities(...utxoAmounts);
-      return arrayOfCoinAndAssets(minUtxoValue, utxoTotals.coins, (asset) => utxoTotals.assets?.[asset] || 0n)
-        .filter((outputsAmounts) => {
-          const outputsTotals = Ogmios.util.coalesceValueQuantities(...outputsAmounts);
-          // Change has to be >= minUtxoValue
-          return utxoTotals.coins - outputsTotals.coins >= minUtxoValue;
-        })
-        .map((outputsAmounts) => ({ utxoAmounts, outputsAmounts }));
-    });
-})();
 
 /**
  * Checks whether UTxO is included in an array of UTxO.


### PR DESCRIPTION
# Context

Original implementation used property-based tests for happy paths only and it's difficult to test all remaining paths with regular example-based tests.

# Proposed Solution

Generate `SelectionConstraints` and assert properties of input selection failure modes.
