### PR TITLE
chore: set node version to >=14.15.0 <15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "An SDK for interacting with the Cardano blockchain",
   "engines": {
-    "node": "^14"
+    "node": ">=14.15.0 <15.0.0"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
# Context

Errors on install when using incompatible version of Node allowed by current engines value.

# Proposed Solution

Set minimum version to `14.15.0`. Also set the maximum to `<15.0.0`, because some of the dependencies are not compatible with Node versions above 14.

## Way to reproduce the error in current master branch:
```
nvm install 14.14.0
yarn install --force
```

Output:
```
error jest@27.0.6: The engine "node" is incompatible with this module. Expected version "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0". Got "14.14.0"
```
