### PR TITLE
fix: blockfrost getAsset

### DIFF
--- a/packages/blockfrost/test/blockfrostAssetProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostAssetProvider.test.ts
@@ -46,7 +46,6 @@ describe('blockfrostAssetProvider', () => {
         fingerprint: Cardano.AssetFingerprint('asset1pkpwyknlvul7az0xx8czhl60pyel45rpje4z8w'),
         history: [
           {
-            action: Cardano.AssetProvisioning.Mint,
             quantity: 12_000n,
             transactionId: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
           }
@@ -93,13 +92,11 @@ describe('blockfrostAssetProvider', () => {
         fingerprint: Cardano.AssetFingerprint('asset1pkpwyknlvul7az0xx8czhl60pyel45rpje4z8w'),
         history: [
           {
-            action: Cardano.AssetProvisioning.Mint,
             quantity: 13_000n,
             transactionId: Cardano.TransactionId('4123d70f66414cc921f6ffc29a899aafc7137a99a0fd453d6b200863ef5702d6')
           },
           {
-            action: Cardano.AssetProvisioning.Burn,
-            quantity: 1000n,
+            quantity: -1000n,
             transactionId: Cardano.TransactionId('01d7366549986d83edeea262e97b68eca3430d3bb052ed1c37d2202fd5458872')
           }
         ],

--- a/packages/blockfrost/test/e2e/config.ts
+++ b/packages/blockfrost/test/e2e/config.ts
@@ -1,15 +1,11 @@
-import { blockfrostWalletProvider } from '../../src';
+import { blockfrostAssetProvider, blockfrostWalletProvider } from '../../src';
 
 const networkId = Number.parseInt(process.env.NETWORK_ID || '');
 if (Number.isNaN(networkId)) throw new Error('NETWORK_ID not set');
 const isTestnet = networkId === 0;
 
-export const walletProvider = (() => {
-  const walletProviderName = process.env.WALLET_PROVIDER;
-  if (walletProviderName === 'blockfrost') {
-    const projectId = process.env.BLOCKFROST_API_KEY;
-    if (!projectId) throw new Error('BLOCKFROST_API_KEY not set');
-    return blockfrostWalletProvider({ isTestnet, projectId });
-  }
-  throw new Error(`WALLET_PROVIDER unsupported: ${walletProviderName}`);
-})();
+const projectId = process.env.BLOCKFROST_API_KEY;
+if (!projectId) throw new Error('BLOCKFROST_API_KEY not set');
+
+export const walletProvider = blockfrostWalletProvider({ isTestnet, projectId });
+export const assetProvider = blockfrostAssetProvider({ isTestnet, projectId });

--- a/packages/blockfrost/test/e2e/getAsset.test.ts
+++ b/packages/blockfrost/test/e2e/getAsset.test.ts
@@ -1,0 +1,20 @@
+import { Cardano } from '@cardano-sdk/core';
+import { assetProvider } from './config';
+
+describe('blockfrostAssetProvider', () => {
+  test('getAsset', async () => {
+    const asset = await assetProvider.getAsset(
+      Cardano.AssetId('6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa7')
+    );
+    expect(typeof asset.assetId).toBe('string');
+    expect(typeof asset.fingerprint).toBe('string');
+    expect(asset.history.length).toBeGreaterThan(1);
+    expect(typeof asset.history[0].quantity).toBe('bigint');
+    expect(typeof asset.history[0].transactionId).toBe('string');
+    expect(typeof asset.metadata).toBe('object');
+    expect(typeof asset.metadata!.ticker).toBe('string');
+    expect(typeof asset.name).toBe('string');
+    expect(typeof asset.policyId).toBe('string');
+    expect(typeof asset.quantity).toBe('bigint');
+  });
+});

--- a/packages/core/src/Cardano/types/Asset.ts
+++ b/packages/core/src/Cardano/types/Asset.ts
@@ -92,15 +92,13 @@ export interface AssetMetadata {
   [key: string]: unknown;
 }
 
-export enum AssetProvisioning {
-  Mint = 'MINT',
-  Burn = 'BURN'
-}
-
 export interface AssetMintOrBurn {
   transactionId: TransactionId;
+  /**
+   * Positive = mint
+   * Negative = burn
+   */
   quantity: bigint;
-  action: AssetProvisioning;
 }
 
 export interface Asset {

--- a/packages/wallet/test/mocks/mockAssetProvider.ts
+++ b/packages/wallet/test/mocks/mockAssetProvider.ts
@@ -5,7 +5,6 @@ export const asset = {
   fingerprint: Cardano.AssetFingerprint('asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3'),
   history: [
     {
-      action: Cardano.AssetProvisioning.Mint,
       quantity: 1000n,
       transactionId: Cardano.TransactionId('886206542d63b23a047864021fbfccf291d78e47c1e59bd4c75fbc67b248c5e8')
     }


### PR DESCRIPTION
# Context

Blockfrost asset provider `getAsset` throws an error for assets that have mint/burn history.

# Important Changes Introduced

Refactor core `AssetMintOrBurn` type to use negative quantity to indicate burn (instead of `action` field).