### PR TITLE
chore: add buffer polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
   <img width="200" src=".github/images/cardano-logo.png"/>
 </p>
 
-[![CI][img_src_CI]][workflow_CI]
+[![CI][img_src_ci]][workflow_ci]
 
 <hr/>
 
 ## Overview
-A suite of TypeScript packages suitable for both Node.js and browser-based development. 
+
+A suite of TypeScript packages suitable for both Node.js and browser-based development.
 
 - [@cardano-sdk/core](./packages/core)
 - [@cardano-sdk/cip2](./packages/cip2)
@@ -19,12 +20,41 @@ A suite of TypeScript packages suitable for both Node.js and browser-based devel
 - [@cardano-sdk/wallet](./packages/wallet)
 
 ### Cardano Provider Implementations
+
 - [@cardano-sdk/cardano-graphql-db-sync](packages/cardano-graphql-db-sync)
 - [@cardano-sdk/blockfrost](packages/blockfrost)
 
 :information_source: Looking to use a Cardano service not listed here? [Let us know!]
 
+### Webpack
+
+You may use the following config when bundling this SDK with Webpack:
+
+```js
+const { IgnorePlugin, ProvidePlugin } = require('webpack');
+{
+  // For browser builds only
+  resolve: {
+    fallback: {
+      // May want to install readable-stream as an explicit dependency
+      stream: require.resolve('readable-stream'),
+      events: require.resolve("events/")
+    }
+  },
+  plugins: [
+    new HtmlWebpackHarddiskPlugin(),
+      // see https://www.npmjs.com/package/bip39
+      new IgnorePlugin(/^\.\/wordlists\/(?!english)/, /bip39\/src$/),
+    ],
+  ],
+  experiments: {
+    asyncWebAssembly: true
+  }
+}
+```
+
 ### Testing
+
 - [@cardano-sdk/golden-test-generator](./packages/golden-test-generator)
 
 ## Development
@@ -32,22 +62,29 @@ A suite of TypeScript packages suitable for both Node.js and browser-based devel
 A Yarn Workspace maintaining a single version across all packages.
 
 #### System Requirements
+
 - Docker `17.12.0`+
 - Docker Compose
 
 #### Install and Build
+
 ```console
 yarn install && \
 yarn build
 ```
+
 #### Run Tests
+
 ```console
 yarn testnet:up
 ```
+
 _In another terminal_
+
 ```console
 yarn test
 ```
+
 or
 
 ```console
@@ -55,36 +92,47 @@ yarn test:debug
 ```
 
 ### Lint
+
 ```console
 yarn lint
 ```
+
 ### Cleanup
+
 ```
 yarn cleanup
 ```
+
 ## Distribute
 
 ### Pack
+
 ```console
 ./scripts/pack.sh
 ```
+
 ### Publish to npm.org
+
 ```console
 ./scripts/publish.sh
 ```
+
 ### Generate Docs
+
 ```console
 yarn docs
 ```
 
 ## Maintenance
 
-## Bump Version
+### Bump Version
+
 ```console
 yarn bump-version
 ```
 
-New package checklist:
+### New package checklist
+
 1. Extend packageMap in [.versionrc.js](./.versionrc.js)
 2. Extend [pack.sh](./scripts/pack.sh)
 3. Extend [publish.sh](./scripts/publish.sh)
@@ -93,6 +141,6 @@ New package checklist:
   <a href="https://input-output-hk.github.io/cardano-js-sdk">:book: Documentation</a>
 </p>
 
-[img_src_CI]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/continuous-integration.yaml/badge.svg
-[workflow_CI]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/continuous-integration.yaml
-[Let us know!]: https://github.com/input-output-hk/cardano-graphql/discussions/new
+[img_src_ci]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/continuous-integration.yaml/badge.svg
+[workflow_ci]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/continuous-integration.yaml
+[let us know!]: https://github.com/input-output-hk/cardano-graphql/discussions/new

--- a/packages/cardano-graphql-db-sync/package.json
+++ b/packages/cardano-graphql-db-sync/package.json
@@ -25,6 +25,7 @@
     "@cardano-graphql/client-ts": "^5.1.0-beta.1",
     "@cardano-ogmios/client": "4.0.0",
     "graphql": "^15.5.1",
+    "buffer": "^6.0.3",
     "graphql-request": "^3.5.0"
   }
 }

--- a/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
+++ b/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
@@ -2,6 +2,7 @@ import { CardanoProvider } from '@cardano-sdk/core';
 import { gql, GraphQLClient } from 'graphql-request';
 import { TransactionSubmitResponse } from '@cardano-graphql/client-ts';
 import { Schema as Cardano } from '@cardano-ogmios/client';
