### PR TITLE
feat(cip2): add functions to create selection constraints

### DIFF
--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -22,7 +22,7 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
             (
               await computeMinimumCost({
                 change: [],
-                utxo,
+                inputs: utxo,
                 fee: maxBigNum(csl),
                 outputs
               })
@@ -48,14 +48,14 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
       utxoSelection: roundRobinSelectionResult,
       estimateTxFee: (utxos, changeValues) =>
         computeMinimumCost({
-          utxo: utxos,
+          inputs: utxos,
           change: changeValues,
           fee: maxBigNum(csl),
           outputs
         })
     });
 
-    if (inputs.length > (await computeSelectionLimit({ utxo: inputs, change, fee: maxBigNum(csl), outputs }))) {
+    if (inputs.length > (await computeSelectionLimit({ inputs, change, fee: maxBigNum(csl), outputs }))) {
       throw new InputSelectionError(InputSelectionFailure.MaximumInputCountExceeded);
     }
 

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -1,7 +1,7 @@
 import { CardanoSerializationLib } from '@cardano-sdk/core';
 import { InputSelectionError, InputSelectionFailure } from '../InputSelectionError';
 import { InputSelectionParameters, InputSelector, SelectionResult } from '../types';
-import { transactionOutputsToArray } from '../util';
+import { maxBigNum, transactionOutputsToArray } from '../util';
 import { computeChangeAndAdjustForFee } from './change';
 import { roundRobinSelection } from './roundRobin';
 import { assertIsBalanceSufficient, preprocessArgs } from './util';
@@ -21,6 +21,7 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
           fee: await computeMinimumCost({
             change: [],
             utxo,
+            fee: maxBigNum(csl),
             outputs
           }),
           change: [],
@@ -45,11 +46,12 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
         computeMinimumCost({
           utxo: utxos,
           change: changeValues,
+          fee: maxBigNum(csl),
           outputs
         })
     });
 
-    if (inputs.length > (await computeSelectionLimit({ utxo: inputs, change, outputs }))) {
+    if (inputs.length > (await computeSelectionLimit({ utxo: inputs, change, fee: maxBigNum(csl), outputs }))) {
       throw new InputSelectionError(InputSelectionFailure.MaximumInputCountExceeded);
     }
 

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -18,12 +18,16 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
         remainingUTxO: utxo,
         selection: {
           inputs: [],
-          fee: await computeMinimumCost({
-            change: [],
-            utxo,
-            fee: maxBigNum(csl),
-            outputs
-          }),
+          fee: csl.BigNum.from_str(
+            (
+              await computeMinimumCost({
+                change: [],
+                utxo,
+                fee: maxBigNum(csl),
+                outputs
+              })
+            ).toString()
+          ),
           change: [],
           outputs
         }
@@ -60,7 +64,7 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
         change,
         inputs,
         outputs,
-        fee
+        fee: csl.BigNum.from_str(fee.toString())
       },
       remainingUTxO
     };

--- a/packages/cip2/src/index.ts
+++ b/packages/cip2/src/index.ts
@@ -1,2 +1,3 @@
 export * from './RoundRobinRandomImprove';
+export * from './selectionConstraints';
 export * from './types';

--- a/packages/cip2/src/selectionConstraints.ts
+++ b/packages/cip2/src/selectionConstraints.ts
@@ -56,8 +56,6 @@ export const tokenBundleSizeExceedsLimit =
     return value.to_bytes().length > maxValueSize;
   };
 
