### PR TITLE
feat(wallet): balance

### DIFF
--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -17,7 +17,7 @@ type EstimateTxFeeWithOriginalOutputs = (utxo: CSL.TransactionUnspentOutput[], c
 interface ChangeComputationArgs {
   csl: CardanoSerializationLib;
   utxoSelection: UtxoSelection;
-  outputValues: Ogmios.util.OgmiosValue[];
+  outputValues: Ogmios.Value[];
   uniqueOutputAssetIDs: string[];
   implicitCoin: ImplicitCoinBigint;
   estimateTxFee: EstimateTxFeeWithOriginalOutputs;
@@ -56,7 +56,7 @@ const getLeftoverAssets = (utxoSelected: UtxoWithValue[], uniqueOutputAssetIDs: 
  */
 const redistributeLeftoverAssets = (
   utxoSelected: UtxoWithValue[],
-  requestedAssetChangeBundles: Ogmios.util.OgmiosValue[],
+  requestedAssetChangeBundles: Ogmios.Value[],
   uniqueOutputAssetIDs: string[]
 ) => {
   const leftovers = getLeftoverAssets(utxoSelected, uniqueOutputAssetIDs);
@@ -87,7 +87,7 @@ const redistributeLeftoverAssets = (
 };
 
 const createBundlePerOutput = (
-  outputValues: Ogmios.util.OgmiosValue[],
+  outputValues: Ogmios.Value[],
   coinTotalRequested: bigint,
   coinChangeTotal: bigint,
   assetTotals: Record<string, { selected: bigint; requested: bigint }>
@@ -100,7 +100,7 @@ const createBundlePerOutput = (
     if (!value.assets) {
       return { coins };
     }
-    const assets: Ogmios.util.TokenMap = {};
+    const assets: Ogmios.TokenMap = {};
     for (const assetId of Object.keys(value.assets)) {
       const outputAmount = value.assets[assetId];
       const { selected, requested } = assetTotals[assetId];
@@ -124,11 +124,11 @@ const createBundlePerOutput = (
  */
 const computeRequestedAssetChangeBundles = (
   utxoSelected: UtxoWithValue[],
-  outputValues: Ogmios.util.OgmiosValue[],
+  outputValues: Ogmios.Value[],
   uniqueOutputAssetIDs: string[],
   implicitCoin: ImplicitCoinBigint,
   fee: bigint
-): Ogmios.util.OgmiosValue[] => {
+): Ogmios.Value[] => {
   const assetTotals: Record<string, { selected: bigint; requested: bigint }> = {};
   for (const assetId of uniqueOutputAssetIDs) {
     assetTotals[assetId] = {
@@ -184,15 +184,15 @@ const pickExtraRandomUtxo = ({ utxoRemaining, utxoSelected }: UtxoSelection): Ut
 
 const coalesceChangeBundlesForMinCoinRequirement = (
   csl: CardanoSerializationLib,
-  changeBundles: Ogmios.util.OgmiosValue[],
+  changeBundles: Ogmios.Value[],
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity
-): Ogmios.util.OgmiosValue[] | undefined => {
+): Ogmios.Value[] | undefined => {
   if (changeBundles.length === 0) {
     return changeBundles;
   }
 
   let sortedBundles = orderBy(changeBundles, ({ coins }) => coins, 'desc');
-  const satisfiesMinCoinRequirement = (valueQuantities: Ogmios.util.OgmiosValue) =>
+  const satisfiesMinCoinRequirement = (valueQuantities: Ogmios.Value) =>
     valueQuantities.coins >= computeMinimumCoinQuantity(Ogmios.ogmiosToCsl(csl).value(valueQuantities).multiasset());
 
   while (sortedBundles.length > 1 && !satisfiesMinCoinRequirement(sortedBundles[sortedBundles.length - 1])) {
@@ -223,12 +223,12 @@ const computeChangeBundles = ({
 }: {
   csl: CardanoSerializationLib;
   utxoSelection: UtxoSelection;
-  outputValues: Ogmios.util.OgmiosValue[];
+  outputValues: Ogmios.Value[];
   uniqueOutputAssetIDs: string[];
   implicitCoin: ImplicitCoinBigint;
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity;
   fee?: bigint;
-}): UtxoSelection & { changeBundles: Ogmios.util.OgmiosValue[] } => {
+}): UtxoSelection & { changeBundles: Ogmios.Value[] } => {
   const requestedAssetChangeBundles = computeRequestedAssetChangeBundles(
     utxoSelection.utxoSelected,
     outputValues,
@@ -269,7 +269,7 @@ const computeChangeBundles = ({
 
 const changeBundlesToValues = (
   csl: CardanoSerializationLib,
-  changeBundles: Ogmios.util.OgmiosValue[],
+  changeBundles: Ogmios.Value[],
   tokenBundleSizeExceedsLimit: TokenBundleSizeExceedsLimit
 ) => {
   const otc = Ogmios.ogmiosToCsl(csl);

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -1,5 +1,5 @@
-import { Lovelace, ProtocolParametersAlonzo } from '@cardano-ogmios/schema';
-import { CSL } from '@cardano-sdk/core';
+import { ProtocolParametersAlonzo } from '@cardano-ogmios/schema';
+import { CSL, Ogmios } from '@cardano-sdk/core';
 
 export interface SelectionSkeleton {
   /**
@@ -74,11 +74,11 @@ export interface ImplicitCoin {
   /**
    * Delegation withdrawals + reclaims
    */
-  input?: Lovelace;
+  input?: Ogmios.Lovelace;
   /**
    * Delegation registration deposit
    */
-  deposit?: Lovelace;
+  deposit?: Ogmios.Lovelace;
 }
 
 export interface InputSelectionParameters {

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -110,8 +110,8 @@ export const assertFailureProperties = ({
   implicitCoin
 }: {
   error: InputSelectionError;
-  utxoAmounts: Ogmios.util.OgmiosValue[];
-  outputsAmounts: Ogmios.util.OgmiosValue[];
+  utxoAmounts: Ogmios.Value[];
+  outputsAmounts: Ogmios.Value[];
   constraints: SelectionConstraints.MockSelectionConstraints;
   implicitCoin?: ImplicitCoin;
 }) => {
@@ -159,11 +159,11 @@ export const generateSelectionParams = (() => {
   /**
    * Generate random amount of coin and assets.
    */
-  const arrayOfCoinAndAssets = (implicitCoin = 0) =>
+  const arrayOfCoinAndAssets = (implicitCoin = 0n) =>
     fc
       .array(
-        fc.record<Ogmios.util.OgmiosValue>({
-          coins: fc.bigUint(cslUtil.MAX_U64 - BigInt(implicitCoin)),
+        fc.record<Ogmios.Value>({
+          coins: fc.bigUint(cslUtil.MAX_U64 - implicitCoin),
           assets: fc.oneof(
             fc
               .set(fc.oneof(...AssetId.All.map((asset) => fc.constant(asset))))
@@ -174,7 +174,7 @@ export const generateSelectionParams = (() => {
                 assets.reduce((quantities, { amount, asset }) => {
                   quantities[asset] = amount;
                   return quantities;
-                }, {} as Ogmios.util.TokenMap)
+                }, {} as Ogmios.TokenMap)
               ),
             fc.constant(void 0)
           )
@@ -196,28 +196,28 @@ export const generateSelectionParams = (() => {
       deposit: fc.oneof(
         fc.constant(void 0),
         fc
-          .tuple(fc.nat(2), fc.nat(2))
-          .map(([numKeyDeposits, numPoolDeposits]) => numKeyDeposits * 2_000_000 + numPoolDeposits * 500_000_000)
+          .tuple(fc.bigUint(2n), fc.bigUint(2n))
+          .map(([numKeyDeposits, numPoolDeposits]) => numKeyDeposits * 2_000_000n + numPoolDeposits * 500_000_000n)
       ),
       input: fc.oneof(
         fc.constant(void 0),
         fc
           .tuple(
-            fc.nat(2),
-            fc.nat(2),
-            fc.oneof(fc.constant(0), fc.constant(1), fc.constant(200_000), fc.constant(2_000_003))
+            fc.bigUint(2n),
+            fc.bigUint(2n),
+            fc.oneof(fc.constant(0n), fc.constant(1n), fc.constant(200_000n), fc.constant(2_000_003n))
           )
           .map(
             ([numKeyDeposits, numPoolDeposits, withdrawals]) =>
-              numKeyDeposits * 2_000_000 + numPoolDeposits * 500_000_000 + withdrawals
+              numKeyDeposits * 2_000_000n + numPoolDeposits * 500_000_000n + withdrawals
           )
       )
     })
   );
 
   return (): Arbitrary<{
-    utxoAmounts: Ogmios.util.OgmiosValue[];
-    outputsAmounts: Ogmios.util.OgmiosValue[];
+    utxoAmounts: Ogmios.Value[];
+    outputsAmounts: Ogmios.Value[];
     constraints: SelectionConstraints.MockSelectionConstraints;
     implicitCoin?: ImplicitCoin;
   }> =>

--- a/packages/core/src/CSL/util.ts
+++ b/packages/core/src/CSL/util.ts
@@ -2,3 +2,18 @@ import { CardanoSerializationLib } from './loadCardanoSerializationLib';
 
 export const MAX_U64 = 18_446_744_073_709_551_615n;
 export const maxBigNum = (csl: CardanoSerializationLib) => csl.BigNum.from_str(MAX_U64.toString());
+
+export type CslObject = { to_bytes: () => Uint8Array };
+
+/**
+ * Check if serialized CSL objects are equal by comparing their byte representations
+ *
+ * @returns {boolean} true if objects are equal, false otherwise
+ */
+export const bytewiseEquals = (obj1: CslObject, obj2: CslObject) => {
+  if (obj1 === obj2) return true;
+  const obj1Bytes = obj1.to_bytes();
+  const obj2Bytes = obj2.to_bytes();
+  if (obj1Bytes.length !== obj2Bytes.length) return false;
+  return obj1Bytes.every((byte, idx) => obj2Bytes[idx] === byte);
+};

--- a/packages/core/src/Ogmios/cslToOgmios.ts
+++ b/packages/core/src/Ogmios/cslToOgmios.ts
@@ -1,14 +1,10 @@
 import { TxIn } from '@cardano-ogmios/schema';
 import { Asset } from '..';
 import { CSL } from '../CSL';
-import { OgmiosValue } from './util';
+import { Value } from './types';
 
-/**
- * OgmiosValue is currently incompatible with Ogmios.Value due to 'coins' type (bigint vs number).
- * TODO: Use Ogmios.Value when ogmios updates lovelace type to bigint
- */
-export const value = (cslValue: CSL.Value): OgmiosValue => {
-  const result: OgmiosValue = {
+export const value = (cslValue: CSL.Value): Value => {
+  const result: Value = {
     coins: BigInt(cslValue.coin().to_str())
   };
   const multiasset = cslValue.multiasset();

--- a/packages/core/src/Ogmios/index.ts
+++ b/packages/core/src/Ogmios/index.ts
@@ -1,3 +1,4 @@
 export * from './ogmiosToCsl';
 export * as cslToOgmios from './cslToOgmios';
 export * as util from './util';
+export * from './types';

--- a/packages/core/src/Ogmios/ogmiosToCsl.ts
+++ b/packages/core/src/Ogmios/ogmiosToCsl.ts
@@ -2,7 +2,7 @@ import { CardanoSerializationLib, CSL } from '../CSL';
 import OgmiosSchema from '@cardano-ogmios/schema';
 import { Buffer } from 'buffer';
 import * as Asset from '../Asset';
-import { OgmiosValue } from './util';
+import { Value } from './types';
 
 export const ogmiosToCsl = (csl: CardanoSerializationLib) => ({
   txIn: (ogmios: OgmiosSchema.TxIn): CSL.TransactionInput =>
@@ -14,7 +14,7 @@ export const ogmiosToCsl = (csl: CardanoSerializationLib) => ({
       csl.TransactionUnspentOutput.new(ogmiosToCsl(csl).txIn(item[0]), ogmiosToCsl(csl).txOut(item[1]))
     ),
   // TODO: Keep only OgmiosSchema.Value when ogmios updates lovelace type to bigint
-  value: ({ coins, assets }: OgmiosValue | OgmiosSchema.Value): CSL.Value => {
+  value: ({ coins, assets }: Value | OgmiosSchema.Value): CSL.Value => {
     const value = csl.Value.new(csl.BigNum.from_str(coins.toString()));
     if (!assets) {
       return value;

--- a/packages/core/src/Ogmios/types.ts
+++ b/packages/core/src/Ogmios/types.ts
@@ -1,0 +1,25 @@
+import { PoolId, Value as _OgmiosValue } from '@cardano-ogmios/schema';
+
+export type Lovelace = bigint;
+
+/**
+ * {[assetId]: amount}
+ */
+export type TokenMap = NonNullable<_OgmiosValue['assets']>;
+
+/**
+ * Total quantities of Coin and Assets in a Value.
+ * TODO: Use Ogmios Value type after it changes lovelaces to bigint;
+ */
+export interface Value {
+  coins: Lovelace;
+  assets?: TokenMap;
+}
+
+/**
+ * TODO: Use Ogmios type after it changes lovelaces to bigint;
+ */
+export interface DelegationsAndRewards {
+  delegate?: PoolId;
+  rewards?: Lovelace;
+}

--- a/packages/core/src/Ogmios/util.ts
+++ b/packages/core/src/Ogmios/util.ts
@@ -1,19 +1,5 @@
-import { Value as _OgmiosValue } from '@cardano-ogmios/schema';
 import { BigIntMath } from '../util/BigIntMath';
-
-/**
- * {[assetId]: amount}
- */
-export type TokenMap = NonNullable<_OgmiosValue['assets']>;
-
-/**
- * Total quantities of Coin and Assets in a Value.
- * TODO: Use Ogmios Value type after it changes lovelaces to bigint;
- */
-export interface OgmiosValue {
-  coins: bigint;
-  assets?: TokenMap;
-}
+import { Value, TokenMap } from './types';
 
 /**
  * Sum asset quantities
@@ -34,7 +20,7 @@ const coalesceTokenMaps = (totals: (TokenMap | undefined)[]): TokenMap | undefin
 /**
  * Sum all quantities
  */
-export const coalesceValueQuantities = (quantities: OgmiosValue[]): OgmiosValue => ({
+export const coalesceValueQuantities = (quantities: Value[]): Value => ({
   coins: BigIntMath.sum(quantities.map(({ coins }) => coins)),
   assets: coalesceTokenMaps(quantities.map(({ assets }) => assets))
 });

--- a/packages/core/src/Provider/types.ts
+++ b/packages/core/src/Provider/types.ts
@@ -1,6 +1,6 @@
 import { CSL } from '../CSL';
 import Cardano, { ProtocolParametersAlonzo } from '@cardano-ogmios/schema';
-import { Transaction } from '..';
+import { Ogmios, Transaction } from '..';
 
 export type ProtocolParametersRequiredByWallet = Pick<
   ProtocolParametersAlonzo,
@@ -16,18 +16,15 @@ export type ProtocolParametersRequiredByWallet = Pick<
   | 'protocolVersion'
 >;
 
-// Todo: Use Cardano.Lovelace when type is updated
-type Lovelace = bigint;
-
 export type AssetSupply = {
-  circulating: Lovelace;
-  max: Lovelace;
-  total: Lovelace;
+  circulating: Ogmios.Lovelace;
+  max: Ogmios.Lovelace;
+  total: Ogmios.Lovelace;
 };
 
 export type StakeSummary = {
-  active: Lovelace;
-  live: Lovelace;
+  active: Ogmios.Lovelace;
+  live: Ogmios.Lovelace;
 };
 
 export type StakePoolStats = {

--- a/packages/core/test/CSL/util.test.ts
+++ b/packages/core/test/CSL/util.test.ts
@@ -1,0 +1,25 @@
+import { cslUtil } from '../../src';
+
+describe('cslUtil', () => {
+  describe('bytewiseEquals', () => {
+    it('returns true if the two CSL objects have equal byte representation', () => {
+      expect(
+        cslUtil.bytewiseEquals({ to_bytes: () => new Uint8Array([1, 2]) }, { to_bytes: () => new Uint8Array([1, 2]) })
+      ).toBe(true);
+    });
+
+    describe('false', () => {
+      it('returns false if the two CSL objects have different byte lengths', () => {
+        expect(
+          cslUtil.bytewiseEquals({ to_bytes: () => new Uint8Array([1, 2]) }, { to_bytes: () => new Uint8Array([1]) })
+        ).toBe(false);
+      });
+
+      it('returns false if the two CSL objects have different byte representations', () => {
+        expect(
+          cslUtil.bytewiseEquals({ to_bytes: () => new Uint8Array([1, 2]) }, { to_bytes: () => new Uint8Array([1, 3]) })
+        ).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/core/test/Ogmios/util.test.ts
+++ b/packages/core/test/Ogmios/util.test.ts
@@ -1,25 +1,26 @@
-import { coalesceValueQuantities, OgmiosValue } from '../../src/Ogmios/util';
+import { coalesceValueQuantities } from '../../src/Ogmios/util';
+import { Value } from '../../src/Ogmios/types';
 
 describe('Ogmios', () => {
   describe('util', () => {
     describe('coalesceValueQuantities', () => {
       it('coin only', () => {
-        const q1: OgmiosValue = { coins: 50n };
-        const q2: OgmiosValue = { coins: 100n };
+        const q1: Value = { coins: 50n };
+        const q2: Value = { coins: 100n };
         expect(coalesceValueQuantities([q1, q2])).toEqual({ coins: 150n });
       });
       it('coin and assets', () => {
         const TSLA_Asset = 'b32_1vk0jj9lmv0cjkvmxw337u467atqcgkauwd4eczaugzagyghp25lTSLA';
         const PXL_Asset = 'b32_1rmy9mnhz0ukepmqlng0yee62ve7un05trpzxxg3lnjtqzp4dmmrPXL';
-        const q1: OgmiosValue = {
+        const q1: Value = {
           coins: 50n,
           assets: {
             [TSLA_Asset]: 50n,
             [PXL_Asset]: 100n
           }
         };
-        const q2: OgmiosValue = { coins: 100n };
-        const q3: OgmiosValue = {
+        const q2: Value = { coins: 100n };
+        const q3: Value = {
           coins: 20n,
           assets: {
             [TSLA_Asset]: 20n

--- a/packages/util-dev/src/cslTestUtil.ts
+++ b/packages/util-dev/src/cslTestUtil.ts
@@ -11,7 +11,7 @@ export const createTxInput = (() => {
 
 export const createUnspentTxOutput = (
   csl: CardanoSerializationLib,
-  valueQuantities: Ogmios.util.OgmiosValue,
+  valueQuantities: Ogmios.Value,
   bech32Addr = 'addr1vy36kffjf87vzkuyqc5g0ys3fe3pez5zvqg9r5z9q9kfrkg2cs093'
 ): CSL.TransactionUnspentOutput => {
   const address = csl.Address.from_bech32(bech32Addr);
@@ -21,7 +21,7 @@ export const createUnspentTxOutput = (
 
 export const createOutput = (
   csl: CardanoSerializationLib,
-  valueQuantities: Ogmios.util.OgmiosValue,
+  valueQuantities: Ogmios.Value,
   bech32Addr = 'addr1vyeljkh3vr4h9s3lyxe7g2meushk3m4nwyzdgtlg96e6mrgg8fnle'
 ): CSL.TransactionOutput =>
   csl.TransactionOutput.new(csl.Address.from_bech32(bech32Addr), Ogmios.ogmiosToCsl(csl).value(valueQuantities));

--- a/packages/wallet/src/BalanceTracker.ts
+++ b/packages/wallet/src/BalanceTracker.ts
@@ -1,0 +1,39 @@
+import { Ogmios } from '@cardano-sdk/core';
+
+export interface Balance extends Ogmios.Value {
+  rewards: Ogmios.Lovelace;
+}
+
+export interface Balances {
+  total: Balance;
+  available: Balance;
+}
+
+export interface BalanceTrackerEvents {
+  balanceChanged: Balances;
+}
+
+// export class BalanceTracker extends Emittery<BalanceTrackerEvents> implements Balances {
+//   total: Balance;
+//   available: Balance;
+
+//   constructor(utxoRepository: UtxoRepository) {
+//     super();
+//     const totalValue = this.#getBalance(utxoRepository.allUtxos);
+//     const availableValue = this.#getBalance(utxoRepository.availableUtxos);
+//     const totalRewards = utxoRepository.rewards;
+//     const availableRewards = utxoRepository.availableRewards;
+//   }
+
+//   #getBalance(utxo: Utxo): Ogmios.Value {
+//     return Ogmios.util.coalesceValueQuantities(
+//       utxo.map(([_, txOut]) => {
+//         const { coins, assets } = txOut.value;
+//         return {
+//           coins: BigInt(coins),
+//           assets
+//         };
+//       })
+//     );
+//   }
+// }

--- a/packages/wallet/src/InMemoryUtxoRepository.ts
+++ b/packages/wallet/src/InMemoryUtxoRepository.ts
@@ -30,7 +30,7 @@ const utxoEquals = ([txIn1]: [Schema.TxIn, Schema.TxOut], [txIn2]: [Schema.TxIn,
 
 export class InMemoryUtxoRepository extends Emittery<UtxoRepositoryEvents> implements UtxoRepository {
   #csl: CardanoSerializationLib;
-  #delegationAndRewards: Schema.DelegationsAndRewards;
+  #delegationAndRewards: Ogmios.DelegationsAndRewards;
   #inputSelector: InputSelector;
   #keyManager: KeyManager;
   #logger: Logger;
@@ -84,7 +84,9 @@ export class InMemoryUtxoRepository extends Emittery<UtxoRepositoryEvents> imple
       this.#logger.debug('Delegation stored', result.delegationAndRewards.delegate);
     }
     if (this.#delegationAndRewards.rewards !== result.delegationAndRewards.rewards) {
-      this.#delegationAndRewards.rewards = result.delegationAndRewards.rewards;
+      this.#delegationAndRewards.rewards = result.delegationAndRewards.rewards
+        ? BigInt(result.delegationAndRewards.rewards)
+        : undefined;
       this.#logger.debug('Rewards balance stored', result.delegationAndRewards.rewards);
     }
   }
@@ -114,7 +116,7 @@ export class InMemoryUtxoRepository extends Emittery<UtxoRepositoryEvents> imple
     return this.allUtxos.filter((utxo) => !this.#lockedUtxoSet.has(utxo));
   }
 
-  public get rewards(): Schema.Lovelace | null {
+  public get rewards(): Ogmios.Lovelace | null {
     return this.#delegationAndRewards.rewards ?? null;
   }
 

--- a/packages/wallet/src/Transaction/CertificateFactory.ts
+++ b/packages/wallet/src/Transaction/CertificateFactory.ts
@@ -1,5 +1,5 @@
-import { Lovelace, ByName } from '@cardano-ogmios/schema';
-import { CardanoSerializationLib, CSL, NotImplementedError } from '@cardano-sdk/core';
+import { ByName } from '@cardano-ogmios/schema';
+import { CardanoSerializationLib, CSL, NotImplementedError, Ogmios } from '@cardano-sdk/core';
 import { KeyManager } from '../KeyManagement';
 
 export type Ed25519KeyHashBech32 = string;
@@ -38,8 +38,8 @@ interface PoolMetadata {
 interface PoolParameters {
   poolKeyHash: Ed25519KeyHashBech32;
   vrfKeyHash: VrfKeyHashBech32;
-  pledge: Lovelace;
-  cost: Lovelace;
+  pledge: Ogmios.Lovelace;
+  cost: Ogmios.Lovelace;
   margin: Ratio;
   rewardAddress: AddressBech32;
   owners: Ed25519KeyHashBech32[];

--- a/packages/wallet/src/Transaction/withdrawal.ts
+++ b/packages/wallet/src/Transaction/withdrawal.ts
@@ -1,5 +1,4 @@
-import { Lovelace } from '@cardano-ogmios/schema';
-import { Cardano, CardanoSerializationLib, CSL } from '@cardano-sdk/core';
+import { Cardano, CardanoSerializationLib, CSL, Ogmios } from '@cardano-sdk/core';
 import { KeyManager } from '../KeyManagement';
 
 export type Withdrawal = {
@@ -10,7 +9,7 @@ export type Withdrawal = {
 export const withdrawal = (
   csl: CardanoSerializationLib,
   keyManager: KeyManager,
-  quantity: Lovelace,
+  quantity: Ogmios.Lovelace,
   network: number = Cardano.NetworkId.mainnet
 ): Withdrawal => ({
   address: csl.RewardAddress.new(network, csl.StakeCredential.from_keyhash(keyManager.stakeKey.hash())),

--- a/packages/wallet/src/TransactionError.ts
+++ b/packages/wallet/src/TransactionError.ts
@@ -1,6 +1,7 @@
 import { CustomError } from 'ts-custom-error';
 
 export enum TransactionFailure {
+  InvalidTransaction = 'INVALID_TRANSACTION',
   FailedToSubmit = 'FAILED_TO_SUBMIT',
   Unknown = 'UNKNOWN',
   CannotTrack = 'CANNOT_TRACK',

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -6,3 +6,4 @@ export * as KeyManagement from './KeyManagement';
 export * from './SingleAddressWallet';
 export * from './types';
 export * from './TransactionError';
+export * from './BalanceTracker';

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -4,36 +4,32 @@ import { CSL, Ogmios } from '@cardano-sdk/core';
 import Emittery from 'emittery';
 
 export enum UtxoRepositoryEvent {
-  OutOfSync = 'out-of-sync',
-  UtxoChanged = 'utxo-changed',
-  RewardsChanged = 'rewards-changed'
+  Changed = 'changed',
+  OutOfSync = 'out-of-sync'
 }
 
-export type UtxoRepositoryEvents = {
-  'out-of-sync': void;
-  'transaction-untracked': CSL.Transaction;
-  'utxo-changed': {
-    allUtxos: Schema.Utxo;
-    availableUtxos: Schema.Utxo;
-  };
-  'rewards-changed': {
-    allRewards: Schema.Lovelace;
-    availableRewards: Ogmios.Lovelace;
-  };
-};
-export interface UtxoRepository extends Emittery<UtxoRepositoryEvents> {
+export interface UtxoRepositoryFields {
   allUtxos: Schema.Utxo;
   availableUtxos: Schema.Utxo;
   allRewards: Ogmios.Lovelace | null;
   availableRewards: Ogmios.Lovelace | null;
   delegation: Schema.PoolId | null;
+}
+
+export type UtxoRepositoryEvents = {
+  changed: UtxoRepositoryFields;
+  'out-of-sync': void;
+  'transaction-untracked': CSL.Transaction;
+};
+export type UtxoRepository = {
   sync: () => Promise<void>;
   selectInputs: (
     outputs: Set<CSL.TransactionOutput>,
     constraints: SelectionConstraints,
     implicitCoin?: ImplicitCoin
   ) => Promise<SelectionResult>;
-}
+} & UtxoRepositoryFields &
+  Emittery<UtxoRepositoryEvents>;
 
 export interface OnTransactionArgs {
   transaction: CSL.Transaction;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,6 +1,6 @@
 import Schema from '@cardano-ogmios/schema';
 import { ImplicitCoin, SelectionConstraints, SelectionResult } from '@cardano-sdk/cip2';
-import { CSL } from '@cardano-sdk/core';
+import { CSL, Ogmios } from '@cardano-sdk/core';
 import Emittery from 'emittery';
 
 export enum UtxoRepositoryEvent {
@@ -11,7 +11,7 @@ export type UtxoRepositoryEvents = { 'transaction-untracked': CSL.Transaction };
 export interface UtxoRepository extends Emittery<UtxoRepositoryEvents> {
   allUtxos: Schema.Utxo;
   availableUtxos: Schema.Utxo;
-  rewards: Schema.Lovelace | null;
+  rewards: Ogmios.Lovelace | null;
   delegation: Schema.PoolId | null;
   sync: () => Promise<void>;
   selectInputs: (

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -4,14 +4,28 @@ import { CSL, Ogmios } from '@cardano-sdk/core';
 import Emittery from 'emittery';
 
 export enum UtxoRepositoryEvent {
-  TransactionUntracked = 'transaction-untracked'
+  OutOfSync = 'out-of-sync',
+  UtxoChanged = 'utxo-changed',
+  RewardsChanged = 'rewards-changed'
 }
 
-export type UtxoRepositoryEvents = { 'transaction-untracked': CSL.Transaction };
+export type UtxoRepositoryEvents = {
+  'out-of-sync': void;
+  'transaction-untracked': CSL.Transaction;
+  'utxo-changed': {
+    allUtxos: Schema.Utxo;
+    availableUtxos: Schema.Utxo;
+  };
+  'rewards-changed': {
+    allRewards: Schema.Lovelace;
+    availableRewards: Ogmios.Lovelace;
+  };
+};
 export interface UtxoRepository extends Emittery<UtxoRepositoryEvents> {
   allUtxos: Schema.Utxo;
   availableUtxos: Schema.Utxo;
-  rewards: Ogmios.Lovelace | null;
+  allRewards: Ogmios.Lovelace | null;
+  availableRewards: Ogmios.Lovelace | null;
   delegation: Schema.PoolId | null;
   sync: () => Promise<void>;
   selectInputs: (

--- a/packages/wallet/test/BalanceTracker.test.ts
+++ b/packages/wallet/test/BalanceTracker.test.ts
@@ -1,0 +1,44 @@
+import { Ogmios } from '@cardano-sdk/core';
+import { MockUtxoRepository } from './mocks';
+import { BalanceTracker, UtxoRepositoryEvent, UtxoRepositoryFields } from '../src';
+
+const numAssets = (tokenMap?: Ogmios.TokenMap) => Object.keys(tokenMap || {}).length;
+
+describe('BalanceTracker', () => {
+  let balanceTracker: BalanceTracker;
+  let utxoRepository: MockUtxoRepository;
+
+  beforeEach(() => {
+    utxoRepository = new MockUtxoRepository();
+    balanceTracker = new BalanceTracker(utxoRepository);
+  });
+
+  it('constructor sets balances from utxo repository', () => {
+    expect(balanceTracker.total.coins).toBeGreaterThan(0n);
+    expect(balanceTracker.total.assets).toBeTruthy();
+    expect(balanceTracker.total.rewards).toBeGreaterThan(0n);
+  });
+
+  it('updates balances on UtxoRepositoryEvent.Changed', async () => {
+    const totalBefore = balanceTracker.total;
+
+    const allRewards = utxoRepository.allRewards - 1n;
+    const availableRewards = utxoRepository.allRewards - 2n;
+    await utxoRepository.emit(UtxoRepositoryEvent.Changed, {
+      allUtxos: utxoRepository.allUtxos.slice(1),
+      availableUtxos: utxoRepository.allUtxos.slice(2),
+      allRewards,
+      availableRewards,
+      delegation: null
+    } as UtxoRepositoryFields);
+
+    expect(balanceTracker.total.coins).toBeLessThan(totalBefore.coins);
+    expect(balanceTracker.total.coins).toBeGreaterThan(balanceTracker.available.coins);
+
+    expect(numAssets(balanceTracker.total.assets)).toBeLessThan(numAssets(totalBefore.assets));
+    expect(numAssets(balanceTracker.total.assets)).toBeGreaterThan(numAssets(balanceTracker.available.assets));
+
+    expect(balanceTracker.total.rewards).toBe(allRewards);
+    expect(balanceTracker.available.rewards).toBe(availableRewards);
+  });
+});

--- a/packages/wallet/test/InMemoryTransactionTracker.test.ts
+++ b/packages/wallet/test/InMemoryTransactionTracker.test.ts
@@ -1,6 +1,6 @@
 import { CardanoSerializationLib, CSL, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { dummyLogger } from 'ts-log';
-import { ledgerTip, providerStub, ProviderStub, queryTransactionsResult } from './ProviderStub';
+import { ledgerTip, providerStub, ProviderStub, queryTransactionsResult } from './mocks';
 import mockDelay from 'delay';
 import { TransactionTrackerEvent, InMemoryTransactionTracker, TransactionFailure } from '../src';
 

--- a/packages/wallet/test/ProviderStub.ts
+++ b/packages/wallet/test/ProviderStub.ts
@@ -49,7 +49,7 @@ export const utxo: Schema.Utxo = [
 ];
 
 export const delegate = 'pool185g59xpqzt7gf0ljr8v8f3akl95qnmardf2f8auwr3ffx7atjj5';
-export const rewards = 33_333;
+export const rewards = 33_333n;
 export const delegationAndRewards = { delegate, rewards };
 
 export const queryTransactionsResult = [

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { loadCardanoSerializationLib, CardanoSerializationLib, Cardano } from '@cardano-sdk/core';
 import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/cip2';
-import { ProviderStub, providerStub } from './ProviderStub';
+import { ProviderStub, providerStub, txTracker } from './mocks';
 import {
   createSingleAddressWallet,
   InMemoryUtxoRepository,
@@ -10,7 +10,6 @@ import {
   SingleAddressWalletDependencies,
   UtxoRepository
 } from '../src';
-import { txTracker } from './mockTransactionTracker';
 
 describe('Wallet', () => {
   const name = 'Test Wallet';

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -3,6 +3,7 @@ import { loadCardanoSerializationLib, CardanoSerializationLib, Cardano } from '@
 import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/cip2';
 import { ProviderStub, providerStub, txTracker } from './mocks';
 import {
+  BalanceTracker,
   createSingleAddressWallet,
   InMemoryUtxoRepository,
   KeyManagement,
@@ -40,6 +41,7 @@ describe('Wallet', () => {
     expect(wallet.name).toBe(name);
     expect(typeof wallet.initializeTx).toBe('function');
     expect(typeof wallet.signTx).toBe('function');
+    expect(wallet.balance).toBeInstanceOf(BalanceTracker);
   });
 
   describe('wallet behaviour', () => {

--- a/packages/wallet/test/Transaction/CertificateFactory.test.ts
+++ b/packages/wallet/test/Transaction/CertificateFactory.test.ts
@@ -43,8 +43,8 @@ describe('Transaction.CertificateFactory', () => {
     };
     const params = certs
       .poolRegistration({
-        cost: 1000,
-        pledge: 10_000,
+        cost: 1000n,
+        pledge: 10_000n,
         margin: { denominator: 5, numerator: 1 },
         owners: [owner],
         poolKeyHash: stakeKey,

--- a/packages/wallet/test/Transaction/CertificateFactory.test.ts
+++ b/packages/wallet/test/Transaction/CertificateFactory.test.ts
@@ -1,5 +1,5 @@
 import { CardanoSerializationLib, loadCardanoSerializationLib } from '@cardano-sdk/core';
-import { testKeyManager } from '../testKeyManager';
+import { testKeyManager } from '../mocks';
 import { CertificateFactory } from '../../src/Transaction';
 import { KeyManager } from '../../src/KeyManagement';
 

--- a/packages/wallet/test/Transaction/computeImplicitCoin.test.ts
+++ b/packages/wallet/test/Transaction/computeImplicitCoin.test.ts
@@ -16,11 +16,11 @@ describe('Transaction.computeImplicitCoin', () => {
       certs.poolRetirement(keyManager.stakeKey.hash().to_bech32('key'), 1000),
       certs.stakeDelegation('pool1qqvukkkfr3ux4qylfkrky23f6trl2l6xjluv36z90ax7gfa8yxt')
     ];
-    const withdrawals = [Transaction.withdrawal(csl, keyManager, 5)];
+    const withdrawals = [Transaction.withdrawal(csl, keyManager, 5n)];
     const txProps = { certificates, withdrawals } as unknown as InitializeTxProps;
 
     const coin = Transaction.computeImplicitCoin(protocolParameters, txProps);
-    expect(coin.deposit).toBe(2 + 2);
-    expect(coin.input).toBe(2 + 3 + 5);
+    expect(coin.deposit).toBe(2n + 2n);
+    expect(coin.input).toBe(2n + 3n + 5n);
   });
 });

--- a/packages/wallet/test/Transaction/computeImplicitCoin.test.ts
+++ b/packages/wallet/test/Transaction/computeImplicitCoin.test.ts
@@ -1,5 +1,5 @@
 import { loadCardanoSerializationLib, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
-import { testKeyManager } from '../testKeyManager';
+import { testKeyManager } from '../mocks';
 import { Transaction } from '../../src';
 import { InitializeTxProps } from '../../src/Transaction';
 

--- a/packages/wallet/test/Transaction/createTransactionInternals.test.ts
+++ b/packages/wallet/test/Transaction/createTransactionInternals.test.ts
@@ -1,18 +1,14 @@
 import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/cip2';
 import { loadCardanoSerializationLib, CardanoSerializationLib, CSL, CardanoProvider, Ogmios } from '@cardano-sdk/core';
 import { SelectionConstraints } from '@cardano-sdk/util-dev';
-import { providerStub } from '../ProviderStub';
+import { providerStub, txTracker, testKeyManager } from '../mocks';
 import {
   CertificateFactory,
   createTransactionInternals,
   CreateTxInternalsProps,
   Withdrawal
 } from '../../src/Transaction';
-import { KeyManager } from '../../src/KeyManagement';
-import { testKeyManager } from '../testKeyManager';
-import { UtxoRepository } from '../../src/types';
-import { InMemoryUtxoRepository } from '../../src/InMemoryUtxoRepository';
-import { txTracker } from '../mockTransactionTracker';
+import { UtxoRepository, InMemoryUtxoRepository, KeyManagement } from '../../src';
 
 const address =
   'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g';
@@ -22,7 +18,7 @@ describe('Transaction.createTransactionInternals', () => {
   let provider: CardanoProvider;
   let inputSelector: InputSelector;
   let utxoRepository: UtxoRepository;
-  let keyManager: KeyManager;
+  let keyManager: KeyManagement.KeyManager;
   let outputs: Set<CSL.TransactionOutput>;
 
   const createSimpleTransactionInternals = async (props?: Partial<CreateTxInternalsProps>) => {

--- a/packages/wallet/test/Transaction/withdrawal.test.ts
+++ b/packages/wallet/test/Transaction/withdrawal.test.ts
@@ -1,5 +1,5 @@
 import { loadCardanoSerializationLib } from '@cardano-sdk/core';
-import { testKeyManager } from '../testKeyManager';
+import { testKeyManager } from '../mocks';
 import { Transaction } from '../../src';
 
 describe('Transaction.withdrawal', () => {

--- a/packages/wallet/test/Transaction/withdrawal.test.ts
+++ b/packages/wallet/test/Transaction/withdrawal.test.ts
@@ -6,7 +6,7 @@ describe('Transaction.withdrawal', () => {
   it('creates objects of correct types', async () => {
     const csl = await loadCardanoSerializationLib();
     const keyManager = await testKeyManager(csl);
-    const withdrawal = Transaction.withdrawal(csl, keyManager, 5000);
+    const withdrawal = Transaction.withdrawal(csl, keyManager, 5000n);
     expect(withdrawal.address).toBeInstanceOf(csl.RewardAddress);
     expect(withdrawal.quantity).toBeInstanceOf(csl.BigNum);
   });

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-fallthrough */
 import { roundRobinRandomImprove } from '@cardano-sdk/cip2';
 import { Cardano, CardanoSerializationLib, loadCardanoSerializationLib } from '@cardano-sdk/core';
 import {
@@ -34,7 +35,7 @@ describe('integration/withdrawal', () => {
     keyManager = KeyManagement.createInMemoryKeyManager({ csl, mnemonicWords, password, networkId });
     const provider = providerStub();
     const inputSelector = roundRobinRandomImprove(csl);
-    txTracker = new InMemoryTransactionTracker({ csl, provider });
+    txTracker = new InMemoryTransactionTracker({ csl, provider, pollInterval: 1 });
     utxoRepository = new InMemoryUtxoRepository({ csl, provider, txTracker, inputSelector, keyManager });
     wallet = await createSingleAddressWallet(walletProps, {
       csl,
@@ -49,34 +50,45 @@ describe('integration/withdrawal', () => {
   });
 
   it('does not throw', async () => {
-    // This is not testing anything, just a usage example
-    utxoRepository.on(UtxoRepositoryEvent.TransactionUntracked, (tx) => {
-      // UtxoRepository is not sure whether it's UTxO can be spent due to failing to track transaction confirmation.
-      // SubmitTxResult.confirmed has rejected. Calling track() will lock UTxO again:
-      txTracker.track(tx).catch((error) => {
-        /* eslint-disable-next-line sonarjs/no-all-duplicated-branches */
-        if (error instanceof TransactionError && error.reason === TransactionFailure.Timeout) {
-          // Transaction has expired and will not be confirmed. Therefore it's safe to spend the UTxO again.
-        } else {
-          // Probably wait a little bit and retry
-        }
-      });
+    utxoRepository.on(UtxoRepositoryEvent.OutOfSync, () => {
+      // This is emitted when cardano-js-sdk calls sync() internally and it fails.
+      // User should attempt to resync using utxoRepository.sync()
     });
 
     const certFactory = new Transaction.CertificateFactory(csl, keyManager);
 
     const { body, hash } = await wallet.initializeTx({
       certificates: [certFactory.stakeKeyDeregistration()],
-      withdrawals: [Transaction.withdrawal(csl, keyManager, utxoRepository.rewards || 0n)],
+      withdrawals: [Transaction.withdrawal(csl, keyManager, utxoRepository.availableRewards || 0n)],
       outputs: new Set() // In a real transaction you would probably want to have some outputs
     });
     // Calculated fee is returned by invoking body.fee()
     const tx = await wallet.signTx(body, hash);
 
     const { submitted, confirmed } = wallet.submitTx(tx);
-    // Transaction is submitting. UTxO is locked.
-    await submitted;
-    // Transaction is successfully submitted, but not confirmed yet
-    await confirmed;
+    try {
+      // Transaction is submitting. UTxO is locked.
+      await submitted;
+      // Transaction is successfully submitted, but not confirmed yet
+      await confirmed;
+    } catch (error) {
+      if (error instanceof TransactionError) {
+        switch (error.reason) {
+          case TransactionFailure.InvalidTransaction:
+          // Invalid transaction, probably no validity interval set
+          case TransactionFailure.Timeout:
+          // Transaction has expired and will not be confirmed. Therefore it's safe to spend the UTxO again.
+          case TransactionFailure.FailedToSubmit:
+          // Probably attempt to resubmit
+          case TransactionFailure.CannotTrack:
+          // Failed when attempting to track transaction confirmation.
+          // Probably just attempt to track it again by calling txTracker.track(tx)
+          case TransactionFailure.Unknown:
+          // Most likely a bug in cardano-js-sdk
+        }
+      } else {
+        // Most likely a bug in cardano-js-sdk
+      }
+    }
   });
 });

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -67,7 +67,7 @@ describe('integration/withdrawal', () => {
 
     const { body, hash } = await wallet.initializeTx({
       certificates: [certFactory.stakeKeyDeregistration()],
-      withdrawals: [Transaction.withdrawal(csl, keyManager, utxoRepository.rewards || 0)],
+      withdrawals: [Transaction.withdrawal(csl, keyManager, utxoRepository.rewards || 0n)],
       outputs: new Set() // In a real transaction you would probably want to have some outputs
     });
     // Calculated fee is returned by invoking body.fee()

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -16,7 +16,7 @@ import {
   UtxoRepositoryEvent
 } from '@cardano-sdk/wallet';
 // Not testing with a real provider
-import { providerStub } from '../ProviderStub';
+import { providerStub } from '../mocks';
 
 const walletProps: SingleAddressWalletProps = { name: 'some-wallet' };
 const networkId = Cardano.NetworkId.mainnet;

--- a/packages/wallet/test/mocks/MockTransactionTracker.ts
+++ b/packages/wallet/test/mocks/MockTransactionTracker.ts
@@ -1,5 +1,5 @@
 import Emittery from 'emittery';
-import { TransactionTrackerEvents } from '../src';
+import { TransactionTrackerEvents } from '../../src';
 
 export class MockTransactionTracker extends Emittery<TransactionTrackerEvents> {
   track = jest.fn();

--- a/packages/wallet/test/mocks/MockUtxoRepository.ts
+++ b/packages/wallet/test/mocks/MockUtxoRepository.ts
@@ -1,0 +1,13 @@
+import Emittery from 'emittery';
+import { delegate, rewards, utxo } from './ProviderStub';
+import { UtxoRepository, UtxoRepositoryEvents } from '../../src';
+
+export class MockUtxoRepository extends Emittery<UtxoRepositoryEvents> implements UtxoRepository {
+  sync = jest.fn().mockResolvedValue(void 0);
+  selectInputs = jest.fn();
+  allUtxos = utxo;
+  availableUtxos = utxo;
+  allRewards = rewards;
+  availableRewards = rewards;
+  delegation = delegate;
+}

--- a/packages/wallet/test/mocks/ProviderStub.ts
+++ b/packages/wallet/test/mocks/ProviderStub.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 import * as Schema from '@cardano-ogmios/schema';
+import { PXL, TSLA } from '@cardano-sdk/util-dev/src/assetId';
 
 export const stakeKeyHash = 'stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d';
 
@@ -13,7 +14,11 @@ export const utxo: Schema.Utxo = [
       address:
         'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
       value: {
-        coins: 4_027_026_465
+        coins: 4_027_026_465,
+        assets: {
+          [TSLA]: 10n,
+          [PXL]: 5n
+        }
       },
       datum: null
     }
@@ -27,7 +32,10 @@ export const utxo: Schema.Utxo = [
       address:
         'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g',
       value: {
-        coins: 3_289_566
+        coins: 3_289_566,
+        assets: {
+          [TSLA]: 15n
+        }
       },
       datum: null
     }

--- a/packages/wallet/test/mocks/index.ts
+++ b/packages/wallet/test/mocks/index.ts
@@ -1,0 +1,4 @@
+export * from './ProviderStub';
+export * from './MockUtxoRepository';
+export * from './MockTransactionTracker';
+export * from './testKeyManager';

--- a/packages/wallet/test/mocks/testKeyManager.ts
+++ b/packages/wallet/test/mocks/testKeyManager.ts
@@ -1,5 +1,5 @@
 import { Cardano, CardanoSerializationLib } from '@cardano-sdk/core';
-import { KeyManagement } from '../src';
+import { KeyManagement } from '../../src';
 
 export const testKeyManager = (csl: CardanoSerializationLib) =>
   KeyManagement.createInMemoryKeyManager({


### PR DESCRIPTION
# Context

Need to have a convenient way to get available balance of coin, assets and rewards.

# Proposed Solution

- [x] add `UtxoRepository.availableRewards` (lock in the same way as locking UTxO until transaction is confirmed)
- [x] add `UtxoRepositoryEvent.Changed`
- [x] add `SingleAddressWallet.balance`, something like this:
  ```typescript
  interface Balance extends Ogmios.Value {
    rewards: Ogmios.Lovelace;
  }
  interface Balances {
      total: Balance;
      available: Balance;
  }
  ```  

# Important Changes Introduced

- export Lovelace=bigint from core/Ogmios and use it where appropriate
- export ogmios types directly from core/Ogmios (`Ogmios.util.Type` -> `Ogmios.Type`)
- add `core/cslUtil.bytewiseEquals` utility function
- fix a potential bug with UTxO locking: in-memory UTxO set might be incorrect if user calls `UtxoRepository.sync` while transaction is in pending state. To mitigate this, instead of computing new UTxO set in-memory, `UtxoRepository` will always call `sync()` after transaction is confirmed or if the confirmation fails. As a result, removing `UtxoRepositoryEvent.TransactionUntracked` and adding `UtxoRepositoryEvent.OutOfSync`.
