### PR TITLE
feat: preparation for SingleAddressWallet persistence implementation

### DIFF
--- a/packages/wallet/src/persistence/inMemoryStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores.ts
@@ -1,0 +1,99 @@
+import { Asset, Cardano, ProtocolParametersRequiredByWallet, TimeSettings } from '@cardano-sdk/core';
+import { CollectionStore, DocumentStore, GetDocId, OrderedCollectionStore, RewardAccountDocument } from './types';
+import { Observable, of } from 'rxjs';
+import { sortedIndexBy } from 'lodash-es';
+
+export class InMemoryCollectionStore<T> implements CollectionStore<T> {
+  protected readonly docs: T[] = [];
+  protected readonly getDocId: GetDocId<T>;
+
+  constructor(getDocId: GetDocId<T>) {
+    this.getDocId = getDocId;
+  }
+
+  get(): Observable<T[]> {
+    return of(this.docs);
+  }
+  upsert(docs: T[]): Observable<void> {
+    for (const newDoc of docs) {
+      const newDocId = this.getDocId(newDoc);
+      if (!this.docs.some(this.docIdEquals(newDocId))) {
+        this.addDoc(newDoc);
+      }
+    }
+    return of(void 0);
+  }
+  delete(docs: T[]): Observable<void> {
+    for (const doc of docs) {
+      const docId = this.getDocId(doc);
+      const docIndex = this.docs.findIndex(this.docIdEquals(docId));
+      if (docIndex >= 0) this.docs.splice(docIndex, 1);
+    }
+    return of(void 0);
+  }
+
+  protected addDoc(newDoc: T) {
+    this.docs.push(newDoc);
+  }
+
+  protected docIdEquals(docId: string) {
+    return (localDoc: T) => this.getDocId(localDoc) === docId;
+  }
+}
+
+export class InMemoryOrderedCollectionStore<T> extends InMemoryCollectionStore<T> implements OrderedCollectionStore<T> {
+  #sortBy: (t: T) => number;
+
+  constructor(getDocId: GetDocId<T>, sortBy: (t: T) => number) {
+    super(getDocId);
+    this.#sortBy = sortBy;
+  }
+
+  protected addDoc(newDoc: T): void {
+    this.docs.splice(sortedIndexBy(this.docs, newDoc, this.#sortBy), 0, newDoc);
+  }
+}
+
+export class InMemoryDocumentStore<T> implements DocumentStore<T> {
+  private doc: T | null = null;
+  get(): Observable<T | null> {
+    return of(this.doc);
+  }
+  set(doc: T): Observable<void> {
+    this.doc = doc;
+    return of(void 0);
+  }
+}
+
+export class InMemoryUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {
+  constructor() {
+    super(([{ txId, index }]) => `${txId}-${index}`);
+  }
+}
+export class InMemoryTransactionsStore extends InMemoryOrderedCollectionStore<Cardano.TxAlonzo> {
+  constructor() {
+    super(
+      ({ id }) => id.toString(),
+      // Multiplying blockNo by 10_000 in order to distinguish between:
+      // - blockNo: 1, index: 1
+      // - blockNo: 2, index: 0
+      // That should be sufficient since there shouldn't be a block with 1kk TXes
+      ({ index, blockHeader: { blockNo } }) => blockNo * 1_000_000 + index
+    );
+  }
+}
+export class InMemoryRewardAccountsStore extends InMemoryCollectionStore<RewardAccountDocument> {
+  constructor() {
+    super(({ rewardAccount }) => rewardAccount.toString());
+  }
+}
+export class InMemoryAssetsStore extends InMemoryCollectionStore<Asset.AssetInfo> {
+  constructor() {
+    super(({ assetId }) => assetId.toString());
+  }
+}
+
+export class InMemoryTipStore extends InMemoryDocumentStore<Cardano.Tip> {}
+export class InMemoryProtocolParametersStore extends InMemoryDocumentStore<ProtocolParametersRequiredByWallet> {}
+export class InMemoryGenesisParametersStore extends InMemoryDocumentStore<Cardano.CompactGenesis> {}
+export class InMemoryTimeSettingsStore extends InMemoryDocumentStore<TimeSettings> {}

--- a/packages/wallet/src/persistence/index.ts
+++ b/packages/wallet/src/persistence/index.ts
@@ -1,0 +1,2 @@
+export * from './inMemoryStores';
+export * from './types';

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -4,7 +4,13 @@ import { Observable } from 'rxjs';
 
 export interface CollectionStore<T> {
   get(): Observable<T[]>;
-  upsert(docs: T[]): Observable<void>; // make sure to not write duplicates
+  /**
+   * Store the documents.
+   * Note: caller is allowed to do `upsert(x);upsert(x);`, expecting to have only 1 x stored.
+   *
+   * @param docs documents to store
+   */
+  upsert(docs: T[]): Observable<void>;
   delete(docs: T[]): Observable<void>;
 }
 

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -1,0 +1,40 @@
+import { Asset, Cardano, ProtocolParametersRequiredByWallet, TimeSettings } from '@cardano-sdk/core';
+import { Delegatee } from '../services';
+import { Observable } from 'rxjs';
+
+export interface CollectionStore<T> {
+  get(): Observable<T[]>;
+  upsert(docs: T[]): Observable<void>; // make sure to not write duplicates
+  delete(docs: T[]): Observable<void>;
+}
+
+export type OrderedCollectionStore<T> = CollectionStore<T>;
+
+export interface DocumentStore<T> {
+  get(): Observable<T | null>;
+  set(doc: T): Observable<void>;
+}
+
+export interface RewardAccountDocument {
+  rewardAccount: Cardano.RewardAccount;
+  rewards: Cardano.Lovelace;
+  delegatee: Delegatee;
+}
+
+export interface AssetDocument {
+  assetId: Cardano.AssetId;
+  info: Asset.AssetInfo;
+}
+
+export interface WalletStores {
+  tip: DocumentStore<Cardano.Tip>;
+  utxo: CollectionStore<Cardano.Utxo>;
+  transactions: OrderedCollectionStore<Cardano.TxAlonzo>;
+  rewardAccounts: CollectionStore<RewardAccountDocument>;
+  protocolParameters: DocumentStore<ProtocolParametersRequiredByWallet>;
+  genesisParameters: DocumentStore<Cardano.CompactGenesis>;
+  timeSettings: DocumentStore<TimeSettings>;
+  assets: CollectionStore<AssetDocument>;
+}
+
+export type GetDocId<T> = (doc: T) => string;

--- a/packages/wallet/src/services/ProviderStatusTracker.ts
+++ b/packages/wallet/src/services/ProviderStatusTracker.ts
@@ -1,0 +1,72 @@
+import {
+  EMPTY,
+  Observable,
+  combineLatest,
+  concat,
+  distinctUntilChanged,
+  map,
+  merge,
+  mergeMap,
+  of,
+  skipWhile,
+  switchMap,
+  timer
+} from 'rxjs';
+import { Milliseconds } from './types';
+import { SyncStatus } from '../types';
+import { TrackedWalletProvider, WalletProviderFnStats } from './TrackedWalletProvider';
+import { TrackerSubject } from './util';
+
+const getDefaultWalletProviderSyncRelevantStats = (
+  walletProvider: TrackedWalletProvider
+): Observable<WalletProviderFnStats[]> =>
+  combineLatest([
+    walletProvider.stats.ledgerTip$,
+    walletProvider.stats.currentWalletProtocolParameters$,
+    walletProvider.stats.genesisParameters$,
+    walletProvider.stats.networkInfo$,
+    walletProvider.stats.queryBlocksByHashes$,
+    walletProvider.stats.queryTransactionsByAddresses$,
+    walletProvider.stats.rewardsHistory$,
+    walletProvider.stats.utxoDelegationAndRewards$
+  ]);
+
+export interface ProviderStatusTrackerProps {
+  consideredOutOfSyncAfter: Milliseconds;
+}
+
+export interface ProviderStatusTrackerDependencies {
+  walletProvider: TrackedWalletProvider;
+}
+
+export interface ProviderStatusTrackerInternals {
+  /**
+   * @returns Observable of WalletProvider stats that are considered
+   * when determining Wallet sync status
+   */
+  getWalletProviderSyncRelevantStats?: typeof getDefaultWalletProviderSyncRelevantStats;
+}
+
+export const createProviderStatusTracker = (
+  { walletProvider }: ProviderStatusTrackerDependencies,
+  { consideredOutOfSyncAfter }: ProviderStatusTrackerProps,
+  {
+    getWalletProviderSyncRelevantStats = getDefaultWalletProviderSyncRelevantStats
+  }: ProviderStatusTrackerInternals = {}
+): TrackerSubject<SyncStatus> => {
+  const relevantStats = getWalletProviderSyncRelevantStats(walletProvider);
+  const upToDate$ = relevantStats.pipe(
+    skipWhile((allStats) => allStats.every(({ numCalls, numResponses }) => numCalls === 0 && numResponses === 0)),
+    mergeMap((allStats) => (allStats.some(({ numCalls, numResponses }) => numCalls > numResponses) ? EMPTY : of(true)))
+  );
+  return new TrackerSubject<SyncStatus>(
+    concat(
+      of(SyncStatus.Syncing),
+      upToDate$.pipe(
+        switchMap(() =>
+          merge(of(SyncStatus.UpToDate), timer(consideredOutOfSyncAfter).pipe(map(() => SyncStatus.Syncing)))
+        )
+      )
+    ).pipe(distinctUntilChanged())
+  );
+};

--- a/packages/wallet/src/services/TrackedWalletProvider.ts
+++ b/packages/wallet/src/services/TrackedWalletProvider.ts
@@ -1,0 +1,98 @@
+import { BehaviorSubject } from 'rxjs';
+import { RewardHistoryProps, WalletProvider } from '@cardano-sdk/core';
+
+export interface WalletProviderFnStats {
+  numCalls: number;
+  numResponses: number;
+}
+
+export const CLEAN_FN_STATS = { numCalls: 0, numResponses: 0 };
+
+export class WalletProviderStats {
+  readonly currentWalletProtocolParameters$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly genesisParameters$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly ledgerTip$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly networkInfo$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly queryBlocksByHashes$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly queryTransactionsByAddresses$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly queryTransactionsByHashes$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly rewardsHistory$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly submitTx$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly utxoDelegationAndRewards$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly stakePoolStats$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+
+  reset() {
+    this.currentWalletProtocolParameters$.next(CLEAN_FN_STATS);
+    this.genesisParameters$.next(CLEAN_FN_STATS);
+    this.ledgerTip$.next(CLEAN_FN_STATS);
+    this.networkInfo$.next(CLEAN_FN_STATS);
+    this.queryBlocksByHashes$.next(CLEAN_FN_STATS);
+    this.queryTransactionsByAddresses$.next(CLEAN_FN_STATS);
+    this.queryTransactionsByHashes$.next(CLEAN_FN_STATS);
+    this.rewardsHistory$.next(CLEAN_FN_STATS);
+    this.submitTx$.next(CLEAN_FN_STATS);
+    this.utxoDelegationAndRewards$.next(CLEAN_FN_STATS);
+    this.stakePoolStats$.next(CLEAN_FN_STATS);
+  }
+}
+
+/**
+ * Wraps a WalletProvider, tracking # of calls of each function
+ */
+export class TrackedWalletProvider implements WalletProvider {
+  readonly stats = new WalletProviderStats();
+  readonly stakePoolStats: WalletProvider['stakePoolStats'];
+  readonly ledgerTip: WalletProvider['ledgerTip'];
+  readonly networkInfo: WalletProvider['networkInfo'];
+  readonly submitTx: WalletProvider['submitTx'];
+  readonly utxoDelegationAndRewards: WalletProvider['utxoDelegationAndRewards'];
+  readonly queryTransactionsByAddresses: WalletProvider['queryTransactionsByAddresses'];
+  readonly queryTransactionsByHashes: WalletProvider['queryTransactionsByHashes'];
+  readonly queryBlocksByHashes: WalletProvider['queryBlocksByHashes'];
+  readonly currentWalletProtocolParameters: WalletProvider['currentWalletProtocolParameters'];
+  readonly genesisParameters: WalletProvider['genesisParameters'];
+  readonly rewardsHistory: WalletProvider['rewardsHistory'];
+
+  constructor(walletProvider: WalletProvider) {
+    walletProvider = walletProvider;
+
+    this.stakePoolStats =
+      typeof walletProvider.stakePoolStats !== 'undefined'
+        ? () => this.#trackedCall(walletProvider.stakePoolStats!, this.stats.stakePoolStats$)
+        : undefined;
+    this.ledgerTip = () => this.#trackedCall(walletProvider.ledgerTip, this.stats.ledgerTip$);
+    this.networkInfo = () => this.#trackedCall(walletProvider.networkInfo, this.stats.networkInfo$);
+    this.submitTx = (signedTransaction) =>
+      this.#trackedCall(() => walletProvider.submitTx(signedTransaction), this.stats.submitTx$);
+    this.utxoDelegationAndRewards = (addresses, rewardAccount) =>
+      this.#trackedCall(
+        () => walletProvider.utxoDelegationAndRewards(addresses, rewardAccount),
+        this.stats.utxoDelegationAndRewards$
+      );
+    this.queryTransactionsByAddresses = (addresses) =>
+      this.#trackedCall(
+        () => walletProvider.queryTransactionsByAddresses(addresses),
+        this.stats.queryTransactionsByAddresses$
+      );
+    this.queryTransactionsByHashes = (hashes) =>
+      this.#trackedCall(() => walletProvider.queryTransactionsByHashes(hashes), this.stats.queryTransactionsByHashes$);
+    this.queryBlocksByHashes = (hashes) =>
+      this.#trackedCall(() => walletProvider.queryBlocksByHashes(hashes), this.stats.queryBlocksByHashes$);
+    this.currentWalletProtocolParameters = () =>
+      this.#trackedCall(walletProvider.currentWalletProtocolParameters, this.stats.currentWalletProtocolParameters$);
+    this.genesisParameters = () => this.#trackedCall(walletProvider.genesisParameters, this.stats.genesisParameters$);
+    this.rewardsHistory = (props: RewardHistoryProps) =>
+      this.#trackedCall(() => walletProvider.rewardsHistory(props), this.stats.rewardsHistory$);
+  }
+
+  #trackedCall<T>(call: () => Promise<T>, tracker: BehaviorSubject<WalletProviderFnStats>) {
+    tracker.next({ ...tracker.value, numCalls: tracker.value.numCalls + 1 });
+    return call().then((result: T) => {
+      tracker.next({
+        ...tracker.value,
+        numResponses: tracker.value.numResponses + 1
+      });
+      return result;
+    });
+  }
+}

