### PR TITLE
fix(cip2): property tests generate quantities >0

### DIFF
--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -163,7 +163,7 @@ export const generateSelectionParams = (() => {
             fc
               .set(fc.oneof(...AssetId.All.map((asset) => fc.constant(asset))))
               .chain((assets) =>
-                fc.tuple(...assets.map((asset) => fc.bigUint(cslUtil.MAX_U64).map((amount) => ({ amount, asset }))))
+                fc.tuple(...assets.map((asset) => fc.bigInt(1n, cslUtil.MAX_U64).map((amount) => ({ amount, asset }))))
               )
               .map(
                 (assets) =>
@@ -171,7 +171,7 @@ export const generateSelectionParams = (() => {
               ),
             fc.constant(void 0)
           ),
-          coins: fc.bigUint(cslUtil.MAX_U64 - implicitCoin)
+          coins: fc.bigInt(1n, cslUtil.MAX_U64 - implicitCoin)
         }),
         { maxLength: 11 }
       )


### PR DESCRIPTION
# Context

cip2 property tests are occasionally failing due to having 0 quantity of tokens, which doesn't make sense to have as an output.

# Proposed Solution

Only test with quantities >0