### PR TITLE
chore(core): exclude nodejs version of csl from webpack browser builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,9 @@
   "devDependencies": {
     "shx": "^0.3.3"
   },
+  "browser": {
+    "./dist/CSL/nodejs.js": false
+  },
   "dependencies": {
     "@cardano-ogmios/schema": "^4.0.0-beta.6",
     "@emurgo/cardano-serialization-lib-nodejs": "8.0.0",

--- a/packages/core/src/CSL/browser.ts
+++ b/packages/core/src/CSL/browser.ts
@@ -1,0 +1,1 @@
+export * from '@emurgo/cardano-serialization-lib-browser';

--- a/packages/core/src/CSL/index.ts
+++ b/packages/core/src/CSL/index.ts
@@ -1,3 +1,4 @@
-export * from './loadCardanoSerializationLib';
 // Only to be used for types
-export * as CSL from '@emurgo/cardano-serialization-lib-nodejs';
+import type * as CSL from '@emurgo/cardano-serialization-lib-browser';
+export * from './loadCardanoSerializationLib';
+export { CSL };

--- a/packages/core/src/CSL/loadCardanoSerializationLib.ts
+++ b/packages/core/src/CSL/loadCardanoSerializationLib.ts
@@ -1,16 +1,10 @@
-export const isNodeJs = (): boolean => {
-  try {
-    return !!process;
-  } catch {
-    return false;
-  }
-};
+export const isNodeJs = (): boolean => typeof process !== 'undefined' && !!process.versions && !!process.versions.node;
 
-export type CardanoSerializationLib = typeof import('@emurgo/cardano-serialization-lib-nodejs');
+export type CardanoSerializationLib = typeof import('./browser');
 
 /**
  * Dynamically loads the environment-specific library.
  * The type of each complete library is the same.
  */
 export const loadCardanoSerializationLib = (): Promise<CardanoSerializationLib> =>
-  isNodeJs() ? import('@emurgo/cardano-serialization-lib-nodejs') : import('@emurgo/cardano-serialization-lib-browser');
+  isNodeJs() ? import('./nodejs') : import('./browser');

--- a/packages/core/src/CSL/nodejs.ts
+++ b/packages/core/src/CSL/nodejs.ts
@@ -1,0 +1,1 @@
+export * from '@emurgo/cardano-serialization-lib-nodejs';

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -34,7 +34,7 @@ describe('createTransactionInternals', () => {
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });
-    outputs = CSL.TransactionOutputs.new();
+    outputs = csl.TransactionOutputs.new();
 
     outputs.add(
       Ogmios.ogmiosToCsl(csl).txOut({


### PR DESCRIPTION
# Context

Using `cardano-sdk/core` as a dependency in a project built with webpack is failing due to statically loading `@emurgo/cardano-serialization-lib-nodejs` in browser builds.

# Proposed Solution

Load `@emurgo/cardano-serialization-lib-nodejs` dynamically in nodejs environment and exclude it from browser builds by utilizing `package.json/browser` field.

# Important Changes Introduced

Exporting CSL types is now better, TypeScript won't allow you to use it as objects, only as types.