### PR TITLE
fix: reward account format

### DIFF
--- a/packages/wallet/src/KeyManagement/InMemoryKeyManager.ts
+++ b/packages/wallet/src/KeyManagement/InMemoryKeyManager.ts
@@ -32,7 +32,10 @@ export const createInMemoryKeyManager = ({
   const privateParentKey = accountPrivateKey.derive(0).derive(0);
   const publicParentKey = privateParentKey.to_public();
   const publicKey = accountPrivateKey.to_public();
+
   const stakeKey = publicKey.derive(2).derive(0);
+  const stakeKeyRaw = stakeKey.to_raw_key();
+  const stakeKeyCredential = CSL.StakeCredential.from_keyhash(stakeKeyRaw.hash());
 
   return {
     deriveAddress: (addressIndex, index) => {
@@ -40,13 +43,14 @@ export const createInMemoryKeyManager = ({
       const baseAddr = CSL.BaseAddress.new(
         networkId,
         CSL.StakeCredential.from_keyhash(utxoPubKey.to_raw_key().hash()),
-        CSL.StakeCredential.from_keyhash(stakeKey.to_raw_key().hash())
+        stakeKeyCredential
       );
 
       return baseAddr.to_address().to_bech32();
     },
     publicKey: publicKey.to_raw_key(),
     publicParentKey: publicParentKey.to_raw_key(),
+    rewardAccount: CSL.RewardAddress.new(networkId, stakeKeyCredential).to_address().to_bech32(),
     signMessage: async (_addressType, _signingIndex, message) => ({
       publicKey: publicParentKey.toString(),
       signature: `Signature for ${message} is not implemented yet`
@@ -58,6 +62,6 @@ export const createInMemoryKeyManager = ({
         [vkeyWitness.vkey().public_key().to_bech32()]: vkeyWitness.signature().to_hex()
       };
     },
-    stakeKey: stakeKey.to_raw_key()
+    stakeKey: stakeKeyRaw
   };
 };

--- a/packages/wallet/src/KeyManagement/types.ts
+++ b/packages/wallet/src/KeyManagement/types.ts
@@ -14,6 +14,5 @@ export interface KeyManager {
   // TODO: make signatures object key type clear with type alias
   signTransaction: (txHash: Cardano.Hash16) => Promise<Cardano.Witness['signatures']>;
   stakeKey: CSL.PublicKey;
-  // TODO:
-  // stakeAddress: CardanoAddress;
+  rewardAccount: Cardano.Address;
 }

--- a/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
@@ -10,8 +10,7 @@ export const createRewardsHistoryProvider =
   (walletProvider: WalletProvider, keyManager: KeyManager, retryBackoffConfig: RetryBackoffConfig) =>
   (lowerBound: Cardano.Epoch) =>
     coldObservableProvider(
-      () =>
-        walletProvider.rewardsHistory({ epochs: { lowerBound }, stakeAddresses: [keyManager.stakeKey.to_bech32()] }),
+      () => walletProvider.rewardsHistory({ epochs: { lowerBound }, stakeAddresses: [keyManager.rewardAccount] }),
       retryBackoffConfig
     );
 

--- a/packages/wallet/src/services/RewardsTracker.ts
+++ b/packages/wallet/src/services/RewardsTracker.ts
@@ -5,9 +5,6 @@ import { RetryBackoffConfig } from 'backoff-rxjs';
 import { TrackerSubject, coldObservableProvider, strictEquals } from './util';
 import { TransactionalTracker } from './types';
 
-const getStakeKeyHash = (keyManager: KeyManager): string =>
-  Buffer.from(keyManager.stakeKey.hash().to_bytes()).toString('hex');
-
 export const createRewardsProvider = (
   epoch$: Observable<Cardano.Epoch>,
   walletProvider: WalletProvider,
@@ -15,7 +12,7 @@ export const createRewardsProvider = (
   retryBackoffConfig: RetryBackoffConfig
 ) =>
   coldObservableProvider(
-    () => walletProvider.utxoDelegationAndRewards([], getStakeKeyHash(keyManager)),
+    () => walletProvider.utxoDelegationAndRewards([], keyManager.rewardAccount),
     retryBackoffConfig,
     epoch$
   ).pipe(map(({ delegationAndRewards: { rewards } }) => rewards || 0n));

--- a/packages/wallet/test/KeyManagement/InMemoryKeyManager.test.ts
+++ b/packages/wallet/test/KeyManagement/InMemoryKeyManager.test.ts
@@ -32,4 +32,8 @@ describe('InMemoryKeyManager', () => {
     expect(Object.keys(witnessSet)).toHaveLength(1);
     expect(typeof witnessSet[Object.keys(witnessSet)[0]]).toBe('string');
   });
+
+  test('rewardAccount', () => {
+    expect(keyManager.rewardAccount.startsWith('stake_test')).toBe(true);
+  });
 });

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -36,9 +36,9 @@ describe('integration/withdrawal', () => {
     const availableRewards = wallet.balance.available$.value!.rewards;
 
     const txInternals = await wallet.initializeTx({
-      certificates: [{ __typename: CertificateType.StakeDeregistration, address: keyManager.stakeKey.to_bech32() }],
+      certificates: [{ __typename: CertificateType.StakeDeregistration, address: keyManager.rewardAccount }],
       outputs: new Set(), // In a real transaction you would probably want to have some outputs
-      withdrawals: [{ quantity: availableRewards, stakeAddress: keyManager.stakeKey.to_bech32() }]
+      withdrawals: [{ quantity: availableRewards, stakeAddress: keyManager.rewardAccount }]
     });
     expect(typeof txInternals.body.fee).toBe('bigint');
     const tx = await wallet.finalizeTx(txInternals);

--- a/packages/wallet/test/services/RewardsTracker.test.ts
+++ b/packages/wallet/test/services/RewardsTracker.test.ts
@@ -13,7 +13,7 @@ describe('createRewardsTracker', () => {
 
   it('fetches rewards from WalletProvider and locks when spent in a transaction in flight', () => {
     const keyManager = testKeyManager();
-    const stakeAddress = keyManager.stakeKey.to_bech32();
+    const stakeAddress = keyManager.rewardAccount;
     createTestScheduler().run(({ cold, expectObservable }) => {
       const transactionsInFlight$ = cold('-a-b-', {
         a: [],


### PR DESCRIPTION
# Context

Blockfrost provider expects bech32 format for reward address and SDK using key hash.

# Proposed Solution

- [x] Add `KeyManager.rewardAccount` and use it everywhere where bech32 format of reward account address is required
