### PR TITLE
feat: nft metadata

### DIFF
--- a/packages/blockfrost/src/blockfrostAssetProvider.ts
+++ b/packages/blockfrost/src/blockfrostAssetProvider.ts
@@ -39,7 +39,7 @@ export const blockfrostAssetProvider = (options: Options): AssetProvider => {
 
   const getAsset: AssetProvider['getAsset'] = async (assetId) => {
     const response = await blockfrost.assetsById(assetId.toString());
-    const name = Buffer.from(Asset.util.assetNameFromAssetId(assetId), 'hex').toString('utf-8');
+    const name = Asset.util.assetNameFromAssetId(assetId);
     const quantity = BigInt(response.quantity);
     return {
       assetId,

--- a/packages/blockfrost/test/blockfrostAssetProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostAssetProvider.test.ts
@@ -58,7 +58,7 @@ describe('blockfrostAssetProvider', () => {
           ticker: 'nutc',
           url: 'https://www.stakenuts.com/'
         },
-        name: 'nutcoin',
+        name: Cardano.AssetName('6e7574636f696e'),
         policyId: Cardano.PolicyId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7'),
         quantity: 12_000n
       });
@@ -108,7 +108,7 @@ describe('blockfrostAssetProvider', () => {
           ticker: 'nutc',
           url: 'https://www.stakenuts.com/'
         },
-        name: 'nutcoin',
+        name: Cardano.AssetName('6e7574636f696e'),
         policyId: Cardano.PolicyId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7'),
         quantity: 12_000n
       });

--- a/packages/core/src/CSL/certificate.ts
+++ b/packages/core/src/CSL/certificate.ts
@@ -124,6 +124,7 @@ export const poolRetirement = (poolId: Cardano.PoolId, epoch: number) =>
 
 export const stakeDelegation = (rewardAccount: Cardano.RewardAccount, delegatee: Cardano.PoolId) =>
   Certificate.new_stake_delegation(
+    // TODO: add coreToCsl support for genesis pool IDs
     StakeDelegation.new(stakeAddressToCredential(rewardAccount), Ed25519KeyHash.from_bech32(delegatee.toString()))
   );
 

--- a/packages/core/src/CSL/coreToCsl.ts
+++ b/packages/core/src/CSL/coreToCsl.ts
@@ -58,6 +58,7 @@ export const txIn = (core: Cardano.TxIn): TransactionInput =>
   TransactionInput.new(TransactionHash.from_bytes(Buffer.from(core.txId, 'hex')), core.index);
 
 export const txOut = (core: Cardano.TxOut): TransactionOutput =>
+  // TODO: add support for base 58 addresses
   TransactionOutput.new(Address.from_bech32(core.address.toString()), value(core.value));
 
 export const utxo = (core: Cardano.Utxo[]): TransactionUnspentOutput[] =>

--- a/packages/core/src/Cardano/types/Address.ts
+++ b/packages/core/src/Cardano/types/Address.ts
@@ -1,13 +1,20 @@
-import * as util from '../util';
+import * as typesUtil from '../util';
+import { InvalidStringError } from '../..';
+import { util as addressUtil } from '../../Address';
 
 /**
  * mainnet or testnet address as bech32 string, consisting of
  * network tag, payment credential and optional stake credential
  */
-export type Address = util.OpaqueString<'Address'>;
+export type Address = typesUtil.OpaqueString<'Address'>;
 
 /**
- * @param {string} value mainnet or testnet address as bech32 string
+ * @param {string} value mainnet or testnet address
  * @throws InvalidStringError
  */
-export const Address = (value: string): Address => util.typedBech32(value, ['addr', 'addr_test'], [47, 92]);
+export const Address = (value: string): Address => {
+  if (addressUtil.isAddress(value)) {
+    return value as unknown as Address;
+  }
+  throw new InvalidStringError(`Invalid address: ${value}`);
+};

--- a/packages/core/src/Cardano/types/Asset.ts
+++ b/packages/core/src/Cardano/types/Asset.ts
@@ -107,6 +107,9 @@ export interface Asset {
   name: string;
   fingerprint: AssetFingerprint;
   quantity: bigint;
+  /**
+   * Sorted by slot
+   */
   history: AssetMintOrBurn[];
   metadata?: AssetMetadata;
 }

--- a/packages/core/src/Cardano/types/Asset.ts
+++ b/packages/core/src/Cardano/types/Asset.ts
@@ -4,6 +4,9 @@ import { TransactionId } from './Transaction';
 
 export type AssetId = OpaqueString<'AssetId'>;
 
+/**
+ * Hex-encoded asset name
+ */
 export type AssetName = OpaqueString<'AssetName'>;
 export const AssetName = (value: string): AssetName => {
   if (value.length > 0) {
@@ -26,6 +29,9 @@ export const AssetId = (value: string): AssetId => {
   return value as unknown as AssetId;
 };
 
+/**
+ * Hex-encoded policy id
+ */
 export type PolicyId = Hash28ByteBase16<'PolicyId'>;
 export const PolicyId = (value: string): PolicyId => Hash28ByteBase16(value);
 
@@ -104,7 +110,7 @@ export interface AssetMintOrBurn {
 export interface Asset {
   assetId: AssetId;
   policyId: PolicyId;
-  name: string;
+  name: AssetName;
   fingerprint: AssetFingerprint;
   quantity: bigint;
   /**

--- a/packages/core/src/Cardano/types/AuxiliaryData.ts
+++ b/packages/core/src/Cardano/types/AuxiliaryData.ts
@@ -6,7 +6,7 @@
 // } else if (Array.isArray(metadatum)) {
 // } else if (metadatum instanceof Uint8Array) {
 // } else {
-//   // a is MetadatumMap
+//   // metadatum is MetadatumMap
 // }
 
 import * as Cardano from '.';

--- a/packages/core/src/Cardano/types/StakePool/primitives.ts
+++ b/packages/core/src/Cardano/types/StakePool/primitives.ts
@@ -1,16 +1,27 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hash28ByteBase16, OpaqueString, typedBech32, typedHex } from '../../util';
+import { InvalidStringError } from '../../..';
 
 /**
- * pool operator verification key hash as bech32 string
+ * pool operator verification key hash as bech32 string or a genesis pool ID
  */
 export type PoolId = OpaqueString<'PoolId'>;
 
 /**
- * @param {string} value blake2b_224 digest of an operator verification key hash
+ * @param {string} value blake2b_224 digest of an operator verification key hash or a genesis pool ID
  * @throws InvalidStringError
  */
-export const PoolId = (value: string): PoolId => typedBech32(value, 'pool', 45);
+export const PoolId = (value: string): PoolId => {
+  try {
+    return typedBech32(value, 'pool', 45);
+  } catch (error: unknown) {
+    // eslint-disable-next-line prettier/prettier
+    if ((/^ShelleyGenesis-[\dA-Fa-f]{16}$/).test(value)) {
+      return value as unknown as PoolId;
+    }
+    throw new InvalidStringError('Expected PoolId to be either bech32 or genesis stake pool', error);
+  }
+};
 
 /**
  * pool operator verification key hash as hex string

--- a/packages/core/src/Cardano/util/index.ts
+++ b/packages/core/src/Cardano/util/index.ts
@@ -1,3 +1,4 @@
 export * from './coalesceValueQuantities';
 export * from './computeMinUtxoValue';
 export * from './primitives';
+export * as metadatum from './metadatum';

--- a/packages/core/src/Cardano/util/metadatum.ts
+++ b/packages/core/src/Cardano/util/metadatum.ts
@@ -1,0 +1,21 @@
+import { Metadatum, MetadatumMap } from '../types';
+
+/**
+ * @returns {MetadatumMap | null} null if Metadatum is not MetadatumMap
+ */
+export const asMetadatumMap = (metadatum: Metadatum): MetadatumMap | null => {
+  if (typeof metadatum === 'object' && !Array.isArray(metadatum) && !(metadatum instanceof Uint8Array)) {
+    return metadatum;
+  }
+  return null;
+};
+
+/**
+ * @returns {Metadatum[] | null} null if Metadatum is not an array of metadatum
+ */
+export const asMetadatumArray = (metadatum: Metadatum): Metadatum[] | null => {
+  if (Array.isArray(metadatum)) {
+    return metadatum;
+  }
+  return null;
+};

--- a/packages/core/test/Cardano/types/Address.test.ts
+++ b/packages/core/test/Cardano/types/Address.test.ts
@@ -1,25 +1,23 @@
 import { Cardano } from '../../../src';
 
-jest.mock('../../../src/Cardano/util/primitives', () => {
-  const actual = jest.requireActual('../../../src/Cardano/util/primitives');
+// eslint-disable-next-line sonarjs/no-duplicate-string
+jest.mock('../../../src/Address/util', () => {
+  const actual = jest.requireActual('../../../src/Address/util');
   return {
-    typedBech32: jest.fn().mockImplementation((...args) => actual.typedBech32(...args))
+    isAddress: jest.fn().mockImplementation((...args) => actual.isAddress(...args))
   };
 });
+const addressUtilMock = jest.requireMock('../../../src/Address/util');
 
 describe('Cardano/types/Address', () => {
-  afterEach(() => (Cardano.util.typedBech32 as jest.Mock).mockReset());
-
   it('Address() accepts a valid mainnet grouped address and is implemented using util.typedBech32', () => {
     expect(() =>
       Cardano.Address(
         'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
       )
     ).not.toThrow();
-    expect(Cardano.util.typedBech32).toBeCalledWith(
-      'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn',
-      ['addr', 'addr_test'],
-      [47, 92]
+    expect(addressUtilMock.isAddress).toBeCalledWith(
+      'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
     );
   });
 

--- a/packages/core/test/Cardano/types/StakePool.test.ts
+++ b/packages/core/test/Cardano/types/StakePool.test.ts
@@ -5,6 +5,10 @@ describe('Cardano/types/StakePool', () => {
     expect(() => Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh')).not.toThrow();
   });
 
+  it('PoolId() accepts a valid genesis pool ID', () => {
+    expect(() => Cardano.PoolId('ShelleyGenesis-eff1b5b26e65b791')).not.toThrow();
+  });
+
   it('PoolIdHex() accepts a valid pool id hex string', () => {
     expect(() => Cardano.PoolIdHex('e4b1c8ec89415ce6349755a1aa44b4affbb5f1248ff29943d190c715')).not.toThrow();
   });

--- a/packages/core/test/Cardano/util/metadatum.test.ts
+++ b/packages/core/test/Cardano/util/metadatum.test.ts
@@ -1,0 +1,27 @@
+import { Cardano } from '@cardano-sdk/core';
+
+describe('Cardano.util.metadatum', () => {
+  describe('asMetadatumMap', () => {
+    it('returns argument if it is a MetadatumMap', () => {
+      const metadatum: Cardano.Metadatum = { some: 'metadatum' };
+      expect(Cardano.util.metadatum.asMetadatumMap(metadatum)).toBe(metadatum);
+    });
+
+    it('returns null for any other metadatum type', () => {
+      const metadatum: Cardano.Metadatum = [{ some: 'metadatum' }];
+      expect(Cardano.util.metadatum.asMetadatumMap(metadatum)).toBeNull();
+    });
+  });
+
+  describe('asMetadatumArray', () => {
+    it('returns argument if it is Metadatum[]', () => {
+      const metadatum: Cardano.Metadatum = [{ some: 'metadatum' }];
+      expect(Cardano.util.metadatum.asMetadatumArray(metadatum)).toBe(metadatum);
+    });
+
+    it('returns null for any other metadatum type', () => {
+      const metadatum: Cardano.Metadatum = { some: 'metadatum' };
+      expect(Cardano.util.metadatum.asMetadatumArray(metadatum)).toBeNull();
+    });
+  });
+});

--- a/packages/wallet/src/KeyManagement/types.ts
+++ b/packages/wallet/src/KeyManagement/types.ts
@@ -66,7 +66,6 @@ export interface SerializableInMemoryKeyAgentData extends SerializableKeyAgentDa
 
 export type SerializableKeyAgentData = SerializableInMemoryKeyAgentData;
 
-// TODO: utility to cache password for specified duration
 /**
  * @returns password used to decrypt root private key
  */

--- a/packages/wallet/src/NftMetadata/createNftMetadataProvider.ts
+++ b/packages/wallet/src/NftMetadata/createNftMetadataProvider.ts
@@ -1,0 +1,22 @@
+import { Cardano, WalletProvider } from '@cardano-sdk/core';
+import { NftMetadataProvider } from './types';
+import { Observable, firstValueFrom, from, map, mergeMap, of, take } from 'rxjs';
+import { last } from 'lodash-es';
+import { metadatumToCip25 } from './metadatumToCip25';
+
+export const createNftMetadataProvider =
+  (walletProvider: WalletProvider, transactions$: Observable<Cardano.TxAlonzo[]>): NftMetadataProvider =>
+  (asset) => {
+    const latestMintTxId = last(asset.history.filter(({ quantity }) => quantity > 0))!.transactionId;
+    return firstValueFrom(
+      transactions$.pipe(
+        take(1),
+        map((transactions) => transactions.find((tx) => tx.id === latestMintTxId)),
+        mergeMap((localTx) =>
+          // Use local transaction if available, otherwise fetch from WalletProvider
+          localTx ? of(localTx) : from(walletProvider.queryTransactionsByHashes([latestMintTxId]).then(([tx]) => tx))
+        ),
+        map(({ auxiliaryData }) => metadatumToCip25(asset, auxiliaryData?.body.blob))
+      )
+    );
+  };

--- a/packages/wallet/src/NftMetadata/index.ts
+++ b/packages/wallet/src/NftMetadata/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './metadatumToCip25';
+export * from './createNftMetadataProvider';

--- a/packages/wallet/src/NftMetadata/metadatumToCip25.ts
+++ b/packages/wallet/src/NftMetadata/metadatumToCip25.ts
@@ -2,7 +2,7 @@ import { Cardano } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 import { ImageMediaType, MediaType, NftMetadata, NftMetadataFile, Uri } from './types';
 import { dummyLogger } from 'ts-log';
-import { omit } from 'lodash';
+import { omit } from 'lodash-es';
 
 class InvalidFileError extends CustomError {}
 

--- a/packages/wallet/src/NftMetadata/metadatumToCip25.ts
+++ b/packages/wallet/src/NftMetadata/metadatumToCip25.ts
@@ -1,0 +1,89 @@
+import { Cardano } from '@cardano-sdk/core';
+import { CustomError } from 'ts-custom-error';
+import { ImageMediaType, MediaType, NftMetadata, NftMetadataFile, Uri } from './types';
+import { dummyLogger } from 'ts-log';
+import { omit } from 'lodash';
+
+class InvalidFileError extends CustomError {}
+
+const asString = (obj: unknown): string | undefined => {
+  if (typeof obj === 'string') {
+    return obj;
+  }
+};
+
+const mapOtherProperties = (metadata: Cardano.MetadatumMap, primaryProperties: string[]) => {
+  const extraProperties = omit(metadata, primaryProperties);
+  return Object.keys(extraProperties).length > 0 ? extraProperties : undefined;
+};
+
+const mapFile = (metadatum: Cardano.Metadatum): NftMetadataFile => {
+  const file = Cardano.util.metadatum.asMetadatumMap(metadatum);
+  if (!file) throw new InvalidFileError();
+  const mediaType = asString(file.mediaType);
+  const name = asString(file.name);
+  const srcAsString = asString(file.src);
+  const src = srcAsString
+    ? Uri(srcAsString)
+    : Cardano.util.metadatum.asMetadatumArray(file.src)?.map((fileSrc) => {
+        const fileSrcAsString = asString(fileSrc);
+        if (!fileSrcAsString) throw new InvalidFileError();
+        return Uri(fileSrcAsString);
+      });
+  if (!name || !mediaType || !src) throw new InvalidFileError();
+  return {
+    mediaType: MediaType(mediaType),
+    name,
+    otherProperties: mapOtherProperties(file, ['mediaType', 'name', 'src']),
+    src
+  };
+};
+
+/**
+ * Also considers asset name encoded in utf8 within metadata valid
+ */
+const getAssetMetadata = (policy: Cardano.MetadatumMap, asset: Cardano.Asset) =>
+  Cardano.util.metadatum.asMetadatumMap(
+    policy[asset.name.toString()] || policy[Buffer.from(asset.name, 'hex').toString('utf8')]
+  );
+
+// TODO: consider hoisting this function together with cip25 types to core or a new cip25 package
+/**
+ * @returns {NftMetadata | undefined} CIP-0025 NFT metadata
+ */
+export const metadatumToCip25 = (
+  asset: Cardano.Asset,
+  metadatumMap: Cardano.MetadatumMap | undefined,
+  logger = dummyLogger
+): NftMetadata | undefined => {
+  const cip25Metadata = metadatumMap?.['721'];
+  if (!cip25Metadata) return;
+  const cip25MetadatumMap = Cardano.util.metadatum.asMetadatumMap(cip25Metadata);
+  if (!cip25MetadatumMap) return;
+  const policy = Cardano.util.metadatum.asMetadatumMap(cip25MetadatumMap[asset.policyId.toString()]);
+  if (!policy) return;
+  const assetMetadata = getAssetMetadata(policy, asset);
+  if (!assetMetadata) return;
+  const name = asString(assetMetadata.name);
+  const image = asString(assetMetadata.image);
+  if (!name || !image) {
+    logger.warn('Invalid CIP-25 metadata', assetMetadata);
+    return;
+  }
+  const mediaType = asString(assetMetadata.mediaType);
+  const files = Cardano.util.metadatum.asMetadatumArray(assetMetadata.files);
+  try {
+    return {
+      description: asString(assetMetadata.description),
+      files: files ? files.map(mapFile) : undefined,
+      image: Uri(image),
+      mediaType: mediaType ? ImageMediaType(mediaType) : undefined,
+      name,
+      otherProperties: mapOtherProperties(assetMetadata, ['name', 'image', 'mediaType', 'description', 'files']),
+      version: asString(policy.version) || '1.0'
+    };
+  } catch (error: unknown) {
+    // Any error here means metadata was invalid
+    logger.warn('Invalid CIP-25 metadata', assetMetadata, error);
+  }
+};

--- a/packages/wallet/src/NftMetadata/types.ts
+++ b/packages/wallet/src/NftMetadata/types.ts
@@ -35,7 +35,7 @@ export interface NftMetadataFile {
   mediaType: MediaType;
   src: Uri | Uri[];
   otherProperties?: {
-    [key: string]: Cardano.Metadatum;
+    [key: string]: Cardano.Metadatum | undefined;
   };
 }
 
@@ -50,7 +50,7 @@ export interface NftMetadata {
   files?: NftMetadataFile[];
   description?: string | string[];
   otherProperties?: {
-    [key: string]: Cardano.Metadatum;
+    [key: string]: Cardano.Metadatum | undefined;
   };
 }
 

--- a/packages/wallet/src/NftMetadata/types.ts
+++ b/packages/wallet/src/NftMetadata/types.ts
@@ -1,0 +1,59 @@
+/* eslint-disable wrap-regex */
+import { Cardano, InvalidStringError } from '@cardano-sdk/core';
+
+export type Uri = Cardano.util.OpaqueString<'Uri'>;
+export const Uri = (uri: string) => {
+  if (/^[a-z]+:\/\/.+/.test(uri)) {
+    return uri as unknown as Uri;
+  }
+  throw new InvalidStringError(
+    'Expected Uri to start with "[protocol]://", where protocol is usually "https" or "ipfs"'
+  );
+};
+
+export type ImageMediaType = Cardano.util.OpaqueString<'ImageMediaType'>;
+export const ImageMediaType = (mediaType: string) => {
+  if (/^image\/.+$/.test(mediaType)) {
+    return mediaType as unknown as ImageMediaType;
+  }
+  throw new InvalidStringError('Expected media type to be "image/*"');
+};
+
+export type MediaType = Cardano.util.OpaqueString<'MediaType'>;
+export const MediaType = (mediaType: string) => {
+  if (/^[a-z]+\/.+$/.test(mediaType)) {
+    return mediaType as unknown as MediaType;
+  }
+  throw new InvalidStringError('Expected media type to be "*/*"');
+};
+
+/**
+ * https://cips.cardano.org/cips/cip25/
+ */
+export interface NftMetadataFile {
+  name: string;
+  mediaType: MediaType;
+  src: Uri | Uri[];
+  otherProperties?: {
+    [key: string]: Cardano.Metadatum;
+  };
+}
+
+/**
+ * https://cips.cardano.org/cips/cip25/
+ */
+export interface NftMetadata {
+  name: string;
+  image: Uri | Uri[];
+  version: string;
+  mediaType?: ImageMediaType;
+  files?: NftMetadataFile[];
+  description?: string | string[];
+  otherProperties?: {
+    [key: string]: Cardano.Metadatum;
+  };
+}
+
+export interface NftMetadataProvider {
+  (asset: Cardano.Asset): Promise<NftMetadata | undefined>;
+}

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -41,6 +41,7 @@ import { Logger, dummyLogger } from 'ts-log';
 import { Observable, Subject, combineLatest, firstValueFrom, lastValueFrom, map, take } from 'rxjs';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { TxInternals, computeImplicitCoin, createTransactionInternals, ensureValidityInterval } from './Transaction';
+import { createNftMetadataProvider } from './NftMetadata';
 import { isEqual } from 'lodash-es';
 
 export interface SingleAddressWalletProps {
@@ -155,6 +156,11 @@ export class SingleAddressWallet implements Wallet {
       createAssetsTracker({
         assetProvider,
         balanceTracker: this.balance,
+        nftMetadataProvider: createNftMetadataProvider(
+          walletProvider,
+          // this is not very efficient, consider storing TxAlonzo[] in transactions tracker history
+          this.transactions.history.all$.pipe(map((txs) => txs.map(({ tx }) => tx)))
+        ),
         retryBackoffConfig
       })
     );

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -1,5 +1,6 @@
 export * as Transaction from './Transaction';
 export * as KeyManagement from './KeyManagement';
+export * as NftMetadata from './NftMetadata';
 export * from './SingleAddressWallet';
 export * from './types';
 export * from './services';

--- a/packages/wallet/src/services/AssetsTracker.ts
+++ b/packages/wallet/src/services/AssetsTracker.ts
@@ -1,37 +1,53 @@
+import { Asset, Assets } from '../types';
 import { AssetProvider, Cardano } from '@cardano-sdk/core';
-import { Assets } from '../types';
 import { Balance, TransactionalTracker } from './types';
+import { NftMetadataProvider } from '../NftMetadata';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { coldObservableProvider } from './util';
-import { distinct, from, mergeMap, of, scan, startWith } from 'rxjs';
+import { distinct, from, map, mergeMap, of, scan, startWith } from 'rxjs';
 
-export const createGetAssetProvider =
+export const createAssetService =
   (assetProvider: AssetProvider, retryBackoffConfig: RetryBackoffConfig) => (assetId: Cardano.AssetId) =>
     coldObservableProvider(
       () => assetProvider.getAsset(assetId),
       retryBackoffConfig,
       of(true) // fetch only once
     );
-export type GetAssetProvider = ReturnType<typeof createGetAssetProvider>;
+export type AssetService = ReturnType<typeof createAssetService>;
+
+export const createNftMetadataService =
+  (nftMetadataProvider: NftMetadataProvider, retryBackoffConfig: RetryBackoffConfig) => (asset: Cardano.Asset) =>
+    coldObservableProvider(
+      () => nftMetadataProvider(asset),
+      retryBackoffConfig,
+      of(true) // fetch only once
+    );
+export type NftMetadataService = ReturnType<typeof createNftMetadataService>;
 
 export interface AssetsTrackerProps {
   balanceTracker: TransactionalTracker<Balance>;
+  nftMetadataProvider: NftMetadataProvider;
   assetProvider: AssetProvider;
   retryBackoffConfig: RetryBackoffConfig;
 }
 
 interface AssetsTrackerInternals {
-  getAssetProvider?: GetAssetProvider;
+  assetService?: AssetService;
+  nftMetadataService?: NftMetadataService;
 }
 
 export const createAssetsTracker = (
-  { assetProvider, balanceTracker, retryBackoffConfig }: AssetsTrackerProps,
-  { getAssetProvider = createGetAssetProvider(assetProvider, retryBackoffConfig) }: AssetsTrackerInternals = {}
+  { assetProvider, balanceTracker, retryBackoffConfig, nftMetadataProvider }: AssetsTrackerProps,
+  {
+    nftMetadataService = createNftMetadataService(nftMetadataProvider, retryBackoffConfig),
+    assetService = createAssetService(assetProvider, retryBackoffConfig)
+  }: AssetsTrackerInternals = {}
 ) =>
   balanceTracker.total$.pipe(
     mergeMap(({ assets }) => from(assets?.keys() || [])),
     distinct(),
-    mergeMap((assetId) => getAssetProvider(assetId)),
-    scan((assets, asset) => new Map([...assets, [asset.assetId, asset]]), new Map<Cardano.AssetId, Cardano.Asset>()),
+    mergeMap((assetId) => assetService(assetId)),
+    mergeMap((asset) => nftMetadataService(asset).pipe(map((nftMetadata) => ({ ...asset, nftMetadata })))),
+    scan((assets, asset) => new Map([...assets, [asset.assetId, asset]]), new Map<Cardano.AssetId, Asset>()),
     startWith({} as Assets)
   );

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -4,20 +4,6 @@ import { GroupedAddress } from './KeyManagement';
 import { SelectionSkeleton } from '@cardano-sdk/cip2';
 import { TxInternals } from './Transaction';
 
-export interface SerializableStatic<T, OpaqueStringT> {
-  deserialize(serialized: OpaqueStringT): T;
-}
-
-export const staticImplements =
-  <T>() =>
-  <U extends T>(constructor: U) => {
-    constructor;
-  };
-
-export interface Serializable<OpaqueStringT> {
-  serialize(): OpaqueStringT;
-}
-
 export type InitializeTxProps = {
   outputs?: Set<Cardano.TxOut>;
   certificates?: Cardano.Certificate[];

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,6 +1,7 @@
 import { Balance, BehaviorObservable, DelegationTracker, TransactionalTracker, TransactionsTracker } from './services';
 import { Cardano, NetworkInfo, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
 import { GroupedAddress } from './KeyManagement';
+import { NftMetadata } from './NftMetadata';
 import { SelectionSkeleton } from '@cardano-sdk/cip2';
 import { TxInternals } from './Transaction';
 
@@ -17,7 +18,11 @@ export interface FinalizeTxProps {
   readonly body: Cardano.TxBodyAlonzo;
 }
 
-export type Assets = Map<Cardano.AssetId, Cardano.Asset>;
+export type Asset = Cardano.Asset & {
+  nftMetadata?: NftMetadata;
+};
+
+export type Assets = Map<Cardano.AssetId, Asset>;
 
 export interface MinimumCoinQuantity {
   minimumCoin: Cardano.Lovelace;

--- a/packages/wallet/test/NftMetadata/createNftMetadataProvider.test.ts
+++ b/packages/wallet/test/NftMetadata/createNftMetadataProvider.test.ts
@@ -1,0 +1,38 @@
+import { Cardano } from '@cardano-sdk/core';
+import { WalletProvider } from '@cardano-sdk/blockfrost';
+import { createNftMetadataProvider } from '../../src/NftMetadata';
+import { of } from 'rxjs';
+
+jest.mock('../../src/NftMetadata/metadatumToCip25');
+const { metadatumToCip25 } = jest.requireMock('../../src/NftMetadata/metadatumToCip25');
+
+describe('NftMetadata/createNftMetadataProvider', () => {
+  const metadatum = { some: 'metadatum' };
+  const transactionId = 'txId';
+  const asset = { history: [{ quantity: 1, transactionId }] } as unknown as Cardano.Asset;
+  const assetMetadata = { cip25: 'metadata' };
+
+  beforeAll(() => metadatumToCip25.mockReturnValue(assetMetadata));
+  afterEach(() => metadatumToCip25.mockClear());
+
+  it('queries tx and returns nft metadata', async () => {
+    const walletProvider = {
+      queryTransactionsByHashes: jest.fn().mockResolvedValueOnce([{ auxiliaryData: { body: { blob: metadatum } } }])
+    } as unknown as WalletProvider;
+    const provider = createNftMetadataProvider(walletProvider, of([]));
+    expect(await provider(asset)).toBe(assetMetadata);
+    expect(metadatumToCip25).toBeCalledWith(asset, metadatum);
+    expect(walletProvider.queryTransactionsByHashes).toBeCalledWith([transactionId]);
+  });
+
+  it('doesnt query wallet provider if there is a local tx', async () => {
+    // will throw if walletProvider.queryTransactionsByHashes is called
+    const walletProvider = undefined as unknown as WalletProvider;
+    const provider = createNftMetadataProvider(
+      walletProvider,
+      of([{ auxiliaryData: { body: { blob: metadatum } }, id: transactionId } as unknown as Cardano.TxAlonzo])
+    );
+    expect(await provider(asset)).toBe(assetMetadata);
+    expect(metadatumToCip25).toBeCalledWith(asset, metadatum);
+  });
+});

--- a/packages/wallet/test/NftMetadata/metadatumToCip25.test.ts
+++ b/packages/wallet/test/NftMetadata/metadatumToCip25.test.ts
@@ -1,0 +1,137 @@
+import { Cardano } from '@cardano-sdk/core';
+import { metadatumToCip25 } from '../../src/NftMetadata';
+import { omit } from 'lodash';
+
+describe('NftMetadata/metadatumToCip25', () => {
+  const asset = {
+    name: Cardano.AssetName('abc123'),
+    policyId: Cardano.PolicyId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7')
+  } as Cardano.Asset;
+
+  const minimalMetadata = {
+    image: 'ipfs://image',
+    name: 'test nft'
+  };
+
+  const minimalConvertedMetadata = {
+    image: 'ipfs://image',
+    name: 'test nft',
+    version: '1.0'
+  };
+
+  it('returns undefined for non-cip25 metadatum', () => {
+    const metadatum: Cardano.MetadatumMap = {
+      other: 'metadatum'
+    };
+    expect(metadatumToCip25(asset, metadatum)).toBeUndefined();
+  });
+
+  it('returns undefined for cip25 metadatum with no metadata for given policyId', () => {
+    const metadatum: Cardano.MetadatumMap = {
+      '721': {
+        other_policy_id: minimalMetadata
+      }
+    };
+    expect(metadatumToCip25(asset, metadatum)).toBeUndefined();
+  });
+
+  it('returns undefined for cip25 metadatum with no metadata for given assetId', () => {
+    const metadatum: Cardano.MetadatumMap = {
+      '721': {
+        [asset.policyId.toString()]: {
+          other_asset_id: minimalMetadata
+        }
+      }
+    };
+    expect(metadatumToCip25(asset, metadatum)).toBeUndefined();
+  });
+
+  it('converts minimal metadata', () => {
+    const metadatum: Cardano.MetadatumMap = {
+      '721': {
+        [asset.policyId.toString()]: {
+          [asset.name.toString()]: minimalMetadata
+        }
+      }
+    };
+    expect(metadatumToCip25(asset, metadatum)).toEqual(minimalConvertedMetadata);
+  });
+
+  // CIP-25 doesn't explicitly say anything about encoding.
+  // It is most likely assumed to be hex strings,
+  // but people are likely to specify utf8, because it's named '<asset_name>'
+  it('supports asset name as utf8 string', () => {
+    const metadatum: Cardano.MetadatumMap = {
+      '721': {
+        [asset.policyId.toString()]: {
+          [Buffer.from(asset.name.toString()).toString('utf8')]: minimalMetadata
+        }
+      }
+    };
+    expect(metadatumToCip25(asset, metadatum)).toEqual(minimalConvertedMetadata);
+  });
+
+  it('converts version', () => {
+    const metadatum: Cardano.MetadatumMap = {
+      '721': {
+        [asset.policyId.toString()]: {
+          [asset.name.toString()]: minimalMetadata,
+          version: '2.0'
+        }
+      }
+    };
+    expect(metadatumToCip25(asset, metadatum)).toEqual({
+      ...minimalConvertedMetadata,
+      version: '2.0'
+    });
+  });
+
+  it('coverts optional properties (mediaType, description and <other properties>)', () => {
+    const metadatum: Cardano.MetadatumMap = {
+      '721': {
+        [asset.policyId.toString()]: {
+          [asset.name.toString()]: {
+            ...minimalMetadata,
+            description: 'description',
+            extraProp: 'extra',
+            mediaType: 'image/png'
+          }
+        }
+      }
+    };
+    expect(metadatumToCip25(asset, metadatum)).toEqual({
+      ...minimalConvertedMetadata,
+      description: 'description',
+      mediaType: 'image/png',
+      otherProperties: { extraProp: 'extra' }
+    });
+  });
+
+  it('coverts files', () => {
+    const file1 = {
+      mediaType: 'image/jpg',
+      name: 'file1',
+      src: 'https://file1.location'
+    };
+    const file2 = {
+      extraProp: 'extra',
+      mediaType: 'image/png',
+      name: 'file2',
+      src: ['https://file2.location']
+    };
+    const metadatum: Cardano.MetadatumMap = {
+      '721': {
+        [asset.policyId.toString()]: {
+          [asset.name.toString()]: {
+            ...minimalMetadata,
+            files: [file1, file2]
+          }
+        }
+      }
+    };
+    expect(metadatumToCip25(asset, metadatum)).toEqual({
+      ...minimalConvertedMetadata,
+      files: [file1, { ...omit(file2, 'extraProp'), otherProperties: { extraProp: 'extra' } }]
+    });
+  });
+});

--- a/packages/wallet/test/NftMetadata/types.test.ts
+++ b/packages/wallet/test/NftMetadata/types.test.ts
@@ -1,0 +1,34 @@
+import * as NftMetadata from '../../src/NftMetadata';
+import { InvalidStringError } from '@cardano-sdk/core';
+
+describe('NftMetadata/types', () => {
+  describe('Uri', () => {
+    it('accepts a string starting with protocol://', () => {
+      expect(() => NftMetadata.Uri('http://some.url')).not.toThrow();
+      expect(() => NftMetadata.Uri('ipfs://abc123')).not.toThrow();
+    });
+    it('throws for string without protocol:// prefix', () => {
+      expect(() => NftMetadata.Uri('abc123')).toThrowError(InvalidStringError);
+    });
+  });
+
+  describe('ImageMediaType', () => {
+    it('accepts a string starting with image/', () => {
+      expect(() => NftMetadata.ImageMediaType('image/svg+xml')).not.toThrow();
+    });
+    it('throws for non-image media type', () => {
+      expect(() => NftMetadata.ImageMediaType('video/webm')).toThrowError(InvalidStringError);
+    });
+  });
+
+  describe('MediaType', () => {
+    it('accepts any media type in format "type/subtype"', () => {
+      expect(() => NftMetadata.MediaType('image/svg+xml')).not.toThrow();
+      expect(() => NftMetadata.MediaType('video/mp4')).not.toThrow();
+      expect(() => NftMetadata.MediaType('audio/x-wav')).not.toThrow();
+    });
+    it('throws for incorrectly formatted media type', () => {
+      expect(() => NftMetadata.MediaType('videomp4')).toThrowError(InvalidStringError);
+    });
+  });
+});

--- a/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
@@ -1,6 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
-import { SingleAddressWallet, StakeKeyStatus, Wallet } from '../../src';
-import { assetProvider, keyAgentReady, poolId1, poolId2, stakePoolSearchProvider, walletProvider } from './config';
+import { SingleAddressWallet, StakeKeyStatus, Wallet } from '../../../src';
+import { assetProvider, keyAgentReady, poolId1, poolId2, stakePoolSearchProvider, walletProvider } from '../config';
 import { distinctUntilChanged, filter, firstValueFrom, map, merge, mergeMap, skip, tap, timer } from 'rxjs';
 
 const faucetAddress = Cardano.Address(
@@ -45,7 +45,7 @@ const waitForNewStakePoolIdAfterTx = (wallet: Wallet) =>
     )
   );
 
-describe('SingleAddressWallet', () => {
+describe('SingleAddressWallet/delegation', () => {
   let rewardAccount: Cardano.RewardAccount;
   let wallet: Wallet;
 

--- a/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
@@ -1,0 +1,52 @@
+import { Cardano } from '@cardano-sdk/core';
+import { KeyManagement, SingleAddressWallet, Wallet } from '../../../src';
+import { assetProvider, keyAgentReady, stakePoolSearchProvider, walletProvider } from '../config';
+import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
+
+describe('SingleAddressWallet/delegation', () => {
+  let wallet: Wallet;
+
+  beforeAll(async () => {
+    wallet = new SingleAddressWallet(
+      {
+        address: {
+          accountIndex: 0,
+          address: Cardano.Address(
+            // eslint-disable-next-line max-len
+            'addr_test1qqlgm2dh3vpv07cjfcyuu6vhaqhf8998qcx6s8ucpkly6f8l0dw5r75vk42mv3ykq8vyjeaanvpytg79xqzymqy5acmqtjmugu'
+          ),
+          index: 0,
+          networkId: Cardano.NetworkId.testnet,
+          rewardAccount: Cardano.RewardAccount('stake_test1urlhkh2pl2xt24dkgjtqrkzfv77ekqj950znqpzdsz2wuds0xlsk6'),
+          type: KeyManagement.AddressType.External
+        },
+        name: 'Test Wallet'
+      },
+      {
+        assetProvider,
+        keyAgent: await keyAgentReady,
+        stakePoolSearchProvider,
+        walletProvider
+      }
+    );
+  });
+
+  afterAll(() => wallet.shutdown());
+
+  it('parses simple NFT metadata', async () => {
+    const nfts = await firstValueFrom(
+      combineLatest([wallet.assets$, wallet.balance.total$]).pipe(
+        filter(([assets, balance]) => assets.size === balance.assets?.size), // when all assets loaded
+        map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
+      )
+    );
+    expect(nfts.find(({ nftMetadata }) => nftMetadata?.name === 'Test NFT #470')?.nftMetadata).toEqual({
+      image: 'ipfs://XXXXYYYYZZZZ',
+      name: 'Test NFT #470',
+      version: '1.0'
+    });
+  });
+
+  it.todo('parses NFT metadata "files"');
+  it.todo('parses NFT metadata <other_properties> into nftMetadata.otherProperties');
+});

--- a/packages/wallet/test/mocks/mockAssetProvider.ts
+++ b/packages/wallet/test/mocks/mockAssetProvider.ts
@@ -9,7 +9,7 @@ export const asset = {
       transactionId: Cardano.TransactionId('886206542d63b23a047864021fbfccf291d78e47c1e59bd4c75fbc67b248c5e8')
     }
   ],
-  name: 'TSLA',
+  name: Cardano.AssetName('54534c41'),
   policyId: Cardano.PolicyId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373'),
   quantity: 1000n
 } as Cardano.Asset;

--- a/packages/wallet/test/services/AssetsTracker.test.ts
+++ b/packages/wallet/test/services/AssetsTracker.test.ts
@@ -1,6 +1,7 @@
+import { Asset } from '../../src/types';
 import { AssetId } from '@cardano-sdk/util-dev';
 import { AssetsTrackerProps, Balance, TransactionalTracker, createAssetsTracker } from '../../src/services';
-import { Cardano } from '@cardano-sdk/core';
+import { NftMetadata } from '../../src/NftMetadata/types';
 import { createTestScheduler } from '../testScheduler';
 import { of } from 'rxjs';
 
@@ -19,10 +20,18 @@ describe('createAssetsTracker', () => {
           } as Balance
         })
       } as unknown as TransactionalTracker<Balance>;
-      const asset1 = { assetId: AssetId.TSLA, name: 'TSLA' } as Cardano.Asset;
-      const asset2 = { assetId: AssetId.PXL, name: 'PXL' } as Cardano.Asset;
-      const getAssetProvider = jest.fn().mockReturnValueOnce(of(asset1)).mockReturnValueOnce(of(asset2));
-      const target$ = createAssetsTracker({ balanceTracker } as AssetsTrackerProps, { getAssetProvider });
+      const nftMetadata = { name: 'nft' } as NftMetadata;
+      const nftMetadataService = jest
+        .fn()
+        .mockReturnValueOnce(cold('a', { a: undefined }))
+        .mockReturnValueOnce(cold('a', { a: nftMetadata }));
+      const asset1 = { assetId: AssetId.TSLA } as Asset;
+      const asset2 = { assetId: AssetId.PXL, nftMetadata } as Asset;
+      const assetService = jest.fn().mockReturnValueOnce(of(asset1)).mockReturnValueOnce(of(asset2));
+      const target$ = createAssetsTracker({ balanceTracker } as AssetsTrackerProps, {
+        assetService,
+        nftMetadataService
+      });
       expectObservable(target$).toBe('a-b-c', {
         a: {},
         b: new Map([[AssetId.TSLA, asset1]]),


### PR DESCRIPTION
# Context

As an developer integrating the SDK wallet into an application
I want to show NFT metadata
so that I can present a rich user interface for my users that includes metadata that describes the asset

# Proposed Solution

Add optional NFT metadata to `Wallet.assets$`

# Important Changes Introduced

`core` package:
- Add partial support for Byron (base58) addresses (using it in a new tx is out of scope of this PR)
- Add partial support for genesis pool IDs (using it in a new tx is out of scope of this PR)
- Add a few metadatum parsing utils
- (BREAKING) change type of Asset.name to AssetName opaque string

## Notes

- Since CIP-0025 does not specify encoding for `<asset_name>`, we'll support both hex and utf8 encoded strings.
- `<other properties>` are currently modeled like that:
```typescript
export interface NftMetadata {
    ...
   otherProperties: {
      [otherProperty: string]: Cardano.Metadatum | undefined;
   }
}
``` 
It is not great for backwards compatibility (breaking change if some property was used and added to CIP schema later). An alternative would be this:
```typescript
export interface NftMetadata {
    ...
    [otherProperty: string]: Cardano.Metadatum | MediaType | Uri | Uri[] | undefined;
}
```
While more backwards-compatible, it's not great for TypeScript usage, as the type is too wide - it can only be `Cardano.Metadatum | undefined`.

Assuming "version" is going to be bumped when adding new fields to the CIP, we could keep the convenient implementation and create discriminated union types by version later.