### PR TITLE
docs(wallet): add comment to highlight fees being a function of the tx body

### DIFF
--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -19,6 +19,9 @@ async () => {
     withdrawals: [Transaction.withdrawal(csl, keyManager, 5_000_000n)],
     ...
   });
+  
+  // Calculated fee is returned by invoking body.fee()
+  
   const tx = await wallet.signTx(body, hash);
 
   await wallet.submitTx(tx);


### PR DESCRIPTION
# Context
We're missing some direction when it comes to knowing the calculated fees when initialising a transaction.

# Proposed Solution
Add comment to highlight fees being a function of the tx body 
