### PR TITLE
fix(blockfrost): interpret 404s in Blockfrost provider and optimise batching

### DIFF
--- a/packages/blockfrost/src/BlockfrostToCore.ts
+++ b/packages/blockfrost/src/BlockfrostToCore.ts
@@ -7,7 +7,8 @@ type BlockfrostInputs = Responses['tx_content_utxo']['inputs'];
 type BlockfrostInput = Pick<Unpacked<BlockfrostInputs>, 'address' | 'amount' | 'output_index' | 'tx_hash'>;
 type BlockfrostOutputs = Responses['tx_content_utxo']['outputs'];
 type BlockfrostOutput = Unpacked<BlockfrostOutputs>;
-type BlockfrostUtxo = Unpacked<BlockfrostAddressUtxoContent>;
+export type BlockfrostTransactionContent = Unpacked<Responses['address_transactions_content']>;
+export type BlockfrostUtxo = Unpacked<BlockfrostAddressUtxoContent>;
 
 export const BlockfrostToCore = {
   addressUtxoContent: (address: string, blockfrost: Responses['address_utxo_content']): Cardano.Utxo[] =>

--- a/packages/blockfrost/src/blockfrostProvider.ts
+++ b/packages/blockfrost/src/blockfrostProvider.ts
@@ -163,20 +163,22 @@ export const blockfrostProvider = (options: Options, logger = dummyLogger): Wall
       )
     );
     const utxo = utxoResults.flat(1);
-
-    try {
-      const accountResponse = await blockfrost.accounts(rewardAccount);
-      const delegationAndRewards = {
-        delegate: accountResponse.pool_id || undefined,
-        rewards: BigInt(accountResponse.withdrawable_amount)
-      };
-      return { delegationAndRewards, utxo };
-    } catch (error) {
-      if (error.status_code === 404) {
-        return { utxo };
+    if (rewardAccount !== undefined) {
+      try {
+        const accountResponse = await blockfrost.accounts(rewardAccount);
+        const delegationAndRewards = {
+          delegate: accountResponse.pool_id || undefined,
+          rewards: BigInt(accountResponse.withdrawable_amount)
+        };
+        return { delegationAndRewards, utxo };
+      } catch (error) {
+        if (error.status_code === 404) {
+          return { utxo };
+        }
+        throw error;
       }
-      throw error;
     }
+    return { utxo };
   };
 
   const fetchRedeemers = async ({

--- a/packages/core/src/Cardano/types/DelegationsAndRewards.ts
+++ b/packages/core/src/Cardano/types/DelegationsAndRewards.ts
@@ -5,5 +5,5 @@ import { Lovelace, PoolId } from '.';
  */
 export interface DelegationsAndRewards {
   delegate?: PoolId;
-  rewards?: Lovelace;
+  rewards: Lovelace;
 }

--- a/packages/core/src/WalletProvider/types.ts
+++ b/packages/core/src/WalletProvider/types.ts
@@ -82,8 +82,8 @@ export interface WalletProvider {
   // TODO: split utxoDelegationAndRewards this into 2 or 3 functions
   utxoDelegationAndRewards: (
     addresses: Cardano.Address[],
-    stakeKeyHash: Cardano.Hash16
-  ) => Promise<{ utxo: Cardano.Utxo[]; delegationAndRewards: Cardano.DelegationsAndRewards }>;
+    rewardAccount: Cardano.Address
+  ) => Promise<{ utxo: Cardano.Utxo[]; delegationAndRewards?: Cardano.DelegationsAndRewards }>;
   /**
    * TODO: add an optional 'since: Slot' argument for querying transactions and utxos.
    * When doing so we need to also consider how best we can use the volatile block range of the chain

--- a/packages/core/src/WalletProvider/types.ts
+++ b/packages/core/src/WalletProvider/types.ts
@@ -82,7 +82,7 @@ export interface WalletProvider {
   // TODO: split utxoDelegationAndRewards this into 2 or 3 functions
   utxoDelegationAndRewards: (
     addresses: Cardano.Address[],
-    rewardAccount: Cardano.Address
+    rewardAccount?: Cardano.Address
   ) => Promise<{ utxo: Cardano.Utxo[]; delegationAndRewards?: Cardano.DelegationsAndRewards }>;
   /**
    * TODO: add an optional 'since: Slot' argument for querying transactions and utxos.

--- a/packages/wallet/src/services/RewardsTracker.ts
+++ b/packages/wallet/src/services/RewardsTracker.ts
@@ -15,7 +15,7 @@ export const createRewardsProvider = (
     () => walletProvider.utxoDelegationAndRewards([], keyManager.rewardAccount),
     retryBackoffConfig,
     epoch$
-  ).pipe(map(({ delegationAndRewards: { rewards } }) => rewards || 0n));
+  ).pipe(map(({ delegationAndRewards }) => delegationAndRewards?.rewards || 0n));
 
 export interface RewardsTrackerProps {
   walletProvider: WalletProvider;


### PR DESCRIPTION
# Context
Currently 404s for address-based lookups are allowed to fall through to an error state,
however, they need to be interpreted as expected results since it indicates the address is unused.

# Proposed Solution
- Refactors the Blockfrost client implementation to remove `addressesUtxosAll`
in favour of `addressesUtxos`, and `addressesTransactionsAll` with `addressesTransactions`
as each of the former sends a batch of requests asynchronously, often over-fetching and
over-consuming the API quota. The new implementation fetches results sequentially as needed.

# Important Changes Introduced
- Replaces the `utxoDelegationAndRewards` parameter `stakeKeyHash` with `stakeAddress`
