### PR TITLE
fix(cip2): omit 0 qty assets from change bundles

### DIFF
--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -185,7 +185,13 @@ const coalesceChangeBundlesForMinCoinRequirement = (
     return changeBundles;
   }
 
-  let sortedBundles = orderBy(changeBundles, ({ coins }) => coins, 'desc');
+  const noZeroQuantityAssetChangeBundles = changeBundles.map(
+    ({ coins, assets }): Cardano.Value => ({
+      assets: assets ? new Map([...assets.entries()].filter(([_, quantity]) => quantity > 0n)) : undefined,
+      coins
+    })
+  );
+  let sortedBundles = orderBy(noZeroQuantityAssetChangeBundles, ({ coins }) => coins, 'desc');
   const satisfiesMinCoinRequirement = (valueQuantities: Cardano.Value) =>
     valueQuantities.coins >= computeMinimumCoinQuantity(valueQuantities.assets);
 

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -34,6 +34,17 @@ describe('RoundRobinRandomImprove', () => {
           }
         });
       });
+      it('0 token change', async () => {
+        // Regression
+        await testInputSelectionProperties({
+          createOutputs: () => [TxTestUtil.createOutput({ assets: new Map([[AssetId.TSLA, 7001n]]), coins: 1000n })],
+          createUtxo: () => [
+            TxTestUtil.createUnspentTxOutput({ assets: new Map([[AssetId.TSLA, 7001n]]), coins: 11_999_994n })
+          ],
+          getAlgorithm: roundRobinRandomImprove,
+          mockConstraints: SelectionConstraints.MOCK_NO_CONSTRAINTS
+        });
+      });
       it('Selects UTxO even when implicit input covers outputs', async () => {
         const utxo = new Set([TxTestUtil.createUnspentTxOutput({ coins: 10_000_000n })]);
         const outputs = new Set([TxTestUtil.createOutput({ coins: 1_000_000n })]);


### PR DESCRIPTION
# Context

`cip2` property tests [failed](https://github.com/input-output-hk/cardano-js-sdk/runs/4871444863?check_suite_focus=true#step:7:51)

# Proposed Solution

Filter out assets in change bundles at the last step of change calculation
