### PR TITLE
feat(core): isAddress util

### DIFF
--- a/packages/core/src/Address/index.ts
+++ b/packages/core/src/Address/index.ts
@@ -1,0 +1,1 @@
+export * as util from './util';

--- a/packages/core/src/Address/util.ts
+++ b/packages/core/src/Address/util.ts
@@ -1,0 +1,17 @@
+import { CSL } from '../CSL';
+/**
+ * Validate input as a Cardano Address from all Cardano eras and networks
+ */
+export const isAddress = (input: string): boolean => {
+  try {
+    CSL.Address.from_bech32(input);
+    return true;
+  } catch {
+    try {
+      CSL.ByronAddress.from_base58(input);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+};

--- a/packages/core/test/Address/util.test.ts
+++ b/packages/core/test/Address/util.test.ts
@@ -1,0 +1,45 @@
+import { isAddress } from '../../src/Address/util';
+
+export const addresses = {
+  shelley: {
+    testnet:
+      'addr_test1qqydn46r6mhge0kfpqmt36m6q43knzsd9ga32n96m89px3nuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qypp3m9',
+    mainnet: 'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
+  },
+  byron: {
+    mainnet: {
+      daedalus:
+        'DdzFFzCqrhsw3prhfMFDNFowbzUku3QmrMwarfjUbWXRisodn97R436SHc1rimp4MhPNmbdYb1aTdqtGSJixMVMi5MkArDQJ6Sc1n3Ez',
+      icarus: 'Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi'
+    },
+    testnet: {
+      daedalus:
+        '37btjrVyb4KEB2STADSsj3MYSAdj52X5FrFWpw2r7Wmj2GDzXjFRsHWuZqrw7zSkwopv8Ci3VWeg6bisU9dgJxW5hb2MZYeduNKbQJrqz3zVBsu9nT',
+      icarus: '2cWKMJemoBakkUSWX3DZdx8eXGeqjN6mkgVUCND1RNB736qWS5v1CGgQGNNTFUZSXaVLj'
+    }
+  },
+  invalid: {
+    short: 'EkxDbkPo',
+    networkMagic:
+      '3reY92cShRkjtmz7q31547czPNHbrhbRGhVLehTrNDNDNeDaKJwcM8aMmWg2zd7cHVFvhdui4a86nEdsSEE7g7kcZKKvBw7nzixnbX1'
+  }
+};
+
+describe('Address', () => {
+  describe('util', () => {
+    describe('isAddress', () => {
+      it('returns true if the input is a valid Shelley or Byron-era address, on either the mainnet or testnets', async () => {
+        expect(isAddress(addresses.shelley.testnet)).toBe(true);
+        expect(isAddress(addresses.shelley.mainnet)).toBe(true);
+        expect(isAddress(addresses.byron.mainnet.daedalus)).toBe(true);
+        expect(isAddress(addresses.byron.mainnet.icarus)).toBe(true);
+        expect(isAddress(addresses.byron.testnet.daedalus)).toBe(true);
+        expect(isAddress(addresses.byron.testnet.icarus)).toBe(true);
+      });
+      test('returns false if the input is not a Cardano address', async () => {
+        expect(isAddress(addresses.invalid.short)).toBe(false);
+        expect(isAddress(addresses.invalid.networkMagic)).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Context
User interfaces validate address input to avoid transaction failure that could be easily prevented.

# Proposed Solution

Input validation covering addresses of all types and networks. It does not allow an assertion to be made against a known networks to detect a network mismatch, however this is a nice-to-have since it poses no risk for loss of funds, and it's not easily implemented with the CSL.

# Important Changes Introduced
