### PR TITLE
fix(wallet): UtxoTracker should not query rewards

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/node": "^16.0.0",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
+    "dotenv": "^10.0.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-filenames": "^1.3.2",

--- a/packages/wallet/.env.example
+++ b/packages/wallet/.env.example
@@ -1,0 +1,6 @@
+WALLET_PROVIDER=blockfrost
+STAKE_POOL_SEARCH_PROVIDER=stub
+BLOCKFROST_API_KEY=testnetNElagmhpQDubE6Ic4XBUVJjV5DROyijO
+NETWORK_ID=0
+MNEMONIC_WORDS="actor scout worth mansion thumb device mass pave gospel secret height document merge text broom kind lesson invest across estate erase interest end century"
+WALLET_PASSWORD=some_password

--- a/packages/wallet/.gitignore
+++ b/packages/wallet/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+.env

--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -6,5 +6,13 @@ See [integration tests] for usage examples
 
 See [code coverage report]
 
+### e2e
+
+There is a separate e2e test suite: `yarn test:e2e`
+
+It requires a `.env` file in package root, see [.env.example](./.env.example)
+
+Tests assume that wallet has some ADA available
+
 [integration tests]: https://github.com/input-output-hk/cardano-js-sdk/tree/master/packages/wallet/test/integration
 [code coverage report]: https://input-output-hk.github.io/cardano-js-sdk/coverage/wallet

--- a/packages/wallet/e2e.jest.config.js
+++ b/packages/wallet/e2e.jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../test/e2e.jest.config');

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
     "prepack": "yarn build",
     "test": "jest -c ./jest.config.js",
