### PR TITLE
fix(wallet): fix emip3decrypt to work in polyfilled browsers

### DIFF
--- a/packages/wallet/src/KeyManagement/emip3.ts
+++ b/packages/wallet/src/KeyManagement/emip3.ts
@@ -46,5 +46,5 @@ export const emip3decrypt = async (encrypted: Uint8Array, password: Uint8Array):
   const decipher = chacha.createDecipher(key, Buffer.from(nonce));
   decipher.setAuthTag(Buffer.from(tag));
   decipher.setAAD(AAD);
-  return Buffer.concat([decipher.update(data), decipher.final()]);
+  return Buffer.concat([decipher.update(Buffer.from(data)), decipher.final()]);
 };


### PR DESCRIPTION
# Context

emip3decrypt throws when called with Uint8Array data in browser env: it attempts to call `readUInt16LE` which is only available on Buffer.

# Proposed Solution

Convert data to Buffer