+import { Buffer } from 'buffer';
 import {
   CardanoGraphqlToOgmios,
   GraphqlCurrentWalletProtocolParameters,

--- a/packages/core/src/Ogmios/ogmiosToCsl.ts
+++ b/packages/core/src/Ogmios/ogmiosToCsl.ts
@@ -1,5 +1,6 @@
 import { CardanoSerializationLib, CSL } from '../CSL';
 import OgmiosSchema from '@cardano-ogmios/schema';
+import { Buffer } from 'buffer';
 import * as Asset from '../Asset';
 
 export const ogmiosToCsl = (csl: CardanoSerializationLib) => ({

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -29,7 +29,8 @@
     "@cardano-ogmios/schema": "4.0.0",
     "@cardano-sdk/cip2": "0.1.2",
     "@cardano-sdk/core": "0.1.2",
-    "bip39": "^3.0.4",
+    "isomorphic-bip39": "^3.0.5",
+    "buffer": "^6.0.3",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.3"
   }

--- a/packages/wallet/src/InMemoryUtxoRepository.ts
+++ b/packages/wallet/src/InMemoryUtxoRepository.ts
@@ -1,4 +1,5 @@
 import Schema, { TxIn, TxOut } from '@cardano-ogmios/schema';
+import { Buffer } from 'buffer';
 import { UtxoRepository } from './UtxoRepository';
 import { CardanoProvider, Ogmios, CardanoSerializationLib, CSL } from '@cardano-sdk/core';
 import { dummyLogger, Logger } from 'ts-log';

--- a/packages/wallet/src/KeyManagement/InMemoryKeyManager.ts
+++ b/packages/wallet/src/KeyManagement/InMemoryKeyManager.ts
@@ -1,5 +1,6 @@
-import * as bip39 from 'bip39';
+import * as bip39 from 'isomorphic-bip39';
 import { Cardano, CardanoSerializationLib, CSL } from '@cardano-sdk/core';
+import { Buffer } from 'buffer';
 import * as errors from './errors';
 import { KeyManager } from './KeyManager';
 import { harden } from './util';

--- a/packages/wallet/src/KeyManagement/InMemoryKeyManager.ts
+++ b/packages/wallet/src/KeyManagement/InMemoryKeyManager.ts
@@ -3,7 +3,7 @@ import { Cardano, CardanoSerializationLib, CSL } from '@cardano-sdk/core';
 import { Buffer } from 'buffer';
 import * as errors from './errors';
 import { KeyManager } from './KeyManager';
-import { harden } from './util';
+import { harden, joinMnemonicWords } from './util';
 
 /**
  *
@@ -12,19 +12,20 @@ export const createInMemoryKeyManager = ({
   csl,
   password,
   accountIndex,
-  mnemonic,
+  mnemonicWords,
   networkId
 }: {
   csl: CardanoSerializationLib;
   password: string;
   accountIndex?: number;
-  mnemonic: string;
+  mnemonicWords: string[];
   networkId: Cardano.NetworkId;
 }): KeyManager => {
   if (!accountIndex) {
     accountIndex = 0;
   }
 
+  const mnemonic = joinMnemonicWords(mnemonicWords);
   const validMnemonic = bip39.validateMnemonic(mnemonic);
   if (!validMnemonic) throw new errors.InvalidMnemonic();
 

--- a/packages/wallet/src/KeyManagement/util.ts
+++ b/packages/wallet/src/KeyManagement/util.ts
@@ -3,7 +3,8 @@ import * as bip39 from 'isomorphic-bip39';
 /**
  * A wrapper around the bip39 package function, with default strength applied to produce 24 words
  */
-export const generateMnemonic = (strength = 256) => bip39.generateMnemonic(strength);
+export const generateMnemonicWords = (strength = 256) => bip39.generateMnemonic(strength).split(' ');
+export const joinMnemonicWords = (mnenomic: string[]) => mnenomic.join(' ');
 
 /**
  * A wrapper around the bip39 package function

--- a/packages/wallet/src/KeyManagement/util.ts
+++ b/packages/wallet/src/KeyManagement/util.ts
@@ -1,4 +1,4 @@
-import * as bip39 from 'bip39';
+import * as bip39 from 'isomorphic-bip39';
 
 /**
  * A wrapper around the bip39 package function, with default strength applied to produce 24 words

--- a/packages/wallet/test/InMemoryUtxoRepository.test.ts
+++ b/packages/wallet/test/InMemoryUtxoRepository.test.ts
@@ -21,7 +21,7 @@ describe('InMemoryUtxoRepository', () => {
     inputSelector = roundRobinRandomImprove(csl);
     const keyManager = KeyManagement.createInMemoryKeyManager({
       csl,
-      mnemonic: KeyManagement.util.generateMnemonic(),
+      mnemonicWords: KeyManagement.util.generateMnemonicWords(),
       networkId: 0,
       password: '123'
     });

--- a/packages/wallet/test/KeyManagement/InMemoryKeyManager.test.ts
+++ b/packages/wallet/test/KeyManagement/InMemoryKeyManager.test.ts
@@ -8,10 +8,10 @@ describe('InMemoryKeyManager', () => {
 
   beforeEach(async () => {
     csl = await loadCardanoSerializationLib();
-    const mnemonic = KeyManagement.util.generateMnemonic();
+    const mnemonicWords = KeyManagement.util.generateMnemonicWords();
     keyManager = KeyManagement.createInMemoryKeyManager({
       csl,
-      mnemonic,
+      mnemonicWords,
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });

--- a/packages/wallet/test/KeyManagement/InMemoryKeyManager.test.ts
+++ b/packages/wallet/test/KeyManagement/InMemoryKeyManager.test.ts
@@ -1,4 +1,5 @@
 import { Cardano, CardanoSerializationLib, loadCardanoSerializationLib } from '@cardano-sdk/core';
+import { Buffer } from 'buffer';
 import { KeyManagement } from '../../src';
 
 describe('InMemoryKeyManager', () => {

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -21,7 +21,7 @@ describe('Wallet', () => {
     csl = await loadCardanoSerializationLib();
     keyManager = KeyManagement.createInMemoryKeyManager({
       csl,
-      mnemonic: KeyManagement.util.generateMnemonic(),
+      mnemonicWords: KeyManagement.util.generateMnemonicWords(),
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });

--- a/packages/wallet/test/createTransactionInternals.test.ts
+++ b/packages/wallet/test/createTransactionInternals.test.ts
@@ -27,7 +27,7 @@ describe('createTransactionInternals', () => {
     inputSelector = roundRobinRandomImprove(csl);
     const keyManager = KeyManagement.createInMemoryKeyManager({
       csl,
-      mnemonic: KeyManagement.util.generateMnemonic(),
+      mnemonicWords: KeyManagement.util.generateMnemonicWords(),
       networkId: Cardano.NetworkId.testnet,
       password: '123'
     });

--- a/prototype/package.json
+++ b/prototype/package.json
@@ -53,7 +53,7 @@
     "@types/cbor": "^2.0.0",
     "babel-polyfill": "^6.26.0",
     "bech32": "^1.1.3",
-    "bip39": "^3.0.1",
+    "isomorphic-bip39": "^3.0.5",
     "bs58": "^4.0.1",
     "cardano-wallet": "1.1.0",
     "cardano-wallet-browser": "1.1.0",

--- a/prototype/src/Utils/mnemonic.ts
+++ b/prototype/src/Utils/mnemonic.ts
@@ -1,1 +1,1 @@
-export { generateMnemonic } from 'bip39'
+export { generateMnemonic } from 'isomorphic-bip39'

--- a/prototype/src/lib/KeyManagers/InMemoryKey/index.ts
+++ b/prototype/src/lib/KeyManagers/InMemoryKey/index.ts
@@ -1,4 +1,4 @@
-import { validateMnemonic } from 'bip39'
+import { validateMnemonic } from 'isomorphic-bip39'
 import { KeyManager, InvalidMnemonic } from '../../../KeyManager'
 import { ChainSettings, Cardano } from '../../../Cardano'
 

--- a/prototype/src/test/RemoteWalletIntegration.spec.ts
+++ b/prototype/src/test/RemoteWalletIntegration.spec.ts
@@ -1,7 +1,7 @@
 import { expect, use } from 'chai'
 import * as chaiAsPromised from 'chai-as-promised'
 import CardanoSDK, { CardanoWalletProvider } from '..'
-import { generateMnemonic } from 'bip39'
+import { generateMnemonic } from 'isomorphic-bip39'
 import { RemotePayment, RemoteUnit } from '../Remote'
 import { RequestError } from '../lib'
 import { mockProvider } from './utils'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,16 +2235,6 @@ binjumper@^0.1.4:
   resolved "https://registry.yarnpkg.com/binjumper/-/binjumper-0.1.4.tgz#4acc0566832714bd6508af6d666bd9e5e21fc7f8"
   integrity sha512-Gdxhj+U295tIM6cO4bJO1jsvSjBVHNpj2o/OwW7pqDEtaqF6KdOxjtbo93jMMKAkP7+u09+bV8DhSqjIv4qR3w==
 
-bip39@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
-  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
-  dependencies:
-    "@types/node" "11.11.6"
-    create-hash "^1.1.0"
-    pbkdf2 "^3.0.9"
-    randombytes "^2.0.1"
-
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -4567,6 +4557,17 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+isomorphic-bip39@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/isomorphic-bip39/-/isomorphic-bip39-3.0.5.tgz#15ee9115cc07e7d26162f067928efafcdced7c79"
+  integrity sha512-pnACWL0N5WBbsNdmrLVn5CwhjQRiRMvmsVaz9VRa7H8RzouF+nAX7S+dsM08mJOFzZVt3rTw1IpkIztqdk3fyA==
+  dependencies:
+    "@types/node" "11.11.6"
+    buffer "^6.0.3"
+    create-hash "^1.1.0"
+    pbkdf2 "^3.0.9"
+    randombytes "^2.0.1"
 
 isomorphic-ws@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
# Context

`Buffer` needs a polyfill in browser env.

# Proposed Solution

- [x] `require('buffer')` on all usages of Buffer (except for prototype pkg)
- [x] replace `bip39` with `isomorphic-bip39`
