### PR TITLE
feat: slot datetime computation util

### DIFF
--- a/packages/cardano-graphql/scripts/buildSchema.js
+++ b/packages/cardano-graphql/scripts/buildSchema.js
@@ -1,3 +1,10 @@
+// This is a little hacky, it would be better to set up ESM builds instead
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function () {
+  return originalRequire.apply(this, arguments[0] === 'lodash-es' ? ['lodash'] : arguments);
+};
+
 const path = require('path');
 const fs = require('fs');
 const generateSchema = require('./generateSchema');

--- a/packages/core/src/Provider/TimeSettingsProvider/index.ts
+++ b/packages/core/src/Provider/TimeSettingsProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/core/src/Provider/TimeSettingsProvider/types.ts
+++ b/packages/core/src/Provider/TimeSettingsProvider/types.ts
@@ -1,0 +1,5 @@
+import { TimeSettings } from '../..';
+
+export interface TimeSettingsProvider {
+  (): Promise<TimeSettings[]>;
+}

--- a/packages/core/src/Provider/index.ts
+++ b/packages/core/src/Provider/index.ts
@@ -1,3 +1,4 @@
 export * from './StakePoolSearchProvider';
 export * from './WalletProvider';
 export * from './AssetProvider';
+export * from './TimeSettingsProvider';

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from './BigIntMath';
 export * as util from './misc';
+export * from './slotTimeCalc';

--- a/packages/core/src/util/slotTimeCalc.ts
+++ b/packages/core/src/util/slotTimeCalc.ts
@@ -1,0 +1,48 @@
+import { CustomError } from 'ts-custom-error';
+import { orderBy } from 'lodash-es';
+
+export interface TimeSettings {
+  /**
+   * 1st slot date (of the epoch when these settings take effect)
+   */
+  fromSlotDate: Date;
+  /**
+   * 1st slot number (of the epoch when these settings take effect)
+   */
+  fromSlotNo: number;
+  /**
+   * Slot length in milliseconds
+   */
+  slotLength: number;
+}
+
+export class TimeSettingsError extends CustomError {}
+
+/**
+ * Were valid at 2022-01-14
+ */
+export const testnetTimeSettings: TimeSettings[] = [
+  { fromSlotDate: new Date(1_563_999_616_000), fromSlotNo: 0, slotLength: 20_000 },
+  { fromSlotDate: new Date(1_595_964_016_000), fromSlotNo: 1_598_400, slotLength: 1000 }
+];
+
+export const createSlotTimeCalc = (timeSettings: TimeSettings[]) => {
+  const timeSettingsDesc = orderBy(timeSettings, ({ fromSlotNo }) => fromSlotNo, 'desc');
+
+  return (slotNo: number): Date => {
+    const activeTimeSettings = timeSettingsDesc.find(({ fromSlotNo }) => fromSlotNo <= slotNo);
+    if (!activeTimeSettings) {
+      throw new TimeSettingsError(`No TimeSettings for slot ${slotNo} found`);
+    }
+    return new Date(
+      activeTimeSettings.fromSlotDate.getTime() +
+        (slotNo - activeTimeSettings.fromSlotNo) * activeTimeSettings.slotLength
+    );
+  };
+};
+
+/**
+ * @throws TimeSettingsError
+ * @returns {Date} date of the slot
+ */
+export type SlotTimeCalc = ReturnType<typeof createSlotTimeCalc>;

--- a/packages/core/test/util/slotTimeCalc.test.ts
+++ b/packages/core/test/util/slotTimeCalc.test.ts
@@ -1,0 +1,35 @@
+import { SlotTimeCalc, TimeSettingsError, createSlotTimeCalc, testnetTimeSettings } from '../../src';
+
+describe('slotTimeCalc', () => {
+  describe('testnet', () => {
+    const slotTimeCalc: SlotTimeCalc = createSlotTimeCalc(testnetTimeSettings);
+
+    it('correctly computes date of the 1st block', () =>
+      expect(slotTimeCalc(1031)).toEqual(new Date(1_564_020_236_000)));
+
+    it('correctly computes date of the genesis block', () =>
+      expect(slotTimeCalc(0)).toEqual(new Date(1_563_999_616_000)));
+
+    it('correctly computes date of some Byron block', () =>
+      expect(slotTimeCalc(1_209_592)).toEqual(new Date(1_588_191_456_000)));
+
+    it('correctly computes date of the last Byron block', () =>
+      expect(slotTimeCalc(1_598_399)).toEqual(new Date(1_595_967_596_000)));
+
+    it('correctly computes date of the 1st Shelley block', () =>
+      expect(slotTimeCalc(1_598_400)).toEqual(new Date(1_595_964_016_000)));
+
+    it('correctly computes date of the 2nd Shelley block', () =>
+      expect(slotTimeCalc(1_598_420)).toEqual(new Date(1_595_964_036_000)));
+
+    it('correctly computes date of some Shelley block', () =>
+      expect(slotTimeCalc(8_078_371)).toEqual(new Date(1_602_443_987_000)));
+
+    it('throws with invalid slot', () => expect(() => slotTimeCalc(-1)).toThrowError(TimeSettingsError));
+  });
+
+  it('throws with invalid TimeSettings', () => {
+    const slotTimeCalc = createSlotTimeCalc([{ fromSlotDate: new Date(), fromSlotNo: 5, slotLength: 1 }]);
+    expect(() => slotTimeCalc(4)).toThrowError(TimeSettingsError);
+  });
+});

