### PR TITLE
fix: change build target modules to esm (BREAKING)

### DIFF
--- a/packages/cip2/jest.config.js
+++ b/packages/cip2/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   ...require('../../test/jest.config'),
-  setupFilesAfterEnv: ['../../test/jest.setup.js', './test/jest.setup.js'],
+  setupFilesAfterEnv: ['./test/jest.setup.js'],
 };

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,8 +1,16 @@
 module.exports = {
-  setupFilesAfterEnv: [require.resolve('./jest.setup.js')],
-  preset: 'ts-jest',
-  transform: {
-    "^.+\\.test.ts?$": "ts-jest"
+  preset: 'ts-jest/presets/js-with-ts-esm',
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    // Alternatively could use this, but it takes a very long time to build without cache (~10 times longer)
+    // babel instead of tsc to transform js files would probably be faster
+    // transformIgnorePatterns: ["/node_modules/(?!(lodash-es)/)"],
+    "lodash-es": "lodash"
   },
   coveragePathIgnorePatterns: ['\.config\.js'],
   testTimeout: process.env.CI ? 120000 : 12000,

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,4 +1,0 @@
-// TODO: jest environment is not happy with 'lodash-es' exports.
-// I think using non-es-module 'lodash' in 'dependencies' is too heavy.
-// eslint-disable-next-line unicorn/prefer-module
-jest.mock('lodash-es', () => require('lodash'));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
     "composite": true,
-    "module": "commonjs",
+    "module": "es2020",
+    "moduleResolution": "node",
     "target": "es2020",
     "esModuleInterop": true,
+    "allowJs": true,
     "declaration": true,
     "declarationMap": true,
     "noEmitOnError": true,


### PR DESCRIPTION
# Context

Dynamic imports only work with es modules and our build target is commonjs

# Proposed Solution

a) Build to esm modules (done in this PR). Might also want to add extra configuration to emit `.mjs` instead of `.js` for better compatibility.
b) Do not use dynamic imports and ditch all the CSL injections, relying on sdk user to use tooling like webpack to replace CSL module with the one targeting browser.

