### PR TITLE
fix: recompute fee after selecting extra utxo due to min utxo value

### DIFF
--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -2,7 +2,7 @@ import { Cardano } from '@cardano-sdk/core';
 import { ComputeMinimumCoinQuantity, TokenBundleSizeExceedsLimit } from '../types';
 import { InputSelectionError, InputSelectionFailure } from '../InputSelectionError';
 import { UtxoSelection, assetQuantitySelector, getCoinQuantity, toValues } from './util';
-import { orderBy } from 'lodash-es';
+import { orderBy, pick } from 'lodash-es';
 
 type EstimateTxFeeWithOriginalOutputs = (utxo: Cardano.Utxo[], change: Cardano.Value[]) => Promise<Cardano.Lovelace>;
 
@@ -222,7 +222,6 @@ const computeChangeBundles = ({
   uniqueOutputAssetIDs,
   implicitCoin,
   computeMinimumCoinQuantity,
-  random,
   fee = 0n
 }: {
   utxoSelection: UtxoSelection;
@@ -231,8 +230,7 @@ const computeChangeBundles = ({
   implicitCoin: Required<Cardano.ImplicitCoin>;
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity;
   fee?: bigint;
-  random: typeof Math.random;
-}): UtxoSelection & { changeBundles: Cardano.Value[] } => {
+}): (UtxoSelection & { changeBundles: Cardano.Value[] }) | false => {
   const requestedAssetChangeBundles = computeRequestedAssetChangeBundles(
     utxoSelection.utxoSelected,
     outputValues,
@@ -250,22 +248,7 @@ const computeChangeBundles = ({
     computeMinimumCoinQuantity
   );
   if (!changeBundles) {
-    // Coalesced all bundles to 1 and it's still less than min utxo value
-    if (utxoSelection.utxoRemaining.length > 0) {
-      return computeChangeBundles({
-        computeMinimumCoinQuantity,
-        fee,
-        implicitCoin,
-        outputValues,
-        random,
-        uniqueOutputAssetIDs,
-        utxoSelection: pickExtraRandomUtxo(utxoSelection, random)
-      });
-    }
-    // This is not a great error type for this, because the spec says
-    // "due to various restrictions that coin selection algorithms impose on themselves when selecting UTxO entries."
-    // This happens due to blockchain restriction on minimum utxo coin quantity, not due to the algorithm restriction.
-    throw new InputSelectionError(InputSelectionFailure.UtxoFullyDepleted);
+    return false;
   }
   return { changeBundles, ...utxoSelection };
 };
@@ -304,52 +287,68 @@ export const computeChangeAndAdjustForFee = async ({
   random,
   utxoSelection
 }: ChangeComputationArgs): Promise<ChangeComputationResult> => {
-  const changeInclFee = computeChangeBundles({
+  const recomputeChangeAndAdjustForFeeWithExtraUtxo = (currentUtxoSelection: UtxoSelection) => {
+    if (currentUtxoSelection.utxoRemaining.length > 0) {
+      return computeChangeAndAdjustForFee({
+        computeMinimumCoinQuantity,
+        estimateTxFee,
+        implicitCoin,
+        outputValues,
+        random,
+        tokenBundleSizeExceedsLimit,
+        uniqueOutputAssetIDs,
+        utxoSelection: pickExtraRandomUtxo(currentUtxoSelection, random)
+      });
+    }
+    // This is not a great error type for this, because the spec says
+    // "due to various restrictions that coin selection algorithms impose on themselves when selecting UTxO entries."
+    // Sometimes this happens due to blockchain restriction on minimum utxo coin quantity,
+    // not due to the algorithm restriction.
+    throw new InputSelectionError(InputSelectionFailure.UtxoFullyDepleted);
+  };
+
+  const selectionWithChangeAndFee = computeChangeBundles({
     computeMinimumCoinQuantity,
     implicitCoin,
     outputValues,
-    random,
     uniqueOutputAssetIDs,
     utxoSelection
   });
+  if (!selectionWithChangeAndFee) return recomputeChangeAndAdjustForFeeWithExtraUtxo(utxoSelection);
 
   // Calculate fee with change outputs that include fee.
   // It will cover the fee of final selection,
   // where fee is excluded from change bundles
   const fee = await estimateTxFee(
-    changeInclFee.utxoSelected,
-    validateChangeBundles(changeInclFee.changeBundles, tokenBundleSizeExceedsLimit)
+    selectionWithChangeAndFee.utxoSelected,
+    validateChangeBundles(selectionWithChangeAndFee.changeBundles, tokenBundleSizeExceedsLimit)
   );
 
   // Ensure fee quantity is covered by current selection
   const totalOutputCoin = getCoinQuantity(outputValues) + fee + implicitCoin.deposit;
-  const totalInputCoin = getCoinQuantity(toValues(changeInclFee.utxoSelected)) + implicitCoin.input;
+  const totalInputCoin = getCoinQuantity(toValues(selectionWithChangeAndFee.utxoSelected)) + implicitCoin.input;
   if (totalOutputCoin > totalInputCoin) {
-    if (changeInclFee.utxoRemaining.length === 0) {
+    if (selectionWithChangeAndFee.utxoRemaining.length === 0) {
       throw new InputSelectionError(InputSelectionFailure.UtxoBalanceInsufficient);
     }
     // Recompute change and fee with an extra selected UTxO
-    return computeChangeAndAdjustForFee({
-      computeMinimumCoinQuantity,
-      estimateTxFee,
-      implicitCoin,
-      outputValues,
-      random,
-      tokenBundleSizeExceedsLimit,
-      uniqueOutputAssetIDs,
-      utxoSelection: pickExtraRandomUtxo(changeInclFee, random)
-    });
+    return recomputeChangeAndAdjustForFeeWithExtraUtxo(selectionWithChangeAndFee);
   }
 
-  const { changeBundles, utxoSelected, utxoRemaining } = computeChangeBundles({
+  const finalSelection = computeChangeBundles({
     computeMinimumCoinQuantity,
     fee,
     implicitCoin,
     outputValues,
-    random,
     uniqueOutputAssetIDs,
-    utxoSelection: { utxoRemaining: changeInclFee.utxoRemaining, utxoSelected: changeInclFee.utxoSelected }
+    utxoSelection: pick(selectionWithChangeAndFee, ['utxoRemaining', 'utxoSelected'])
   });
+
+  if (!finalSelection) {
+    return recomputeChangeAndAdjustForFeeWithExtraUtxo(selectionWithChangeAndFee);
+  }
+
+  const { changeBundles, utxoSelected, utxoRemaining } = finalSelection;
 
   return {
     change: validateChangeBundles(changeBundles, tokenBundleSizeExceedsLimit),

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -5,7 +5,13 @@ import { computeChangeAndAdjustForFee } from './change';
 import { cslUtil } from '@cardano-sdk/core';
 import { roundRobinSelection } from './roundRobin';
 
-export const roundRobinRandomImprove = (): InputSelector => ({
+interface RoundRobinRandomImproveOptions {
+  random?: typeof Math.random;
+}
+
+export const roundRobinRandomImprove = ({
+  random = Math.random
+}: RoundRobinRandomImproveOptions = {}): InputSelector => ({
   select: async ({
     utxo: utxoSet,
     outputs: outputSet,
@@ -23,6 +29,7 @@ export const roundRobinRandomImprove = (): InputSelector => ({
     const roundRobinSelectionResult = roundRobinSelection({
       implicitCoin,
       outputs,
+      random,
       uniqueOutputAssetIDs,
       utxo
     });
@@ -38,6 +45,7 @@ export const roundRobinRandomImprove = (): InputSelector => ({
         }),
       implicitCoin,
       outputValues: toValues(outputs),
+      random,
       tokenBundleSizeExceedsLimit,
       uniqueOutputAssetIDs,
       utxoSelection: roundRobinSelectionResult

--- a/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
@@ -66,6 +66,7 @@ export const roundRobinSelection = ({
   utxo: utxosWithValue,
   outputs: outputsWithValue,
   uniqueOutputAssetIDs,
+  random,
   implicitCoin
 }: RoundRobinRandomImproveArgs): UtxoSelection => {
   // The subset of the UTxO that has already been selected:
@@ -81,7 +82,7 @@ export const roundRobinSelection = ({
       // this token from the remaining UTxO set:
       const utxo = filterUtxo(utxoRemaining);
       if (utxo.length > 0) {
-        const inputIdx = Math.floor(Math.random() * utxo.length);
+        const inputIdx = Math.floor(random() * utxo.length);
         const input = utxo[inputIdx];
         if (improvesSelection(utxoSelected, input, minimumTarget, getTotalSelectedQuantity)) {
           utxoSelected.push(input);

--- a/packages/cip2/src/RoundRobinRandomImprove/util.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/util.ts
@@ -8,6 +8,7 @@ export interface RoundRobinRandomImproveArgs {
   outputs: Cardano.TxOut[];
   uniqueOutputAssetIDs: Cardano.AssetId[];
   implicitCoin: Required<Cardano.ImplicitCoin>;
+  random: typeof Math.random;
 }
 
 export interface UtxoSelection {
@@ -24,7 +25,7 @@ export const preprocessArgs = (
   availableUtxo: Set<Cardano.Utxo>,
   outputSet: Set<Cardano.TxOut>,
   partialImplicitCoin: Cardano.ImplicitCoin = noImplicitCoin
-): RoundRobinRandomImproveArgs => {
+): Omit<RoundRobinRandomImproveArgs, 'random'> => {
   const outputs = [...outputSet];
   const uniqueOutputAssetIDs = uniq(outputs.flatMap(({ value: { assets } }) => [...(assets?.keys() || [])]));
   const implicitCoin: Required<Cardano.ImplicitCoin> = {

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -56,6 +56,38 @@ describe('RoundRobinRandomImprove', () => {
         });
         expect(results.selection.inputs.size).toBe(1);
       });
+      it('Recomputes fee after selecting an extra utxo due to change not meeting minimumCoinQuantity', async () => {
+        const utxo = new Set([
+          TxTestUtil.createUnspentTxOutput({ coins: 1_000_000n }),
+          TxTestUtil.createUnspentTxOutput({ coins: 1_000_000n }),
+          TxTestUtil.createUnspentTxOutput({ coins: 1_000_000n }),
+          TxTestUtil.createUnspentTxOutput({ coins: 975_000_000n })
+        ]);
+        const outputs = new Set([TxTestUtil.createOutput({ coins: 1_000_000n })]);
+
+        /**
+         * Round robin:
+         * 1. selects 1 coin
+         * 2. attempts to select 975 which does not improve selection: only (1) is returned.
+         *
+         * Change algorithm:
+         * 1. selects an extra 1 coin utxo due to fee (total 1.2 coin required by output+fee)
+         * 2. selects an extra 1 coin utxo due to change value not meeting minimumCoinQuantity: 1+1-1.2=0.8
+         */
+        const random = jest.fn().mockReturnValue(0).mockReturnValueOnce(0).mockReturnValueOnce(0.99);
+
+        const results = await roundRobinRandomImprove({ random }).select({
+          constraints: SelectionConstraints.mockConstraintsToConstraints({
+            ...SelectionConstraints.MOCK_NO_CONSTRAINTS,
+            minimumCoinQuantity: 900_000n,
+            minimumCostCoefficient: 200_000n
+          }),
+          outputs,
+          utxo
+        });
+        expect(results.selection.inputs.size).toBe(3);
+        expect(results.selection.fee).toBe(600_000n);
+      });
     });
     describe('Failure Modes', () => {
       describe('UtxoBalanceInsufficient', () => {

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -30,7 +30,7 @@ describe('RoundRobinRandomImprove', () => {
           mockConstraints: {
             ...SelectionConstraints.MOCK_NO_CONSTRAINTS,
             minimumCoinQuantity: 9_999_991n,
-            minimumCost: 2_000_003n
+            minimumCostCoefficient: 2_000_003n
           }
         });
       });
@@ -85,7 +85,7 @@ describe('RoundRobinRandomImprove', () => {
             getAlgorithm: roundRobinRandomImprove,
             mockConstraints: {
               ...SelectionConstraints.MOCK_NO_CONSTRAINTS,
-              minimumCost: 1n
+              minimumCostCoefficient: 1n
             }
           });
         });

--- a/packages/cip2/test/jest.setup.js
+++ b/packages/cip2/test/jest.setup.js
@@ -2,6 +2,6 @@
 const { testTimeout } = require('../jest.config');
 require('fast-check').configureGlobal({
   interruptAfterTimeLimit: testTimeout * 0.7,
-  numRuns: testTimeout / 50,
-  markInterruptAsFailure: true
+  markInterruptAsFailure: true,
+  numRuns: testTimeout / 50
 });

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -114,9 +114,10 @@ export const assertFailureProperties = ({
     ...utxoAmounts,
     { coins: BigInt(implicitCoin?.input || 0) }
   ]);
+  const maxPossibleFee = constraints.minimumCostCoefficient * BigInt(utxoAmounts.length);
   const requestedQuantities = Cardano.util.coalesceValueQuantities([
     ...outputsAmounts,
-    { coins: BigInt(implicitCoin?.deposit || 0) + constraints.minimumCost }
+    { coins: BigInt(implicitCoin?.deposit || 0) + maxPossibleFee }
   ]);
   switch (error.failure) {
     case InputSelectionFailure.UtxoBalanceInsufficient: {
@@ -220,7 +221,7 @@ export const generateSelectionParams = (() => {
         constraints: fc.record<SelectionConstraints.MockSelectionConstraints>({
           maxTokenBundleSize: fc.nat(AssetId.All.length),
           minimumCoinQuantity: fc.oneof(...[0n, 1n, 34_482n * 29n, 9_999_991n].map((n) => fc.constant(n))),
-          minimumCost: fc.oneof(...[0n, 1n, 200_000n, 2_000_003n].map((n) => fc.constant(n))),
+          minimumCostCoefficient: fc.oneof(...[0n, 1n, 200_000n, 2_000_003n].map((n) => fc.constant(n))),
           selectionLimit: fc.oneof(...[0, 1, 2, 7, 30, Number.MAX_SAFE_INTEGER].map((n) => fc.constant(n)))
         }),
         implicitCoin: fc.constant(implicitCoin),

--- a/packages/util-dev/src/selectionConstraints.ts
+++ b/packages/util-dev/src/selectionConstraints.ts
@@ -3,7 +3,7 @@ import { SelectionConstraints } from '@cardano-sdk/cip2';
 
 export interface MockSelectionConstraints {
   minimumCoinQuantity: bigint;
-  minimumCost: bigint;
+  minimumCostCoefficient: bigint;
   maxTokenBundleSize: number;
   selectionLimit: number;
 }
@@ -11,13 +11,13 @@ export interface MockSelectionConstraints {
 export const MOCK_NO_CONSTRAINTS: MockSelectionConstraints = {
   maxTokenBundleSize: Number.POSITIVE_INFINITY,
   minimumCoinQuantity: 0n,
-  minimumCost: 0n,
+  minimumCostCoefficient: 0n,
   selectionLimit: Number.POSITIVE_INFINITY
 };
 
 export const mockConstraintsToConstraints = (constraints: MockSelectionConstraints): SelectionConstraints => ({
   computeMinimumCoinQuantity: () => constraints.minimumCoinQuantity,
-  computeMinimumCost: async () => constraints.minimumCost,
+  computeMinimumCost: async ({ inputs }) => constraints.minimumCostCoefficient * BigInt(inputs.size),
   computeSelectionLimit: async () => constraints.selectionLimit,
   tokenBundleSizeExceedsLimit: (assets?: Cardano.TokenMap) => (assets?.size || 0) > constraints.maxTokenBundleSize
 });

--- a/packages/util-dev/test/selectionConstraints.test.ts
+++ b/packages/util-dev/test/selectionConstraints.test.ts
@@ -6,11 +6,12 @@ describe('selectionConstraints', () => {
     const constraints = mockConstraintsToConstraints({
       maxTokenBundleSize: 1,
       minimumCoinQuantity: 10n,
-      minimumCost: 20n,
+      minimumCostCoefficient: 20n,
       selectionLimit: 3
     });
     expect(constraints.computeMinimumCoinQuantity()).toBe(10n);
-    expect(await constraints.computeMinimumCost({} as any)).toBe(20n);
+    expect(await constraints.computeMinimumCost({ inputs: new Set([[]]) } as any)).toBe(20n);
+    expect(await constraints.computeMinimumCost({ inputs: new Set([[], []]) } as any)).toBe(40n);
     expect(await constraints.computeSelectionLimit({} as any)).toBe(3);
     expect(constraints.tokenBundleSizeExceedsLimit()).toBe(false);
     expect(constraints.tokenBundleSizeExceedsLimit({ size: 2 } as any)).toBe(true);


### PR DESCRIPTION
# Context

Transactions occasionally fail due to fee too low. This is due to a bug within input selection, where it does not recompute the fee after selecting an extra utxo.

# Proposed Solution

Reproduce the bug in a test and fix it.

# Important Changes Introduced

- Add support for custom random function for round robin random improve
- Update mock selection constraints fee computation to be a function of selected # of inputs instead of a constant
