### PR TITLE
fix: add support for byron addresses and genesis delegates as slot leaders

### DIFF
--- a/packages/blockfrost/src/blockfrostWalletProvider.ts
+++ b/packages/blockfrost/src/blockfrostWalletProvider.ts
@@ -419,7 +419,7 @@ export const blockfrostWalletProvider = (options: Options, logger = dummyLogger)
         nextBlock: response.next_block ? Cardano.BlockId(response.next_block) : undefined,
         previousBlock: response.previous_block ? Cardano.BlockId(response.previous_block) : undefined,
         size: response.size,
-        slotLeader: Cardano.PoolId(response.slot_leader),
+        slotLeader: Cardano.SlotLeader(response.slot_leader),
         totalOutput: BigInt(response.output || '0'),
         txCount: response.tx_count,
         vrf: Cardano.VrfVkBech32(response.block_vrf)

--- a/packages/blockfrost/test/blockfrostWalletProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostWalletProvider.test.ts
@@ -556,6 +556,18 @@ describe('blockfrostWalletProvider', () => {
     ]);
   });
 
+  test('queryBlocksByHashes, genesis delegate slot leader', async () => {
+    const slotLeader = 'ShelleyGenesis-eff1b5b26e65b791';
+    BlockFrostAPI.prototype.blocks = jest.fn().mockResolvedValue({ ...blockResponse, slot_leader: slotLeader });
+
+    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const response = await client.queryBlocksByHashes([
+      Cardano.BlockId('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5ea4172b2ed')
+    ]);
+
+    expect(response[0].slotLeader).toBe(slotLeader);
+  });
+
   describe('rewardsHistory', () => {
     const pool_id = 'pool1pu5jlj4q9w9jlxeu370a3c9myx47md5j5m2str0naunn2q3lkdy';
     const generateRewardsResponse = (numEpochs: number, firstEpoch = 0): Responses['account_reward_content'] =>

--- a/packages/core/src/Address/util.ts
+++ b/packages/core/src/Address/util.ts
@@ -1,17 +1,6 @@
-import { CSL } from '../CSL';
+import { parseCslAddress } from '../CSL';
+
 /**
  * Validate input as a Cardano Address from all Cardano eras and networks
  */
-export const isAddress = (input: string): boolean => {
-  try {
-    CSL.Address.from_bech32(input);
-    return true;
-  } catch {
-    try {
-      CSL.ByronAddress.from_base58(input);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-};
+export const isAddress = (input: string): boolean => !!parseCslAddress(input);

--- a/packages/core/src/CSL/coreToCsl.ts
+++ b/packages/core/src/CSL/coreToCsl.ts
@@ -28,7 +28,7 @@ import {
 import * as certificate from './certificate';
 import { SerializationError } from '../errors';
 import { SerializationFailure } from '..';
-import { coreToCsl } from '.';
+import { coreToCsl, parseCslAddress } from '.';
 export * as certificate from './certificate';
 
 export const tokenMap = (assets: Cardano.TokenMap) => {
@@ -58,8 +58,7 @@ export const txIn = (core: Cardano.TxIn): TransactionInput =>
   TransactionInput.new(TransactionHash.from_bytes(Buffer.from(core.txId, 'hex')), core.index);
 
 export const txOut = (core: Cardano.TxOut): TransactionOutput =>
-  // TODO: add support for base 58 addresses
-  TransactionOutput.new(Address.from_bech32(core.address.toString()), value(core.value));
+  TransactionOutput.new(parseCslAddress(core.address.toString())!, value(core.value));
 
 export const utxo = (core: Cardano.Utxo[]): TransactionUnspentOutput[] =>
   core.map((item) => TransactionUnspentOutput.new(txIn(item[0]), txOut(item[1])));

--- a/packages/core/src/CSL/index.ts
+++ b/packages/core/src/CSL/index.ts
@@ -3,5 +3,6 @@ import * as CSL from '@emurgo/cardano-serialization-lib-nodejs';
 export * as cslUtil from './util';
 export * as cslToCore from './cslToCore';
 export * as coreToCsl from './coreToCsl';
+export * from './parseCslAddress';
 export * as CSL from '@emurgo/cardano-serialization-lib-nodejs';
 export type CardanoSerializationLib = typeof CSL;

--- a/packages/core/src/CSL/parseCslAddress.ts
+++ b/packages/core/src/CSL/parseCslAddress.ts
@@ -1,0 +1,16 @@
+import { CSL } from '.';
+
+/**
+ * Parse Cardano address from all Cardano eras and networks
+ */
+export const parseCslAddress = (input: string): CSL.Address | null => {
+  try {
+    return CSL.Address.from_bech32(input);
+  } catch {
+    try {
+      return CSL.ByronAddress.from_base58(input).to_address();
+    } catch {
+      return null;
+    }
+  }
+};

--- a/packages/core/src/Cardano/types/Address.ts
+++ b/packages/core/src/Cardano/types/Address.ts
@@ -3,8 +3,7 @@ import { InvalidStringError } from '../..';
 import { util as addressUtil } from '../../Address';
 
 /**
- * mainnet or testnet address as bech32 string, consisting of
- * network tag, payment credential and optional stake credential
+ * mainnet or testnet address (Shelley as bech32 string, Byron as base58-encoded string)
  */
 export type Address = typesUtil.OpaqueString<'Address'>;
 

--- a/packages/core/src/Cardano/types/Block.ts
+++ b/packages/core/src/Cardano/types/Block.ts
@@ -1,7 +1,7 @@
 import { BlockNo, BlockSize, Slot } from '@cardano-ogmios/schema';
-import { Cardano } from '../..';
 import { Epoch, Lovelace, PoolId } from '.';
-import { Hash32ByteBase16, OpaqueString, typedBech32 } from '../util';
+import { Hash28ByteBase16, Hash32ByteBase16, OpaqueString, typedBech32 } from '../util';
+import { InvalidStringError } from '../..';
 
 export { BlockNo } from '@cardano-ogmios/schema';
 
@@ -32,15 +32,41 @@ export { BlockSize };
 export type VrfVkBech32 = OpaqueString<'VrfVkBech32'>;
 export const VrfVkBech32 = (value: string) => typedBech32<VrfVkBech32>(value, 'vrf_vk', 52);
 
+/**
+ * Shelley genesis delegate
+ * Either a 28 byte hex string, or 'ShelleyGenesis-[8byte-hex-string]'
+ */
+export type GenesisDelegate = OpaqueString<'GenesisDelegate'>;
+export const GenesisDelegate = (value: string): GenesisDelegate => {
+  // eslint-disable-next-line wrap-regex
+  if (/ShelleyGenesis-[\da-f]{16}/.test(value)) {
+    return value as unknown as GenesisDelegate;
+  }
+  return Hash28ByteBase16(value);
+};
+
+export type SlotLeader = PoolId | GenesisDelegate;
+export const SlotLeader = (value: string): SlotLeader => {
+  try {
+    return PoolId(value);
+  } catch {
+    try {
+      return GenesisDelegate(value);
+    } catch (error) {
+      throw new InvalidStringError('Expected either PoolId or GenesisDelegate', error);
+    }
+  }
+};
+
 export interface Block {
   header: PartialBlockHeader;
   date: Date;
   epoch: Epoch;
   epochSlot: number;
-  slotLeader: PoolId;
+  slotLeader: SlotLeader;
   size: BlockSize;
   txCount: number;
-  totalOutput: Cardano.Lovelace;
+  totalOutput: Lovelace;
   fees: Lovelace;
   vrf: VrfVkBech32;
   previousBlock?: BlockId;

--- a/packages/core/src/Cardano/types/StakePool/primitives.ts
+++ b/packages/core/src/Cardano/types/StakePool/primitives.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Hash28ByteBase16, OpaqueString, typedBech32, typedHex } from '../../util';
-import { InvalidStringError } from '../../..';
 
 /**
  * pool operator verification key hash as bech32 string or a genesis pool ID
@@ -8,20 +7,10 @@ import { InvalidStringError } from '../../..';
 export type PoolId = OpaqueString<'PoolId'>;
 
 /**
- * @param {string} value blake2b_224 digest of an operator verification key hash or a genesis pool ID
+ * @param {string} value blake2b_224 digest of an operator verification key hash
  * @throws InvalidStringError
  */
-export const PoolId = (value: string): PoolId => {
-  try {
-    return typedBech32(value, 'pool', 45);
-  } catch (error: unknown) {
-    // eslint-disable-next-line prettier/prettier
-    if ((/^ShelleyGenesis-[\dA-Fa-f]{16}$/).test(value)) {
-      return value as unknown as PoolId;
-    }
-    throw new InvalidStringError('Expected PoolId to be either bech32 or genesis stake pool', error);
-  }
-};
+export const PoolId = (value: string): PoolId => typedBech32(value, 'pool', 45);
 
 /**
  * pool operator verification key hash as hex string

--- a/packages/core/test/Address/util.test.ts
+++ b/packages/core/test/Address/util.test.ts
@@ -1,45 +1,19 @@
-/* eslint-disable max-len */
 import { Address } from '../../src';
 
-export const addresses = {
-  byron: {
-    mainnet: {
-      daedalus:
-        'DdzFFzCqrhsw3prhfMFDNFowbzUku3QmrMwarfjUbWXRisodn97R436SHc1rimp4MhPNmbdYb1aTdqtGSJixMVMi5MkArDQJ6Sc1n3Ez',
-      icarus: 'Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi'
-    },
-    testnet: {
-      daedalus:
-        '37btjrVyb4KEB2STADSsj3MYSAdj52X5FrFWpw2r7Wmj2GDzXjFRsHWuZqrw7zSkwopv8Ci3VWeg6bisU9dgJxW5hb2MZYeduNKbQJrqz3zVBsu9nT',
-      icarus: '2cWKMJemoBakkUSWX3DZdx8eXGeqjN6mkgVUCND1RNB736qWS5v1CGgQGNNTFUZSXaVLj'
-    }
-  },
-  invalid: {
-    networkMagic:
-      '3reY92cShRkjtmz7q31547czPNHbrhbRGhVLehTrNDNDNeDaKJwcM8aMmWg2zd7cHVFvhdui4a86nEdsSEE7g7kcZKKvBw7nzixnbX1',
-    short: 'EkxDbkPo'
-  },
-  shelley: {
-    mainnet: 'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn',
-    testnet:
-      'addr_test1qqydn46r6mhge0kfpqmt36m6q43knzsd9ga32n96m89px3nuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qypp3m9'
-  }
-};
+/* eslint-disable max-len */
+jest.mock('../../src/CSL/parseCslAddress');
+const { parseCslAddress } = jest.requireMock('../../src/CSL/parseCslAddress');
 
 describe('Address', () => {
   describe('util', () => {
     describe('isAddress', () => {
-      it('returns true if the input is a valid Shelley or Byron-era address, on either the mainnet or testnets', async () => {
-        expect(Address.util.isAddress(addresses.shelley.testnet)).toBe(true);
-        expect(Address.util.isAddress(addresses.shelley.mainnet)).toBe(true);
-        expect(Address.util.isAddress(addresses.byron.mainnet.daedalus)).toBe(true);
-        expect(Address.util.isAddress(addresses.byron.mainnet.icarus)).toBe(true);
-        expect(Address.util.isAddress(addresses.byron.testnet.daedalus)).toBe(true);
-        expect(Address.util.isAddress(addresses.byron.testnet.icarus)).toBe(true);
+      it('returns false if parseCslAddress returns null', () => {
+        parseCslAddress.mockReturnValueOnce(null);
+        expect(Address.util.isAddress('invalid')).toBe(false);
       });
-      test('returns false if the input is not a Cardano address', async () => {
-        expect(Address.util.isAddress(addresses.invalid.short)).toBe(false);
-        expect(Address.util.isAddress(addresses.invalid.networkMagic)).toBe(false);
+      it('returns true if parseCslAddress returns an Address', () => {
+        parseCslAddress.mockReturnValueOnce('CSL.Address object');
+        expect(Address.util.isAddress('valid')).toBe(true);
       });
     });
   });

--- a/packages/core/test/CSL/coreToCsl.test.ts
+++ b/packages/core/test/CSL/coreToCsl.test.ts
@@ -20,6 +20,12 @@ const txOut: Cardano.TxOut = {
     coins: 10n
   }
 };
+const txOutByron = {
+  ...txOut,
+  address: Cardano.Address(
+    'DdzFFzCqrhsw3prhfMFDNFowbzUku3QmrMwarfjUbWXRisodn97R436SHc1rimp4MhPNmbdYb1aTdqtGSJixMVMi5MkArDQJ6Sc1n3Ez'
+  )
+};
 
 const coreTxBody: Cardano.TxBodyAlonzo = {
   certificates: [
@@ -50,6 +56,7 @@ describe('coreToCsl', () => {
   });
   it('txOut', () => {
     expect(coreToCsl.txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
+    expect(coreToCsl.txOut(txOutByron)).toBeInstanceOf(CSL.TransactionOutput);
   });
   it('utxo', () => {
     expect(coreToCsl.utxo([[txIn, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);

--- a/packages/core/test/CSL/parseCslAddress.test.ts
+++ b/packages/core/test/CSL/parseCslAddress.test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable max-len */
+import { CSL, parseCslAddress } from '../../src';
+
+export const addresses = {
+  byron: {
+    mainnet: {
+      daedalus:
+        'DdzFFzCqrhsw3prhfMFDNFowbzUku3QmrMwarfjUbWXRisodn97R436SHc1rimp4MhPNmbdYb1aTdqtGSJixMVMi5MkArDQJ6Sc1n3Ez',
+      icarus: 'Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi'
+    },
+    testnet: {
+      daedalus:
+        '37btjrVyb4KEB2STADSsj3MYSAdj52X5FrFWpw2r7Wmj2GDzXjFRsHWuZqrw7zSkwopv8Ci3VWeg6bisU9dgJxW5hb2MZYeduNKbQJrqz3zVBsu9nT',
+      icarus: '2cWKMJemoBakkUSWX3DZdx8eXGeqjN6mkgVUCND1RNB736qWS5v1CGgQGNNTFUZSXaVLj'
+    }
+  },
+  invalid: {
+    networkMagic:
+      '3reY92cShRkjtmz7q31547czPNHbrhbRGhVLehTrNDNDNeDaKJwcM8aMmWg2zd7cHVFvhdui4a86nEdsSEE7g7kcZKKvBw7nzixnbX1',
+    short: 'EkxDbkPo'
+  },
+  shelley: {
+    grouped: {
+      mainnet:
+        'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn',
+      testnet:
+        'addr_test1qqydn46r6mhge0kfpqmt36m6q43knzsd9ga32n96m89px3nuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qypp3m9'
+    },
+    single: {
+      mainnet: 'addr1vy36kffjf87vzkuyqc5g0ys3fe3pez5zvqg9r5z9q9kfrkg2cs093',
+      testnet: 'addr_test1vrdkagyspkmt96k6z87rnt9dzzy8mlcex7awjymm8wx434q837u24'
+    }
+  }
+};
+
+describe('parseCslAddress', () => {
+  it('returns true if the input is a valid Shelley or Byron-era address, on either the mainnet or testnets', async () => {
+    expect(parseCslAddress(addresses.shelley.grouped.testnet)).toBeInstanceOf(CSL.Address);
+    expect(parseCslAddress(addresses.shelley.grouped.mainnet)).toBeInstanceOf(CSL.Address);
+    expect(parseCslAddress(addresses.shelley.single.testnet)).toBeInstanceOf(CSL.Address);
+    expect(parseCslAddress(addresses.shelley.single.mainnet)).toBeInstanceOf(CSL.Address);
+    expect(parseCslAddress(addresses.byron.mainnet.daedalus)).toBeInstanceOf(CSL.Address);
+    expect(parseCslAddress(addresses.byron.mainnet.icarus)).toBeInstanceOf(CSL.Address);
+    expect(parseCslAddress(addresses.byron.testnet.daedalus)).toBeInstanceOf(CSL.Address);
+    expect(parseCslAddress(addresses.byron.testnet.icarus)).toBeInstanceOf(CSL.Address);
+  });
+  test('returns false if the input is not a Cardano address', async () => {
+    expect(parseCslAddress(addresses.invalid.short)).toBe(null);
+    expect(parseCslAddress(addresses.invalid.networkMagic)).toBe(null);
+  });
+});

--- a/packages/core/test/Cardano/types/Address.test.ts
+++ b/packages/core/test/Cardano/types/Address.test.ts
@@ -10,7 +10,7 @@ jest.mock('../../../src/Address/util', () => {
 const addressUtilMock = jest.requireMock('../../../src/Address/util');
 
 describe('Cardano/types/Address', () => {
-  it('Address() accepts a valid mainnet grouped address and is implemented using util.typedBech32', () => {
+  it('Address() accepts a valid mainnet grouped address and is implemented using "isAddress" util', () => {
     expect(() =>
       Cardano.Address(
         'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
@@ -19,21 +19,5 @@ describe('Cardano/types/Address', () => {
     expect(addressUtilMock.isAddress).toBeCalledWith(
       'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
     );
-  });
-
-  it('Address() accepts a valid testnet grouped address', () => {
-    expect(() =>
-      Cardano.Address(
-        'addr_test1qqydn46r6mhge0kfpqmt36m6q43knzsd9ga32n96m89px3nuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qypp3m9'
-      )
-    ).not.toThrow();
-  });
-
-  it('Address() accepts a valid mainnet single address', () => {
-    expect(() => Cardano.Address('addr1vy36kffjf87vzkuyqc5g0ys3fe3pez5zvqg9r5z9q9kfrkg2cs093')).not.toThrow();
-  });
-
-  it('Address() accepts a valid testnet single address', () => {
-    expect(() => Cardano.Address('addr_test1vrdkagyspkmt96k6z87rnt9dzzy8mlcex7awjymm8wx434q837u24')).not.toThrow();
   });
 });

--- a/packages/core/test/Cardano/types/Block.test.ts
+++ b/packages/core/test/Cardano/types/Block.test.ts
@@ -1,8 +1,10 @@
-import { BlockId, VrfVkBech32, util } from '../../../src/Cardano';
+import { BlockId, SlotLeader, VrfVkBech32, util } from '../../../src/Cardano';
+import { InvalidStringError } from '../../../src';
 
 jest.mock('../../../src/Cardano/util/primitives', () => {
   const actual = jest.requireActual('../../../src/Cardano/util/primitives');
   return {
+    Hash28ByteBase16: jest.fn().mockImplementation((...args) => actual.Hash28ByteBase16(...args)),
     Hash32ByteBase16: jest.fn().mockImplementation((...args) => actual.Hash32ByteBase16(...args)),
     typedBech32: jest.fn().mockImplementation((...args) => actual.typedBech32(...args))
   };
@@ -21,5 +23,20 @@ describe('Cardano/types/Block', () => {
       'vrf_vk',
       52
     );
+  });
+
+  describe('SlotLeader()', () => {
+    it('accepts a valid PoolId and is implemented using util.typedBech32', () => {
+      expect(() => SlotLeader('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh')).not.toThrow();
+    });
+    it('accepts a valid Shelley genesis delegate', () => {
+      expect(() => SlotLeader('eff1b5b26e65b791d6f236c7c0264012bd1696759d22bdb4dd0f6f56')).not.toThrow();
+    });
+    it('accepts a valid Shelley genesis in prefix format', () => {
+      expect(() => SlotLeader('ShelleyGenesis-eff1b5b26e65b791')).not.toThrow();
+    });
+    it('throws for any other strings', () => {
+      expect(() => SlotLeader('ShelleyGenesis-eff1b5b26e65b79')).toThrowError(InvalidStringError);
+    });
   });
 });

--- a/packages/core/test/Cardano/types/StakePool.test.ts
+++ b/packages/core/test/Cardano/types/StakePool.test.ts
@@ -5,10 +5,6 @@ describe('Cardano/types/StakePool', () => {
     expect(() => Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh')).not.toThrow();
   });
 
-  it('PoolId() accepts a valid genesis pool ID', () => {
-    expect(() => Cardano.PoolId('ShelleyGenesis-eff1b5b26e65b791')).not.toThrow();
-  });
-
   it('PoolIdHex() accepts a valid pool id hex string', () => {
     expect(() => Cardano.PoolIdHex('e4b1c8ec89415ce6349755a1aa44b4affbb5f1248ff29943d190c715')).not.toThrow();
   });


### PR DESCRIPTION
# Context

* Loading a transaction with Byron addresses throws
* Loading a transaction with Shelley genesis delegate as slot leader throws

# Proposed Solution

* (BREAKING) Accept base58-encoded addresses in `Cardano.Address` type and update `coreToCsl` to support that
* (BREAKING) Change type of `Block.slotLeader` to `PoolId | GenesisDelegate` and update `blockfrost` WalletProvider implementation to support that

## Out of Scope

`cardano-graphql` types/schema updates to reflect updated types
