### PR TITLE
fix: chacha lib usage changes to work in polyfilled browser env

### DIFF
--- a/packages/wallet/src/KeyManagement/cachedGetPassword.ts
+++ b/packages/wallet/src/KeyManagement/cachedGetPassword.ts
@@ -2,13 +2,20 @@ import { GetPassword } from './types';
 import { Milliseconds } from '..';
 
 export const cachedGetPassword = (getPassword: () => Promise<Uint8Array>, cacheDuration: Milliseconds): GetPassword => {
-  let cached: Uint8Array | null;
+  let cached: Promise<Uint8Array> | null;
   let timeout: NodeJS.Timeout | null;
-  return async (noCache) => {
+  return (noCache) => {
     if (noCache || !cached) {
-      cached = await getPassword();
-      if (timeout) clearTimeout(timeout);
-      timeout = setTimeout(() => (cached = null), cacheDuration);
+      cached = getPassword()
+        .then((password) => {
+          if (timeout) clearTimeout(timeout);
+          timeout = setTimeout(() => (cached = null), cacheDuration);
+          return password;
+        })
+        .catch((error) => {
+          cached = null;
+          throw error;
+        });
     }
     return cached;
   };

--- a/packages/wallet/src/KeyManagement/emip3.ts
+++ b/packages/wallet/src/KeyManagement/emip3.ts
@@ -26,7 +26,7 @@ export const emip3encrypt = async (data: Uint8Array, password: Uint8Array): Prom
   const key = await createPbkdf2Key(password, salt);
   const nonce = new Uint8Array(NONCE_LENGTH);
   getRandomValues(nonce);
-  const cipher = chacha.createCipher(key, nonce);
+  const cipher = chacha.createCipher(key, Buffer.from(nonce));
   cipher.setAAD(AAD, { plaintextLength: data.length });
   const head = cipher.update(data);
   const final = cipher.final();
@@ -43,8 +43,8 @@ export const emip3decrypt = async (encrypted: Uint8Array, password: Uint8Array):
   const tag = encrypted.slice(SALT_LENGTH + NONCE_LENGTH, SALT_LENGTH + NONCE_LENGTH + TAG_LENGTH);
   const data = encrypted.slice(SALT_LENGTH + NONCE_LENGTH + TAG_LENGTH);
   const key = await createPbkdf2Key(password, salt);
-  const decipher = chacha.createDecipher(key, nonce);
-  decipher.setAuthTag(tag);
+  const decipher = chacha.createDecipher(key, Buffer.from(nonce));
+  decipher.setAuthTag(Buffer.from(tag));
   decipher.setAAD(AAD);
   return Buffer.concat([decipher.update(data), decipher.final()]);
 };

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -3,3 +3,4 @@ export * as KeyManagement from './KeyManagement';
 export * from './SingleAddressWallet';
 export * from './types';
 export * from './services';
+export * as util from './util';

--- a/packages/wallet/src/util.ts
+++ b/packages/wallet/src/util.ts
@@ -1,0 +1,1 @@
+export { firstValueFrom, lastValueFrom } from 'rxjs';

--- a/packages/wallet/test/KeyManagement/cachedGetPassword.test.ts
+++ b/packages/wallet/test/KeyManagement/cachedGetPassword.test.ts
@@ -5,38 +5,64 @@ jest.useFakeTimers();
 describe('cachedGetPassword', () => {
   let getPassword: jest.Mock;
   let cachedGetPassword: KeyManagement.GetPassword;
+  const getPasswordDuration = 10;
   const cacheDuration = 100;
   const password = Buffer.from('password');
 
   beforeEach(() => {
-    getPassword = jest.fn().mockResolvedValue(password);
+    getPassword = jest
+      .fn()
+      .mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(password), getPasswordDuration)));
     cachedGetPassword = KeyManagement.cachedGetPassword(getPassword, cacheDuration);
   });
 
   it('caches password for specified duration"', async () => {
-    const pw1 = await cachedGetPassword();
+    const pw1 = cachedGetPassword();
+    jest.advanceTimersByTime(getPasswordDuration);
+    expect(await pw1).toBe(password);
     expect(getPassword).toBeCalledTimes(1);
-    expect(pw1).toBe(password);
 
-    jest.advanceTimersByTime(cacheDuration / 2);
-    const pw2 = await cachedGetPassword();
+    jest.advanceTimersByTime(cacheDuration - 1);
+    const pw2 = cachedGetPassword();
+    expect(await pw2).toBe(password);
     expect(getPassword).toBeCalledTimes(1);
-    expect(pw2).toBe(password);
 
-    jest.advanceTimersByTime(cacheDuration / 2 + 1);
-    const pw3 = await cachedGetPassword();
+    jest.advanceTimersByTime(1);
+    const pw3 = cachedGetPassword();
+    jest.advanceTimersByTime(getPasswordDuration);
+    expect(await pw3).toBe(password);
     expect(getPassword).toBeCalledTimes(2);
-    expect(pw3).toBe(password);
+  });
+
+  it('does not call underlying "getPassword" again while already authenticating', async () => {
+    const pw1 = cachedGetPassword();
+    jest.advanceTimersByTime(getPasswordDuration / 2);
+    const pw2 = cachedGetPassword();
+    jest.advanceTimersByTime(getPasswordDuration / 2);
+    expect(await pw1).toBe(password);
+    expect(await pw2).toBe(password);
+    expect(getPassword).toBeCalledTimes(1);
+  });
+
+  it('does not cache failed "getPassword"', async () => {
+    getPassword.mockRejectedValueOnce(new Error('any error'));
+    await expect(cachedGetPassword()).rejects.toThrowError();
+    const pw = cachedGetPassword();
+    jest.advanceTimersByTime(getPasswordDuration);
+    expect(await pw).toBe(password);
+    expect(getPassword).toBeCalledTimes(2);
   });
 
   it('ignores cache when "noCache=true', async () => {
-    const pw1 = await cachedGetPassword();
-    expect(pw1).toBe(password);
+    const pw = cachedGetPassword();
+    jest.advanceTimersByTime(getPasswordDuration);
+    expect(await pw).toBe(password);
     expect(getPassword).toBeCalledTimes(1);
 
     jest.advanceTimersByTime(cacheDuration / 2);
-    const pw2 = await cachedGetPassword(true);
+    const pw2 = cachedGetPassword(true);
+    jest.advanceTimersByTime(getPasswordDuration);
+    expect(await pw2).toBe(password);
     expect(getPassword).toBeCalledTimes(2);
-    expect(pw2).toBe(password);
   });
 });


### PR DESCRIPTION
# Context

Using `InMemoryKeyAgent` in (polyfilled) browser environment throws `TypeError: nonce.readUInt32LE is not a function`.

# Proposed Solution

Convert `Uint8Array` to `Buffer`, as `chacha` library expects.

# Important Changes Introduced

- Re-export `firstValueFrom` and `lastValueFrom` from rxjs as `wallet` package util. This will eliminate the need of having `rxjs` as a direct dependency for some use cases.
- `cachedGetPassword` will no longer call underlying `GetPassword` function while already authenticating.
