### PR TITLE
fix(wallet): do not decrypt private key on InMemoryKeyAgent restoration

### DIFF
--- a/packages/wallet/src/KeyManagement/restoreKeyAgent.ts
+++ b/packages/wallet/src/KeyManagement/restoreKeyAgent.ts
@@ -38,14 +38,12 @@ export async function restoreKeyAgent<T extends SerializableKeyAgentData>(
       if (!getPassword) {
         throw new InvalidSerializableDataError('Expected "getPassword" in RestoreKeyAgentProps for InMemoryKeyAgent"');
       }
-      const keyAgent = new InMemoryKeyAgent({
+      return new InMemoryKeyAgent({
         accountIndex: data.accountIndex,
         encryptedRootPrivateKey: new Uint8Array(data.encryptedRootPrivateKeyBytes),
         getPassword,
         networkId: data.networkId
       });
-      await keyAgent.getExtendedAccountPublicKey(); // attempt to decrypt the key
-      return keyAgent;
     }
     default:
       throw new InvalidSerializableDataError(


### PR DESCRIPTION
# Context

Restoring InMemoryKeyAgent requires the passphrase

# Proposed Solution

Do not decrypt private key on InMemoryKeyAgent restoration. If it's desired, user can trigger it manually
