### PR TITLE
fix(blockfrost): ensure tx metadata number type aligns with core

### DIFF
--- a/packages/blockfrost/src/blockfrostWalletProvider.ts
+++ b/packages/blockfrost/src/blockfrostWalletProvider.ts
@@ -11,7 +11,7 @@ import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
 import { BlockfrostToCore, BlockfrostTransactionContent, BlockfrostUtxo } from './BlockfrostToCore';
 import { Options, PaginationOptions } from '@blockfrost/blockfrost-js/lib/types';
 import { dummyLogger } from 'ts-log';
-import { fetchSequentially, formatBlockfrostError, withProviderErrors } from './util';
+import { fetchSequentially, formatBlockfrostError, replaceNumbersWithBigints, withProviderErrors } from './util';
 import { flatten, groupBy } from 'lodash-es';
 
 const fetchByAddressSequentially = async <Item, Response>(props: {
@@ -256,7 +256,7 @@ export const blockfrostWalletProvider = (options: Options, logger = dummyLogger)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const { json_metadata, label } = metadatum as any;
         if (!json_metadata || !label) return map;
-        map[label] = json_metadata;
+        map[label] = replaceNumbersWithBigints(json_metadata) as Cardano.MetadatumMap;
         return map;
       }, {} as Cardano.MetadatumMap);
     } catch (error) {

--- a/packages/blockfrost/src/util.ts
+++ b/packages/blockfrost/src/util.ts
@@ -77,3 +77,19 @@ export const fetchSequentially = async <Item, Arg, Response>(
     throw error;
   }
 };
+
+/**
+ * Recursively replaces all numbers with bigints.
+ */
+export const replaceNumbersWithBigints = (obj: unknown): unknown => {
+  if (typeof obj === 'number') return BigInt(obj);
+  if (typeof obj !== 'object' || obj === null) return obj;
+  if (Array.isArray(obj)) {
+    return obj.map(replaceNumbersWithBigints);
+  }
+  const newObj: any = {};
+  for (const k in obj) {
+    newObj[k] = replaceNumbersWithBigints((obj as any)[k]);
+  }
+  return newObj;
+};

--- a/packages/blockfrost/test/blockfrostWalletProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostWalletProvider.test.ts
@@ -325,7 +325,7 @@ describe('blockfrostWalletProvider', () => {
             ADAUSD: [
               {
                 source: 'ergoOracles',
-                value: '0.10409800535729975'
+                value: 3
               }
             ]
           },
@@ -352,7 +352,7 @@ describe('blockfrostWalletProvider', () => {
                 ADAUSD: [
                   {
                     source: 'ergoOracles',
-                    value: '0.10409800535729975'
+                    value: 3n
                   }
                 ]
               }

--- a/packages/blockfrost/test/util.test.ts
+++ b/packages/blockfrost/test/util.test.ts
@@ -1,6 +1,16 @@
-import { fetchSequentially } from '../src/util';
+import { fetchSequentially, replaceNumbersWithBigints } from '../src/util';
 
 describe('util', () => {
+  test('replaceNumbersWithBigints', () => {
+    expect(replaceNumbersWithBigints(1)).toBe(1n);
+    expect(replaceNumbersWithBigints('a')).toBe('a');
+    expect(replaceNumbersWithBigints(null)).toBe(null);
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    expect(replaceNumbersWithBigints(undefined)).toBe(undefined);
+    expect(replaceNumbersWithBigints(['a', 1, [2]])).toEqual(['a', 1n, [2n]]);
+    expect(replaceNumbersWithBigints({ a: 'a', b: 1, c: { d: 2 } })).toEqual({ a: 'a', b: 1n, c: { d: 2n } });
+  });
+
   test('fetchSequentially', async () => {
     const batch1 = [{ a: 1 }, { a: 2 }];
     const batch2 = [{ a: 3 }, { a: 4 }];


### PR DESCRIPTION
# Context

Transaction metadata from Blockfrost might possibly be of type `number` and our core type only supports `bigint`.

# Proposed Solution

Recursively convert blockfrost metadata json fields from number to bigint