--- a/packages/util-dev/src/createStubTimeSettingsProvider.ts
+++ b/packages/util-dev/src/createStubTimeSettingsProvider.ts
@@ -1,0 +1,9 @@
+import { TimeSettings, TimeSettingsProvider } from '@cardano-sdk/core';
+import delay from 'delay';
+
+export const createStubTimeSettingsProvider =
+  (timeSettings: TimeSettings[], delayMs?: number): TimeSettingsProvider =>
+  async () => {
+    if (delayMs) await delay(delayMs);
+    return timeSettings;
+  };

--- a/packages/util-dev/src/index.ts
+++ b/packages/util-dev/src/index.ts
@@ -4,3 +4,4 @@ export * as TxTestUtil from './txTestUtil';
 export * as SelectionConstraints from './selectionConstraints';
 export * from './util';
 export * from './createStubStakePoolSearchProvider';
+export * from './createStubTimeSettingsProvider';

--- a/packages/util-dev/test/createStubTimeSettingsProvider.test.ts
+++ b/packages/util-dev/test/createStubTimeSettingsProvider.test.ts
@@ -1,0 +1,9 @@
+import { createStubTimeSettingsProvider } from '../src/createStubTimeSettingsProvider';
+import { testnetTimeSettings } from '@cardano-sdk/core';
+
+describe('createStubTimeSettingsProvider', () => {
+  it('resolves with provided TimeSettings[]', async () => {
+    const provider = createStubTimeSettingsProvider(testnetTimeSettings);
+    expect(await provider()).toBe(testnetTimeSettings);
+  });
+});

--- a/packages/wallet/.env.example
+++ b/packages/wallet/.env.example
@@ -1,5 +1,6 @@
 WALLET_PROVIDER=blockfrost
 STAKE_POOL_SEARCH_PROVIDER=stub
+TIME_SETTINGS_PROVIDER=stub_testnet
 BLOCKFROST_API_KEY=testnetNElagmhpQDubE6Ic4XBUVJjV5DROyijO
 NETWORK_ID=0
 MNEMONIC_WORDS="actor scout worth mansion thumb device mass pave gospel secret height document merge text broom kind lesson invest across estate erase interest end century"

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -6,6 +6,8 @@ import {
   NetworkInfo,
   ProtocolParametersRequiredByWallet,
   StakePoolSearchProvider,
+  TimeSettings,
+  TimeSettingsProvider,
   WalletProvider,
   coreToCsl
 } from '@cardano-sdk/core';
@@ -56,6 +58,7 @@ export interface SingleAddressWalletDependencies {
   readonly walletProvider: WalletProvider;
   readonly stakePoolSearchProvider: StakePoolSearchProvider;
   readonly assetProvider: AssetProvider;
+  readonly timeSettingsProvider: TimeSettingsProvider;
   readonly inputSelector?: InputSelector;
   readonly logger?: Logger;
 }
