### PR TITLE
fix: wallet initializeTx stub sign

### DIFF
--- a/packages/wallet/src/KeyManagement/InMemoryKeyAgent.ts
+++ b/packages/wallet/src/KeyManagement/InMemoryKeyAgent.ts
@@ -2,6 +2,7 @@ import * as errors from './errors';
 import {
   AccountKeyDerivationPath,
   GetPassword,
+  GroupedAddress,
   HexBlob,
   KeyAgentType,
   SerializableKeyAgentData,
@@ -16,6 +17,7 @@ import { harden, joinMnemonicWords, mnemonicWordsToEntropy, validateMnemonic } f
 export interface InMemoryKeyAgentProps {
   networkId: Cardano.NetworkId;
   accountIndex: number;
+  knownAddresses: GroupedAddress[];
   encryptedRootPrivateKey: Uint8Array;
   getPassword: GetPassword;
 }
@@ -41,17 +43,29 @@ export class InMemoryKeyAgent extends KeyAgentBase {
   readonly #accountIndex: number;
   readonly #encryptedRootPrivateKey: Uint8Array;
   readonly #getPassword: GetPassword;
+  readonly #knownAddresses: GroupedAddress[];
 
-  constructor({ networkId, accountIndex, encryptedRootPrivateKey, getPassword }: InMemoryKeyAgentProps) {
+  constructor({
+    networkId,
+    accountIndex,
+    encryptedRootPrivateKey,
+    getPassword,
+    knownAddresses
+  }: InMemoryKeyAgentProps) {
     super();
     this.#accountIndex = accountIndex;
     this.#networkId = networkId;
     this.#encryptedRootPrivateKey = encryptedRootPrivateKey;
     this.#getPassword = getPassword;
+    this.#knownAddresses = knownAddresses;
   }
 
   get __typename(): KeyAgentType {
     return KeyAgentType.InMemory;
+  }
+
+  get knownAddresses(): GroupedAddress[] {
+    return this.#knownAddresses;
   }
 
   get serializableData(): SerializableKeyAgentData {
@@ -59,6 +73,7 @@ export class InMemoryKeyAgent extends KeyAgentBase {
       __typename: KeyAgentType.InMemory,
       accountIndex: this.#accountIndex,
       encryptedRootPrivateKeyBytes: [...this.#encryptedRootPrivateKey],
+      knownAddresses: this.#knownAddresses,
       networkId: this.networkId
     };
   }
@@ -119,6 +134,7 @@ export class InMemoryKeyAgent extends KeyAgentBase {
       accountIndex,
       encryptedRootPrivateKey,
       getPassword,
+      knownAddresses: [],
       networkId
     });
   }

--- a/packages/wallet/src/KeyManagement/KeyAgentBase.ts
+++ b/packages/wallet/src/KeyManagement/KeyAgentBase.ts
@@ -15,6 +15,7 @@ export abstract class KeyAgentBase implements KeyAgent {
   abstract get networkId(): Cardano.NetworkId;
   abstract get accountIndex(): number;
   abstract get serializableData(): SerializableKeyAgentData;
+  abstract get knownAddresses(): GroupedAddress[];
   abstract getExtendedAccountPublicKey(): Promise<Cardano.Bip32PublicKey>;
   abstract signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob): Promise<SignBlobResult>;
   abstract derivePublicKey(derivationPath: AccountKeyDerivationPath): Promise<Cardano.Ed25519PublicKey>;
@@ -43,7 +44,7 @@ export abstract class KeyAgentBase implements KeyAgent {
     ).to_address();
 
     const rewardAccount = CSL.RewardAddress.new(this.networkId, stakeKeyCredential).to_address();
-    return {
+    const groupedAddress = {
       accountIndex: this.accountIndex,
       address: Cardano.Address(address.to_bech32()),
       index,
@@ -51,6 +52,8 @@ export abstract class KeyAgentBase implements KeyAgent {
       rewardAccount: Cardano.RewardAccount(rewardAccount.to_bech32()),
       type
     };
+    this.knownAddresses.push(groupedAddress);
+    return groupedAddress;
   }
 
   async signTransaction({ body, hash }: TxInternals): Promise<Cardano.Signatures> {

--- a/packages/wallet/src/KeyManagement/index.ts
+++ b/packages/wallet/src/KeyManagement/index.ts
@@ -5,4 +5,3 @@ export * from './restoreKeyAgent';
 export * as util from './util';
 export * from './emip3';
 export * from './types';
-export * from './cachedGetPassword';

--- a/packages/wallet/src/KeyManagement/restoreKeyAgent.ts
+++ b/packages/wallet/src/KeyManagement/restoreKeyAgent.ts
@@ -42,6 +42,7 @@ export async function restoreKeyAgent<T extends SerializableKeyAgentData>(
         accountIndex: data.accountIndex,
         encryptedRootPrivateKey: new Uint8Array(data.encryptedRootPrivateKeyBytes),
         getPassword,
+        knownAddresses: data.knownAddresses,
         networkId: data.networkId
       });
     }

--- a/packages/wallet/src/KeyManagement/types.ts
+++ b/packages/wallet/src/KeyManagement/types.ts
@@ -62,6 +62,7 @@ export interface SerializableKeyAgentDataBase {
 export interface SerializableInMemoryKeyAgentData extends SerializableKeyAgentDataBase {
   __typename: KeyAgentType.InMemory;
   encryptedRootPrivateKeyBytes: number[];
+  knownAddresses: GroupedAddress[];
 }
 
 export type SerializableKeyAgentData = SerializableInMemoryKeyAgentData;
@@ -75,6 +76,7 @@ export interface KeyAgent {
   get networkId(): Cardano.NetworkId;
   get accountIndex(): number;
   get serializableData(): SerializableKeyAgentData;
+  get knownAddresses(): GroupedAddress[];
   /**
    * @throws AuthenticationError
    */

--- a/packages/wallet/src/KeyManagement/util/bip39.ts
+++ b/packages/wallet/src/KeyManagement/util/bip39.ts
@@ -13,5 +13,3 @@ export const mnemonicWordsToEntropy = (mnenonic: string[]) => bip39.mnemonicToEn
  * A wrapper around the bip39 package function
  */
 export const validateMnemonic = bip39.validateMnemonic;
-
-export const harden = (num: number): number => 0x80_00_00_00 + num;

--- a/packages/wallet/src/KeyManagement/util/cachedGetPassword.ts
+++ b/packages/wallet/src/KeyManagement/util/cachedGetPassword.ts
@@ -1,5 +1,5 @@
-import { GetPassword } from './types';
-import { Milliseconds } from '..';
+import { GetPassword } from '../types';
+import { Milliseconds } from '../../services';
 
 export const cachedGetPassword = (getPassword: () => Promise<Uint8Array>, cacheDuration: Milliseconds): GetPassword => {
   let cached: Promise<Uint8Array> | null;

--- a/packages/wallet/src/KeyManagement/util/index.ts
+++ b/packages/wallet/src/KeyManagement/util/index.ts
@@ -1,3 +1,4 @@
 export * from './bip39';
 export * from './key';
 export * from './ownSignatureKeyPaths';
+export * from './cachedGetPassword';

--- a/packages/wallet/src/KeyManagement/util/index.ts
+++ b/packages/wallet/src/KeyManagement/util/index.ts
@@ -1,0 +1,3 @@
+export * from './bip39';
+export * from './key';
+export * from './ownSignatureKeyPaths';

--- a/packages/wallet/src/KeyManagement/util/index.ts
+++ b/packages/wallet/src/KeyManagement/util/index.ts
@@ -2,3 +2,4 @@ export * from './bip39';
 export * from './key';
 export * from './ownSignatureKeyPaths';
 export * from './cachedGetPassword';
+export * from './stubSignTransaction';

--- a/packages/wallet/src/KeyManagement/util/key.ts
+++ b/packages/wallet/src/KeyManagement/util/key.ts
@@ -1,0 +1,1 @@
+export const harden = (num: number): number => 0x80_00_00_00 + num;

--- a/packages/wallet/src/KeyManagement/util/ownSignatureKeyPaths.ts
+++ b/packages/wallet/src/KeyManagement/util/ownSignatureKeyPaths.ts
@@ -1,0 +1,27 @@
+import { Cardano, util } from '@cardano-sdk/core';
+import { GroupedAddress, KeyType } from '../types';
+import { uniq } from 'lodash-es';
+
+export interface PartialDerivationPath {
+  role: KeyType;
+  index: number;
+}
+
+/**
+ * Assumes that a single staking key is used for all addresses (index=0)
+ *
+ * @returns {PartialDerivationPath[]} derivation paths for keys to sign transaction with
+ */
+export const ownSignatureKeyPaths = (
+  txBody: Cardano.TxBodyAlonzo,
+  knownAddresses: GroupedAddress[]
+): PartialDerivationPath[] => {
+  const paymentKeyPaths = uniq(
+    txBody.inputs.map((input) => knownAddresses.find(({ address }) => address === input.address)).filter(util.isNotNil)
+  ).map(({ type, index }) => ({ index, role: Number(type) }));
+  const isStakingKeySignatureRequired = txBody.certificates?.length;
+  if (isStakingKeySignatureRequired) {
+    return [...paymentKeyPaths, { index: 0, role: KeyType.Stake }];
+  }
+  return paymentKeyPaths;
+};

--- a/packages/wallet/src/KeyManagement/util/stubSignTransaction.ts
+++ b/packages/wallet/src/KeyManagement/util/stubSignTransaction.ts
@@ -1,0 +1,20 @@
+import { Cardano } from '@cardano-sdk/core';
+import { GroupedAddress } from '../types';
+import { ownSignatureKeyPaths } from './ownSignatureKeyPaths';
+
+const randomHexChar = () => Math.floor(Math.random() * 16).toString(16);
+const randomPublicKey = () => Cardano.Ed25519PublicKey(Array.from({ length: 64 }).map(randomHexChar).join(''));
+
+export const stubSignTransaction = (
+  txBody: Cardano.TxBodyAlonzo,
+  knownAddresses: GroupedAddress[]
+): Cardano.Signatures =>
+  new Map(
+    ownSignatureKeyPaths(txBody, knownAddresses).map(() => [
+      randomPublicKey(),
+      Cardano.Ed25519Signature(
+        // eslint-disable-next-line max-len
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      )
+    ])
+  );

--- a/packages/wallet/test/KeyManagement/InMemoryKeyAgent.test.ts
+++ b/packages/wallet/test/KeyManagement/InMemoryKeyAgent.test.ts
@@ -52,6 +52,7 @@ describe('InMemoryKeyAgent', () => {
       expect(typeof serializableData.__typename).toBe('string');
       expect(typeof serializableData.accountIndex).toBe('number');
       expect(typeof serializableData.networkId).toBe('number');
+      expect(Array.isArray(serializableData.knownAddresses)).toBe(true);
       expect(serializableData.encryptedRootPrivateKeyBytes.length > 0).toBe(true);
     });
 
@@ -148,6 +149,7 @@ describe('InMemoryKeyAgent', () => {
         accountIndex: 0,
         encryptedRootPrivateKey: Buffer.from(yoroiEncryptedRootPrivateKeyHex, 'hex'),
         getPassword,
+        knownAddresses: [],
         networkId: Cardano.NetworkId.testnet
       });
       const exportedPrivateKeyHex = await keyAgentFromEncryptedKey.exportRootPrivateKey();
@@ -203,6 +205,7 @@ describe('InMemoryKeyAgent', () => {
         accountIndex: 0,
         encryptedRootPrivateKey: Buffer.from(daedelusEncryptedRootPrivateKeyHex, 'hex'),
         getPassword: jest.fn().mockResolvedValue(Buffer.from('nMmys*X002')), // daedelus enforces min length of 10
+        knownAddresses: [],
         networkId: Cardano.NetworkId.testnet
       });
       const derivedAddress = await keyAgentFromEncryptedKey.deriveAddress({

--- a/packages/wallet/test/KeyManagement/InMemoryKeyAgent.test.ts
+++ b/packages/wallet/test/KeyManagement/InMemoryKeyAgent.test.ts
@@ -108,17 +108,6 @@ describe('InMemoryKeyAgent', () => {
     expect(getPassword).toBeCalledWith(true);
   });
 
-  test('signTransaction', async () => {
-    const witnessSet = await keyAgent.signTransaction({
-      body: {
-        certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration }]
-      } as unknown as Cardano.TxBodyAlonzo,
-      hash: Cardano.TransactionId('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec')
-    });
-    expect(witnessSet.size).toBe(2);
-    expect(typeof [...witnessSet.values()][0]).toBe('string');
-  });
-
   describe('yoroi compatibility', () => {
     const yoroiMnemonic = [
       'glide',

--- a/packages/wallet/test/KeyManagement/KeyAgentBase.test.ts
+++ b/packages/wallet/test/KeyManagement/KeyAgentBase.test.ts
@@ -6,6 +6,7 @@ const NETWORK_ID = Cardano.NetworkId.testnet;
 const ACCOUNT_INDEX = 1;
 
 class MockKeyAgent extends KeyManagement.KeyAgentBase {
+  #knownAddresses = [];
   get networkId(): Cardano.NetworkId {
     return NETWORK_ID;
   }
@@ -14,6 +15,9 @@ class MockKeyAgent extends KeyManagement.KeyAgentBase {
   }
   get serializableData() {
     return this.serializableDataImpl();
+  }
+  get knownAddresses(): KeyManagement.GroupedAddress[] {
+    return this.#knownAddresses;
   }
   serializableDataImpl = jest.fn();
   getExtendedAccountPublicKey = jest.fn();
@@ -53,6 +57,7 @@ describe('KeyAgentBase', () => {
     expect(address.networkId).toBe(NETWORK_ID);
     expect(address.address.startsWith('addr_test')).toBe(true);
     expect(address.rewardAccount.startsWith('stake_test')).toBe(true);
+    expect(keyAgent.knownAddresses).toHaveLength(1);
   });
 
   describe('signTransaction', () => {

--- a/packages/wallet/test/KeyManagement/restoreKeyAgent.test.ts
+++ b/packages/wallet/test/KeyManagement/restoreKeyAgent.test.ts
@@ -1,3 +1,4 @@
+import { Cardano } from '@cardano-sdk/core';
 import { InvalidSerializableDataError } from '../../src/KeyManagement/errors';
 import { KeyManagement } from '../../src';
 
@@ -15,13 +16,26 @@ describe('KeyManagement/restoreKeyAgent', () => {
         66, 141, 241, 161, 163, 19, 81, 122, 125, 149, 49, 175, 149, 111, 48, 138, 254, 189, 69, 35, 135, 62, 177, 43,
         152, 95, 7, 87, 78, 204, 222, 109, 3, 239, 117
       ],
+      knownAddresses: [
+        {
+          accountIndex: 0,
+          address: Cardano.Address(
+            'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
+          ),
+          index: 0,
+          networkId: Cardano.NetworkId.mainnet,
+          rewardAccount: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
+          type: KeyManagement.AddressType.External
+        }
+      ],
       networkId: 0
     };
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const getPassword: KeyManagement.GetPassword = async () => Buffer.from('password');
 
     it('can restore key manager from valid data and password', async () => {
-      await expect(KeyManagement.restoreKeyAgent(inMemoryKeyAgentData, getPassword)).resolves.not.toThrow();
+      const keyAgent = await KeyManagement.restoreKeyAgent(inMemoryKeyAgentData, getPassword);
+      expect(keyAgent.knownAddresses).toBe(inMemoryKeyAgentData.knownAddresses);
     });
 
     it('throws when attempting to restore key manager from valid data and no password', async () => {

--- a/packages/wallet/test/KeyManagement/util/cachedGetPassword.test.ts
+++ b/packages/wallet/test/KeyManagement/util/cachedGetPassword.test.ts
@@ -1,4 +1,4 @@
-import { KeyManagement } from '../../src';
+import { KeyManagement } from '../../../src';
 
 jest.useFakeTimers();
 
@@ -13,7 +13,7 @@ describe('cachedGetPassword', () => {
     getPassword = jest
       .fn()
       .mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(password), getPasswordDuration)));
-    cachedGetPassword = KeyManagement.cachedGetPassword(getPassword, cacheDuration);
+    cachedGetPassword = KeyManagement.util.cachedGetPassword(getPassword, cacheDuration);
   });
 
   it('caches password for specified duration"', async () => {

--- a/packages/wallet/test/KeyManagement/util/ownSignaturePaths.test.ts
+++ b/packages/wallet/test/KeyManagement/util/ownSignaturePaths.test.ts
@@ -1,0 +1,46 @@
+import { AddressType, GroupedAddress, KeyType, util } from '../../../src/KeyManagement';
+import { Cardano } from '@cardano-sdk/core';
+
+const createAddressInput = (address: Cardano.Address) =>
+  ({
+    address
+  } as Cardano.TxIn);
+
+const createGroupedAddress = (address: Cardano.Address, type: AddressType, index: number): GroupedAddress =>
+  ({
+    address,
+    index,
+    type
+  } as GroupedAddress);
+
+describe('KeyManagement.util.ownSignaturePaths', () => {
+  it('returns distinct derivation paths required to sign the transaction', () => {
+    const address1 = Cardano.Address(
+      'addr_test1qra788mu4sg8kwd93ns9nfdh3k4ufxwg4xhz2r3n064tzfgxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flkns6cy45x'
+    );
+    const address2 = Cardano.Address(
+      'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+    );
+    const txBody = {
+      certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration }],
+      inputs: [address1, address2, address1].map(createAddressInput)
+    } as Cardano.TxBodyAlonzo;
+    const knownAddresses = [address1, address2].map((address, index) =>
+      createGroupedAddress(address, AddressType.External, index)
+    );
+    expect(util.ownSignatureKeyPaths(txBody, knownAddresses)).toEqual([
+      {
+        index: 0,
+        role: KeyType.External
+      },
+      {
+        index: 1,
+        role: KeyType.External
+      },
+      {
+        index: 0,
+        role: KeyType.Stake
+      }
+    ]);
+  });
+});

--- a/packages/wallet/test/KeyManagement/util/stubSignTransaction.test.ts
+++ b/packages/wallet/test/KeyManagement/util/stubSignTransaction.test.ts
@@ -1,0 +1,17 @@
+import { Cardano } from '@cardano-sdk/core';
+import { GroupedAddress } from '../../../src/KeyManagement';
+import { stubSignTransaction } from '../../../src/KeyManagement/util';
+
+jest.mock('../../../src/KeyManagement/util/ownSignatureKeyPaths');
+const { ownSignatureKeyPaths } = jest.requireMock('../../../src/KeyManagement/util/ownSignatureKeyPaths');
+
+describe('KeyManagement.util.stubSignTransaction', () => {
+  it('returns as many signatures as number of keys returned by ownSignaturePaths', () => {
+    const txBody = {} as Cardano.TxBodyAlonzo;
+    const knownAddresses = [{} as GroupedAddress];
+    ownSignatureKeyPaths.mockReturnValueOnce([{}]).mockReturnValueOnce([{}, {}]);
+    expect(stubSignTransaction(txBody, knownAddresses).size).toBe(1);
+    expect(stubSignTransaction(txBody, knownAddresses).size).toBe(2);
+    expect(ownSignatureKeyPaths).toBeCalledWith(txBody, knownAddresses);
+  });
+});

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -38,7 +38,6 @@ describe('SingleAddressWallet', () => {
   });
 
   afterEach(() => {
-    getPassword.mockClear();
     wallet.shutdown();
   });
 
@@ -139,8 +138,8 @@ describe('SingleAddressWallet', () => {
       });
     });
 
-    // TODO
-    it.skip('initializeTx', async () => {
+    it('initializeTx', async () => {
+      getPassword.mockClear();
       const { body, hash, inputSelection } = await wallet.initializeTx(props);
       expect(body.outputs).toHaveLength(props.outputs.size + 1 /* change output */);
       expect(typeof hash).toBe('string');

--- a/packages/wallet/test/mocks/mockWalletProvider.ts
+++ b/packages/wallet/test/mocks/mockWalletProvider.ts
@@ -101,7 +101,7 @@ export const queryTransactionsResult: Cardano.TxAlonzo[] = [
       inputs: [
         {
           address: Cardano.Address(
-            'addr_test1qpfhhfy2qgls50r9u4yh0l7z67xpg0a5rrhkmvzcuqrd0znuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q9gw0lz'
+            'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
           ),
           index: 0,
           txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')

--- a/packages/wallet/test/mocks/testKeyAgent.ts
+++ b/packages/wallet/test/mocks/testKeyAgent.ts
@@ -1,9 +1,11 @@
 import { Cardano } from '@cardano-sdk/core';
 import { KeyManagement } from '../../src';
 
+export const getPassword = jest.fn(async () => Buffer.from('password'));
+
 export const testKeyAgent = () =>
   KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords({
-    getPassword: async () => Buffer.from('password'),
+    getPassword,
     mnemonicWords: KeyManagement.util.generateMnemonicWords(),
     networkId: Cardano.NetworkId.testnet
   });


### PR DESCRIPTION
# Context

`SingleAddressWallet.initializeTx` calls input selection, which attempts to build a full transaction in order to compute it's size. It results in doing the actual transaction signing, which is not necessary at this point.

# Proposed Solution

Use stub (any) signatures for input selection constraints.

# Important Changes Introduced

- (BREAKING) Track known/derived addresses in KeyAgent. As a result there's an extra field in `SerializableInMemoryKeyAgentData`.
- Add `KeyManagement.util.ownSignaturePaths` which returns partial derivation paths required to sign a given transaction.
- (BREAKING) Consolidate KeyManagement utils under 1 directory. The breaking part is `KeyManagement.cachedGetPassword`->`KeyManagement.util.cachedGetPassword`

