### PR TITLE
Feature: wallet name

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -18,6 +18,14 @@ export interface SingleAddressWallet {
   submitTx: (tx: CSL.Transaction) => Promise<boolean>;
 }
 
+export interface SingleAddressWalletDependencies {
+  csl: CardanoSerializationLib;
+  keyManager: KeyManagement.KeyManager;
+  logger?: Logger;
+  provider: CardanoProvider;
+  utxoRepository: UtxoRepository;
+}
+
 const ensureValidityInterval = (
   currentSlot: number,
   validityInterval?: Transaction.ValidityInterval
@@ -25,13 +33,13 @@ const ensureValidityInterval = (
   // Todo: Based this on slot duration, to equal 2hrs
   ({ invalidHereafter: currentSlot + 3600, ...validityInterval });
 
-export const createSingleAddressWallet = async (
-  csl: CardanoSerializationLib,
-  provider: CardanoProvider,
-  keyManager: KeyManagement.KeyManager,
-  utxoRepository: UtxoRepository,
-  logger: Logger = dummyLogger
-): Promise<SingleAddressWallet> => {
+export const createSingleAddressWallet = async ({
+  csl,
+  provider,
+  keyManager,
+  utxoRepository,
+  logger = dummyLogger
+}: SingleAddressWalletDependencies): Promise<SingleAddressWallet> => {
   const address = keyManager.deriveAddress(0, 0);
   const protocolParameters = await provider.currentWalletProtocolParameters();
   return {

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -7,6 +7,7 @@ import {
   InMemoryUtxoRepository,
   KeyManagement,
   SingleAddressWallet,
+  SingleAddressWalletDependencies,
   UtxoRepository
 } from '../src';
 
@@ -16,6 +17,7 @@ describe('Wallet', () => {
   let keyManager: KeyManagement.KeyManager;
   let provider: CardanoProvider;
   let utxoRepository: UtxoRepository;
+  let walletDependencies: SingleAddressWalletDependencies;
 
   beforeEach(async () => {
     csl = await loadCardanoSerializationLib();
@@ -28,10 +30,11 @@ describe('Wallet', () => {
     provider = providerStub();
     inputSelector = roundRobinRandomImprove(csl);
     utxoRepository = new InMemoryUtxoRepository(csl, provider, keyManager, inputSelector);
+    walletDependencies = { csl, keyManager, provider, utxoRepository };
   });
 
   test('createWallet', async () => {
-    const wallet = await createSingleAddressWallet(csl, provider, keyManager, utxoRepository);
+    const wallet = await createSingleAddressWallet(walletDependencies);
     expect(wallet.address).toBeDefined();
     expect(typeof wallet.initializeTx).toBe('function');
     expect(typeof wallet.signTx).toBe('function');
@@ -50,7 +53,7 @@ describe('Wallet', () => {
     };
 
     beforeEach(async () => {
-      wallet = await createSingleAddressWallet(csl, provider, keyManager, utxoRepository);
+      wallet = await createSingleAddressWallet(walletDependencies);
     });
 
     test('initializeTx', async () => {

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src';
 
 describe('Wallet', () => {
+  const name = 'Test Wallet';
   let csl: CardanoSerializationLib;
   let inputSelector: InputSelector;
   let keyManager: KeyManagement.KeyManager;
@@ -34,8 +35,9 @@ describe('Wallet', () => {
   });
 
   test('createWallet', async () => {
-    const wallet = await createSingleAddressWallet(walletDependencies);
+    const wallet = await createSingleAddressWallet({ name }, walletDependencies);
     expect(wallet.address).toBeDefined();
+    expect(wallet.name).toBe(name);
     expect(typeof wallet.initializeTx).toBe('function');
     expect(typeof wallet.signTx).toBe('function');
   });
@@ -53,7 +55,7 @@ describe('Wallet', () => {
     };
 
     beforeEach(async () => {
-      wallet = await createSingleAddressWallet(walletDependencies);
+      wallet = await createSingleAddressWallet({ name }, walletDependencies);
     });
 
     test('initializeTx', async () => {


### PR DESCRIPTION
# Context
We're missing the wallet name property, and the `createSingleAddressWallet` function interface could be improved before simply adding another property.

# Proposed Solution
Restructure to group dependencies in an object, then add another as the first to carry wallet props.