@@ -80,6 +83,7 @@ export class SingleAddressWallet implements Wallet {
   addresses$: TrackerSubject<GroupedAddress[]>;
   protocolParameters$: TrackerSubject<ProtocolParametersRequiredByWallet>;
   genesisParameters$: TrackerSubject<Cardano.CompactGenesis>;
+  timeSettings$: TrackerSubject<TimeSettings[]>;
   assets$: TrackerSubject<Assets>;
   name: string;
 
@@ -98,6 +102,7 @@ export class SingleAddressWallet implements Wallet {
       stakePoolSearchProvider,
       keyAgent,
       assetProvider,
+      timeSettingsProvider,
       logger = dummyLogger,
       inputSelector = roundRobinRandomImprove()
     }: SingleAddressWalletDependencies
@@ -117,6 +122,9 @@ export class SingleAddressWallet implements Wallet {
       coldObservableProvider(walletProvider.networkInfo, retryBackoffConfig, tipBlockHeight$, isEqual)
     );
     const epoch$ = distinctEpoch(this.networkInfo$);
+    this.timeSettings$ = new TrackerSubject(
+      coldObservableProvider(timeSettingsProvider, retryBackoffConfig, epoch$, isEqual)
+    );
     this.protocolParameters$ = new TrackerSubject(
       coldObservableProvider(walletProvider.currentWalletProtocolParameters, retryBackoffConfig, epoch$, isEqual)
     );

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,5 +1,5 @@
 import { Balance, BehaviorObservable, DelegationTracker, TransactionalTracker, TransactionsTracker } from './services';
-import { Cardano, NetworkInfo, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { Cardano, NetworkInfo, ProtocolParametersRequiredByWallet, TimeSettings } from '@cardano-sdk/core';
 import { GroupedAddress } from './KeyManagement';
 import { NftMetadata } from './NftMetadata';
 import { SelectionSkeleton } from '@cardano-sdk/cip2';
@@ -43,6 +43,7 @@ export interface Wallet {
   readonly utxo: TransactionalTracker<Cardano.Utxo[]>;
   readonly transactions: TransactionsTracker;
   readonly tip$: BehaviorObservable<Cardano.Tip>;
+  readonly timeSettings$: BehaviorObservable<TimeSettings[]>;
   readonly genesisParameters$: BehaviorObservable<Cardano.CompactGenesis>;
   readonly networkInfo$: BehaviorObservable<NetworkInfo>;
   readonly protocolParameters$: BehaviorObservable<ProtocolParametersRequiredByWallet>;

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import * as mocks from './mocks';
-import { AssetId, createStubStakePoolSearchProvider } from '@cardano-sdk/util-dev';
-import { Cardano } from '@cardano-sdk/core';
+import { AssetId, createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
+import { Cardano, testnetTimeSettings } from '@cardano-sdk/core';
 import { KeyManagement, SingleAddressWallet } from '../src';
 import { firstValueFrom, skip } from 'rxjs';
 import { testKeyAgent } from './mocks';
@@ -20,11 +20,15 @@ describe('SingleAddressWallet', () => {
     walletProvider = mocks.mockWalletProvider();
     assetProvider = mocks.mockAssetProvider();
     const stakePoolSearchProvider = createStubStakePoolSearchProvider();
+    const timeSettingsProvider = createStubTimeSettingsProvider(testnetTimeSettings);
     keyAgent.deriveAddress = jest.fn().mockResolvedValue({
       address,
       rewardAccount
     });
-    wallet = new SingleAddressWallet({ name }, { assetProvider, keyAgent, stakePoolSearchProvider, walletProvider });
+    wallet = new SingleAddressWallet(
+      { name },
+      { assetProvider, keyAgent, stakePoolSearchProvider, timeSettingsProvider, walletProvider }
+    );
   });
 
   afterEach(() => wallet.shutdown());
@@ -83,6 +87,9 @@ describe('SingleAddressWallet', () => {
     });
     it('"assets$"', async () => {
       expect(await firstValueFrom(wallet.assets$)).toEqual(new Map([[AssetId.TSLA, mocks.asset]]));
+    });
+    it('timeSettings$', async () => {
+      expect(await firstValueFrom(wallet.timeSettings$)).toEqual(testnetTimeSettings);
     });
   });
 

--- a/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
@@ -1,6 +1,14 @@
 import { Cardano } from '@cardano-sdk/core';
 import { SingleAddressWallet, StakeKeyStatus, Wallet } from '../../../src';
-import { assetProvider, keyAgentReady, poolId1, poolId2, stakePoolSearchProvider, walletProvider } from '../config';
+import {
+  assetProvider,
+  keyAgentReady,
+  poolId1,
+  poolId2,
+  stakePoolSearchProvider,
+  timeSettingsProvider,
+  walletProvider
+} from '../config';
 import { distinctUntilChanged, filter, firstValueFrom, map, merge, mergeMap, skip, tap, timer } from 'rxjs';
 
 const faucetAddress = Cardano.Address(
@@ -64,6 +72,7 @@ describe('SingleAddressWallet/delegation', () => {
         assetProvider,
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
+        timeSettingsProvider,
         walletProvider
       }
     );

--- a/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
@@ -1,6 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
 import { KeyManagement, SingleAddressWallet, Wallet } from '../../../src';
-import { assetProvider, keyAgentReady, stakePoolSearchProvider, walletProvider } from '../config';
+import { assetProvider, keyAgentReady, stakePoolSearchProvider, timeSettingsProvider, walletProvider } from '../config';
 import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
 
 describe('SingleAddressWallet/delegation', () => {
@@ -26,6 +26,7 @@ describe('SingleAddressWallet/delegation', () => {
         assetProvider,
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
+        timeSettingsProvider,
         walletProvider
       }
     );

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -1,7 +1,7 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, testnetTimeSettings } from '@cardano-sdk/core';
 import { InMemoryKeyAgent } from '../../src/KeyManagement';
 import { blockfrostAssetProvider, blockfrostWalletProvider } from '@cardano-sdk/blockfrost';
-import { createStubStakePoolSearchProvider } from '@cardano-sdk/util-dev';
+import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 
 const networkId = Number.parseInt(process.env.NETWORK_ID || '');
 if (Number.isNaN(networkId)) throw new Error('NETWORK_ID not set');
@@ -41,6 +41,14 @@ export const stakePoolSearchProvider = (() => {
     return createStubStakePoolSearchProvider();
   }
   throw new Error(`STAKE_POOL_SEARCH_PROVIDER unsupported: ${stakePoolSearchProviderName}`);
+})();
+
+export const timeSettingsProvider = (() => {
+  const timeSettingsProviderName = process.env.TIME_SETTINGS_PROVIDER;
+  if (timeSettingsProviderName === 'stub_testnet') {
+    return createStubTimeSettingsProvider(testnetTimeSettings);
+  }
+  throw new Error(`TIME_SETTINGS_PROVIDER unsupported: ${timeSettingsProviderName}`);
 })();
 
 if (!process.env.POOL_ID_1) throw new Error('POOL_ID_1 not set');

--- a/packages/wallet/test/integration/transactionTime.test.ts
+++ b/packages/wallet/test/integration/transactionTime.test.ts
@@ -1,0 +1,42 @@
+import { Cardano, createSlotTimeCalc, testnetTimeSettings } from '@cardano-sdk/core';
+import { KeyManagement, SingleAddressWallet, SingleAddressWalletProps } from '../../src';
+import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
+import { firstValueFrom } from 'rxjs';
+import { mockAssetProvider, mockWalletProvider } from '../mocks';
+
+const walletProps: SingleAddressWalletProps = { name: 'some-wallet' };
+const networkId = Cardano.NetworkId.mainnet;
+const mnemonicWords = KeyManagement.util.generateMnemonicWords();
+const getPassword = async () => Buffer.from('your_password');
+
+describe('integration/transactionTime', () => {
+  let keyAgent: KeyManagement.KeyAgent;
+  let wallet: SingleAddressWallet;
+
+  beforeAll(async () => {
+    keyAgent = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords({
+      getPassword,
+      mnemonicWords,
+      networkId
+    });
+    const walletProvider = mockWalletProvider();
+    const stakePoolSearchProvider = createStubStakePoolSearchProvider();
+    const timeSettingsProvider = createStubTimeSettingsProvider(testnetTimeSettings);
+    const assetProvider = mockAssetProvider();
+    wallet = new SingleAddressWallet(walletProps, {
+      assetProvider,
+      keyAgent,
+      stakePoolSearchProvider,
+      timeSettingsProvider,
+      walletProvider
+    });
+  });
+
+  it('provides utils necessary for computing transaction time', async () => {
+    const transactions = await firstValueFrom(wallet.transactions.history.incoming$);
+    const timeSettings = await firstValueFrom(wallet.timeSettings$);
+    const slotTimeCalc = createSlotTimeCalc(timeSettings);
+    const transactionTime = slotTimeCalc(transactions[0].blockHeader.slot);
+    expect(typeof transactionTime.getTime()).toBe('number');
+  });
+});

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -1,6 +1,6 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, testnetTimeSettings } from '@cardano-sdk/core';
 import { KeyManagement, SingleAddressWallet, SingleAddressWalletProps, TransactionFailure } from '../../src';
-import { createStubStakePoolSearchProvider } from '@cardano-sdk/util-dev';
+import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 import { firstValueFrom } from 'rxjs';
 import { mockAssetProvider, mockWalletProvider } from '../mocks';
 
@@ -21,11 +21,13 @@ describe('integration/withdrawal', () => {
     });
     const walletProvider = mockWalletProvider();
     const stakePoolSearchProvider = createStubStakePoolSearchProvider();
+    const timeSettingsProvider = createStubTimeSettingsProvider(testnetTimeSettings);
     const assetProvider = mockAssetProvider();
     wallet = new SingleAddressWallet(walletProps, {
       assetProvider,
       keyAgent,
       stakePoolSearchProvider,
+      timeSettingsProvider,
       walletProvider
     });
   });


### PR DESCRIPTION
# Context

Wallet needs to display transaction date

# Proposed Solution

- add util for computing slot date given ledger time settings in `core` package
- add a new provider type (`TimeSettingsProvider`) in `core` package
- add a stub `TimeSettingsProvider` implementation in `util-dev` package
- add `Wallet.timeSettings$` and an integration test for usage example

## Out of scope

An actual provider implementation is out of scope of this PR. Blockfrost doesn't seem to support this, so will implement it for `cardano-graphql`.

## Other changes

Running `buildSchema.js` script in `cardano-graphql` package broke due to not knowing how to import ES modules from `lodash-es`. Having mixed modules is not great, we should probably set up the packages to build both esm and cjs. For now I added a workaround so that it can build successfully.