### PR TITLE
Chore/golden-test-generator Alonzo block support

### DIFF
--- a/packages/blockfrost/package.json
+++ b/packages/blockfrost/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@blockfrost/blockfrost-js": "^1.3.0",
-    "@cardano-ogmios/schema": "^4.0.0-beta.6",
+    "@cardano-ogmios/schema": "4.0.0",
     "@cardano-sdk/core": "0.1.0"
   }
 }

--- a/packages/cardano-graphql-db-sync/package.json
+++ b/packages/cardano-graphql-db-sync/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@cardano-graphql/client-ts": "^5.1.0-beta.1",
-    "@cardano-ogmios/client": "^4.0.0-beta.6",
+    "@cardano-ogmios/client": "4.0.0",
     "graphql": "^15.5.1",
     "graphql-request": "^3.5.0"
   }

--- a/packages/cip2/package.json
+++ b/packages/cip2/package.json
@@ -19,7 +19,7 @@
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {
-    "@cardano-ogmios/schema": "^4.0.0-beta.6",
+    "@cardano-ogmios/schema": "4.0.0",
     "@types/lodash-es": "^4.17.5",
     "fast-check": "^2.17.0",
     "lodash": "^4.17.21",

--- a/packages/cip30/package.json
+++ b/packages/cip30/package.json
@@ -28,7 +28,7 @@
     "webextension-polyfill": "^0.8.0"
   },
   "dependencies": {
-    "@cardano-ogmios/client": "^4.0.0-beta.6",
+    "@cardano-ogmios/client": "4.0.0",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.3"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "./dist/CSL/nodejs.js": false
   },
   "dependencies": {
-    "@cardano-ogmios/schema": "^4.0.0-beta.6",
+    "@cardano-ogmios/schema": "4.0.0",
     "@emurgo/cardano-serialization-lib-nodejs": "8.0.0",
     "@emurgo/cardano-serialization-lib-browser": "8.0.0",
     "buffer": "^6.0.3"

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -25,7 +25,7 @@
     "coverage": "shx echo No coverage report for this package"
   },
   "dependencies": {
-    "@cardano-ogmios/client": "^4.0.0",
+    "@cardano-ogmios/client": "4.0.0",
     "chalk": "^4.1.1",
     "clear": "^0.1.0",
     "cli-progress": "^3.9.0",

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -25,14 +25,16 @@
     "coverage": "shx echo No coverage report for this package"
   },
   "dependencies": {
-    "@cardano-ogmios/client": "^4.0.0-beta.6",
+    "@cardano-ogmios/client": "^4.0.0",
     "chalk": "^4.1.1",
     "clear": "^0.1.0",
     "cli-progress": "^3.9.0",
     "commander": "^8.0.0",
     "fs-extra": "^10.0.0",
     "git-last-commit": "^1.0.0",
-    "object-hash": "^2.2.0"
+    "json-bigint": "^1.0.0",
+    "object-hash": "^2.2.0",
+    "ts-log": "^2.2.3"
   },
   "devDependencies": {
     "@types/cli-progress": "^3.9.2",

--- a/packages/golden-test-generator/src/index.ts
+++ b/packages/golden-test-generator/src/index.ts
@@ -5,7 +5,8 @@ import { Command } from 'commander';
 import hash from 'object-hash';
 import path from 'node:path';
 import { SingleBar, Options } from 'cli-progress';
-import { ensureDir, writeJson } from 'fs-extra';
+import { ensureDir, writeFile } from 'fs-extra';
+import JSONBig from 'json-bigint';
 import { AddressBalancesResponse, getOnChainAddressBalances } from './AddressBalance';
 import { getBlocks, GetBlocksResponse } from './Block';
 import { prepareContent } from './Content';
@@ -68,7 +69,7 @@ program
       const fileName = path.join(outDir, `address-balances-${hash(content)}.json`);
 
       console.log(`Writing ${fileName}`);
-      await writeJson(fileName, content, { spaces: 2 });
+      await writeFile(fileName, JSONBig.stringify(content, undefined, 2));
       process.exit(0);
     } catch (error) {
       console.error(error);
@@ -95,6 +96,7 @@ program
       await ensureDir(outDir);
       progress.start(lastblockHeight, 0);
       const { blocks, metadata } = await getBlocks(sortedblockHeights, {
+        logger: console,
         ogmiosConnectionConfig: { host: ogmiosHost, port: ogmiosPort, tls: ogmiosTls },
         onBlock: (blockHeight) => {
           progress.update(blockHeight);
@@ -105,7 +107,7 @@ program
       const fileName = path.join(outDir, `blocks-${hash(content)}.json`);
 
       console.log(`Writing ${fileName}`);
-      await writeJson(fileName, content, { spaces: 2 });
+      await writeFile(fileName, JSONBig.stringify(content, undefined, 2));
       process.exit(0);
     } catch (error) {
       console.error(error);

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -26,7 +26,7 @@
     "shx": "^0.3.3"
   },
   "dependencies": {
-    "@cardano-ogmios/schema": "^4.0.0-beta.6",
+    "@cardano-ogmios/schema": "4.0.0",
     "@cardano-sdk/cip2": "0.1.0",
     "@cardano-sdk/core": "0.1.0",
     "bip39": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,7 +499,7 @@
   resolved "https://registry.yarnpkg.com/@cardano-graphql/client-ts/-/client-ts-5.1.0-beta.1.tgz#440d1e48a07e6e454e9b5d9fb4336d6e649127f4"
   integrity sha512-FrOv5eV74o4BNrh95VNmzl166QeLxr7K8HYqHI3N+tFujbU6ELjRu8A15HKzcsjYaUiakFaj0d7PGzY5SG8r5w==
 
-"@cardano-ogmios/client@^4.0.0":
+"@cardano-ogmios/client@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@cardano-ogmios/client/-/client-4.0.0.tgz#0d8637753db15cf6b1f72d553d434f2658b0c078"
   integrity sha512-WYxX2CI78RSAPjOZAqgrepBp6PG36i5h+QFxUvK33ih8BgOatsqk2haURY/SHnd2RT96053t9DeZpyGz5PgbgQ==
@@ -514,35 +514,10 @@
     ts-custom-error "^3.2.0"
     ws "^7.4.6"
 
-"@cardano-ogmios/client@^4.0.0-beta.6":
-  version "4.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@cardano-ogmios/client/-/client-4.0.0-beta.6.tgz#ba16c227c49cfd58d44d8b06354bee3e4ad68ed6"
-  integrity sha512-cOxNLRH2sjha3yLrSZgetT2KeTv7ZfWN7CmEHBOINiqmK9AHLGQdq/1W/A38BBbYR7tepF2sF9LSzO3FjEInyw==
-  dependencies:
-    "@cardano-ogmios/schema" "4.0.0-beta.6"
-    "@types/json-bigint" "^1.0.1"
-    cross-fetch "^3.1.4"
-    fastq "^1.11.0"
-    isomorphic-ws "^4.0.1"
-    json-bigint "^1.0.0"
-    nanoid "^3.1.22"
-    ts-custom-error "^3.2.0"
-    ws "^7.4.6"
-
 "@cardano-ogmios/schema@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@cardano-ogmios/schema/-/schema-4.0.0.tgz#47d35aa17ce1e63295962c0624f562fda3244e03"
   integrity sha512-fZnkNjQlolTx6FiGyz/D7YFsmugxKjIyx4Wr5ZPKJOHqAt5td/eU733atL9Dn2j0eb+ChM7Q5aTe1s7O6I9BrQ==
-
-"@cardano-ogmios/schema@4.0.0-beta.6":
-  version "4.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@cardano-ogmios/schema/-/schema-4.0.0-beta.6.tgz#4aca740b6b70e310d342fb187bc7b03438447bef"
-  integrity sha512-7pHaU/fje4dRwV45rmLPowEe/3L5DuZt1f0892iCfvA76FTe3psRQNgvSN+vJ4lpPumz+IWKpMxrpZfKwzUdHw==
-
-"@cardano-ogmios/schema@^4.0.0-beta.6":
-  version "4.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@cardano-ogmios/schema/-/schema-4.0.0-beta.9.tgz#081b96e03deb541fd9ce391c77d365104fc064d0"
-  integrity sha512-F/UYk2Ur83RnMFPgJzrnT7rev7K1i6A/wNWH7hUXU5eh1rAP6YqJaanKWicPiqjUzAFlMzyCxVUfgzP8WhL4JA==
 
 "@commitlint/cli@^13.1.0":
   version "13.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,6 +499,21 @@
   resolved "https://registry.yarnpkg.com/@cardano-graphql/client-ts/-/client-ts-5.1.0-beta.1.tgz#440d1e48a07e6e454e9b5d9fb4336d6e649127f4"
   integrity sha512-FrOv5eV74o4BNrh95VNmzl166QeLxr7K8HYqHI3N+tFujbU6ELjRu8A15HKzcsjYaUiakFaj0d7PGzY5SG8r5w==
 
+"@cardano-ogmios/client@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@cardano-ogmios/client/-/client-4.0.0.tgz#0d8637753db15cf6b1f72d553d434f2658b0c078"
+  integrity sha512-WYxX2CI78RSAPjOZAqgrepBp6PG36i5h+QFxUvK33ih8BgOatsqk2haURY/SHnd2RT96053t9DeZpyGz5PgbgQ==
+  dependencies:
+    "@cardano-ogmios/schema" "4.0.0"
+    "@types/json-bigint" "^1.0.1"
+    cross-fetch "^3.1.4"
+    fastq "^1.11.0"
+    isomorphic-ws "^4.0.1"
+    json-bigint CardanoSolutions/json-bigint#d277387d
+    nanoid "^3.1.22"
+    ts-custom-error "^3.2.0"
+    ws "^7.4.6"
+
 "@cardano-ogmios/client@^4.0.0-beta.6":
   version "4.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/@cardano-ogmios/client/-/client-4.0.0-beta.6.tgz#ba16c227c49cfd58d44d8b06354bee3e4ad68ed6"
@@ -513,6 +528,11 @@
     nanoid "^3.1.22"
     ts-custom-error "^3.2.0"
     ws "^7.4.6"
+
+"@cardano-ogmios/schema@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@cardano-ogmios/schema/-/schema-4.0.0.tgz#47d35aa17ce1e63295962c0624f562fda3244e03"
+  integrity sha512-fZnkNjQlolTx6FiGyz/D7YFsmugxKjIyx4Wr5ZPKJOHqAt5td/eU733atL9Dn2j0eb+ChM7Q5aTe1s7O6I9BrQ==
 
 "@cardano-ogmios/schema@4.0.0-beta.6":
   version "4.0.0-beta.6"
@@ -5140,6 +5160,12 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+json-bigint@CardanoSolutions/json-bigint#d277387d:
+  version "1.0.0"
+  resolved "https://codeload.github.com/CardanoSolutions/json-bigint/tar.gz/d277387d7750ff4e698677d0aa0db97ebb60c581"
+  dependencies:
+    bignumber.js "^9.0.0"
 
 json-bigint@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Context
The GTG has been lagging behind in the Mary era. We're also depending on a beta version of Ogmios.

# Proposed Solution
Add support for Alonzo blocks in the GTG, bump to a pinned version of Ogmios across all packages.

# Important Changes Introduced
