### PR TITLE
docs: generate code coverage reports

### DIFF
--- a/collectCoverage.mjs
+++ b/collectCoverage.mjs
@@ -1,0 +1,20 @@
+import fs from 'fs-extra';
+import path from 'path';
+import url from 'url';
+
+const rootDir = path.dirname(url.fileURLToPath(import.meta.url));
+
+const coverageIndexDir = path.join(rootDir, 'docs', 'coverage');
+if (!fs.existsSync(coverageIndexDir)) {
+  fs.mkdirSync(coverageIndexDir);
+}
+
+const packagesDir = path.join(rootDir, 'packages');
+for (const packageName of fs.readdirSync(packagesDir)) {
+  const packageDir = path.join(packagesDir, packageName);
+  if (!fs.lstatSync(packageDir).isDirectory()) continue;
+  const coverageDir = path.join(packageDir, 'coverage', 'lcov-report');
+  if (!fs.existsSync(coverageDir) || !fs.lstatSync(coverageDir).isDirectory()) continue;
+  const targetDir = path.join(coverageIndexDir, packageName);
+  fs.copySync(coverageDir, targetDir, { recursive: true });
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "yarn workspaces run build",
     "predocs": "yarn build",
-    "docs": "typedoc --packages .",
+    "docs": "typedoc --packages . && yarn workspaces run coverage && node collectCoverage.mjs",
     "cleanup": "yarn workspaces run cleanup && shx rm -rf node_modules",
     "lint": "yarn workspaces run lint",
     "tscNoEmit": "yarn workspaces run tscNoEmit",
@@ -66,6 +66,7 @@
     "eslint-plugin-sonarjs": "^0.9.1",
     "eslint-plugin-unicorn": "^35.0.0",
     "eslint-watch": "^7.0.0",
+    "fs-extra": "^10.0.0",
     "husky": "^7.0.1",
     "jest": "^27.0.6",
     "lint-staged": "^11.1.2",

--- a/packages/blockfrost/package.json
+++ b/packages/blockfrost/package.json
@@ -15,7 +15,8 @@
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
-    "test": "jest -c ./test/jest.config.js"
+    "test": "jest -c ./test/jest.config.js",
+    "coverage": "shx echo No coverage report for this package"
   },
   "devDependencies": {
     "shx": "^0.3.3"

--- a/packages/cardano-graphql-db-sync/package.json
+++ b/packages/cardano-graphql-db-sync/package.json
@@ -15,7 +15,8 @@
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
-    "test": "jest -c ./test/jest.config.js"
+    "test": "jest -c ./test/jest.config.js",
+    "coverage": "shx echo No coverage report for this package"
   },
   "devDependencies": {
     "shx": "^0.3.3"

--- a/packages/cardano-serialization-lib/package.json
+++ b/packages/cardano-serialization-lib/package.json
@@ -18,6 +18,7 @@
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./test/jest.config.js",
+    "coverage": "shx echo No coverage report for this package",
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {

--- a/packages/cip2/README.md
+++ b/packages/cip2/README.md
@@ -47,6 +47,9 @@ RoundRobinRandomImprove has 100% code coverage when using high `numRuns` option 
 
 Note that to run it with high `numRuns` you need to increase _Jest_ and _fast-check_ timeout.
 
+See [code coverage report].
+
 [cip-0002]: https://cips.cardano.org/cips/cip2/
 [random-improve]: https://cips.cardano.org/cips/cip2/#randomimprove
 [fast-check]: https://github.com/dubzzz/fast-check
+[code coverage report]: https://input-output-hk.github.io/cardano-js-sdk/coverage/cip2

--- a/packages/cip2/package.json
+++ b/packages/cip2/package.json
@@ -15,6 +15,7 @@
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./jest.config.js",
+    "coverage": "yarn test --coverage",
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {

--- a/packages/cip30/package.json
+++ b/packages/cip30/package.json
@@ -18,6 +18,7 @@
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "jest -c ./test/jest.config.js",
+    "coverage": "shx echo No coverage report for this package",
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,8 @@
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
-    "test": "jest -c ./jest.config.js"
+    "test": "jest -c ./jest.config.js",
+    "coverage": "shx echo No coverage report for this package"
   },
   "devDependencies": {
     "@cardano-sdk/cardano-serialization-lib": "0.1.0",

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -21,7 +21,8 @@
     "prestart": "yarn build",
     "start": "API_PORT=3000 OGMIOS_HOST=localhost OGMIOS_PORT=1337 ts-node ./src/index.ts",
     "pretest": "yarn build",
-    "test": "jest -c ./test/jest.config.js"
+    "test": "jest -c ./test/jest.config.js",
+    "coverage": "shx echo No coverage report for this package"
   },
   "dependencies": {
     "@cardano-ogmios/client": "^4.0.0-beta.6",

--- a/packages/in-memory-key-manager/package.json
+++ b/packages/in-memory-key-manager/package.json
@@ -15,7 +15,8 @@
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
-    "test": "jest -c ./test/jest.config.js"
+    "test": "jest -c ./test/jest.config.js",
+    "coverage": "shx echo No coverage report for this package"
   },
   "devDependencies": {
     "shx": "^0.3.3"

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -19,6 +19,7 @@
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "test": "shx echo No tests in this package",
+    "coverage": "shx echo No coverage report for this package",
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {


### PR DESCRIPTION
# Context

We aim to have high code coverage. Generating coverage reports on each build would be nice.

# Proposed Solution

Generate and upload coverage reports to gh-pages together with docs.
