### PR TITLE
fix(blockfrost): early return from tallyPools function

### DIFF
--- a/packages/blockfrost/src/blockfrostProvider.ts
+++ b/packages/blockfrost/src/blockfrostProvider.ts
@@ -87,11 +87,15 @@ export const blockfrostProvider = (options: Options): WalletProvider => {
   };
 
   const stakePoolStats: WalletProvider['stakePoolStats'] = async () => {
-    const tallyPools = async (query: 'pools' | 'poolsRetired' | 'poolsRetiring', count = 0, page = 1) => {
+    const tallyPools = async (
+      query: 'pools' | 'poolsRetired' | 'poolsRetiring',
+      count = 0,
+      page = 1
+    ): Promise<number> => {
       const result = await blockfrost[query]({ page });
       const newCount = count + result.length;
       if (result.length === 100) {
-        await tallyPools(query, newCount, page + 1);
+        return tallyPools(query, newCount, page + 1);
       }
       return newCount;
     };


### PR DESCRIPTION
# Context
The `stakePoolStats` provider method is returning an invalid result that appears to correlate with a single page of Blockfrost results.

# Proposed Solution
Improve the test to simulates paginated results, and fix the bug with a then failing test.

# Important Changes Introduced
N/A