+    "test:e2e": "jest -c ./e2e.jest.config.js",
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {

--- a/packages/wallet/src/services/UtxoTracker.ts
+++ b/packages/wallet/src/services/UtxoTracker.ts
@@ -23,7 +23,7 @@ export const createUtxoProvider = (
   retryBackoffConfig: RetryBackoffConfig
 ) =>
   coldObservableProvider(
-    () => walletProvider.utxoDelegationAndRewards(addresses, '').then(({ utxo }) => utxo),
+    () => walletProvider.utxoDelegationAndRewards(addresses).then(({ utxo }) => utxo),
     retryBackoffConfig,
     tipBlockHeight$,
     utxoEquals

--- a/packages/wallet/test/e2e/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet.test.ts
@@ -1,0 +1,52 @@
+import { SingleAddressWallet, Wallet } from '../../src';
+import { filter, firstValueFrom, tap } from 'rxjs';
+import { keyManager, stakePoolSearchProvider, walletProvider } from './config';
+
+const faucetAddress =
+  'addr_test1qrydm8hsalwjmuqj624cwnyrs554zu6a8n8wg64dxk3zarsxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flknsq3qxgd';
+
+describe('SingleAddressWallet', () => {
+  let wallet: Wallet;
+
+  beforeAll(() => {
+    wallet = new SingleAddressWallet(
+      { name: 'Test Wallet' },
+      {
+        keyManager,
+        stakePoolSearchProvider,
+        walletProvider
+      }
+    );
+  });
+
+  afterAll(() => wallet.shutdown());
+
+  it('has an address', () => {
+    expect(wallet.addresses[0].bech32.startsWith('addr')).toBe(true);
+  });
+
+  test('balance', async () => {
+    // has some coin on load
+    const initialTotalBalance = await firstValueFrom(wallet.balance.total$);
+    const initialAvailableBalance = await firstValueFrom(wallet.balance.available$);
+    expect(initialTotalBalance.coins).toBeGreaterThan(0n);
+    expect(initialTotalBalance.coins).toBe(initialAvailableBalance.coins);
+    // available balance changes when tx is submitted
+    const txCoins = 1_000_000n;
+    const expectedCoinsAfterTx = initialTotalBalance.coins - txCoins;
+    const txInternals = await wallet.initializeTx({
+      outputs: new Set([{ address: faucetAddress, value: { coins: txCoins } }])
+    });
+    await wallet.submitTx(await wallet.finalizeTx(txInternals));
+    const afterTxTotalBalance = await firstValueFrom(wallet.balance.total$);
+    const afterTxAvailableBalance = await firstValueFrom(wallet.balance.available$);
+    expect(afterTxTotalBalance.coins).toBe(initialTotalBalance.coins);
+    expect(afterTxAvailableBalance.coins).toBe(expectedCoinsAfterTx);
+    await firstValueFrom(
+      wallet.balance.total$.pipe(
+        filter(({ coins }) => coins === expectedCoinsAfterTx),
+        tap(({ coins }) => expect(wallet.balance.available$.value?.coins).toBe(coins))
+      )
+    );
+  });
+});

--- a/packages/wallet/test/e2e/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet.test.ts
@@ -1,9 +1,10 @@
+import { Cardano } from '@cardano-sdk/core';
 import { SingleAddressWallet, Wallet } from '../../src';
 import { filter, firstValueFrom, tap } from 'rxjs';
 import { keyManager, stakePoolSearchProvider, walletProvider } from './config';
 
 const faucetAddress =
-  'addr_test1qrydm8hsalwjmuqj624cwnyrs554zu6a8n8wg64dxk3zarsxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flknsq3qxgd';
+  'addr_test1qqr585tvlc7ylnqvz8pyqwauzrdu0mxag3m7q56grgmgu7sxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flknswgndm3';
 
 describe('SingleAddressWallet', () => {
   let wallet: Wallet;
@@ -33,18 +34,27 @@ describe('SingleAddressWallet', () => {
     expect(initialTotalBalance.coins).toBe(initialAvailableBalance.coins);
     // available balance changes when tx is submitted
     const txCoins = 1_000_000n;
-    const expectedCoinsAfterTx = initialTotalBalance.coins - txCoins;
     const txInternals = await wallet.initializeTx({
       outputs: new Set([{ address: faucetAddress, value: { coins: txCoins } }])
     });
     await wallet.submitTx(await wallet.finalizeTx(txInternals));
+
     const afterTxTotalBalance = await firstValueFrom(wallet.balance.total$);
     const afterTxAvailableBalance = await firstValueFrom(wallet.balance.available$);
     expect(afterTxTotalBalance.coins).toBe(initialTotalBalance.coins);
-    expect(afterTxAvailableBalance.coins).toBe(expectedCoinsAfterTx);
+
+    const utxo = wallet.utxo.total$.value!;
+    const expectedCoinsWhileTxPending =
+      initialTotalBalance.coins -
+      Cardano.util.coalesceValueQuantities(
+        txInternals.body.inputs.map((txInput) => utxo.find(([txIn]) => txIn.txId === txInput.txId)![1].value)
+      ).coins;
+    expect(afterTxAvailableBalance.coins).toBe(expectedCoinsWhileTxPending);
+
+    const expectedAfterTxCoins = initialTotalBalance.coins - txCoins - txInternals.body.fee;
     await firstValueFrom(
       wallet.balance.total$.pipe(
-        filter(({ coins }) => coins === expectedCoinsAfterTx),
+        filter(({ coins }) => coins === expectedAfterTxCoins),
         tap(({ coins }) => expect(wallet.balance.available$.value?.coins).toBe(coins))
       )
     );

--- a/packages/wallet/test/e2e/config.test.ts
+++ b/packages/wallet/test/e2e/config.test.ts
@@ -1,0 +1,9 @@
+import { keyManager, stakePoolSearchProvider, walletProvider } from './config';
+
+describe('config', () => {
+  test('all config variables are set', () => {
+    expect(walletProvider).toBeTruthy();
+    expect(stakePoolSearchProvider).toBeTruthy();
+    expect(keyManager).toBeTruthy();
+  });
+});

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -1,0 +1,32 @@
+import { blockfrostProvider } from '@cardano-sdk/blockfrost';
+import { createInMemoryKeyManager } from '../../src/KeyManagement';
+import { createStubStakePoolSearchProvider } from '@cardano-sdk/util-dev';
+
+const networkId = Number.parseInt(process.env.NETWORK_ID || '');
+if (Number.isNaN(networkId)) throw new Error('NETWORK_ID not set');
+
+export const walletProvider = (() => {
+  const walletProviderName = process.env.WALLET_PROVIDER;
+  if (walletProviderName === 'blockfrost') {
+    const projectId = process.env.BLOCKFROST_API_KEY;
+    if (!projectId) throw new Error('BLOCKFROST_API_KEY not set');
+    return blockfrostProvider({ isTestnet: networkId === 0, projectId });
+  }
+  throw new Error(`WALLET_PROVIDER unsupported: ${walletProviderName}`);
+})();
+
+export const keyManager = (() => {
+  const mnemonicWords = (process.env.MNEMONIC_WORDS || '').split(' ');
+  if (mnemonicWords.length === 0) throw new Error('MNEMONIC_WORDS not set');
+  const password = process.env.WALLET_PASSWORD;
+  if (!password) throw new Error('WALLET_PASSWORD not set');
+  return createInMemoryKeyManager({ mnemonicWords, networkId, password });
+})();
+
+export const stakePoolSearchProvider = (() => {
+  const stakePoolSearchProviderName = process.env.STAKE_POOL_SEARCH_PROVIDER;
+  if (stakePoolSearchProviderName === 'stub') {
+    return createStubStakePoolSearchProvider();
+  }
+  throw new Error(`STAKE_POOL_SEARCH_PROVIDER unsupported: ${stakePoolSearchProviderName}`);
+})();

--- a/test/base.jest.config.js
+++ b/test/base.jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  coveragePathIgnorePatterns: ['.config.js'],
+  moduleNameMapper: {
+    '^lodash-es$': 'lodash'
+  },
+  preset: 'ts-jest',
+  testTimeout: process.env.CI ? 120_000 : 12_000,
+  transform: {
+    '^.+\\.test.ts?$': 'ts-jest'
+  }
+};

--- a/test/e2e.jest.config.js
+++ b/test/e2e.jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  ...require('./base.jest.config'),
+  testRegex: '(/e2e/.*(test|spec))\\.[jt]sx?$',
+  setupFiles: ['dotenv/config'],
+  testTimeout: 600_000
+};

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -1,11 +1,4 @@
 module.exports = {
-  preset: 'ts-jest',
-  moduleNameMapper: {
-    "^lodash-es$": "lodash"
-  },
-  transform: {
-    "^.+\\.test.ts?$": "ts-jest"
-  },
-  coveragePathIgnorePatterns: ['\.config\.js'],
-  testTimeout: process.env.CI ? 120000 : 12000,
+  ...require('./base.jest.config'),
+  testPathIgnorePatterns: ['/e2e/']
 }


### PR DESCRIPTION
# Context

UtxoTracker currently passes an empty string as RewardsAccount. The argument is now optional.

# Proposed Solution

Remove the argument.

# Important Changes Introduced

Set up e2e tests for `wallet` package. Add e2e test for `SingleAddressWallet.balance`.
