### PR TITLE
feat: InitializeTxProps validation

### DIFF
--- a/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
@@ -1,19 +1,11 @@
 import { BigIntMath, Cardano } from '@cardano-sdk/core';
-import {
-  ImplicitCoinBigint,
-  OutputWithValue,
-  RoundRobinRandomImproveArgs,
-  UtxoSelection,
-  UtxoWithValue,
-  assetWithValueQuantitySelector,
-  getWithValuesCoinQuantity
-} from './util';
+import { RoundRobinRandomImproveArgs, UtxoSelection, assetQuantitySelector, getCoinQuantity, toValues } from './util';
 
 const improvesSelection = (
-  utxoAlreadySelected: UtxoWithValue[],
-  input: UtxoWithValue,
+  utxoAlreadySelected: Cardano.Utxo[],
+  input: Cardano.Utxo,
   minimumTarget: bigint,
-  getQuantity: (utxo: UtxoWithValue[]) => bigint
+  getQuantity: (utxo: Cardano.Utxo[]) => bigint
 ): boolean => {
   const oldQuantity = getQuantity(utxoAlreadySelected);
   // We still haven't reached the minimum target of
@@ -37,22 +29,30 @@ const improvesSelection = (
 
 const listTokensWithin = (
   uniqueOutputAssetIDs: Cardano.AssetId[],
-  outputs: OutputWithValue[],
-  implicitCoin: ImplicitCoinBigint
+  outputs: Cardano.TxOut[],
+  implicitCoin: Required<Cardano.ImplicitCoin>
 ) => [
   ...uniqueOutputAssetIDs.map((id) => {
-    const getQuantity = assetWithValueQuantitySelector(id);
+    const getQuantity = assetQuantitySelector(id);
     return {
-      filterUtxo: (utxo: UtxoWithValue[]) => utxo.filter(({ value: { assets } }) => assets?.get(id)),
-      getTotalSelectedQuantity: (utxo: UtxoWithValue[]) => getQuantity(utxo),
-      minimumTarget: getQuantity(outputs)
+      filterUtxo: (utxo: Cardano.Utxo[]) =>
+        utxo.filter(
+          ([
+            _,
+            {
+              value: { assets }
+            }
+          ]) => assets?.get(id)
+        ),
+      getTotalSelectedQuantity: (utxo: Cardano.Utxo[]) => getQuantity(toValues(utxo)),
+      minimumTarget: getQuantity(toValues(outputs))
     };
   }),
   {
-    filterUtxo: (utxo: UtxoWithValue[]) => utxo,
+    filterUtxo: (utxo: Cardano.Utxo[]) => utxo,
     // Lovelace
-    getTotalSelectedQuantity: (utxo: UtxoWithValue[]) => getWithValuesCoinQuantity(utxo) + implicitCoin.input,
-    minimumTarget: getWithValuesCoinQuantity(outputs) + implicitCoin.deposit
+    getTotalSelectedQuantity: (utxo: Cardano.Utxo[]) => getCoinQuantity(toValues(utxo)) + implicitCoin.input,
+    minimumTarget: getCoinQuantity(toValues(outputs)) + implicitCoin.deposit
   }
 ];
 
@@ -63,13 +63,13 @@ const listTokensWithin = (
  * Considers all outputs collectively, as a combined output bundle.
  */
 export const roundRobinSelection = ({
-  utxosWithValue,
-  outputsWithValue,
+  utxo: utxosWithValue,
+  outputs: outputsWithValue,
   uniqueOutputAssetIDs,
   implicitCoin
 }: RoundRobinRandomImproveArgs): UtxoSelection => {
   // The subset of the UTxO that has already been selected:
-  const utxoSelected: UtxoWithValue[] = [];
+  const utxoSelected: Cardano.Utxo[] = [];
   // The subset of the UTxO that remains available for selection:
   const utxoRemaining = [...utxosWithValue];
   // The set of tokens that we still need to cover:

--- a/packages/cip2/src/index.ts
+++ b/packages/cip2/src/index.ts
@@ -1,3 +1,4 @@
 export * from './RoundRobinRandomImprove';
 export * from './selectionConstraints';
 export * from './types';
+export * from './InputSelectionError';

--- a/packages/cip2/src/selectionConstraints.ts
+++ b/packages/cip2/src/selectionConstraints.ts
@@ -1,4 +1,4 @@
-import { CSL, InvalidProtocolParametersError, cslUtil } from '@cardano-sdk/core';
+import { CSL, InvalidProtocolParametersError, coreToCsl, cslUtil } from '@cardano-sdk/core';
 import {
   ComputeMinimumCoinQuantity,
   ComputeSelectionLimit,
@@ -44,7 +44,7 @@ export const computeMinimumCoinQuantity =
     const minUTxOValue = CSL.BigNum.from_str((coinsPerUtxoWord * 29).toString());
     const value = CSL.Value.new(CSL.BigNum.from_str('0'));
     if (multiasset) {
-      value.set_multiasset(multiasset);
+      value.set_multiasset(coreToCsl.tokenMap(multiasset));
     }
     return BigInt(CSL.min_ada_required(value, minUTxOValue).to_str());
   };
@@ -56,7 +56,7 @@ export const tokenBundleSizeExceedsLimit =
       return false;
     }
     const value = CSL.Value.new(cslUtil.maxBigNum);
-    value.set_multiasset(tokenBundle);
+    value.set_multiasset(coreToCsl.tokenMap(tokenBundle));
     return value.to_bytes().length > maxValueSize;
   };
 

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -1,4 +1,4 @@
-import { CSL, Cardano } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 
 export interface SelectionSkeleton {
   /**
@@ -7,22 +7,22 @@ export interface SelectionSkeleton {
    * From the point of view of a wallet, this represents the value
    * that has been selected from the wallet in order to cover the total payment value.
    */
-  inputs: Set<CSL.TransactionUnspentOutput>;
+  inputs: Set<Cardano.Utxo>;
   /**
    * Set of payments to be made to recipient addresses.
    */
-  outputs: Set<CSL.TransactionOutput>;
+  outputs: Set<Cardano.TxOut>;
   /**
    * A set of change values. Does not account for fee.
    *
    * From the point of view of a wallet, this represents the change to be returned to the wallet.
    */
-  change: Set<CSL.Value>;
+  change: Set<Cardano.Value>;
   /**
    * Estimated fee for the transaction.
    * This value is included in 'change', so the actual change returned by the transaction is change-fee.
    */
-  fee: CSL.BigNum;
+  fee: Cardano.Lovelace;
 }
 
 export type Selection = SelectionSkeleton;
@@ -35,23 +35,23 @@ export interface SelectionResult {
    * It represents the set of values that remain after the coin selection algorithm
    * has removed values to pay for entries in the requested output set.
    */
-  remainingUTxO: Set<CSL.TransactionUnspentOutput>;
+  remainingUTxO: Set<Cardano.Utxo>;
 }
 
 /**
  * @returns minimum transaction fee in Lovelace.
  */
-export type EstimateTxFee = (selectionSkeleton: SelectionSkeleton) => Promise<bigint>;
+export type EstimateTxFee = (selectionSkeleton: SelectionSkeleton) => Promise<Cardano.Lovelace>;
 
 /**
  * @returns true if token bundle size exceeds it's maximum size limit.
  */
-export type TokenBundleSizeExceedsLimit = (tokenBundle?: CSL.MultiAsset) => boolean;
+export type TokenBundleSizeExceedsLimit = (tokenBundle?: Cardano.TokenMap) => boolean;
 
 /**
  * @returns minimum lovelace amount in a UTxO
  */
-export type ComputeMinimumCoinQuantity = (assetQuantities?: CSL.MultiAsset) => bigint;
+export type ComputeMinimumCoinQuantity = (assetQuantities?: Cardano.TokenMap) => Cardano.Lovelace;
 
 /**
  * @returns an upper bound for the number of ordinary inputs to
@@ -70,11 +70,11 @@ export interface InputSelectionParameters {
   /**
    * The set of inputs available for selection.
    */
-  utxo: Set<CSL.TransactionUnspentOutput>;
+  utxo: Set<Cardano.Utxo>;
   /**
    * The set of outputs requested for payment.
    */
-  outputs: Set<CSL.TransactionOutput>;
+  outputs: Set<Cardano.TxOut>;
   /**
    * Input selection constraints
    */

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -1,4 +1,4 @@
-import { AssetId, CslTestUtil, SelectionConstraints } from '@cardano-sdk/util-dev';
+import { AssetId, SelectionConstraints, TxTestUtil } from '@cardano-sdk/util-dev';
 import { InputSelectionError, InputSelectionFailure } from '../src/InputSelectionError';
 import {
   assertFailureProperties,
@@ -15,8 +15,8 @@ describe('RoundRobinRandomImprove', () => {
     describe('Properties', () => {
       it('No change', async () => {
         await testInputSelectionProperties({
-          createOutputs: () => [CslTestUtil.createOutput({ coins: 3_000_000n })],
-          createUtxo: () => [CslTestUtil.createUnspentTxOutput({ coins: 3_000_000n })],
+          createOutputs: () => [TxTestUtil.createOutput({ coins: 3_000_000n })],
+          createUtxo: () => [TxTestUtil.createUnspentTxOutput({ coins: 3_000_000n })],
           getAlgorithm: roundRobinRandomImprove,
           mockConstraints: SelectionConstraints.MOCK_NO_CONSTRAINTS
         });
@@ -25,7 +25,7 @@ describe('RoundRobinRandomImprove', () => {
         // Regression
         await testInputSelectionProperties({
           createOutputs: () => [],
-          createUtxo: () => [CslTestUtil.createUnspentTxOutput({ coins: 11_999_994n })],
+          createUtxo: () => [TxTestUtil.createUnspentTxOutput({ coins: 11_999_994n })],
           getAlgorithm: roundRobinRandomImprove,
           mockConstraints: {
             ...SelectionConstraints.MOCK_NO_CONSTRAINTS,
@@ -35,8 +35,8 @@ describe('RoundRobinRandomImprove', () => {
         });
       });
       it('Selects UTxO even when implicit input covers outputs', async () => {
-        const utxo = new Set([CslTestUtil.createUnspentTxOutput({ coins: 10_000_000n })]);
-        const outputs = new Set([CslTestUtil.createOutput({ coins: 1_000_000n })]);
+        const utxo = new Set([TxTestUtil.createUnspentTxOutput({ coins: 10_000_000n })]);
+        const outputs = new Set([TxTestUtil.createOutput({ coins: 1_000_000n })]);
         const results = await roundRobinRandomImprove().select({
           constraints: SelectionConstraints.NO_CONSTRAINTS,
           implicitCoin: { input: 2_000_000n },
@@ -51,12 +51,12 @@ describe('RoundRobinRandomImprove', () => {
         it('Coin (Outputs>UTxO)', async () => {
           await testInputSelectionFailureMode({
             createOutputs: () => [
-              CslTestUtil.createOutput({ coins: 12_000_000n }),
-              CslTestUtil.createOutput({ coins: 2_000_000n })
+              TxTestUtil.createOutput({ coins: 12_000_000n }),
+              TxTestUtil.createOutput({ coins: 2_000_000n })
             ],
             createUtxo: () => [
-              CslTestUtil.createUnspentTxOutput({ coins: 3_000_000n }),
-              CslTestUtil.createUnspentTxOutput({ coins: 10_000_000n })
+              TxTestUtil.createUnspentTxOutput({ coins: 3_000_000n }),
+              TxTestUtil.createUnspentTxOutput({ coins: 10_000_000n })
             ],
             expectedError: InputSelectionFailure.UtxoBalanceInsufficient,
             getAlgorithm: roundRobinRandomImprove,
@@ -65,10 +65,10 @@ describe('RoundRobinRandomImprove', () => {
         });
         it('Coin (Outputs+Fee>UTxO)', async () => {
           await testInputSelectionFailureMode({
-            createOutputs: () => [CslTestUtil.createOutput({ coins: 9_000_000n })],
+            createOutputs: () => [TxTestUtil.createOutput({ coins: 9_000_000n })],
             createUtxo: () => [
-              CslTestUtil.createUnspentTxOutput({ coins: 4_000_000n }),
-              CslTestUtil.createUnspentTxOutput({ coins: 5_000_000n })
+              TxTestUtil.createUnspentTxOutput({ coins: 4_000_000n }),
+              TxTestUtil.createUnspentTxOutput({ coins: 5_000_000n })
             ],
             expectedError: InputSelectionFailure.UtxoBalanceInsufficient,
             getAlgorithm: roundRobinRandomImprove,
@@ -81,10 +81,10 @@ describe('RoundRobinRandomImprove', () => {
         it('Asset', async () => {
           await testInputSelectionFailureMode({
             createOutputs: () => [
-              CslTestUtil.createOutput({ assets: new Map([[AssetId.TSLA, 7001n]]), coins: 5_000_000n })
+              TxTestUtil.createOutput({ assets: new Map([[AssetId.TSLA, 7001n]]), coins: 5_000_000n })
             ],
             createUtxo: () => [
-              CslTestUtil.createUnspentTxOutput({ assets: new Map([[AssetId.TSLA, 7000n]]), coins: 10_000_000n })
+              TxTestUtil.createUnspentTxOutput({ assets: new Map([[AssetId.TSLA, 7000n]]), coins: 10_000_000n })
             ],
             expectedError: InputSelectionFailure.UtxoBalanceInsufficient,
             getAlgorithm: roundRobinRandomImprove,
@@ -93,7 +93,7 @@ describe('RoundRobinRandomImprove', () => {
         });
         it('No UTxO', async () => {
           await testInputSelectionFailureMode({
-            createOutputs: () => [CslTestUtil.createOutput({ coins: 5_000_000n })],
+            createOutputs: () => [TxTestUtil.createOutput({ coins: 5_000_000n })],
             createUtxo: () => [],
             expectedError: InputSelectionFailure.UtxoBalanceInsufficient,
             getAlgorithm: roundRobinRandomImprove,
@@ -104,10 +104,10 @@ describe('RoundRobinRandomImprove', () => {
       describe('UTxO Fully Depleted', () => {
         it('Change bundle value is less than constrained', async () => {
           await testInputSelectionFailureMode({
-            createOutputs: () => [CslTestUtil.createOutput({ coins: 2_999_999n })],
+            createOutputs: () => [TxTestUtil.createOutput({ coins: 2_999_999n })],
             createUtxo: () => [
-              CslTestUtil.createUnspentTxOutput({ coins: 1_000_000n }),
-              CslTestUtil.createUnspentTxOutput({ coins: 2_000_000n })
+              TxTestUtil.createUnspentTxOutput({ coins: 1_000_000n }),
+              TxTestUtil.createUnspentTxOutput({ coins: 2_000_000n })
             ],
             expectedError: InputSelectionFailure.UtxoFullyDepleted,
             getAlgorithm: roundRobinRandomImprove,
@@ -120,7 +120,7 @@ describe('RoundRobinRandomImprove', () => {
         it('Change bundle size exceeds constraint', async () => {
           await testInputSelectionFailureMode({
             createOutputs: () => [
-              CslTestUtil.createOutput({
+              TxTestUtil.createOutput({
                 assets: new Map([
                   [AssetId.TSLA, 500n],
                   [AssetId.PXL, 500n]
@@ -129,7 +129,7 @@ describe('RoundRobinRandomImprove', () => {
               })
             ],
             createUtxo: () => [
-              CslTestUtil.createUnspentTxOutput({
+              TxTestUtil.createUnspentTxOutput({
                 assets: new Map([
                   [AssetId.TSLA, 1000n],
                   [AssetId.PXL, 1000n]
@@ -148,11 +148,11 @@ describe('RoundRobinRandomImprove', () => {
       });
       it('Maximum Input Count Exceeded', async () => {
         await testInputSelectionFailureMode({
-          createOutputs: () => [CslTestUtil.createOutput({ coins: 6_000_000n })],
+          createOutputs: () => [TxTestUtil.createOutput({ coins: 6_000_000n })],
           createUtxo: () => [
-            CslTestUtil.createUnspentTxOutput({ coins: 2_000_000n }),
-            CslTestUtil.createUnspentTxOutput({ coins: 2_000_000n }),
-            CslTestUtil.createUnspentTxOutput({ coins: 3_000_000n })
+            TxTestUtil.createUnspentTxOutput({ coins: 2_000_000n }),
+            TxTestUtil.createUnspentTxOutput({ coins: 2_000_000n }),
+            TxTestUtil.createUnspentTxOutput({ coins: 3_000_000n })
           ],
           expectedError: InputSelectionFailure.MaximumInputCountExceeded,
           getAlgorithm: roundRobinRandomImprove,
@@ -173,10 +173,8 @@ describe('RoundRobinRandomImprove', () => {
         generateSelectionParams(),
         async ({ utxoAmounts, outputsAmounts, constraints, implicitCoin }) => {
           // Run input selection
-          const utxo = new Set(
-            utxoAmounts.map((valueQuantities) => CslTestUtil.createUnspentTxOutput(valueQuantities))
-          );
-          const outputs = new Set(outputsAmounts.map((valueQuantities) => CslTestUtil.createOutput(valueQuantities)));
+          const utxo = new Set(utxoAmounts.map((valueQuantities) => TxTestUtil.createUnspentTxOutput(valueQuantities)));
+          const outputs = new Set(outputsAmounts.map((valueQuantities) => TxTestUtil.createOutput(valueQuantities)));
 
           try {
             const results = await algorithm.select({

--- a/packages/cip2/test/selectionConstraints.test.ts
+++ b/packages/cip2/test/selectionConstraints.test.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable unicorn/consistent-function-scoping */
 import { AssetId } from '@cardano-sdk/util-dev';
-import { CSL, InvalidProtocolParametersError, coreToCsl } from '@cardano-sdk/core';
+import { CSL, InvalidProtocolParametersError } from '@cardano-sdk/core';
 import { DefaultSelectionConstraintsProps, defaultSelectionConstraints } from '../src/selectionConstraints';
 import { ProtocolParametersForInputSelection, SelectionSkeleton } from '../src/types';
 
@@ -57,19 +57,14 @@ describe('defaultSelectionConstraints', () => {
 
   it('computeMinimumCoinQuantity', () => {
     cslMock.Value.new.mockImplementation(cslActual.Value.new);
-    const withAssets = coreToCsl
-      .value({
-        assets: new Map([
-          [AssetId.TSLA, 5000n],
-          [AssetId.PXL, 3000n]
-        ]),
-        coins: 10_000n
-      })
-      .multiasset();
+    const assets = new Map([
+      [AssetId.TSLA, 5000n],
+      [AssetId.PXL, 3000n]
+    ]);
     const constraints = defaultSelectionConstraints({
       protocolParameters
     } as DefaultSelectionConstraintsProps);
-    const minCoinWithAssets = constraints.computeMinimumCoinQuantity(withAssets);
+    const minCoinWithAssets = constraints.computeMinimumCoinQuantity(assets);
     const minCoinWithoutAssets = constraints.computeMinimumCoinQuantity();
     expect(typeof minCoinWithAssets).toBe('bigint');
     expect(typeof minCoinWithoutAssets).toBe('bigint');
@@ -121,7 +116,7 @@ describe('defaultSelectionConstraints', () => {
       const constraints = defaultSelectionConstraints({
         protocolParameters
       } as DefaultSelectionConstraintsProps);
-      expect(constraints.tokenBundleSizeExceedsLimit({} as any)).toBe(false);
+      expect(constraints.tokenBundleSizeExceedsLimit(new Map())).toBe(false);
     });
 
     it('exceeds max value size', () => {
@@ -129,7 +124,7 @@ describe('defaultSelectionConstraints', () => {
       const constraints = defaultSelectionConstraints({
         protocolParameters
       } as DefaultSelectionConstraintsProps);
-      expect(constraints.tokenBundleSizeExceedsLimit({} as any)).toBe(true);
+      expect(constraints.tokenBundleSizeExceedsLimit(new Map())).toBe(true);
     });
   });
 });

--- a/packages/cip2/test/util/tests.ts
+++ b/packages/cip2/test/util/tests.ts
@@ -1,4 +1,4 @@
-import { CSL } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { InputSelectionError, InputSelectionFailure } from '../../src/InputSelectionError';
 import { InputSelector } from '../../src/types';
 import { SelectionConstraints } from '@cardano-sdk/util-dev';
@@ -12,11 +12,11 @@ export interface InputSelectionPropertiesTestParams {
   /**
    * Available UTxO
    */
-  createUtxo: () => CSL.TransactionUnspentOutput[];
+  createUtxo: () => Cardano.Utxo[];
   /**
    * Transaction outputs
    */
-  createOutputs: () => CSL.TransactionOutput[];
+  createOutputs: () => Cardano.TxOut[];
   /**
    * Input selection constraints passed to the algorithm.
    */

--- a/packages/core/src/CSL/coreToCsl.ts
+++ b/packages/core/src/CSL/coreToCsl.ts
@@ -31,22 +31,25 @@ import { SerializationFailure } from '..';
 import { coreToCsl } from '.';
 export * as certificate from './certificate';
 
+export const tokenMap = (assets: Cardano.TokenMap) => {
+  const multiasset = MultiAsset.new();
+  for (const assetId of assets.keys()) {
+    const { scriptHash, assetName } = Asset.util.parseAssetId(assetId);
+    const assetsObj = Assets.new();
+    const amount = BigNum.from_str(assets.get(assetId)!.toString());
+    assetsObj.insert(assetName, amount);
+    multiasset.insert(scriptHash, assetsObj);
+  }
+  return multiasset;
+};
+
 export const value = ({ coins, assets }: Cardano.Value): Value => {
   const result = Value.new(BigNum.from_str(coins.toString()));
   if (!assets) {
     return result;
   }
-  const assetIds = [...assets.keys()];
-  if (assetIds.length > 0) {
-    const multiasset = MultiAsset.new();
-    for (const assetId of assetIds) {
-      const { scriptHash, assetName } = Asset.util.parseAssetId(assetId);
-      const assetsObj = Assets.new();
-      const amount = BigNum.from_str(assets.get(assetId)!.toString());
-      assetsObj.insert(assetName, amount);
-      multiasset.insert(scriptHash, assetsObj);
-    }
-    result.set_multiasset(multiasset);
+  if (assets.size > 0) {
+    result.set_multiasset(tokenMap(assets));
   }
   return result;
 };

--- a/packages/core/test/CSL/coreToCsl.test.ts
+++ b/packages/core/test/CSL/coreToCsl.test.ts
@@ -74,6 +74,16 @@ describe('coreToCsl', () => {
       expect(value).toBeInstanceOf(CSL.Value);
     });
   });
+  it('tokenMap', () => {
+    const multiasset = coreToCsl.tokenMap(txOut.value.assets!);
+    expect(multiasset).toBeInstanceOf(CSL.MultiAsset);
+    expect(multiasset.len()).toBe(2);
+    for (const [assetId, expectedAssetQuantity] of txOut.value.assets!.entries()) {
+      const { scriptHash, assetName } = Asset.util.parseAssetId(assetId);
+      const assetQuantity = BigInt(multiasset.get(scriptHash)!.get(assetName)!.to_str());
+      expect(assetQuantity).toBe(expectedAssetQuantity);
+    }
+  });
   it('txBody', () => {
     const cslBody = coreToCsl.txBody(coreTxBody);
     expect(cslBody.certs()?.get(0).as_pool_retirement()?.epoch()).toBe(500);

--- a/packages/util-dev/src/index.ts
+++ b/packages/util-dev/src/index.ts
@@ -1,5 +1,6 @@
 export * as AssetId from './assetId';
 export * as CslTestUtil from './cslTestUtil';
+export * as TxTestUtil from './txTestUtil';
 export * as SelectionConstraints from './selectionConstraints';
 export * from './util';
 export * from './createStubStakePoolSearchProvider';

--- a/packages/util-dev/src/selectionConstraints.ts
+++ b/packages/util-dev/src/selectionConstraints.ts
@@ -1,4 +1,4 @@
-import { CSL } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { SelectionConstraints } from '@cardano-sdk/cip2';
 
 export interface MockSelectionConstraints {
@@ -19,8 +19,7 @@ export const mockConstraintsToConstraints = (constraints: MockSelectionConstrain
   computeMinimumCoinQuantity: () => constraints.minimumCoinQuantity,
   computeMinimumCost: async () => constraints.minimumCost,
   computeSelectionLimit: async () => constraints.selectionLimit,
-  tokenBundleSizeExceedsLimit: (multiasset?: CSL.MultiAsset) =>
-    (multiasset?.len() || 0) > constraints.maxTokenBundleSize
+  tokenBundleSizeExceedsLimit: (assets?: Cardano.TokenMap) => (assets?.size || 0) > constraints.maxTokenBundleSize
 });
 
 export const NO_CONSTRAINTS = mockConstraintsToConstraints(MOCK_NO_CONSTRAINTS);

--- a/packages/util-dev/src/txTestUtil.ts
+++ b/packages/util-dev/src/txTestUtil.ts
@@ -1,0 +1,20 @@
+import { Cardano } from '@cardano-sdk/core';
+
+export const createTxInput = (() => {
+  let defaultIndex = 0;
+  return (
+    txId = Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
+    address = Cardano.Address('addr1vy36kffjf87vzkuyqc5g0ys3fe3pez5zvqg9r5z9q9kfrkg2cs093'),
+    index = defaultIndex++
+  ) => ({ address, index, txId });
+})();
+
+export const createUnspentTxOutput = (
+  value: Cardano.Value,
+  address = Cardano.Address('addr1vy36kffjf87vzkuyqc5g0ys3fe3pez5zvqg9r5z9q9kfrkg2cs093')
+): Cardano.Utxo => [createTxInput(), { address, value }];
+
+export const createOutput = (
+  value: Cardano.Value,
+  address = Cardano.Address('addr1vyeljkh3vr4h9s3lyxe7g2meushk3m4nwyzdgtlg96e6mrgg8fnle')
+): Cardano.TxOut => ({ address, value });

--- a/packages/util-dev/test/selectionConstraints.test.ts
+++ b/packages/util-dev/test/selectionConstraints.test.ts
@@ -12,7 +12,7 @@ describe('selectionConstraints', () => {
     expect(constraints.computeMinimumCoinQuantity()).toBe(10n);
     expect(await constraints.computeMinimumCost({} as any)).toBe(20n);
     expect(await constraints.computeSelectionLimit({} as any)).toBe(3);
-    expect(await constraints.tokenBundleSizeExceedsLimit()).toBe(false);
-    expect(await constraints.tokenBundleSizeExceedsLimit({ len: () => 2 } as any)).toBe(true);
+    expect(constraints.tokenBundleSizeExceedsLimit()).toBe(false);
+    expect(constraints.tokenBundleSizeExceedsLimit({ size: 2 } as any)).toBe(true);
   });
 });

--- a/packages/util-dev/test/txTestUtil.test.ts
+++ b/packages/util-dev/test/txTestUtil.test.ts
@@ -1,0 +1,15 @@
+import { createOutput, createTxInput, createUnspentTxOutput } from '../src/txTestUtil';
+
+describe('txTestUtil', () => {
+  describe('createTxInput', () => {
+    it('returns new input index on each call', () => {
+      expect(createTxInput().index).not.toEqual(createTxInput().index);
+    });
+  });
+  test('createOutput', () => {
+    expect(createOutput({ coins: 1n }).value.coins).toBe(1n);
+  });
+  test('createUnspentTxOutput', () => {
+    expect(createUnspentTxOutput({ coins: 1n })[1].value.coins).toBe(1n);
+  });
+});

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -30,7 +30,7 @@ import {
   distinctBlock,
   distinctEpoch
 } from './services';
-import { InitializeTxProps, MinimumCoinQuantity, TxValidationResult, Wallet } from './types';
+import { InitializeTxProps, InitializeTxPropsValidationResult, MinimumCoinQuantity, Wallet } from './types';
 import {
   InputSelector,
   computeMinimumCoinQuantity,
@@ -159,7 +159,7 @@ export class SingleAddressWallet implements Wallet {
       })
     );
   }
-  async validateTx(props: InitializeTxProps): Promise<TxValidationResult> {
+  async validateInitializeTxProps(props: InitializeTxProps): Promise<InitializeTxPropsValidationResult> {
     const { coinsPerUtxoWord } = await firstValueFrom(this.protocolParameters$);
     const minimumCoinQuantities = new Map<Cardano.TxOut, MinimumCoinQuantity>();
     for (const output of props.outputs || []) {

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -1,6 +1,7 @@
 import { AddressType, GroupedAddress, KeyAgent } from './KeyManagement';
 import {
   AssetProvider,
+  BigIntMath,
   Cardano,
   NetworkInfo,
   ProtocolParametersRequiredByWallet,
@@ -29,10 +30,15 @@ import {
   distinctBlock,
   distinctEpoch
 } from './services';
-import { InitializeTxProps, Wallet } from './types';
-import { InputSelector, defaultSelectionConstraints, roundRobinRandomImprove } from '@cardano-sdk/cip2';
+import { InitializeTxProps, MinimumCoinQuantity, TxValidationResult, Wallet } from './types';
+import {
+  InputSelector,
+  computeMinimumCoinQuantity,
+  defaultSelectionConstraints,
+  roundRobinRandomImprove
+} from '@cardano-sdk/cip2';
 import { Logger, dummyLogger } from 'ts-log';
-import { Observable, Subject, combineLatest, from, lastValueFrom, map, mergeMap, take } from 'rxjs';
+import { Observable, Subject, combineLatest, firstValueFrom, lastValueFrom, map, take } from 'rxjs';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { TxInternals, computeImplicitCoin, createTransactionInternals, ensureValidityInterval } from './Transaction';
 import { isEqual } from 'lodash-es';
@@ -153,50 +159,34 @@ export class SingleAddressWallet implements Wallet {
       })
     );
   }
-
-  initializeTx(props: InitializeTxProps): Promise<TxInternals> {
-    return lastValueFrom(
-      combineLatest([this.tip$, this.utxo.available$, this.protocolParameters$, this.addresses$]).pipe(
-        take(1),
-        mergeMap(([tip, utxo, protocolParameters, [{ address: changeAddress }]]) => {
-          const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
-          const txOutputs = new Set([...(props.outputs || [])].map((output) => coreToCsl.txOut(output)));
-          const constraints = defaultSelectionConstraints({
-            buildTx: async (inputSelection) => {
-              this.#logger.debug('Building TX for selection constraints', inputSelection);
-              const txInternals = await createTransactionInternals({
-                certificates: props.certificates,
-                changeAddress,
-                inputSelection,
-                validityInterval,
-                withdrawals: props.withdrawals
-              });
-              return coreToCsl.tx(await this.finalizeTx(txInternals));
-            },
-            protocolParameters
-          });
-          const implicitCoin = computeImplicitCoin(protocolParameters, props);
-          return from(
-            this.#inputSelector
-              .select({
-                constraints,
-                implicitCoin,
-                outputs: txOutputs,
-                utxo: new Set(coreToCsl.utxo(utxo))
-              })
-              .then((inputSelectionResult) =>
-                createTransactionInternals({
-                  certificates: props.certificates,
-                  changeAddress,
-                  inputSelection: inputSelectionResult.selection,
-                  validityInterval,
-                  withdrawals: props.withdrawals
-                })
-              )
-          );
-        })
-      )
-    );
+  async validateTx(props: InitializeTxProps): Promise<TxValidationResult> {
+    const { coinsPerUtxoWord } = await firstValueFrom(this.protocolParameters$);
+    const minimumCoinQuantities = new Map<Cardano.TxOut, MinimumCoinQuantity>();
+    for (const output of props.outputs || []) {
+      const multiasset = output.value.assets ? coreToCsl.value(output.value).multiasset() : undefined;
+      const minimumCoin = BigInt(computeMinimumCoinQuantity(coinsPerUtxoWord)(multiasset));
+      minimumCoinQuantities.set(output, {
+        coinMissing: BigIntMath.max([minimumCoin - output.value.coins, 0n])!,
+        minimumCoin
+      });
+    }
+    return { minimumCoinQuantities };
+  }
+  async initializeTx(props: InitializeTxProps): Promise<TxInternals> {
+    const { constraints, utxo, implicitCoin, validityInterval, changeAddress } = await this.#prepareTx(props);
+    const selectionResult = await this.#inputSelector.select({
+      constraints,
+      implicitCoin,
+      outputs: new Set([...(props.outputs || [])].map((output) => coreToCsl.txOut(output))),
+      utxo: new Set(coreToCsl.utxo(utxo))
+    });
+    return createTransactionInternals({
+      certificates: props.certificates,
+      changeAddress,
+      inputSelection: selectionResult.selection,
+      validityInterval,
+      withdrawals: props.withdrawals
+    });
   }
   async finalizeTx(tx: TxInternals, auxiliaryData?: Cardano.AuxiliaryData): Promise<Cardano.NewTxAlonzo> {
     const signatures = await this.#keyAgent.signTransaction(tx);
@@ -234,6 +224,33 @@ export class SingleAddressWallet implements Wallet {
     this.genesisParameters$.complete();
     this.#tip$.complete();
     this.addresses$.complete();
+  }
+
+  #prepareTx(props: InitializeTxProps) {
+    return lastValueFrom(
+      combineLatest([this.tip$, this.utxo.available$, this.protocolParameters$, this.addresses$]).pipe(
+        take(1),
+        map(([tip, utxo, protocolParameters, [{ address: changeAddress }]]) => {
+          const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
+          const constraints = defaultSelectionConstraints({
+            buildTx: async (inputSelection) => {
+              this.#logger.debug('Building TX for selection constraints', inputSelection);
+              const txInternals = await createTransactionInternals({
+                certificates: props.certificates,
+                changeAddress,
+                inputSelection,
+                validityInterval,
+                withdrawals: props.withdrawals
+              });
+              return coreToCsl.tx(await this.finalizeTx(txInternals));
+            },
+            protocolParameters
+          });
+          const implicitCoin = computeImplicitCoin(protocolParameters, props);
+          return { changeAddress, constraints, implicitCoin, utxo, validityInterval };
+        })
+      )
+    );
   }
 
   #initializeAddress(existingAddress?: GroupedAddress): Observable<GroupedAddress[]> {

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -163,8 +163,7 @@ export class SingleAddressWallet implements Wallet {
     const { coinsPerUtxoWord } = await firstValueFrom(this.protocolParameters$);
     const minimumCoinQuantities = new Map<Cardano.TxOut, MinimumCoinQuantity>();
     for (const output of props.outputs || []) {
-      const multiasset = output.value.assets ? coreToCsl.value(output.value).multiasset() : undefined;
-      const minimumCoin = BigInt(computeMinimumCoinQuantity(coinsPerUtxoWord)(multiasset));
+      const minimumCoin = BigInt(computeMinimumCoinQuantity(coinsPerUtxoWord)(output.value.assets));
       minimumCoinQuantities.set(output, {
         coinMissing: BigIntMath.max([minimumCoin - output.value.coins, 0n])!,
         minimumCoin
@@ -177,8 +176,8 @@ export class SingleAddressWallet implements Wallet {
     const { selection: inputSelection } = await this.#inputSelector.select({
       constraints,
       implicitCoin,
-      outputs: new Set([...(props.outputs || [])].map((output) => coreToCsl.txOut(output))),
-      utxo: new Set(coreToCsl.utxo(utxo))
+      outputs: props.outputs || new Set(),
+      utxo: new Set(utxo)
     });
     const { body, hash } = await createTransactionInternals({
       certificates: props.certificates,

--- a/packages/wallet/src/Transaction/createTransactionInternals.ts
+++ b/packages/wallet/src/Transaction/createTransactionInternals.ts
@@ -1,4 +1,4 @@
-import { CSL, Cardano, coreToCsl, cslToCore } from '@cardano-sdk/core';
+import { CSL, Cardano, coreToCsl } from '@cardano-sdk/core';
 import { SelectionResult } from '@cardano-sdk/cip2';
 
 export type TxInternals = {
@@ -21,9 +21,8 @@ export const createTransactionInternals = async ({
   validityInterval,
   inputSelection
 }: CreateTxInternalsProps): Promise<TxInternals> => {
-  const outputs = [...inputSelection.outputs].map(cslToCore.txOut);
-  for (const cslValue of inputSelection.change) {
-    const value = cslToCore.value(cslValue);
+  const outputs = [...inputSelection.outputs];
+  for (const value of inputSelection.change) {
     outputs.push({
       address: changeAddress,
       value
@@ -33,10 +32,8 @@ export const createTransactionInternals = async ({
     // TODO: return more fields. Also add support in coreToCsl.txBody:
     // collaterals, mint, requiredExtraSignatures, scriptIntegrityHash
     certificates,
-    fee: BigInt(inputSelection.fee.to_str()),
-    inputs: [...inputSelection.inputs].map((cslInput) =>
-      cslToCore.txIn(cslInput.input(), Cardano.Address(cslInput.output().address().to_bech32()))
-    ),
+    fee: inputSelection.fee,
+    inputs: [...inputSelection.inputs].map(([txIn]) => txIn),
     outputs,
     validityInterval,
     withdrawals

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,6 +1,7 @@
 import { Balance, BehaviorObservable, DelegationTracker, TransactionalTracker, TransactionsTracker } from './services';
 import { Cardano, NetworkInfo, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
 import { GroupedAddress } from './KeyManagement';
+import { SelectionSkeleton } from '@cardano-sdk/cip2';
 import { TxInternals } from './Transaction';
 
 export interface SerializableStatic<T, OpaqueStringT> {
@@ -42,7 +43,7 @@ export interface TxValidationResult {
   minimumCoinQuantities: MinimumCoinQuantityPerOutput;
 }
 
-export type InitializeTxResult = TxInternals;
+export type InitializeTxResult = TxInternals & { inputSelection: SelectionSkeleton };
 
 export interface Wallet {
   name: string;
@@ -62,7 +63,7 @@ export interface Wallet {
    * @param props transaction body data
    */
   validateTx(props: InitializeTxProps): Promise<TxValidationResult>;
-  initializeTx(props: InitializeTxProps): Promise<TxInternals>;
+  initializeTx(props: InitializeTxProps): Promise<InitializeTxResult>;
   finalizeTx(props: TxInternals): Promise<Cardano.NewTxAlonzo>;
   /**
    * @throws {Cardano.TxSubmissionError}

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -32,6 +32,18 @@ export interface FinalizeTxProps {
 
 export type Assets = Map<Cardano.AssetId, Cardano.Asset>;
 
+export interface MinimumCoinQuantity {
+  minimumCoin: bigint;
+  coinMissing: bigint;
+}
+export type MinimumCoinQuantityPerOutput = Map<Cardano.TxOut, MinimumCoinQuantity>;
+
+export interface TxValidationResult {
+  minimumCoinQuantities: MinimumCoinQuantityPerOutput;
+}
+
+export type InitializeTxResult = TxInternals;
+
 export interface Wallet {
   name: string;
   readonly balance: TransactionalTracker<Balance>;
@@ -44,6 +56,12 @@ export interface Wallet {
   readonly protocolParameters$: BehaviorObservable<ProtocolParametersRequiredByWallet>;
   readonly addresses$: BehaviorObservable<GroupedAddress[]>;
   readonly assets$: BehaviorObservable<Assets>;
+  /**
+   * Compute minimum coin quantity for each transaction output
+   *
+   * @param props transaction body data
+   */
+  validateTx(props: InitializeTxProps): Promise<TxValidationResult>;
   initializeTx(props: InitializeTxProps): Promise<TxInternals>;
   finalizeTx(props: TxInternals): Promise<Cardano.NewTxAlonzo>;
   /**

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -34,12 +34,12 @@ export interface FinalizeTxProps {
 export type Assets = Map<Cardano.AssetId, Cardano.Asset>;
 
 export interface MinimumCoinQuantity {
-  minimumCoin: bigint;
-  coinMissing: bigint;
+  minimumCoin: Cardano.Lovelace;
+  coinMissing: Cardano.Lovelace;
 }
 export type MinimumCoinQuantityPerOutput = Map<Cardano.TxOut, MinimumCoinQuantity>;
 
-export interface TxValidationResult {
+export interface InitializeTxPropsValidationResult {
   minimumCoinQuantities: MinimumCoinQuantityPerOutput;
 }
 
@@ -59,10 +59,11 @@ export interface Wallet {
   readonly assets$: BehaviorObservable<Assets>;
   /**
    * Compute minimum coin quantity for each transaction output
-   *
-   * @param props transaction body data
    */
-  validateTx(props: InitializeTxProps): Promise<TxValidationResult>;
+  validateInitializeTxProps(props: InitializeTxProps): Promise<InitializeTxPropsValidationResult>;
+  /**
+   * @throws InputSelectionError
+   */
   initializeTx(props: InitializeTxProps): Promise<InitializeTxResult>;
   finalizeTx(props: TxInternals): Promise<Cardano.NewTxAlonzo>;
   /**

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -87,16 +87,41 @@ describe('SingleAddressWallet', () => {
   });
 
   describe('creating transactions', () => {
-    const props = {
-      outputs: new Set([
-        {
-          address: Cardano.Address(
-            'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w'
-          ),
-          value: { coins: 11_111_111n }
+    const outputs = [
+      {
+        address: Cardano.Address(
+          'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w'
+        ),
+        value: { coins: 11_111_111n }
+      },
+      {
+        address: Cardano.Address(
+          'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+        ),
+        value: {
+          assets: new Map([[AssetId.TSLA, 6n]]),
+          coins: 5n
         }
-      ])
+      }
+    ];
+    const props = {
+      outputs: new Set<Cardano.TxOut>(outputs)
     };
+
+    describe('validateTx', () => {
+      it('returns minimum coin quantity per output', async () => {
+        const { minimumCoinQuantities } = await wallet.validateTx(props);
+        expect(minimumCoinQuantities.size).toBe(2);
+        const outputWithoutAssetsMinimumCoin = minimumCoinQuantities.get(outputs[0])!;
+        const outputWithAssetsMinimumCoin = minimumCoinQuantities.get(outputs[1])!;
+        expect(outputWithoutAssetsMinimumCoin.minimumCoin).toBeGreaterThan(0n);
+        expect(outputWithAssetsMinimumCoin.minimumCoin).toBeGreaterThan(outputWithoutAssetsMinimumCoin.minimumCoin);
+        expect(outputWithoutAssetsMinimumCoin.coinMissing).toBe(0n);
+        expect(outputWithAssetsMinimumCoin.coinMissing).toBe(
+          outputWithAssetsMinimumCoin.minimumCoin - outputs[1].value.coins
+        );
+      });
+    });
 
     it('initializeTx', async () => {
       const { body, hash } = await wallet.initializeTx(props);

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import * as mocks from './mocks';
 import { AssetId, createStubStakePoolSearchProvider } from '@cardano-sdk/util-dev';
-import { CSL, Cardano } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { KeyManagement, SingleAddressWallet } from '../src';
 import { firstValueFrom, skip } from 'rxjs';
 import { testKeyAgent } from './mocks';
@@ -129,7 +129,7 @@ describe('SingleAddressWallet', () => {
       expect(typeof hash).toBe('string');
       expect(inputSelection.outputs.size).toBe(props.outputs.size);
       expect(inputSelection.inputs.size).toBeGreaterThan(0);
-      expect(inputSelection.fee instanceof CSL.BigNum).toBe(true);
+      expect(inputSelection.fee).toBeGreaterThan(0n);
       expect(inputSelection.change.size).toBeGreaterThan(0);
     });
 

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import * as mocks from './mocks';
 import { AssetId, createStubStakePoolSearchProvider } from '@cardano-sdk/util-dev';
-import { Cardano } from '@cardano-sdk/core';
+import { CSL, Cardano } from '@cardano-sdk/core';
 import { KeyManagement, SingleAddressWallet } from '../src';
 import { firstValueFrom, skip } from 'rxjs';
 import { testKeyAgent } from './mocks';
@@ -124,9 +124,13 @@ describe('SingleAddressWallet', () => {
     });
 
     it('initializeTx', async () => {
-      const { body, hash } = await wallet.initializeTx(props);
+      const { body, hash, inputSelection } = await wallet.initializeTx(props);
       expect(body.outputs).toHaveLength(props.outputs.size + 1 /* change output */);
       expect(typeof hash).toBe('string');
+      expect(inputSelection.outputs.size).toBe(props.outputs.size);
+      expect(inputSelection.inputs.size).toBeGreaterThan(0);
+      expect(inputSelection.fee instanceof CSL.BigNum).toBe(true);
+      expect(inputSelection.change.size).toBeGreaterThan(0);
     });
 
     it('finalizeTx', async () => {

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -110,7 +110,7 @@ describe('SingleAddressWallet', () => {
 
     describe('validateTx', () => {
       it('returns minimum coin quantity per output', async () => {
-        const { minimumCoinQuantities } = await wallet.validateTx(props);
+        const { minimumCoinQuantities } = await wallet.validateInitializeTxProps(props);
         expect(minimumCoinQuantities.size).toBe(2);
         const outputWithoutAssetsMinimumCoin = minimumCoinQuantities.get(outputs[0])!;
         const outputWithAssetsMinimumCoin = minimumCoinQuantities.get(outputs[1])!;

--- a/packages/wallet/test/Transaction/createTransactionInternals.test.ts
+++ b/packages/wallet/test/Transaction/createTransactionInternals.test.ts
@@ -1,4 +1,4 @@
-import { Cardano, WalletProvider, coreToCsl } from '@cardano-sdk/core';
+import { Cardano, WalletProvider } from '@cardano-sdk/core';
 import { CreateTxInternalsProps, createTransactionInternals } from '../../src/Transaction';
 import { SelectionConstraints } from '@cardano-sdk/util-dev';
 import { SelectionSkeleton, roundRobinRandomImprove } from '@cardano-sdk/cip2';
@@ -27,8 +27,8 @@ describe('Transaction.createTransactionInternals', () => {
   ) => {
     const result = await roundRobinRandomImprove().select({
       constraints: SelectionConstraints.NO_CONSTRAINTS,
-      outputs: new Set(outputs.map((output) => coreToCsl.txOut(output))),
-      utxo: new Set(coreToCsl.utxo(utxo))
+      outputs: new Set(outputs),
+      utxo: new Set(utxo)
     });
     const ledgerTip = await provider.ledgerTip();
     const overrides = props(result.selection);


### PR DESCRIPTION
# Context

Wallets need to know minimum coin quantity on outputs so that they can create a valid transaction.

# Proposed Solution

```typescript
interface MinimumCoinQuantity {
  minimumCoin: Cardano.Lovelace;
  coinMissing: Cardano.Lovelace;
}
type MinimumCoinQuantityPerOutput = Map<Cardano.TxOut, MinimumCoinQuantity>;
interface InitializeTxPropsValidationResult {
  minimumCoinQuantities: MinimumCoinQuantityPerOutput;
}
interface Wallet {
  validateInitializeTxProps(props: InitializeTxProps): Promise<InitializeTxPropsValidationResult>;
}
```

# Important Changes Introduced

- Update `cip2` package types to use SDK's core types instead of CSL. As a result,
  - Add a few new test utils to `util-dev` package
  - Add `coreToCsl.tokenMap`
- Add `inputSelection` field to result of `wallet.initializeTx`