--- a/packages/wallet/src/services/index.ts
+++ b/packages/wallet/src/services/index.ts
@@ -6,3 +6,4 @@ export * from './TransactionsTracker';
 export * from './AssetsTracker';
 export * from './types';
 export * from './createNftMetadataProvider';
+export * from './TrackedWalletProvider';

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -32,6 +32,7 @@ export interface PollingConfig {
    * Max timeout for exponential backoff on errors
    */
   readonly maxInterval?: Milliseconds;
+  readonly consideredOutOfSyncAfter?: Milliseconds;
 }
 
 export enum TransactionDirection {

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -35,6 +35,11 @@ export type InitializeTxResult = TxInternals & { inputSelection: SelectionSkelet
 
 export type SignDataProps = Omit<Cip30SignDataRequest, 'keyAgent'>;
 
+export enum SyncStatus {
+  Syncing,
+  UpToDate
+}
+
 export interface Wallet {
   name: string;
   readonly balance: TransactionalTracker<Balance>;
@@ -48,6 +53,7 @@ export interface Wallet {
   readonly protocolParameters$: BehaviorObservable<ProtocolParametersRequiredByWallet>;
   readonly addresses$: BehaviorObservable<GroupedAddress[]>;
   readonly assets$: BehaviorObservable<Assets>;
+  readonly syncStatus$: BehaviorObservable<SyncStatus>;
   /**
    * Compute minimum coin quantity for each transaction output
    */

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -102,6 +102,9 @@ describe('SingleAddressWallet', () => {
     it('timeSettings$', async () => {
       expect(await firstValueFrom(wallet.timeSettings$)).toEqual(testnetTimeSettings);
     });
+    it('syncStatus$', async () => {
+      expect(await firstValueFrom(wallet.syncStatus$)).not.toBeUndefined();
+    });
   });
 
   describe('creating transactions', () => {

--- a/packages/wallet/test/persistence/inMemoryStores.test.ts
+++ b/packages/wallet/test/persistence/inMemoryStores.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  InMemoryAssetsStore,
+  InMemoryCollectionStore,
+  InMemoryDocumentStore,
+  InMemoryGenesisParametersStore,
+  InMemoryOrderedCollectionStore,
+  InMemoryProtocolParametersStore,
+  InMemoryRewardAccountsStore,
+  InMemoryTimeSettingsStore,
+  InMemoryTipStore,
+  InMemoryTransactionsStore,
+  InMemoryUtxoStore
+} from '../../src/persistence';
+import { firstValueFrom } from 'rxjs';
+
+describe('InMemoryStores', () => {
+  describe('InMemoryDocumentStore', () => {
+    it('remembers the last set document', async () => {
+      const store = new InMemoryDocumentStore();
+      expect(await firstValueFrom(store.get())).toBeNull();
+      const doc = { a: 'b' };
+      await firstValueFrom(store.set(doc));
+      expect(await firstValueFrom(store.get())).toBe(doc);
+    });
+  });
+
+  describe('InMemoryCollectionStore', () => {
+    it('remembers all unique upserted documents', async () => {
+      const doc1 = { a: 'b' };
+      const doc2 = { a: 'c' };
+      const doc3 = { a: 'd' };
+      const store = new InMemoryCollectionStore<typeof doc1>((doc) => doc.a);
+      expect(await firstValueFrom(store.get())).toEqual([]);
+      await firstValueFrom(store.upsert([doc1, doc2]));
+      expect(await firstValueFrom(store.get())).toEqual([doc1, doc2]);
+      await firstValueFrom(store.upsert([doc2, doc3]));
+      expect(await firstValueFrom(store.get())).toEqual([doc1, doc2, doc3]);
+      await firstValueFrom(store.delete([doc2]));
+      expect(await firstValueFrom(store.get())).toEqual([doc1, doc3]);
+    });
+  });
+
+  describe('InMemoryOrderedCollectionStore', () => {
+    it('remembers all unique upserted documents, sorted by result of provided fn', async () => {
+      const doc1 = { a: 'b', order: 2 };
+      const doc2 = { a: 'c', order: 1 };
+      const doc3 = { a: 'd', order: 3 };
+      const store = new InMemoryOrderedCollectionStore<typeof doc1>(
+        ({ a }) => a,
+        ({ order }) => order
+      );
+      expect(await firstValueFrom(store.get())).toEqual([]);
+      await firstValueFrom(store.upsert([doc1, doc2]));
+      expect(await firstValueFrom(store.get())).toEqual([doc2, doc1]);
+      await firstValueFrom(store.upsert([doc2, doc3]));
+      expect(await firstValueFrom(store.get())).toEqual([doc2, doc1, doc3]);
+    });
+  });
+
+  describe('InMemoryUtxoStore', () => {
+    const store = new InMemoryUtxoStore();
+    it('is implemented using InMemoryCollectionStore', () => expect(store).toBeInstanceOf(InMemoryCollectionStore));
+    it('documents are unique by tx id and index', async () => {
+      const doc1: any = [{ index: 0, txId: 'tx1' }];
+      const doc2: any = [{ index: 0, txId: 'tx2' }];
+      const doc3: any = [{ index: 1, txId: 'tx1' }];
+      await firstValueFrom(store.upsert([doc1, doc2, doc3, [{ ...doc1[0] }]]));
+      expect(await firstValueFrom(store.get())).toEqual([doc1, doc2, doc3]);
+    });
+  });
+
+  describe('InMemoryRewardAccountsStore ', () => {
+    const store = new InMemoryRewardAccountsStore();
+    it('is implemented using InMemoryCollectionStore', () => expect(store).toBeInstanceOf(InMemoryCollectionStore));
+    it('documents are unique by rewardAccount', async () => {
+      const doc1: any = { rewardAccount: 'acc1' };
+      const doc2: any = { rewardAccount: 'acc2' };
+      await firstValueFrom(store.upsert([doc1, doc2, { ...doc1 }]));
+      expect(await firstValueFrom(store.get())).toEqual([doc1, doc2]);
+    });
+  });
+
+  describe('InMemoryAssetsStore', () => {
+    const store = new InMemoryAssetsStore();
+    it('is implemented using InMemoryCollectionStore', () => expect(store).toBeInstanceOf(InMemoryCollectionStore));
+    it('documents are unique by assetId', async () => {
+      const doc1: any = { assetId: 'asset1' };
+      const doc2: any = { assetId: 'asset2' };
+      await firstValueFrom(store.upsert([doc1, doc2, { ...doc1 }]));
+      expect(await firstValueFrom(store.get())).toEqual([doc1, doc2]);
+    });
+  });
+
+  describe('InMemoryTransactionsStore', () => {
+    const store = new InMemoryTransactionsStore();
+    const doc1: any = { blockHeader: { blockNo: 2 }, id: 'tx1', index: 1 };
+    const doc2: any = { blockHeader: { blockNo: 2 }, id: 'tx2', index: 0 };
+    const doc3: any = { blockHeader: { blockNo: 1 }, id: 'tx3', index: 0 };
+
+    it('is implemented using InMemoryOrderedCollectionStore', () =>
+      expect(store).toBeInstanceOf(InMemoryOrderedCollectionStore));
+    it('documents are unique by transaction id', async () => {
+      await firstValueFrom(store.upsert([doc1, doc2, { ...doc1 }]));
+      expect(await firstValueFrom(store.get())).toEqual([doc2, doc1]);
+    });
+    it('documents are sorted blockNo+index', async () => {
+      await firstValueFrom(store.upsert([doc3]));
+      expect(await firstValueFrom(store.get())).toEqual([doc3, doc2, doc1]);
+    });
+  });
+
+  it('Specific document stores are implemented using InMemoryDocumentStore', () => {
+    expect(new InMemoryTipStore()).toBeInstanceOf(InMemoryDocumentStore);
+    expect(new InMemoryProtocolParametersStore()).toBeInstanceOf(InMemoryDocumentStore);
+    expect(new InMemoryGenesisParametersStore()).toBeInstanceOf(InMemoryDocumentStore);
+    expect(new InMemoryTimeSettingsStore()).toBeInstanceOf(InMemoryDocumentStore);
+  });
+});

--- a/packages/wallet/test/services/ProviderStatusTracker.test.ts
+++ b/packages/wallet/test/services/ProviderStatusTracker.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable prettier/prettier */
+/* eslint-disable no-multi-spaces */
+import { CLEAN_FN_STATS, SyncStatus, TrackedWalletProvider, WalletProviderFnStats } from '../../src';
+import { createProviderStatusTracker } from '../../src/services/ProviderStatusTracker';
+import { createTestScheduler } from '../testScheduler';
+import { mockWalletProvider } from '../mocks';
+
+describe('syncStatus', () => {
+  it('is "Syncing" until all requests resolve, then "UpToDate" until timeout', async () => {
+    const walletProvider = new TrackedWalletProvider(mockWalletProvider());
+    const timeout = 5000;
+    createTestScheduler().run(({ cold, expectObservable }) => {
+      const getWalletProviderSyncRelevantStats = jest.fn().mockReturnValueOnce(
+        cold<WalletProviderFnStats[]>(`abcdef ${timeout}ms g`, {
+          a: [CLEAN_FN_STATS, CLEAN_FN_STATS],                    // Initial state
+          b: [{ numCalls: 1, numResponses: 0 }, CLEAN_FN_STATS],  // One provider fn called
+          c: [
+            { numCalls: 1, numResponses: 0 },                     // Both provider fns called
+            { numCalls: 1, numResponses: 0 }
+          ],
+          d: [                                                    // One provider fn resolved
+            { numCalls: 1, numResponses: 1 },
+            { numCalls: 1, numResponses: 0 }
+          ],
+          e: [
+            { numCalls: 1, numResponses: 1 },                     // Both provider fns resolved
+            { numCalls: 1, numResponses: 1 }
+          ],
+          f: [                                                    // Both provider fns called again
+            { numCalls: 2, numResponses: 1 },
+            { numCalls: 2, numResponses: 1 }
+          ],
+          g: [                                                    // Both provider fns resolved
+            { numCalls: 2, numResponses: 2 },
+            { numCalls: 2, numResponses: 2 }
+          ]
+        })
+      );
+      const tracker = createProviderStatusTracker(
+        { walletProvider },
+        { consideredOutOfSyncAfter: timeout },
+        { getWalletProviderSyncRelevantStats }
+      );
+      expectObservable(tracker, `^ ${timeout * 2}ms !`).toBe(`a---e ${timeout - 1}ms f-g`, {
+        a: SyncStatus.Syncing,
+        e: SyncStatus.UpToDate,
+        f: SyncStatus.Syncing,
+        g: SyncStatus.UpToDate
+      });
+    });
+  });
+});

--- a/packages/wallet/test/services/TrackedWalletProvider.test.ts
+++ b/packages/wallet/test/services/TrackedWalletProvider.test.ts
@@ -1,0 +1,123 @@
+import { BehaviorSubject } from 'rxjs';
+import { CLEAN_FN_STATS, TrackedWalletProvider, WalletProviderFnStats, WalletProviderStats } from '../../src';
+import { WalletProvider } from '@cardano-sdk/core';
+import { mockWalletProvider } from '../mocks';
+
+describe('TrackedWalletProvider', () => {
+  let walletProvider: WalletProvider;
+  let trackedWalletProvider: TrackedWalletProvider;
+  beforeEach(() => {
+    walletProvider = mockWalletProvider();
+    trackedWalletProvider = new TrackedWalletProvider(walletProvider);
+  });
+
+  test('CLEAN_FN_STATS numResponses is 0', () => {
+    expect(CLEAN_FN_STATS).toEqual({ numCalls: 0, numResponses: 0 });
+  });
+
+  describe('wraps underlying provider functions, tracks # of calls/responses and resets on stats.reset()', () => {
+    const testFunctionStats =
+      <T>(
+        call: (walletProvider: WalletProvider) => Promise<T>,
+        selectStats: (stats: WalletProviderStats) => BehaviorSubject<WalletProviderFnStats>
+        // eslint-disable-next-line unicorn/consistent-function-scoping
+      ) =>
+      async () => {
+        expect(selectStats(trackedWalletProvider.stats).value).toEqual(CLEAN_FN_STATS);
+        const result = call(trackedWalletProvider);
+        expect(selectStats(trackedWalletProvider.stats).value).toEqual({ ...CLEAN_FN_STATS, numCalls: 1 });
+        await result;
+        expect(selectStats(trackedWalletProvider.stats).value).toEqual({ numCalls: 1, numResponses: 1 });
+        trackedWalletProvider.stats.reset();
+        expect(selectStats(trackedWalletProvider.stats).value).toEqual(CLEAN_FN_STATS);
+      };
+
+    test(
+      'currentWalletProtocolParameters',
+      testFunctionStats(
+        (wp) => wp.currentWalletProtocolParameters(),
+        (stats) => stats.currentWalletProtocolParameters$
+      )
+    );
+
+    test(
+      'genesisParameters',
+      testFunctionStats(
+        (wp) => wp.genesisParameters(),
+        (stats) => stats.genesisParameters$
+      )
+    );
+
+    test(
+      'ledgerTip',
+      testFunctionStats(
+        (wp) => wp.ledgerTip(),
+        (stats) => stats.ledgerTip$
+      )
+    );
+
+    test(
+      'networkInfo',
+      testFunctionStats(
+        (wp) => wp.networkInfo(),
+        (stats) => stats.networkInfo$
+      )
+    );
+
+    test(
+      'queryBlocksByHashes',
+      testFunctionStats(
+        (wp) => wp.queryBlocksByHashes([]),
+        (stats) => stats.queryBlocksByHashes$
+      )
+    );
+
+    test(
+      'queryTransactionsByAddresses',
+      testFunctionStats(
+        (wp) => wp.queryTransactionsByAddresses([]),
+        (stats) => stats.queryTransactionsByAddresses$
+      )
+    );
+
+    test(
+      'queryTransactionsByHashes',
+      testFunctionStats(
+        (wp) => wp.queryTransactionsByHashes([]),
+        (stats) => stats.queryTransactionsByHashes$
+      )
+    );
+
+    test(
+      'rewardsHistory',
+      testFunctionStats(
+        (wp) => wp.rewardsHistory({ stakeAddresses: [] }),
+        (stats) => stats.rewardsHistory$
+      )
+    );
+
+    test(
+      'submitTx',
+      testFunctionStats(
+        (wp) => wp.submitTx(new Uint8Array()),
+        (stats) => stats.submitTx$
+      )
+    );
+
+    test(
+      'utxoDelegationAndRewards',
+      testFunctionStats(
+        (wp) => wp.utxoDelegationAndRewards([]),
+        (stats) => stats.utxoDelegationAndRewards$
+      )
+    );
+
+    test(
+      'stakePoolStats',
+      testFunctionStats(
+        (wp) => wp.stakePoolStats!(),
+        (stats) => stats.stakePoolStats$
+      )
+    );
+  });
+});


### PR DESCRIPTION
# Context

`SingleAddressWallet` takes a long time to load (fetching all transactions and utxo)

# Proposed Solution

In preparation to implementing wallet persistence, do the following:
- (BREAKING) Remove `address` prop from `SingleAddressWallet` constructor, using `KeyAgent.knownAddresses` for initialization
- Define storage interfaces, implement in-memory storage (intended for development and testing, but could potentially be used to initialize wallets that do not want to store their state, or when shutting down and then restoring the wallet)
- Add `Wallet.syncStatus$` {Syncing, UpToDate}, so that wallet users have some insight on whether their wallet is currently synced or outdated. Implement it by wrapping a `WalletProvider` and tracking calls/responses of each function.