-// TODO: move this to core package and test it by comparing
-// the result to result of serializing the transaction via cardano-cli
 const getTxSize = (tx: CSL.Transaction) => tx.to_bytes().length;
 
 /**

--- a/packages/cip2/src/selectionConstraints.ts
+++ b/packages/cip2/src/selectionConstraints.ts
@@ -1,12 +1,12 @@
 import { CardanoSerializationLib, CSL, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
 import { ComputeSelectionLimit, SelectionConstraints, TokenBundleSizeExceedsLimit } from '.';
 import { ComputeMinimumCoinQuantity, EstimateTxFee, SelectionSkeleton } from './types';
-import { MAX_U64 } from './util';
+import { maxBigNum } from './util';
 
 export type BuildTx = (selection: SelectionSkeleton) => Promise<CSL.Transaction>;
 export interface DefaultSelectionConstraintsProps {
   csl: CardanoSerializationLib;
-  protocolParams: ProtocolParametersRequiredByWallet;
+  protocolParameters: ProtocolParametersRequiredByWallet;
   buildTx: BuildTx;
 }
 
@@ -51,7 +51,7 @@ export const tokenBundleSizeExceedsLimit =
     if (!tokenBundle) {
       return false;
     }
-    const value = csl.Value.new(csl.BigNum.from_str(MAX_U64.toString()));
+    const value = csl.Value.new(maxBigNum(csl));
     value.set_multiasset(tokenBundle);
     return value.to_bytes().length > maxValueSize;
   };
@@ -71,18 +71,18 @@ export const computeSelectionLimit =
     const tx = await buildTx(selectionSkeleton);
     const txSize = getTxSize(tx);
     if (txSize <= maxTxSize) {
-      return selectionSkeleton.utxo.length;
+      return selectionSkeleton.inputs.length;
     }
-    return selectionSkeleton.utxo.length + 1;
+    return selectionSkeleton.inputs.length + 1;
   };
 
 export const defaultSelectionConstraints = ({
   csl,
-  protocolParams,
+  protocolParameters,
   buildTx
 }: DefaultSelectionConstraintsProps): SelectionConstraints => ({
-  computeMinimumCost: computeMinimumCost(csl, protocolParams, buildTx),
-  computeMinimumCoinQuantity: computeMinimumCoinQuantity(csl, protocolParams),
-  computeSelectionLimit: computeSelectionLimit(protocolParams, buildTx),
-  tokenBundleSizeExceedsLimit: tokenBundleSizeExceedsLimit(csl, protocolParams)
+  computeMinimumCost: computeMinimumCost(csl, protocolParameters, buildTx),
+  computeMinimumCoinQuantity: computeMinimumCoinQuantity(csl, protocolParameters),
+  computeSelectionLimit: computeSelectionLimit(protocolParameters, buildTx),
+  tokenBundleSizeExceedsLimit: tokenBundleSizeExceedsLimit(csl, protocolParameters)
 });

--- a/packages/cip2/src/selectionConstraints.ts
+++ b/packages/cip2/src/selectionConstraints.ts
@@ -1,0 +1,90 @@
+import { CardanoSerializationLib, CSL, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { ComputeSelectionLimit, SelectionConstraints, TokenBundleSizeExceedsLimit } from '.';
+import { ComputeMinimumCoinQuantity, EstimateTxFee, SelectionSkeleton } from './types';
+
+export type BuildTx = (selection: SelectionSkeleton) => Promise<CSL.Transaction>;
+export interface DefaultSelectionConstraintsProps {
+  csl: CardanoSerializationLib;
+  protocolParams: ProtocolParametersRequiredByWallet;
+  buildTx: BuildTx;
+}
+
+export const computeMinimumCost =
+  (
+    csl: CardanoSerializationLib,
+    { minFeeCoefficient, minFeeConstant }: ProtocolParametersRequiredByWallet,
+    buildTx: BuildTx
+  ): EstimateTxFee =>
+  async (selection) => {
+    const tx = await buildTx(selection);
+    return BigInt(
+      csl
+        .min_fee(
+          tx,
+          csl.LinearFee.new(
+            csl.BigNum.from_str(minFeeCoefficient.toString()),
+            csl.BigNum.from_str(minFeeConstant.toString())
+          )
+        )
+        .to_str()
+    );
+  };
+
+export const computeMinimumCoinQuantity =
+  (
+    csl: CardanoSerializationLib,
+    { coinsPerUtxoWord }: ProtocolParametersRequiredByWallet
+  ): ComputeMinimumCoinQuantity =>
+  (multiasset) => {
+    const minUTxOValue = CSL.BigNum.from_str((coinsPerUtxoWord * 29).toString());
+    const value = csl.Value.new(csl.BigNum.from_str('0'));
+    if (multiasset) {
+      value.set_multiasset(multiasset);
+    }
+    return BigInt(csl.min_ada_required(value, minUTxOValue).to_str());
+  };
+
+export const tokenBundleSizeExceedsLimit =
+  (csl: CardanoSerializationLib, { maxValueSize }: ProtocolParametersRequiredByWallet): TokenBundleSizeExceedsLimit =>
+  (tokenBundle) => {
+    if (!tokenBundle) {
+      return false;
+    }
+    // Review: assuming coin serializes to the same size regardless of quantity
+    const value = csl.Value.new(csl.BigNum.from_str('0'));
+    value.set_multiasset(tokenBundle);
+    return value.to_bytes().length > maxValueSize;
+  };
+
+// TODO: move this to core package and test it by comparing
+// the result to result of serializing the transaction via cardano-cli
+const getTxSize = (tx: CSL.Transaction) => tx.to_bytes().length;
+
+/**
+ * This constraint implementation is not intended to used by selection algorithms
+ * that adjust selection based on selection limit. RRRI implementation uses this after selecting all the inputs
+ * and throws MaximumInputCountExceeded if the constraint returns a limit higher than number of selected utxo.
+ *
+ * @returns {ComputeSelectionLimit} constraint that returns txSize <= maxTxSize ? utxo[].length : utxo[].length+1
+ */
+export const computeSelectionLimit =
+  ({ maxTxSize }: ProtocolParametersRequiredByWallet, buildTx: BuildTx): ComputeSelectionLimit =>
+  async (selectionSkeleton) => {
+    const tx = await buildTx(selectionSkeleton);
+    const txSize = getTxSize(tx);
+    if (txSize <= maxTxSize) {
+      return selectionSkeleton.utxo.length;
+    }
+    return selectionSkeleton.utxo.length + 1;
+  };
+
+export const defaultSelectionConstraints = ({
+  csl,
+  protocolParams,
+  buildTx
+}: DefaultSelectionConstraintsProps): SelectionConstraints => ({
+  computeMinimumCost: computeMinimumCost(csl, protocolParams, buildTx),
+  computeMinimumCoinQuantity: computeMinimumCoinQuantity(csl, protocolParams),
+  computeSelectionLimit: computeSelectionLimit(protocolParams, buildTx),
+  tokenBundleSizeExceedsLimit: tokenBundleSizeExceedsLimit(csl, protocolParams)
+});

