### PR TITLE
fix(cip2): exclude fee from change bundles

### DIFF
--- a/packages/cip2/README.md
+++ b/packages/cip2/README.md
@@ -18,7 +18,7 @@ const demo = async (protocolParameters: ProtocolParametersRequiredByWallet): Pro
   // Bad: TransactionUnspentOutput.new(...)
   // Good: csl.TransactionUnspentOutput.new(...)
   const utxo: CSL.TransactionUnspentOutput[] = [csl.TransactionUnspentOutput.new(...), ...];
-  const outputs: CSL.TransactionOutputs = csl.TransactionOutputs.new(...);
+  const outputs: CSL.TransactionOutput[] = [csl.TransactionOutput.new(...), ...];
   // Used to estimate min fee and validate transaction size
   const buildTx = (inputSelection: SelectionSkeleton): Promise<CSL.Transaction> => {...};
   const constraints = defaultSelectionConstraints({

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -14,9 +14,9 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
   }: InputSelectionParameters): Promise<SelectionResult> => {
     const { uniqueOutputAssetIDs, utxoWithTotals, outputsWithTotals } = preprocessArgs(utxo, outputs);
 
-    const utxoQuantities = totalsToValueQuantities(utxoWithTotals);
-    const outputsQuantities = totalsToValueQuantities(outputsWithTotals);
-    assertIsBalanceSufficient(uniqueOutputAssetIDs, utxoQuantities, outputsQuantities);
+    const utxoValues = totalsToValueQuantities(utxoWithTotals);
+    const outputValues = totalsToValueQuantities(outputsWithTotals);
+    assertIsBalanceSufficient(uniqueOutputAssetIDs, utxoValues, outputValues);
 
     const roundRobinSelectionResult = roundRobinSelection(utxoWithTotals, outputsWithTotals, uniqueOutputAssetIDs);
 
@@ -24,7 +24,7 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
       csl,
       computeMinimumCoinQuantity,
       tokenBundleSizeExceedsLimit,
-      outputsQuantities,
+      outputValues,
       uniqueOutputAssetIDs,
       utxoSelection: roundRobinSelectionResult,
       estimateTxFee: (utxos, changeValues) =>

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -1,7 +1,7 @@
 import { CardanoSerializationLib } from '@cardano-sdk/core';
 import { InputSelectionError, InputSelectionFailure } from '../InputSelectionError';
 import { InputSelectionParameters, InputSelector, SelectionResult } from '../types';
-import { maxBigNum, transactionOutputsToArray } from '../util';
+import { maxBigNum } from '../util';
 import { computeChangeAndAdjustForFee } from './change';
 import { roundRobinSelection } from './roundRobin';
 import { assertIsBalanceSufficient, preprocessArgs, totalsToValueQuantities } from './util';
@@ -12,8 +12,7 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
     outputs,
     constraints: { computeMinimumCost, computeSelectionLimit, computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit }
   }: InputSelectionParameters): Promise<SelectionResult> => {
-    const outputsArray = transactionOutputsToArray(outputs);
-    const { uniqueOutputAssetIDs, utxoWithTotals, outputsWithTotals } = preprocessArgs(utxo, outputsArray);
+    const { uniqueOutputAssetIDs, utxoWithTotals, outputsWithTotals } = preprocessArgs(utxo, outputs);
 
     const utxoQuantities = totalsToValueQuantities(utxoWithTotals);
     const outputsQuantities = totalsToValueQuantities(outputsWithTotals);

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -37,7 +37,8 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
         })
     });
 
-    if (inputs.length > (await computeSelectionLimit({ inputs, change, fee: maxBigNum(csl), outputs }))) {
+    const feeBigNum = csl.BigNum.from_str(fee.toString());
+    if (inputs.length > (await computeSelectionLimit({ inputs, change, fee: feeBigNum, outputs }))) {
       throw new InputSelectionError(InputSelectionFailure.MaximumInputCountExceeded);
     }
 
@@ -46,7 +47,7 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
         change,
         inputs,
         outputs,
-        fee: csl.BigNum.from_str(fee.toString())
+        fee: feeBigNum
       },
       remainingUTxO
     };

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -4,7 +4,7 @@ import { InputSelectionParameters, InputSelector, SelectionResult } from '../typ
 import { maxBigNum } from '../util';
 import { computeChangeAndAdjustForFee } from './change';
 import { roundRobinSelection } from './roundRobin';
-import { assertIsBalanceSufficient, preprocessArgs, totalsToValueQuantities } from './util';
+import { assertIsBalanceSufficient, preprocessArgs, withValuesToValues } from './util';
 
 export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSelector => ({
   select: async ({
@@ -12,13 +12,13 @@ export const roundRobinRandomImprove = (csl: CardanoSerializationLib): InputSele
     outputs,
     constraints: { computeMinimumCost, computeSelectionLimit, computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit }
   }: InputSelectionParameters): Promise<SelectionResult> => {
-    const { uniqueOutputAssetIDs, utxoWithTotals, outputsWithTotals } = preprocessArgs(utxo, outputs);
+    const { uniqueOutputAssetIDs, utxosWithValue, outputsWithValue } = preprocessArgs(utxo, outputs);
 
-    const utxoValues = totalsToValueQuantities(utxoWithTotals);
-    const outputValues = totalsToValueQuantities(outputsWithTotals);
+    const utxoValues = withValuesToValues(utxosWithValue);
+    const outputValues = withValuesToValues(outputsWithValue);
     assertIsBalanceSufficient(uniqueOutputAssetIDs, utxoValues, outputValues);
 
-    const roundRobinSelectionResult = roundRobinSelection(utxoWithTotals, outputsWithTotals, uniqueOutputAssetIDs);
+    const roundRobinSelectionResult = roundRobinSelection(utxosWithValue, outputsWithValue, uniqueOutputAssetIDs);
 
     const { change, inputs, remainingUTxO, fee } = await computeChangeAndAdjustForFee({
       csl,

--- a/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
@@ -1,18 +1,18 @@
 import { BigIntMath } from '@cardano-sdk/core';
 import {
-  assetTotalsQuantitySelector,
-  getCoinTotalsQuantity,
-  OutputWithTotals,
-  Totals,
+  assetWithValueQuantitySelector,
+  getWithValuesCoinQuantity,
+  OutputWithValue,
+  WithValue,
   UtxoSelection,
-  UtxoWithTotals
+  UtxoWithValue
 } from './util';
 
 const improvesSelection = (
-  utxoAlreadySelected: UtxoWithTotals[],
-  input: UtxoWithTotals,
+  utxoAlreadySelected: UtxoWithValue[],
+  input: UtxoWithValue,
   minimumTarget: bigint,
-  getQuantity: (totals: Totals[]) => bigint
+  getQuantity: (totals: WithValue[]) => bigint
 ): boolean => {
   const oldQuantity = getQuantity(utxoAlreadySelected);
   // We still haven't reached the minimum target of
@@ -34,20 +34,20 @@ const improvesSelection = (
   return false;
 };
 
-const listTokensWithin = (uniqueOutputAssetIDs: string[], outputs: OutputWithTotals[]) => [
+const listTokensWithin = (uniqueOutputAssetIDs: string[], outputs: OutputWithValue[]) => [
   ...uniqueOutputAssetIDs.map((id) => {
-    const getQuantity = assetTotalsQuantitySelector(id);
+    const getQuantity = assetWithValueQuantitySelector(id);
     return {
       getQuantity,
       minimumTarget: getQuantity(outputs),
-      filterUtxo: (utxo: UtxoWithTotals[]) => utxo.filter(({ totals: { assets } }) => assets?.[id])
+      filterUtxo: (utxo: UtxoWithValue[]) => utxo.filter(({ value: { assets } }) => assets?.[id])
     };
   }),
   {
     // Lovelace
-    getQuantity: (totals: Totals[]) => getCoinTotalsQuantity(totals),
-    minimumTarget: getCoinTotalsQuantity(outputs),
-    filterUtxo: (utxo: UtxoWithTotals[]) => utxo
+    getQuantity: (totals: WithValue[]) => getWithValuesCoinQuantity(totals),
+    minimumTarget: getWithValuesCoinQuantity(outputs),
+    filterUtxo: (utxo: UtxoWithValue[]) => utxo
   }
 ];
 
@@ -58,12 +58,12 @@ const listTokensWithin = (uniqueOutputAssetIDs: string[], outputs: OutputWithTot
  * Considers all outputs collectively, as a combined output bundle.
  */
 export const roundRobinSelection = (
-  availableUtxo: UtxoWithTotals[],
-  outputs: OutputWithTotals[],
+  availableUtxo: UtxoWithValue[],
+  outputs: OutputWithValue[],
   uniqueOutputAssetIDs: string[]
 ): UtxoSelection => {
   // The subset of the UTxO that has already been selected:
-  const utxoSelected: UtxoWithTotals[] = [];
+  const utxoSelected: UtxoWithValue[] = [];
   // The subset of the UTxO that remains available for selection:
   const utxoRemaining = [...availableUtxo];
   // The set of tokens that we still need to cover:

--- a/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
@@ -1,7 +1,7 @@
 import { BigIntMath } from '@cardano-sdk/core';
 import {
-  assetQuantitySelector,
-  getCoinQuantity,
+  assetTotalsQuantitySelector,
+  getCoinTotalsQuantity,
   OutputWithTotals,
   Totals,
   UtxoSelection,
@@ -36,7 +36,7 @@ const improvesSelection = (
 
 const listTokensWithin = (uniqueOutputAssetIDs: string[], outputs: OutputWithTotals[]) => [
   ...uniqueOutputAssetIDs.map((id) => {
-    const getQuantity = assetQuantitySelector(id);
+    const getQuantity = assetTotalsQuantitySelector(id);
     return {
       getQuantity,
       minimumTarget: getQuantity(outputs),
@@ -45,8 +45,8 @@ const listTokensWithin = (uniqueOutputAssetIDs: string[], outputs: OutputWithTot
   }),
   {
     // Lovelace
-    getQuantity: (totals: Totals[]) => getCoinQuantity(totals),
-    minimumTarget: getCoinQuantity(outputs),
+    getQuantity: (totals: Totals[]) => getCoinTotalsQuantity(totals),
+    minimumTarget: getCoinTotalsQuantity(outputs),
     filterUtxo: (utxo: UtxoWithTotals[]) => utxo
   }
 ];
@@ -56,8 +56,6 @@ const listTokensWithin = (uniqueOutputAssetIDs: string[], outputs: OutputWithTot
  *
  * Assumes we have already checked that the available UTxO balance is sufficient to cover all tokens in the outputs.
  * Considers all outputs collectively, as a combined output bundle.
- *
- * @throws InputSelectionError (UtxoBalanceInsufficient)
  */
 export const roundRobinSelection = (
   availableUtxo: UtxoWithTotals[],

--- a/packages/cip2/src/RoundRobinRandomImprove/util.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/util.ts
@@ -3,59 +3,59 @@ import { uniq } from 'lodash-es';
 import { InputSelectionError, InputSelectionFailure } from '../InputSelectionError';
 import { OgmiosValue, valueToValueQuantities } from '../util';
 
-export interface Totals {
-  totals: OgmiosValue;
+export interface WithValue {
+  value: OgmiosValue;
 }
 
-export interface UtxoWithTotals extends Totals {
+export interface UtxoWithValue extends WithValue {
   utxo: CSL.TransactionUnspentOutput;
 }
 
-export interface OutputWithTotals extends Totals {
+export interface OutputWithValue extends WithValue {
   output: CSL.TransactionOutput;
 }
 
 export interface RoundRobinRandomImproveArgs {
-  utxoWithTotals: UtxoWithTotals[];
-  outputsWithTotals: OutputWithTotals[];
+  utxosWithValue: UtxoWithValue[];
+  outputsWithValue: OutputWithValue[];
   uniqueOutputAssetIDs: string[];
 }
 
 export interface UtxoSelection {
-  utxoSelected: UtxoWithTotals[];
-  utxoRemaining: UtxoWithTotals[];
+  utxoSelected: UtxoWithValue[];
+  utxoRemaining: UtxoWithValue[];
 }
 
 export const preprocessArgs = (
   availableUtxo: CSL.TransactionUnspentOutput[],
   outputs: CSL.TransactionOutput[]
 ): RoundRobinRandomImproveArgs => {
-  const utxoWithTotals = availableUtxo.map((utxo) => ({
+  const utxosWithValue = availableUtxo.map((utxo) => ({
     utxo,
-    totals: valueToValueQuantities(utxo.output().amount())
+    value: valueToValueQuantities(utxo.output().amount())
   }));
-  const outputsWithTotals = outputs.map((output) => ({
+  const outputsWithValue = outputs.map((output) => ({
     output,
-    totals: valueToValueQuantities(output.amount())
+    value: valueToValueQuantities(output.amount())
   }));
   const uniqueOutputAssetIDs = uniq(
-    outputsWithTotals.flatMap(({ totals: { assets } }) => (assets && Object.keys(assets)) || [])
+    outputsWithValue.flatMap(({ value: { assets } }) => (assets && Object.keys(assets)) || [])
   );
-  return { uniqueOutputAssetIDs, utxoWithTotals, outputsWithTotals };
+  return { uniqueOutputAssetIDs, utxosWithValue, outputsWithValue };
 };
 
-export const totalsToValueQuantities = (totals: Totals[]) => totals.map((t) => t.totals);
+export const withValuesToValues = (totals: WithValue[]) => totals.map((t) => t.value);
 export const assetQuantitySelector =
   (id: string) =>
   (quantities: OgmiosValue[]): bigint =>
     BigIntMath.sum(quantities.map(({ assets }) => assets?.[id] || 0n));
-export const assetTotalsQuantitySelector =
+export const assetWithValueQuantitySelector =
   (id: string) =>
-  (totals: Totals[]): bigint =>
-    assetQuantitySelector(id)(totalsToValueQuantities(totals));
+  (totals: WithValue[]): bigint =>
+    assetQuantitySelector(id)(withValuesToValues(totals));
 export const getCoinQuantity = (quantities: OgmiosValue[]): bigint =>
   BigIntMath.sum(quantities.map(({ coins }) => coins));
-export const getCoinTotalsQuantity = (totals: Totals[]): bigint => getCoinQuantity(totalsToValueQuantities(totals));
+export const getWithValuesCoinQuantity = (totals: WithValue[]): bigint => getCoinQuantity(withValuesToValues(totals));
 
 export const assertIsCoinBalanceSufficient = (utxoValues: OgmiosValue[], outputValues: OgmiosValue[]) => {
   const utxoCoinTotal = getCoinQuantity(utxoValues);

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -12,7 +12,7 @@ export interface SelectionResult {
     /**
      * Set of payments to be made to recipient addresses.
      */
-    outputs: CSL.TransactionOutputs;
+    outputs: CSL.TransactionOutput[];
     /**
      * A set of change values. Does not account for fee.
      *
@@ -36,7 +36,7 @@ export interface SelectionResult {
 
 export interface SelectionSkeleton {
   inputs: CSL.TransactionUnspentOutput[];
-  outputs: CSL.TransactionOutputs;
+  outputs: CSL.TransactionOutput[];
   change: CSL.Value[];
   fee: CSL.BigNum;
 }
@@ -77,7 +77,7 @@ export interface InputSelectionParameters {
   /**
    * The set of outputs requested for payment.
    */
-  outputs: CSL.TransactionOutputs;
+  outputs: CSL.TransactionOutput[];
   /**
    * Input selection constraints
    */

--- a/packages/cip2/src/util.ts
+++ b/packages/cip2/src/util.ts
@@ -3,14 +3,14 @@
 // These utils should be moved after CSL is updated to use bigint.
 import { CardanoSerializationLib, CSL, Asset, Ogmios } from '@cardano-sdk/core';
 
-export type AssetQuantities = Ogmios.util.AssetQuantities;
-export type ValueQuantities = Ogmios.util.ValueQuantities;
+export type TokenMap = Ogmios.util.AssetQuantities;
+export type OgmiosValue = Ogmios.util.OgmiosValue;
 
 export const MAX_U64 = 18_446_744_073_709_551_615n;
 export const maxBigNum = (csl: CardanoSerializationLib) => csl.BigNum.from_str(MAX_U64.toString());
 
-export const valueToValueQuantities = (value: CSL.Value): ValueQuantities => {
-  const result: ValueQuantities = {
+export const valueToValueQuantities = (value: CSL.Value): OgmiosValue => {
+  const result: OgmiosValue = {
     coins: BigInt(value.coin().to_str())
   };
   const multiasset = value.multiasset();
@@ -35,7 +35,7 @@ export const valueToValueQuantities = (value: CSL.Value): ValueQuantities => {
 };
 
 // This is equivalent to ogmiosToCsl.value(), so they should be merged.
-export const valueQuantitiesToValue = ({ coins, assets }: ValueQuantities, csl: CardanoSerializationLib): CSL.Value => {
+export const ogmiosValueToCslValue = ({ coins, assets }: OgmiosValue, csl: CardanoSerializationLib): CSL.Value => {
   const value = csl.Value.new(csl.BigNum.from_str(coins.toString()));
   if (!assets) {
     return value;

--- a/packages/cip2/src/util.ts
+++ b/packages/cip2/src/util.ts
@@ -3,7 +3,7 @@
 // These utils should be moved after CSL is updated to use bigint.
 import { CardanoSerializationLib, CSL, Asset, Ogmios } from '@cardano-sdk/core';
 
-export type TokenMap = Ogmios.util.AssetQuantities;
+export type TokenMap = Ogmios.util.TokenMap;
 export type OgmiosValue = Ogmios.util.OgmiosValue;
 
 export const MAX_U64 = 18_446_744_073_709_551_615n;

--- a/packages/cip2/src/util.ts
+++ b/packages/cip2/src/util.ts
@@ -9,15 +9,6 @@ export type ValueQuantities = Ogmios.util.ValueQuantities;
 export const MAX_U64 = 18_446_744_073_709_551_615n;
 export const maxBigNum = (csl: CardanoSerializationLib) => csl.BigNum.from_str(MAX_U64.toString());
 
-export const transactionOutputsToArray = (outputs: CSL.TransactionOutputs): CSL.TransactionOutput[] => {
-  const result: CSL.TransactionOutput[] = [];
-  for (let outputIdx = 0; outputIdx < outputs.len(); outputIdx++) {
-    const output = outputs.get(outputIdx);
-    result.push(output);
-  }
-  return result;
-};
-
 export const valueToValueQuantities = (value: CSL.Value): ValueQuantities => {
   const result: ValueQuantities = {
     coins: BigInt(value.coin().to_str())

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -157,15 +157,14 @@ describe('RoundRobinRandomImprove', () => {
         // Run input selection
         const utxo = utxoAmounts.map((valueQuantities) => utils.createUnspentTxOutput(valueQuantities));
         const outputs = outputsAmounts.map((valueQuantities) => utils.createOutput(valueQuantities));
-        const outputsObj = utils.createOutputsObj(outputs);
 
         try {
           const results = await algorithm.select({
             utxo,
-            outputs: outputsObj,
+            outputs,
             constraints: toConstraints(constraints)
           });
-          assertInputSelectionProperties({ utils, results, outputs, utxo, outputsObj, constraints });
+          assertInputSelectionProperties({ utils, results, outputs, utxo, constraints });
         } catch (error) {
           if (error instanceof InputSelectionError) {
             assertFailureProperties({ error, utxoAmounts, outputsAmounts, constraints });

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -28,6 +28,19 @@ describe('RoundRobinRandomImprove', () => {
           mockConstraints: NO_CONSTRAINTS
         });
       });
+      it('No outputs', async () => {
+        // Regression
+        await testInputSelectionProperties({
+          getAlgorithm: getRoundRobinRandomImprove,
+          createUtxo: (utils) => [utils.createUnspentTxOutput({ coins: 11_999_994n })],
+          createOutputs: () => [],
+          mockConstraints: {
+            ...NO_CONSTRAINTS,
+            minimumCoinQuantity: 9_999_991n,
+            minimumCost: 2_000_003n
+          }
+        });
+      });
     });
     describe('Failure Modes', () => {
       describe('UtxoBalanceInsufficient', () => {

--- a/packages/cip2/test/selectionConstraints.test.ts
+++ b/packages/cip2/test/selectionConstraints.test.ts
@@ -9,7 +9,7 @@ import {
 import { PXL_Asset, TSLA_Asset } from './util';
 import { defaultSelectionConstraints, DefaultSelectionConstraintsProps } from '../src/selectionConstraints';
 import { SelectionSkeleton } from '../src/types';
-import { valueQuantitiesToValue } from '../src/util';
+import { ogmiosValueToCslValue } from '../src/util';
 
 describe('defaultSelectionConstraints', () => {
   let csl: CardanoSerializationLib;
@@ -45,7 +45,7 @@ describe('defaultSelectionConstraints', () => {
   });
 
   it('computeMinimumCoinQuantity', () => {
-    const withAssets = valueQuantitiesToValue(
+    const withAssets = ogmiosValueToCslValue(
       {
         coins: 10_000n,
         assets: {

--- a/packages/cip2/test/util.test.ts
+++ b/packages/cip2/test/util.test.ts
@@ -1,5 +1,5 @@
 import { CardanoSerializationLib, loadCardanoSerializationLib, Asset } from '@cardano-sdk/core';
-import { ValueQuantities, valueQuantitiesToValue, valueToValueQuantities } from '../src/util';
+import { OgmiosValue, ogmiosValueToCslValue, valueToValueQuantities } from '../src/util';
 import { TSLA_Asset, PXL_Asset } from './util';
 
 describe('util', () => {
@@ -8,16 +8,16 @@ describe('util', () => {
     csl = await loadCardanoSerializationLib();
   });
 
-  describe('valueQuantitiesToValue', () => {
+  describe('ogmiosValueToCslValue', () => {
     it('coin only', () => {
       const quantities = { coins: 100_000n };
-      const value = valueQuantitiesToValue(quantities, csl);
+      const value = ogmiosValueToCslValue(quantities, csl);
       expect(value.coin().to_str()).toEqual(quantities.coins.toString());
       expect(value.multiasset()).toBeUndefined();
     });
     it('coin with assets', () => {
-      const quantities: ValueQuantities = { coins: 100_000n, assets: { [TSLA_Asset]: 100n, [PXL_Asset]: 200n } };
-      const value = valueQuantitiesToValue(quantities, csl);
+      const quantities: OgmiosValue = { coins: 100_000n, assets: { [TSLA_Asset]: 100n, [PXL_Asset]: 200n } };
+      const value = ogmiosValueToCslValue(quantities, csl);
       expect(value.coin().to_str()).toEqual(quantities.coins.toString());
       const multiasset = value.multiasset();
       expect(multiasset.len()).toBe(2);
@@ -39,7 +39,7 @@ describe('util', () => {
     it('coin with assets', () => {
       const coins = 100_000n;
       const assets = { [TSLA_Asset]: 100n, [PXL_Asset]: 200n };
-      const value = valueQuantitiesToValue({ coins, assets }, csl);
+      const value = ogmiosValueToCslValue({ coins, assets }, csl);
       const quantities = valueToValueQuantities(value);
       expect(quantities.coins).toEqual(coins);
       expect(quantities.assets).toEqual(assets);

--- a/packages/cip2/test/util.test.ts
+++ b/packages/cip2/test/util.test.ts
@@ -1,18 +1,11 @@
 import { CardanoSerializationLib, loadCardanoSerializationLib, Asset } from '@cardano-sdk/core';
-import {
-  transactionOutputsToArray,
-  ValueQuantities,
-  valueQuantitiesToValue,
-  valueToValueQuantities
-} from '../src/util';
-import { TestUtils, createCslTestUtils, TSLA_Asset, PXL_Asset } from './util';
+import { ValueQuantities, valueQuantitiesToValue, valueToValueQuantities } from '../src/util';
+import { TSLA_Asset, PXL_Asset } from './util';
 
 describe('util', () => {
   let csl: CardanoSerializationLib;
-  let testUtils: TestUtils;
   beforeAll(async () => {
     csl = await loadCardanoSerializationLib();
-    testUtils = createCslTestUtils(csl);
   });
 
   describe('valueQuantitiesToValue', () => {
@@ -51,15 +44,5 @@ describe('util', () => {
       expect(quantities.coins).toEqual(coins);
       expect(quantities.assets).toEqual(assets);
     });
-  });
-
-  it('transactionOutputsToArray', () => {
-    const quantities = [10_000n, 20_000n].map((coins) => ({ coins }));
-    const outputsObj = testUtils.createOutputsObj(quantities.map((q) => testUtils.createOutput(q)));
-    const result = transactionOutputsToArray(outputsObj);
-    expect(result.length).toBe(quantities.length);
-    // Would test whether it's the same objects instead,
-    // but TransactionOutputs.add seems to create a new object.
-    expect(result.map((r) => valueToValueQuantities(r.amount()))).toEqual(quantities);
   });
 });

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -48,7 +48,8 @@ export const assertInputSelectionProperties = ({
 
   // Correctness of Change
   const vChange = utils.getTotalChangeAmounts(results);
-  expect(vSelected.coins).toEqual(vRequested.coins + vChange.coins);
+  const vFee = BigInt(results.selection.fee.to_str());
+  expect(vSelected.coins).toEqual(vRequested.coins + vChange.coins + vFee);
   for (const assetName of AllAssets) {
     expect(vSelected.assets?.[assetName] || 0n).toEqual(
       (vRequested.assets?.[assetName] || 0n) + (vChange.assets?.[assetName] || 0n)
@@ -98,8 +99,9 @@ export const assertFailureProperties = ({
     case InputSelectionFailure.UtxoFullyDepleted: {
       const numUtxoAssets = Object.keys(utxoTotals.assets || {}).length;
       const bundleSizePotentiallyTooLarge = numUtxoAssets > constraints.maxTokenBundleSize;
-      const minimumCoinQuantityNotMet = utxoTotals.coins - outputsTotals.coins < constraints.minimumCoinQuantity;
-      expect(bundleSizePotentiallyTooLarge || minimumCoinQuantityNotMet).toBe(true);
+      const changeMinimumCoinQuantityNotMet =
+        utxoTotals.coins - outputsTotals.coins - constraints.minimumCost < constraints.minimumCoinQuantity;
+      expect(bundleSizePotentiallyTooLarge || changeMinimumCoinQuantityNotMet).toBe(true);
       return;
     }
     case InputSelectionFailure.MaximumInputCountExceeded: {

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -27,14 +27,12 @@ export const assertInputSelectionProperties = ({
   results,
   outputs,
   utxo,
-  outputsObj,
   constraints
 }: {
   utils: TestUtils;
   results: SelectionResult;
   outputs: CSL.TransactionOutput[];
   utxo: CSL.TransactionUnspentOutput[];
-  outputsObj: CSL.TransactionOutputs;
   constraints: MockSelectionConstraints;
 }) => {
   const vSelected = utils.getTotalInputAmounts(results);
@@ -67,7 +65,7 @@ export const assertInputSelectionProperties = ({
   // Conservation of Outputs
   // If this is used to test other algorithms refactor this
   // to clone outputs before and do deepEquals to assert it wasn't mutated
-  expect(results.selection.outputs).toEqual(outputsObj);
+  expect(results.selection.outputs).toBe(outputs);
 
   assertExtraChangeProperties(constraints, results);
 };

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -2,7 +2,7 @@ import { AllAssets, containsUtxo, TestUtils } from './util';
 import { SelectionResult } from '../../src/types';
 import { CSL, Ogmios } from '@cardano-sdk/core';
 import { InputSelectionError, InputSelectionFailure } from '../../src/InputSelectionError';
-import { AssetQuantities, MAX_U64, ValueQuantities, valueToValueQuantities } from '../../src/util';
+import { TokenMap, MAX_U64, OgmiosValue, valueToValueQuantities } from '../../src/util';
 import fc, { Arbitrary } from 'fast-check';
 import { MockSelectionConstraints } from './constraints';
 
@@ -77,8 +77,8 @@ export const assertFailureProperties = ({
   outputsAmounts
 }: {
   error: InputSelectionError;
-  utxoAmounts: ValueQuantities[];
-  outputsAmounts: ValueQuantities[];
+  utxoAmounts: OgmiosValue[];
+  outputsAmounts: OgmiosValue[];
   constraints: MockSelectionConstraints;
 }) => {
   const utxoTotals = Ogmios.util.coalesceValueQuantities(...utxoAmounts);
@@ -122,7 +122,7 @@ export const generateSelectionParams = (() => {
   const arrayOfCoinAndAssets = () =>
     fc
       .array(
-        fc.record<ValueQuantities>({
+        fc.record<OgmiosValue>({
           coins: fc.bigUint(MAX_U64),
           assets: fc.oneof(
             fc
@@ -134,7 +134,7 @@ export const generateSelectionParams = (() => {
                 assets.reduce((quantities, { amount, asset }) => {
                   quantities[asset] = amount;
                   return quantities;
-                }, {} as AssetQuantities)
+                }, {} as TokenMap)
               ),
             fc.constant(void 0)
           )
@@ -148,8 +148,8 @@ export const generateSelectionParams = (() => {
       });
 
   return (): Arbitrary<{
-    utxoAmounts: ValueQuantities[];
-    outputsAmounts: ValueQuantities[];
+    utxoAmounts: OgmiosValue[];
+    outputsAmounts: OgmiosValue[];
     constraints: MockSelectionConstraints;
   }> =>
     fc.record({

--- a/packages/cip2/test/util/tests.ts
+++ b/packages/cip2/test/util/tests.ts
@@ -46,9 +46,9 @@ export const testInputSelectionFailureMode = async ({
   const utxo = createUtxo(utils);
   const outputs = createOutputs(utils);
   const algorithm = getAlgorithm(SerializationLib);
-  await expect(
-    algorithm.select({ utxo, outputs: utils.createOutputsObj(outputs), constraints: toConstraints(mockConstraints) })
-  ).rejects.toThrowError(new InputSelectionError(expectedError));
+  await expect(algorithm.select({ utxo, outputs, constraints: toConstraints(mockConstraints) })).rejects.toThrowError(
+    new InputSelectionError(expectedError)
+  );
 };
 
 /**
@@ -64,8 +64,7 @@ export const testInputSelectionProperties = async ({
   const utils = createCslTestUtils(SerializationLib);
   const utxo = createUtxo(utils);
   const outputs = createOutputs(utils);
-  const outputsObj = utils.createOutputsObj(outputs);
   const algorithm = getAlgorithm(SerializationLib);
-  const results = await algorithm.select({ utxo, outputs: outputsObj, constraints: toConstraints(mockConstraints) });
-  assertInputSelectionProperties({ utils, results, outputs, outputsObj, constraints: mockConstraints, utxo });
+  const results = await algorithm.select({ utxo, outputs, constraints: toConstraints(mockConstraints) });
+  assertInputSelectionProperties({ utils, results, outputs, constraints: mockConstraints, utxo });
 };

--- a/packages/cip2/test/util/util.ts
+++ b/packages/cip2/test/util/util.ts
@@ -66,14 +66,6 @@ export const createCslTestUtils = (csl: CardanoSerializationLib) => {
       csl.TransactionInput.new(csl.TransactionHash.from_bech32(bech32TxHash), index || defaultIdx++);
   })();
 
-  const createOutputsObj = (outputs: CSL.TransactionOutput[]) => {
-    const result = csl.TransactionOutputs.new();
-    for (const output of outputs) {
-      result.add(output);
-    }
-    return result;
-  };
-
   const createUnspentTxOutput = (
     valueQuantities: ValueQuantities,
     bech32Addr = 'addr1vy36kffjf87vzkuyqc5g0ys3fe3pez5zvqg9r5z9q9kfrkg2cs093'
@@ -92,7 +84,6 @@ export const createCslTestUtils = (csl: CardanoSerializationLib) => {
   return {
     createUnspentTxOutput,
     createOutput,
-    createOutputsObj,
     getTotalOutputAmounts,
     getTotalInputAmounts,
     getTotalChangeAmounts

--- a/packages/cip2/test/util/util.ts
+++ b/packages/cip2/test/util/util.ts
@@ -3,7 +3,7 @@
 // And some of them to a new 'dev-util' package.
 import { CardanoSerializationLib, CSL, Ogmios } from '@cardano-sdk/core';
 import { SelectionResult } from '../../src/types';
-import { ValueQuantities, valueToValueQuantities, valueQuantitiesToValue } from '../../src/util';
+import { OgmiosValue, valueToValueQuantities, ogmiosValueToCslValue } from '../../src/util';
 
 export const TSLA_Asset = '659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41';
 export const PXL_Asset = '1ec85dcee27f2d90ec1f9a1e4ce74a667dc9be8b184463223f9c960150584c';
@@ -30,8 +30,8 @@ export const containsUtxo = (haystack: CSL.TransactionUnspentOutput[], needleUtx
   });
 };
 
-const getTotalOutputAmounts = (outputs: CSL.TransactionOutput[]): ValueQuantities => {
-  let result: ValueQuantities = {
+const getTotalOutputAmounts = (outputs: CSL.TransactionOutput[]): OgmiosValue => {
+  let result: OgmiosValue = {
     coins: 0n,
     assets: {} as Record<string, bigint>
   };
@@ -42,16 +42,16 @@ const getTotalOutputAmounts = (outputs: CSL.TransactionOutput[]): ValueQuantitie
   return result;
 };
 
-const getTotalInputAmounts = (results: SelectionResult): ValueQuantities =>
+const getTotalInputAmounts = (results: SelectionResult): OgmiosValue =>
   results.selection.inputs
     .map((input) => input.output().amount())
-    .reduce<ValueQuantities>((sum, value) => Ogmios.util.coalesceValueQuantities(sum, valueToValueQuantities(value)), {
+    .reduce<OgmiosValue>((sum, value) => Ogmios.util.coalesceValueQuantities(sum, valueToValueQuantities(value)), {
       coins: 0n,
       assets: {}
     });
 
-const getTotalChangeAmounts = (results: SelectionResult): ValueQuantities =>
-  results.selection.change.reduce<ValueQuantities>(
+const getTotalChangeAmounts = (results: SelectionResult): OgmiosValue =>
+  results.selection.change.reduce<OgmiosValue>(
     (sum, value) => Ogmios.util.coalesceValueQuantities(sum, valueToValueQuantities(value)),
     {
       assets: {},
@@ -67,19 +67,19 @@ export const createCslTestUtils = (csl: CardanoSerializationLib) => {
   })();
 
   const createUnspentTxOutput = (
-    valueQuantities: ValueQuantities,
+    valueQuantities: OgmiosValue,
     bech32Addr = 'addr1vy36kffjf87vzkuyqc5g0ys3fe3pez5zvqg9r5z9q9kfrkg2cs093'
   ): CSL.TransactionUnspentOutput => {
     const address = csl.Address.from_bech32(bech32Addr);
-    const amount = valueQuantitiesToValue(valueQuantities, csl);
+    const amount = ogmiosValueToCslValue(valueQuantities, csl);
     return csl.TransactionUnspentOutput.new(createTxInput(), csl.TransactionOutput.new(address, amount));
   };
 
   const createOutput = (
-    valueQuantities: ValueQuantities,
+    valueQuantities: OgmiosValue,
     bech32Addr = 'addr1vyeljkh3vr4h9s3lyxe7g2meushk3m4nwyzdgtlg96e6mrgg8fnle'
   ): CSL.TransactionOutput =>
-    csl.TransactionOutput.new(csl.Address.from_bech32(bech32Addr), valueQuantitiesToValue(valueQuantities, csl));
+    csl.TransactionOutput.new(csl.Address.from_bech32(bech32Addr), ogmiosValueToCslValue(valueQuantities, csl));
 
   return {
     createUnspentTxOutput,

--- a/packages/core/src/Ogmios/util.ts
+++ b/packages/core/src/Ogmios/util.ts
@@ -4,7 +4,7 @@ import { BigIntMath } from '../util/BigIntMath';
 /**
  * {[assetId]: amount}
  */
-export type AssetQuantities = _OgmiosValue['assets'];
+export type TokenMap = _OgmiosValue['assets'];
 
 /**
  * Total quantities of Coin and Assets in a Value.
@@ -12,14 +12,14 @@ export type AssetQuantities = _OgmiosValue['assets'];
  */
 export interface OgmiosValue {
   coins: bigint;
-  assets?: AssetQuantities;
+  assets?: TokenMap;
 }
 
 /**
  * Sum asset quantities
  */
-const coalesceAssetTotals = (...totals: (AssetQuantities | undefined)[]): AssetQuantities | undefined => {
-  const result: AssetQuantities = {};
+const coalesceTokenMaps = (...totals: (TokenMap | undefined)[]): TokenMap | undefined => {
+  const result: TokenMap = {};
   for (const assetTotals of totals.filter((quantities) => !!quantities)) {
     for (const assetKey in assetTotals) {
       result[assetKey] = (result[assetKey] || 0n) + assetTotals[assetKey];
@@ -37,5 +37,5 @@ const coalesceAssetTotals = (...totals: (AssetQuantities | undefined)[]): AssetQ
  */
 export const coalesceValueQuantities = (...quantities: OgmiosValue[]): OgmiosValue => ({
   coins: BigIntMath.sum(quantities.map(({ coins }) => coins)),
-  assets: coalesceAssetTotals(...quantities.map(({ assets }) => assets))
+  assets: coalesceTokenMaps(...quantities.map(({ assets }) => assets))
 });

--- a/packages/core/src/Ogmios/util.ts
+++ b/packages/core/src/Ogmios/util.ts
@@ -1,16 +1,16 @@
-import { Value as OgmiosValue } from '@cardano-ogmios/schema';
+import { Value as _OgmiosValue } from '@cardano-ogmios/schema';
 import { BigIntMath } from '../util/BigIntMath';
 
 /**
  * {[assetId]: amount}
  */
-export type AssetQuantities = OgmiosValue['assets'];
+export type AssetQuantities = _OgmiosValue['assets'];
 
 /**
  * Total quantities of Coin and Assets in a Value.
  * TODO: Use Ogmios Value type after it changes lovelaces to bigint;
  */
-export interface ValueQuantities {
+export interface OgmiosValue {
   coins: bigint;
   assets?: AssetQuantities;
 }
@@ -35,7 +35,7 @@ const coalesceAssetTotals = (...totals: (AssetQuantities | undefined)[]): AssetQ
 /**
  * Sum all quantities
  */
-export const coalesceValueQuantities = (...quantities: ValueQuantities[]): ValueQuantities => ({
+export const coalesceValueQuantities = (...quantities: OgmiosValue[]): OgmiosValue => ({
   coins: BigIntMath.sum(quantities.map(({ coins }) => coins)),
   assets: coalesceAssetTotals(...quantities.map(({ assets }) => assets))
 });

--- a/packages/core/test/Ogmios/util.test.ts
+++ b/packages/core/test/Ogmios/util.test.ts
@@ -1,25 +1,25 @@
-import { coalesceValueQuantities, ValueQuantities } from '../../src/Ogmios/util';
+import { coalesceValueQuantities, OgmiosValue } from '../../src/Ogmios/util';
 
 describe('Ogmios', () => {
   describe('util', () => {
     describe('coalesceValueQuantities', () => {
       it('coin only', () => {
-        const q1: ValueQuantities = { coins: 50n };
-        const q2: ValueQuantities = { coins: 100n };
+        const q1: OgmiosValue = { coins: 50n };
+        const q2: OgmiosValue = { coins: 100n };
         expect(coalesceValueQuantities(q1, q2)).toEqual({ coins: 150n });
       });
       it('coin and assets', () => {
         const TSLA_Asset = 'b32_1vk0jj9lmv0cjkvmxw337u467atqcgkauwd4eczaugzagyghp25lTSLA';
         const PXL_Asset = 'b32_1rmy9mnhz0ukepmqlng0yee62ve7un05trpzxxg3lnjtqzp4dmmrPXL';
-        const q1: ValueQuantities = {
+        const q1: OgmiosValue = {
           coins: 50n,
           assets: {
             [TSLA_Asset]: 50n,
             [PXL_Asset]: 100n
           }
         };
-        const q2: ValueQuantities = { coins: 100n };
-        const q3: ValueQuantities = {
+        const q2: OgmiosValue = { coins: 100n };
+        const q3: OgmiosValue = {
           coins: 20n,
           assets: {
             [TSLA_Asset]: 20n

--- a/packages/wallet/src/InMemoryUtxoRepository.ts
+++ b/packages/wallet/src/InMemoryUtxoRepository.ts
@@ -54,7 +54,7 @@ export class InMemoryUtxoRepository implements UtxoRepository {
   }
 
   public async selectInputs(
-    outputs: CSL.TransactionOutputs,
+    outputs: CSL.TransactionOutput[],
     constraints: SelectionConstraints
   ): Promise<SelectionResult> {
     if (this.#utxoSet.size === 0) {

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -39,10 +39,7 @@ export const createSingleAddressWallet = async (
     initializeTx: async (props) => {
       const tip = await provider.ledgerTip();
       const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
-      const txOutputs = csl.TransactionOutputs.new();
-      for (const output of props.outputs) {
-        txOutputs.add(Ogmios.ogmiosToCsl(csl).txOut(output));
-      }
+      const txOutputs = props.outputs.map((output) => Ogmios.ogmiosToCsl(csl).txOut(output));
       const constraints = defaultSelectionConstraints({
         csl,
         protocolParameters,

--- a/packages/wallet/src/UtxoRepository.ts
+++ b/packages/wallet/src/UtxoRepository.ts
@@ -7,5 +7,5 @@ export interface UtxoRepository {
   rewards: Schema.Lovelace;
   delegation: Schema.PoolId;
   sync: () => Promise<void>;
-  selectInputs: (outputs: CSL.TransactionOutputs, constraints: SelectionConstraints) => Promise<SelectionResult>;
+  selectInputs: (outputs: CSL.TransactionOutput[], constraints: SelectionConstraints) => Promise<SelectionResult>;
 }

--- a/packages/wallet/src/createTransactionInternals.ts
+++ b/packages/wallet/src/createTransactionInternals.ts
@@ -20,9 +20,16 @@ export const createTransactionInternals = async (
   for (const utxo of props.inputSelection.inputs) {
     inputs.add(utxo.input());
   }
+  const outputs = csl.TransactionOutputs.new();
+  for (const output of props.inputSelection.outputs) {
+    outputs.add(output);
+  }
+  for (const value of props.inputSelection.change) {
+    outputs.add(csl.TransactionOutput.new(csl.Address.from_bech32(props.changeAddress), value));
+  }
   const body = csl.TransactionBody.new(
     inputs,
-    props.inputSelection.outputs,
+    outputs,
     props.inputSelection.fee,
     props.validityInterval.invalidHereafter
   );

--- a/packages/wallet/test/InMemoryUtxoRepository.test.ts
+++ b/packages/wallet/test/InMemoryUtxoRepository.test.ts
@@ -13,7 +13,7 @@ describe('InMemoryUtxoRepository', () => {
   let provider: CardanoProvider;
   let inputSelector: InputSelector;
   let csl: CardanoSerializationLib;
-  let outputs: CSL.TransactionOutputs;
+  let outputs: CSL.TransactionOutput[];
 
   beforeEach(async () => {
     provider = providerStub();
@@ -25,19 +25,16 @@ describe('InMemoryUtxoRepository', () => {
       networkId: 0,
       password: '123'
     });
-    outputs = csl.TransactionOutputs.new();
-    outputs.add(
+    outputs = [
       Ogmios.ogmiosToCsl(csl).txOut({
         address: addresses[0],
         value: { coins: 4_000_000 }
-      })
-    );
-    outputs.add(
+      }),
       Ogmios.ogmiosToCsl(csl).txOut({
         address: addresses[0],
         value: { coins: 2_000_000 }
       })
-    );
+    ];
     utxoRepository = new InMemoryUtxoRepository(csl, provider, keyManager, inputSelector);
   });
 

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -62,7 +62,7 @@ describe('Wallet', () => {
     test('signTx', async () => {
       const { body, hash } = await wallet.initializeTx(props);
       const tx = await wallet.signTx(body, hash);
-      await expect(tx.body().outputs().len()).toBe(1);
+      await expect(tx.body().outputs().len()).toBe(2);
       await expect(tx.body().inputs().len()).toBeGreaterThan(0);
     });
 

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -19,7 +19,7 @@ describe('createTransactionInternals', () => {
   let provider: CardanoProvider;
   let inputSelector: InputSelector;
   let utxoRepository: UtxoRepository;
-  let outputs: CSL.TransactionOutputs;
+  let outputs: CSL.TransactionOutput[];
 
   beforeEach(async () => {
     csl = await loadCardanoSerializationLib();
@@ -31,20 +31,17 @@ describe('createTransactionInternals', () => {
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });
-    outputs = csl.TransactionOutputs.new();
 
-    outputs.add(
+    outputs = [
       Ogmios.ogmiosToCsl(csl).txOut({
         address,
         value: { coins: 4_000_000 }
-      })
-    );
-    outputs.add(
+      }),
       Ogmios.ogmiosToCsl(csl).txOut({
         address,
         value: { coins: 2_000_000 }
       })
-    );
+    ];
     utxoRepository = new InMemoryUtxoRepository(csl, provider, keyManager, inputSelector);
   });
 


### PR DESCRIPTION
# Context

CIP2 spec didn't contain information about how to return min fee and we made a mistake of including fee quantity in change bundles. This is not the desired behavior and quantities in change bundles are used as transaction outputs to the return address.

# Proposed Solution

After computing initial change bundles, deduct the estimated min fee and re-balance+re-validate change. There might be an exception when change becomes less than min utxo value at this point, in which case need to select an extra utxo and re-estimate the fee.