--- a/packages/cip2/src/selectionConstraints.ts
+++ b/packages/cip2/src/selectionConstraints.ts
@@ -1,6 +1,7 @@
 import { CardanoSerializationLib, CSL, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
 import { ComputeSelectionLimit, SelectionConstraints, TokenBundleSizeExceedsLimit } from '.';
 import { ComputeMinimumCoinQuantity, EstimateTxFee, SelectionSkeleton } from './types';
+import { MAX_U64 } from './util';
 
 export type BuildTx = (selection: SelectionSkeleton) => Promise<CSL.Transaction>;
 export interface DefaultSelectionConstraintsProps {
@@ -36,7 +37,7 @@ export const computeMinimumCoinQuantity =
     { coinsPerUtxoWord }: ProtocolParametersRequiredByWallet
   ): ComputeMinimumCoinQuantity =>
   (multiasset) => {
-    const minUTxOValue = CSL.BigNum.from_str((coinsPerUtxoWord * 29).toString());
+    const minUTxOValue = csl.BigNum.from_str((coinsPerUtxoWord * 29).toString());
     const value = csl.Value.new(csl.BigNum.from_str('0'));
     if (multiasset) {
       value.set_multiasset(multiasset);
@@ -50,8 +51,7 @@ export const tokenBundleSizeExceedsLimit =
     if (!tokenBundle) {
       return false;
     }
-    // Review: assuming coin serializes to the same size regardless of quantity
-    const value = csl.Value.new(csl.BigNum.from_str('0'));
+    const value = csl.Value.new(csl.BigNum.from_str(MAX_U64.toString()));
     value.set_multiasset(tokenBundle);
     return value.to_bytes().length > maxValueSize;
   };

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -22,9 +22,8 @@ export interface SelectionResult {
     /**
      * Estimated fee for the transaction.
      * This value is included in 'change', so the actual change returned by the transaction is change-fee.
-     * TODO: refactor this to return CSL.BigNum?
      */
-    fee: bigint;
+    fee: CSL.BigNum;
   };
   /**
    * The remaining UTxO set is a subset of the initial UTxO set.

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -35,7 +35,7 @@ export interface SelectionResult {
 }
 
 export interface SelectionSkeleton {
-  utxo: CSL.TransactionUnspentOutput[];
+  inputs: CSL.TransactionUnspentOutput[];
   outputs: CSL.TransactionOutputs;
   change: CSL.Value[];
   fee: CSL.BigNum;

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -39,6 +39,7 @@ export interface SelectionSkeleton {
   utxo: CSL.TransactionUnspentOutput[];
   outputs: CSL.TransactionOutputs;
   change: CSL.Value[];
+  fee: CSL.BigNum;
 }
 
 /**

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -22,6 +22,7 @@ export interface SelectionResult {
     /**
      * Estimated fee for the transaction.
      * This value is included in 'change', so the actual change returned by the transaction is change-fee.
+     * TODO: refactor this to return CSL.BigNum?
      */
     fee: bigint;
   };
@@ -48,12 +49,12 @@ export type EstimateTxFee = (selectionSkeleton: SelectionSkeleton) => Promise<bi
 /**
  * @returns true if token bundle size exceeds it's maximum size limit.
  */
-export type TokenBundleSizeExceedsLimit = (tokenBundle: CSL.MultiAsset) => boolean;
+export type TokenBundleSizeExceedsLimit = (tokenBundle?: CSL.MultiAsset) => boolean;
 
 /**
  * @returns minimum lovelace amount in a UTxO
  */
-export type ComputeMinimumCoinQuantity = (assetQuantities: CSL.MultiAsset) => bigint;
+export type ComputeMinimumCoinQuantity = (assetQuantities?: CSL.MultiAsset) => bigint;
 
 /**
  * @returns an upper bound for the number of ordinary inputs to

--- a/packages/cip2/src/util.ts
+++ b/packages/cip2/src/util.ts
@@ -6,6 +6,9 @@ import { CardanoSerializationLib, CSL, Asset, Ogmios } from '@cardano-sdk/core';
 export type AssetQuantities = Ogmios.util.AssetQuantities;
 export type ValueQuantities = Ogmios.util.ValueQuantities;
 
+export const MAX_U64 = 18_446_744_073_709_551_615n;
+export const maxBigNum = (csl: CardanoSerializationLib) => csl.BigNum.from_str(MAX_U64.toString());
+
 export const transactionOutputsToArray = (outputs: CSL.TransactionOutputs): CSL.TransactionOutput[] => {
   const result: CSL.TransactionOutput[] = [];
   for (let outputIdx = 0; outputIdx < outputs.len(); outputIdx++) {

--- a/packages/cip2/test/selectionConstraints.test.ts
+++ b/packages/cip2/test/selectionConstraints.test.ts
@@ -13,7 +13,7 @@ import { valueQuantitiesToValue } from '../src/util';
 
 describe('defaultSelectionConstraints', () => {
   let csl: CardanoSerializationLib;
-  const protocolParams = {
+  const protocolParameters = {
     minFeeCoefficient: 44,
     minFeeConstant: 155_381,
     coinsPerUtxoWord: 34_482,
@@ -35,7 +35,7 @@ describe('defaultSelectionConstraints', () => {
     const selectionSkeleton = {} as SelectionSkeleton;
     const constraints = defaultSelectionConstraints({
       csl: stubCsl,
-      protocolParams,
+      protocolParameters,
       buildTx
     });
     const result = await constraints.computeMinimumCost(selectionSkeleton);
@@ -55,7 +55,10 @@ describe('defaultSelectionConstraints', () => {
       },
       csl
     ).multiasset();
-    const constraints = defaultSelectionConstraints({ csl, protocolParams } as DefaultSelectionConstraintsProps);
+    const constraints = defaultSelectionConstraints({
+      csl,
+      protocolParameters
+    } as DefaultSelectionConstraintsProps);
     const minCoinWithAssets = constraints.computeMinimumCoinQuantity(withAssets);
     const minCoinWithoutAssets = constraints.computeMinimumCoinQuantity();
     expect(typeof minCoinWithAssets).toBe('bigint');
@@ -69,19 +72,19 @@ describe('defaultSelectionConstraints', () => {
     it("doesn't exceed max tx size", async () => {
       const constraints = defaultSelectionConstraints({
         csl,
-        protocolParams,
-        buildTx: buildTxOfLength(protocolParams.maxTxSize)
+        protocolParameters,
+        buildTx: buildTxOfLength(protocolParameters.maxTxSize)
       });
-      expect(await constraints.computeSelectionLimit({ utxo: [1, 2] as any } as SelectionSkeleton)).toEqual(2);
+      expect(await constraints.computeSelectionLimit({ inputs: [1, 2] as any } as SelectionSkeleton)).toEqual(2);
     });
 
     it('exceeds max tx size', async () => {
       const constraints = defaultSelectionConstraints({
         csl,
-        protocolParams,
-        buildTx: buildTxOfLength(protocolParams.maxTxSize + 1)
+        protocolParameters,
+        buildTx: buildTxOfLength(protocolParameters.maxTxSize + 1)
       });
-      expect(await constraints.computeSelectionLimit({ utxo: [1, 2] as any } as SelectionSkeleton)).toEqual(3);
+      expect(await constraints.computeSelectionLimit({ inputs: [1, 2] as any } as SelectionSkeleton)).toEqual(3);
     });
   });
 
@@ -98,22 +101,26 @@ describe('defaultSelectionConstraints', () => {
       } as any as CardanoSerializationLib);
 
     it('empty bundle', () => {
-      const constraints = defaultSelectionConstraints({ csl, protocolParams, buildTx: jest.fn() });
+      const constraints = defaultSelectionConstraints({
+        csl,
+        protocolParameters,
+        buildTx: jest.fn()
+      });
       expect(constraints.tokenBundleSizeExceedsLimit()).toBe(false);
     });
 
     it("doesn't exceed max value size", () => {
       const constraints = defaultSelectionConstraints({
-        csl: stubCslWithValueLength(protocolParams.maxValueSize),
-        protocolParams
+        csl: stubCslWithValueLength(protocolParameters.maxValueSize),
+        protocolParameters
       } as DefaultSelectionConstraintsProps);
       expect(constraints.tokenBundleSizeExceedsLimit({} as any)).toBe(false);
     });
 
     it('exceeds max value size', () => {
       const constraints = defaultSelectionConstraints({
-        csl: stubCslWithValueLength(protocolParams.maxValueSize + 1),
-        protocolParams
+        csl: stubCslWithValueLength(protocolParameters.maxValueSize + 1),
+        protocolParameters
       } as DefaultSelectionConstraintsProps);
       expect(constraints.tokenBundleSizeExceedsLimit({} as any)).toBe(true);
     });

--- a/packages/cip2/test/selectionConstraints.test.ts
+++ b/packages/cip2/test/selectionConstraints.test.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable unicorn/consistent-function-scoping */
+import {
+  CardanoSerializationLib,
+  CSL,
+  loadCardanoSerializationLib,
+  ProtocolParametersRequiredByWallet
+} from '@cardano-sdk/core';
+import { PXL_Asset, TSLA_Asset } from './util';
+import { defaultSelectionConstraints, DefaultSelectionConstraintsProps } from '../src/selectionConstraints';
+import { SelectionSkeleton } from '../src/types';
+import { valueQuantitiesToValue } from '../src/util';
+
+describe('defaultSelectionConstraints', () => {
+  let csl: CardanoSerializationLib;
+  const protocolParams = {
+    minFeeCoefficient: 44,
+    minFeeConstant: 155_381,
+    coinsPerUtxoWord: 34_482,
+    maxTxSize: 16_384,
+    maxValueSize: 5000
+  } as ProtocolParametersRequiredByWallet;
+
+  beforeAll(async () => (csl = await loadCardanoSerializationLib()));
+
+  it('computeMinimumCost', async () => {
+    const fee = 200_000n;
+    // Need this to not have to build Tx
+    const stubCsl = {
+      min_fee: jest.fn().mockReturnValueOnce(csl.BigNum.from_str(fee.toString())),
+      LinearFee: csl.LinearFee,
+      BigNum: csl.BigNum
+    } as any as CardanoSerializationLib;
+    const buildTx = jest.fn();
+    const selectionSkeleton = {} as SelectionSkeleton;
+    const constraints = defaultSelectionConstraints({
+      csl: stubCsl,
+      protocolParams,
+      buildTx
+    });
+    const result = await constraints.computeMinimumCost(selectionSkeleton);
+    expect(result).toEqual(fee);
+    expect(buildTx).toBeCalledTimes(1);
+    expect(buildTx).toBeCalledWith(selectionSkeleton);
+  });
+
+  it('computeMinimumCoinQuantity', () => {
+    const withAssets = valueQuantitiesToValue(
+      {
+        coins: 10_000n,
+        assets: {
+          [TSLA_Asset]: 5000n,
+          [PXL_Asset]: 3000n
+        }
+      },
+      csl
+    ).multiasset();
+    const constraints = defaultSelectionConstraints({ csl, protocolParams } as DefaultSelectionConstraintsProps);
+    const minCoinWithAssets = constraints.computeMinimumCoinQuantity(withAssets);
+    const minCoinWithoutAssets = constraints.computeMinimumCoinQuantity();
+    expect(typeof minCoinWithAssets).toBe('bigint');
+    expect(typeof minCoinWithoutAssets).toBe('bigint');
+    expect(minCoinWithAssets).toBeGreaterThan(minCoinWithoutAssets);
+  });
+
+  describe('computeSelectionLimit', () => {
+    const buildTxOfLength = (length: number) => async () => ({ to_bytes: () => ({ length }) } as CSL.Transaction);
+
+    it("doesn't exceed max tx size", async () => {
+      const constraints = defaultSelectionConstraints({
+        csl,
+        protocolParams,
+        buildTx: buildTxOfLength(protocolParams.maxTxSize)
+      });
+      expect(await constraints.computeSelectionLimit({ utxo: [1, 2] as any } as SelectionSkeleton)).toEqual(2);
+    });
+
+    it('exceeds max tx size', async () => {
+      const constraints = defaultSelectionConstraints({
+        csl,
+        protocolParams,
+        buildTx: buildTxOfLength(protocolParams.maxTxSize + 1)
+      });
+      expect(await constraints.computeSelectionLimit({ utxo: [1, 2] as any } as SelectionSkeleton)).toEqual(3);
+    });
+  });
+
+  describe('tokenBundleSizeExceedsLimit', () => {
+    const stubCslWithValueLength = (length: number) =>
+      ({
+        Value: {
+          new: () => ({
+            set_multiasset: jest.fn(),
+            to_bytes: () => ({ length })
+          })
+        },
+        BigNum: csl.BigNum
+      } as any as CardanoSerializationLib);
+
+    it('empty bundle', () => {
+      const constraints = defaultSelectionConstraints({ csl, protocolParams, buildTx: jest.fn() });
+      expect(constraints.tokenBundleSizeExceedsLimit()).toBe(false);
+    });
+
+    it("doesn't exceed max value size", () => {
+      const constraints = defaultSelectionConstraints({
+        csl: stubCslWithValueLength(protocolParams.maxValueSize),
+        protocolParams
+      } as DefaultSelectionConstraintsProps);
+      expect(constraints.tokenBundleSizeExceedsLimit({} as any)).toBe(false);
+    });
+
+    it('exceeds max value size', () => {
+      const constraints = defaultSelectionConstraints({
+        csl: stubCslWithValueLength(protocolParams.maxValueSize + 1),
+        protocolParams
+      } as DefaultSelectionConstraintsProps);
+      expect(constraints.tokenBundleSizeExceedsLimit({} as any)).toBe(true);
+    });
+  });
+});

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -2,7 +2,7 @@ import { AllAssets, containsUtxo, TestUtils } from './util';
 import { SelectionResult } from '../../src/types';
 import { CSL, Ogmios } from '@cardano-sdk/core';
 import { InputSelectionError, InputSelectionFailure } from '../../src/InputSelectionError';
-import { AssetQuantities, ValueQuantities, valueToValueQuantities } from '../../src/util';
+import { AssetQuantities, MAX_U64, ValueQuantities, valueToValueQuantities } from '../../src/util';
 import fc, { Arbitrary } from 'fast-check';
 import { MockSelectionConstraints } from './constraints';
 
@@ -116,8 +116,6 @@ export const assertFailureProperties = ({
  * @returns {Arbitrary} fast-check arbitrary that generates valid sets of UTxO and outputs for input selection.
  */
 export const generateSelectionParams = (() => {
-  const MAX_U64 = 18_446_744_073_709_551_615n;
-
   /**
    * Generate random amount of coin and assets.
    */

--- a/packages/in-memory-key-manager/test/jest.config.js
+++ b/packages/in-memory-key-manager/test/jest.config.js
@@ -2,6 +2,7 @@ const { pathsToModuleNameMapper } = require('ts-jest/utils')
 const { compilerOptions } = require('./tsconfig')
 
 module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths),
   preset: 'ts-jest',
   transform: {

--- a/packages/in-memory-key-manager/test/jest.setup.js
+++ b/packages/in-memory-key-manager/test/jest.setup.js
@@ -1,0 +1,14 @@
+/* eslint-disable unicorn/prefer-module */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+// TODO: jest environment is not happy with 'lodash-es' exports.
+// I think using non-es-module 'lodash' in 'dependencies' is too heavy.
+// eslint-disable-next-line unicorn/prefer-module
+jest.mock('lodash-es', () => require('lodash'));
+
+const { testTimeout } = require('./jest.config');
+require('fast-check').configureGlobal({
+  interruptAfterTimeLimit: testTimeout * 0.7,
+  numRuns: testTimeout / 50,
+  markInterruptAsFailure: true
+});

--- a/packages/wallet/src/createTransactionInternals.ts
+++ b/packages/wallet/src/createTransactionInternals.ts
@@ -23,7 +23,7 @@ export const createTransactionInternals = async (
   const body = csl.TransactionBody.new(
     inputs,
     props.inputSelection.outputs,
-    csl.BigNum.from_str(props.inputSelection.fee.toString()),
+    props.inputSelection.fee,
     props.validityInterval.invalidHereafter
   );
   if (props.validityInterval.invalidBefore !== undefined) {


### PR DESCRIPTION
# Context

Since the CIP2 package is dependent on the CSL, we may as well include functions to cover the selection constraints:

- computeMinimumCost
- tokenBundleSizeExceedsLimit
- computeMinimumCoinQuantity
- computeSelectionLimit

# Proposed Solution

Implement default selection constraints and export them from cip2 package. Use as defaults in coin selection if applicable.

# Important Changes Introduced
