### PR TITLE
refactor: extract tx submit into own provider

### DIFF
--- a/packages/blockfrost/src/blockfrostAssetProvider.ts
+++ b/packages/blockfrost/src/blockfrostAssetProvider.ts
@@ -1,7 +1,6 @@
 /* eslint-disable unicorn/no-nested-ternary */
 import { Asset, AssetProvider, Cardano, ProviderUtil, util } from '@cardano-sdk/core';
 import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
-import { Options } from '@blockfrost/blockfrost-js/lib/types';
 import { fetchSequentially, toProviderError } from './util';
 import { omit } from 'lodash-es';
 
@@ -26,13 +25,11 @@ const mapMetadata = (
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
  *
- * @param {Options} options BlockFrostAPI options
+ * @param {BlockFrostAPI} blockfrost BlockFrostAPI instance
  * @returns {AssetProvider} WalletProvider
  * @throws ProviderFailure
  */
-export const blockfrostAssetProvider = (options: Options): AssetProvider => {
-  const blockfrost = new BlockFrostAPI(options);
-
+export const blockfrostAssetProvider = (blockfrost: BlockFrostAPI): AssetProvider => {
   const getAssetHistory = async (assetId: Cardano.AssetId): Promise<Asset.AssetMintOrBurn[]> =>
     fetchSequentially({
       arg: assetId.toString(),

--- a/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
+++ b/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
@@ -1,0 +1,26 @@
+import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
+import { Cardano, TxSubmitProvider } from '@cardano-sdk/core';
+import { Options } from '@blockfrost/blockfrost-js/lib/types';
+
+/**
+ * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
+ *
+ * @param {Options} options BlockFrostAPI options
+ * @returns {TxSubmitProvider} TxSubmitProvider
+ * @throws {Cardano.TxSubmissionErrors.UnknownTxSubmissionError}
+ */
+export const blockfrostTxSubmitProvider = (options: Options): TxSubmitProvider => {
+  const blockfrost = new BlockFrostAPI(options);
+
+  const submitTx: TxSubmitProvider['submitTx'] = async (signedTransaction) => {
+    try {
+      await blockfrost.txSubmit(signedTransaction);
+    } catch (error) {
+      throw new Cardano.TxSubmissionErrors.UnknownTxSubmissionError(error);
+    }
+  };
+
+  return {
+    submitTx
+  };
+};

--- a/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
+++ b/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
@@ -1,17 +1,14 @@
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
 import { Cardano, TxSubmitProvider } from '@cardano-sdk/core';
-import { Options } from '@blockfrost/blockfrost-js/lib/types';
 
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
  *
- * @param {Options} options BlockFrostAPI options
+ * @param {BlockFrostAPI} blockfrost BlockFrostAPI instance
  * @returns {TxSubmitProvider} TxSubmitProvider
  * @throws {Cardano.TxSubmissionErrors.UnknownTxSubmissionError}
  */
-export const blockfrostTxSubmitProvider = (options: Options): TxSubmitProvider => {
-  const blockfrost = new BlockFrostAPI(options);
-
+export const blockfrostTxSubmitProvider = (blockfrost: BlockFrostAPI): TxSubmitProvider => {
   const submitTx: TxSubmitProvider['submitTx'] = async (signedTransaction) => {
     try {
       await blockfrost.txSubmit(signedTransaction);

--- a/packages/blockfrost/src/blockfrostWalletProvider.ts
+++ b/packages/blockfrost/src/blockfrostWalletProvider.ts
@@ -90,14 +90,6 @@ export const blockfrostWalletProvider = (options: Options, logger = dummyLogger)
     };
   };
 
-  const submitTx: WalletProvider['submitTx'] = async (signedTransaction) => {
-    try {
-      await blockfrost.txSubmit(signedTransaction);
-    } catch (error) {
-      throw new Cardano.TxSubmissionErrors.UnknownTxSubmissionError(error);
-    }
-  };
-
   const utxoDelegationAndRewards: WalletProvider['utxoDelegationAndRewards'] = async (addresses, rewardAccount) => {
     const utxoResults = await Promise.all(
       addresses.map(async (address) =>
@@ -437,12 +429,8 @@ export const blockfrostWalletProvider = (options: Options, logger = dummyLogger)
     queryTransactionsByHashes,
     rewardsHistory,
     stakePoolStats,
-    submitTx,
     utxoDelegationAndRewards
   };
 
-  return {
-    ...ProviderUtil.withProviderErrors(providerFunctions, toProviderError),
-    submitTx
-  };
+  return ProviderUtil.withProviderErrors(providerFunctions, toProviderError);
 };

--- a/packages/blockfrost/src/blockfrostWalletProvider.ts
+++ b/packages/blockfrost/src/blockfrostWalletProvider.ts
@@ -10,7 +10,7 @@ import {
 } from '@cardano-sdk/core';
 import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
 import { BlockfrostToCore, BlockfrostTransactionContent, BlockfrostUtxo } from './BlockfrostToCore';
-import { Options, PaginationOptions } from '@blockfrost/blockfrost-js/lib/types';
+import { PaginationOptions } from '@blockfrost/blockfrost-js/lib/types';
 import { dummyLogger } from 'ts-log';
 import { fetchSequentially, formatBlockfrostError, jsonToMetadatum, toProviderError } from './util';
 import { flatten, groupBy } from 'lodash-es';
@@ -31,13 +31,11 @@ const fetchByAddressSequentially = async <Item, Response>(props: {
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
  *
- * @param {Options} options BlockFrostAPI options
+ * @param {BlockFrostAPI} blockfrost BlockFrostAPI instance
  * @returns {WalletProvider} WalletProvider
  * @throws {ProviderFailure}
  */
-export const blockfrostWalletProvider = (options: Options, logger = dummyLogger): WalletProvider => {
-  const blockfrost = new BlockFrostAPI(options);
-
+export const blockfrostWalletProvider = (blockfrost: BlockFrostAPI, logger = dummyLogger): WalletProvider => {
   const ledgerTip: WalletProvider['ledgerTip'] = async () => {
     const block = await blockfrost.blocksLatest();
     return BlockfrostToCore.blockToTip(block);

--- a/packages/blockfrost/src/index.ts
+++ b/packages/blockfrost/src/index.ts
@@ -1,4 +1,5 @@
 export { WalletProvider } from '@cardano-sdk/core';
 export * from './blockfrostWalletProvider';
 export * from './blockfrostAssetProvider';
+export * from './blockfrostTxSubmitProvider';
 export { Options } from '@blockfrost/blockfrost-js/lib/types';

--- a/packages/blockfrost/src/index.ts
+++ b/packages/blockfrost/src/index.ts
@@ -3,3 +3,4 @@ export * from './blockfrostWalletProvider';
 export * from './blockfrostAssetProvider';
 export * from './blockfrostTxSubmitProvider';
 export { Options } from '@blockfrost/blockfrost-js/lib/types';
+export { BlockFrostAPI } from '@blockfrost/blockfrost-js';

--- a/packages/blockfrost/test/blockfrostAssetProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostAssetProvider.test.ts
@@ -36,7 +36,8 @@ describe('blockfrostAssetProvider', () => {
     test('asset with only 1 mint', async () => {
       BlockFrostAPI.prototype.assetsById = jest.fn().mockResolvedValue(mockedAssetResponse);
 
-      const client = blockfrostAssetProvider({ isTestnet: true, projectId: apiKey });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const client = blockfrostAssetProvider(blockfrost);
       const response = await client.getAsset(
         Cardano.AssetId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a76e7574636f696e')
       );
@@ -82,7 +83,8 @@ describe('blockfrostAssetProvider', () => {
         }
       ] as Responses['asset_history']);
 
-      const client = blockfrostAssetProvider({ isTestnet: true, projectId: apiKey });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const client = blockfrostAssetProvider(blockfrost);
       const response = await client.getAsset(
         Cardano.AssetId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a76e7574636f696e')
       );

--- a/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable max-len */
+
+import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
+import { Cardano } from '@cardano-sdk/core';
+import { blockfrostTxSubmitProvider } from '../src';
+jest.mock('@blockfrost/blockfrost-js');
+
+describe('blockfrostTxSubmitProvider', () => {
+  const apiKey = 'someapikey';
+
+  describe('submitTx', () => {
+    it('wraps error in UnknownTxSubmissionError', async () => {
+      const innerError = new Error('some error');
+      BlockFrostAPI.prototype.txSubmit = jest.fn().mockRejectedValue(innerError);
+      const provider = blockfrostTxSubmitProvider({ isTestnet: true, projectId: apiKey });
+      await expect(provider.submitTx(null as any)).rejects.toThrowError(
+        Cardano.TxSubmissionErrors.UnknownTxSubmissionError
+      );
+    });
+  });
+});

--- a/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
@@ -13,7 +13,8 @@ describe('blockfrostTxSubmitProvider', () => {
     it('wraps error in UnknownTxSubmissionError', async () => {
       const innerError = new Error('some error');
       BlockFrostAPI.prototype.txSubmit = jest.fn().mockRejectedValue(innerError);
-      const provider = blockfrostTxSubmitProvider({ isTestnet: true, projectId: apiKey });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const provider = blockfrostTxSubmitProvider(blockfrost);
       await expect(provider.submitTx(null as any)).rejects.toThrowError(
         Cardano.TxSubmissionErrors.UnknownTxSubmissionError
       );

--- a/packages/blockfrost/test/blockfrostWalletProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostWalletProvider.test.ts
@@ -48,17 +48,6 @@ const blockResponse = {
 describe('blockfrostWalletProvider', () => {
   const apiKey = 'someapikey';
 
-  describe('submitTx', () => {
-    it('wraps error in UnknownTxSubmissionError', async () => {
-      const innerError = new Error('some error');
-      BlockFrostAPI.prototype.txSubmit = jest.fn().mockRejectedValue(innerError);
-      const provider = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
-      await expect(provider.submitTx(null as any)).rejects.toThrowError(
-        Cardano.TxSubmissionErrors.UnknownTxSubmissionError
-      );
-    });
-  });
-
   test('networkInfo', async () => {
     const mockedEpochsLatestResponse = {
       active_stake: '1060378314781343',

--- a/packages/blockfrost/test/blockfrostWalletProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostWalletProvider.test.ts
@@ -78,7 +78,8 @@ describe('blockfrostWalletProvider', () => {
     BlockFrostAPI.prototype.epochsLatest = jest.fn().mockResolvedValue(mockedEpochsLatestResponse);
     BlockFrostAPI.prototype.network = jest.fn().mockResolvedValue(mockedNetworkResponse);
 
-    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+    const client = blockfrostWalletProvider(blockfrost);
     const response = await client.networkInfo();
 
     expect(response).toMatchObject<NetworkInfo>({
@@ -124,7 +125,8 @@ describe('blockfrostWalletProvider', () => {
       .mockReturnValueOnce(generatePoolsResponseMock(100))
       .mockReturnValueOnce(generatePoolsResponseMock(77));
 
-    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+    const client = blockfrostWalletProvider(blockfrost);
     const response = await client.stakePoolStats!();
 
     expect(response).toMatchObject<StakePoolStats>({
@@ -158,7 +160,8 @@ describe('blockfrostWalletProvider', () => {
       };
       BlockFrostAPI.prototype.accounts = jest.fn().mockResolvedValue(accountsMockResponse);
 
-      const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const client = blockfrostWalletProvider(blockfrost);
       const response = await client.utxoDelegationAndRewards(
         [
           'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
@@ -220,7 +223,8 @@ describe('blockfrostWalletProvider', () => {
       BlockFrostAPI.prototype.addressesUtxos = jest.fn().mockRejectedValue(notFoundBody);
       BlockFrostAPI.prototype.accounts = jest.fn().mockRejectedValue(notFoundBody);
 
-      const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const client = blockfrostWalletProvider(blockfrost);
       const response = await client.utxoDelegationAndRewards(
         [
           'addr_test1qz44wna7xvs8n2ukxw0qat3vktymndgk8nerey6mlxr97s47n48hk78hcuyku03lj7qplmfqscm87j9wv3amxqaur2hs055pjt'
@@ -346,7 +350,8 @@ describe('blockfrostWalletProvider', () => {
       ];
       BlockFrostAPI.prototype.txs = jest.fn().mockResolvedValue(mockedTxResponse);
       BlockFrostAPI.prototype.txsMetadata = jest.fn().mockResolvedValue(mockedMetadataResponse);
-      const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const client = blockfrostWalletProvider(blockfrost);
       const response = await client.queryTransactionsByHashes(
         ['4123d70f66414cc921f6ffc29a899aafc7137a99a0fd453d6b200863ef5702d6'].map(Cardano.TransactionId)
       );
@@ -458,7 +463,8 @@ describe('blockfrostWalletProvider', () => {
     };
     BlockFrostAPI.prototype.genesis = jest.fn().mockResolvedValue(mockedResponse);
 
-    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+    const client = blockfrostWalletProvider(blockfrost);
     const response = await client.genesisParameters();
 
     expect(response).toMatchObject({
@@ -493,7 +499,8 @@ describe('blockfrostWalletProvider', () => {
     };
     BlockFrostAPI.prototype.axiosInstance = jest.fn().mockResolvedValue(mockedResponse) as any;
 
-    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+    const client = blockfrostWalletProvider(blockfrost);
     const response = await client.currentWalletProtocolParameters();
 
     expect(response).toMatchObject({
@@ -513,7 +520,8 @@ describe('blockfrostWalletProvider', () => {
   test('ledgerTip', async () => {
     BlockFrostAPI.prototype.blocksLatest = jest.fn().mockResolvedValue(blockResponse);
 
-    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+    const client = blockfrostWalletProvider(blockfrost);
     const response = await client.ledgerTip();
 
     expect(response).toMatchObject({
@@ -526,7 +534,8 @@ describe('blockfrostWalletProvider', () => {
   test('queryBlocksByHashes', async () => {
     BlockFrostAPI.prototype.blocks = jest.fn().mockResolvedValue(blockResponse);
 
-    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+    const client = blockfrostWalletProvider(blockfrost);
     const response = await client.queryBlocksByHashes([
       Cardano.BlockId('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5ea4172b2ed')
     ]);
@@ -558,7 +567,8 @@ describe('blockfrostWalletProvider', () => {
     const slotLeader = 'ShelleyGenesis-eff1b5b26e65b791';
     BlockFrostAPI.prototype.blocks = jest.fn().mockResolvedValue({ ...blockResponse, slot_leader: slotLeader });
 
-    const client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+    const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+    const client = blockfrostWalletProvider(blockfrost);
     const response = await client.queryBlocksByHashes([
       Cardano.BlockId('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5ea4172b2ed')
     ]);
@@ -581,7 +591,8 @@ describe('blockfrostWalletProvider', () => {
         .fn()
         .mockResolvedValue(generateRewardsResponse(2, 98))
         .mockResolvedValueOnce(generateRewardsResponse(100));
-      client = blockfrostWalletProvider({ isTestnet: true, projectId: apiKey });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      client = blockfrostWalletProvider(blockfrost);
     });
 
     test('epoch bounds & query per stake address', async () => {

--- a/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
+++ b/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncProvider.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer';
 import { Cardano, ProviderError, ProviderFailure, WalletProvider } from '@cardano-sdk/core';
 import {
   CardanoGraphQlTip,
@@ -7,7 +6,6 @@ import {
   TransactionsResponse
 } from './CardanoGraphqlToCore';
 import { GraphQLClient, gql } from 'graphql-request';
-import { TransactionSubmitResponse } from '@cardano-graphql/client-ts';
 
 /**
  * Connect to a [cardano-graphql (cardano-db-sync) service](https://github.com/input-output-hk/cardano-graphql)
@@ -207,31 +205,6 @@ export const cardanoGraphqlDbSyncProvider = (uri: string): WalletProvider => {
     };
   };
 
-  const submitTx: WalletProvider['submitTx'] = async (signedTransaction) => {
-    try {
-      const mutation = gql`
-        mutation ($transaction: String!) {
-          submitTransaction(transaction: $transaction) {
-            hash
-          }
-        }
-      `;
-
-      type Response = TransactionSubmitResponse;
-      type Variables = { transaction: string };
-
-      const response = await client.request<Response, Variables>(mutation, {
-        transaction: Buffer.from(signedTransaction).toString('hex')
-      });
-
-      if (!response.hash) {
-        throw new Error('No "hash" in graphql response');
-      }
-    } catch (error) {
-      throw new ProviderError(ProviderFailure.Unknown, error);
-    }
-  };
-
   // eslint-disable-next-line unicorn/consistent-function-scoping
   const utxoDelegationAndRewards: WalletProvider['utxoDelegationAndRewards'] = async () => {
     throw new ProviderError(ProviderFailure.NotImplemented);
@@ -360,7 +333,6 @@ export const cardanoGraphqlDbSyncProvider = (uri: string): WalletProvider => {
     queryTransactionsByHashes,
     rewardsHistory,
     stakePoolStats,
-    submitTx,
     utxoDelegationAndRewards
   };
 };

--- a/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncTxSubmitProvider.ts
+++ b/packages/cardano-graphql-db-sync/src/cardanoGraphqlDbSyncTxSubmitProvider.ts
@@ -1,0 +1,44 @@
+import { Buffer } from 'buffer';
+import { GraphQLClient, gql } from 'graphql-request';
+import { ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { TransactionSubmitResponse } from '@cardano-graphql/client-ts';
+
+/**
+ * Connect to a [cardano-graphql (cardano-db-sync) service](https://github.com/input-output-hk/cardano-graphql)
+ * ```typescript
+ * const provider = cardanoGraphqlDbSyncTxSubmitProvider(uri: 'http://localhost:3100');
+ * ```
+ */
+
+export const cardanoGraphqlDbSyncTxSubmitProvider = (uri: string): TxSubmitProvider => {
+  const client = new GraphQLClient(uri);
+
+  const submitTx: TxSubmitProvider['submitTx'] = async (signedTransaction) => {
+    try {
+      const mutation = gql`
+        mutation ($transaction: String!) {
+          submitTransaction(transaction: $transaction) {
+            hash
+          }
+        }
+      `;
+
+      type Response = TransactionSubmitResponse;
+      type Variables = { transaction: string };
+
+      const response = await client.request<Response, Variables>(mutation, {
+        transaction: Buffer.from(signedTransaction).toString('hex')
+      });
+
+      if (!response.hash) {
+        throw new Error('No "hash" in graphql response');
+      }
+    } catch (error) {
+      throw new ProviderError(ProviderFailure.Unknown, error);
+    }
+  };
+
+  return {
+    submitTx
+  };
+};

--- a/packages/cardano-graphql-db-sync/src/index.ts
+++ b/packages/cardano-graphql-db-sync/src/index.ts
@@ -1,2 +1,3 @@
 export { WalletProvider } from '@cardano-sdk/core';
 export * from './cardanoGraphqlDbSyncProvider';
+export * from './cardanoGraphqlDbSyncTxSubmitProvider';

--- a/packages/core/src/Provider/TxSubmitProvider/index.ts
+++ b/packages/core/src/Provider/TxSubmitProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/core/src/Provider/TxSubmitProvider/types.ts
+++ b/packages/core/src/Provider/TxSubmitProvider/types.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import Cardano from '../..';
+
+export interface TxSubmitProvider {
+  /**
+   * @param signedTransaction signed and serialized cbor
+   * @throws {Cardano.TxSubmissionError} (see Cardano.TxSubmissionErrors)
+   */
+  submitTx: (signedTransaction: Uint8Array) => Promise<void>;
+}

--- a/packages/core/src/Provider/WalletProvider/types.ts
+++ b/packages/core/src/Provider/WalletProvider/types.ts
@@ -77,11 +77,6 @@ export interface WalletProvider {
   networkInfo: () => Promise<NetworkInfo>;
   // TODO: move stakePoolStats out to other provider type, since it's not required for wallet operation
   stakePoolStats?: () => Promise<StakePoolStats>;
-  /**
-   * @param signedTransaction signed and serialized cbor
-   * @throws {Cardano.TxSubmissionError} (see Cardano.TxSubmissionErrors)
-   */
-  submitTx: (signedTransaction: Uint8Array) => Promise<void>;
   // TODO: split utxoDelegationAndRewards this into 2 or 3 functions
   utxoDelegationAndRewards: (
     addresses: Cardano.Address[],

--- a/packages/core/src/Provider/index.ts
+++ b/packages/core/src/Provider/index.ts
@@ -2,5 +2,6 @@ export * from './StakePoolSearchProvider';
 export * from './WalletProvider';
 export * from './AssetProvider';
 export * from './TimeSettingsProvider';
+export * from './TxSubmitProvider';
 export * from './NftMetadataProvider';
 export * as ProviderUtil from './providerUtil';

--- a/packages/wallet/src/services/ProviderTracker/ProviderTracker.ts
+++ b/packages/wallet/src/services/ProviderTracker/ProviderTracker.ts
@@ -1,0 +1,24 @@
+import { BehaviorSubject } from 'rxjs';
+
+export const CLEAN_FN_STATS = { numCalls: 0, numResponses: 0 };
+
+export interface ProviderFnStats {
+  numCalls: number;
+  numResponses: number;
+}
+
+/**
+ * Wraps a Provider, tracking # of calls of each function
+ */
+export abstract class ProviderTracker {
+  protected trackedCall<T>(call: () => Promise<T>, tracker: BehaviorSubject<ProviderFnStats>) {
+    tracker.next({ ...tracker.value, numCalls: tracker.value.numCalls + 1 });
+    return call().then((result: T) => {
+      tracker.next({
+        ...tracker.value,
+        numResponses: tracker.value.numResponses + 1
+      });
+      return result;
+    });
+  }
+}

--- a/packages/wallet/src/services/ProviderTracker/TrackedTxSubmitProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedTxSubmitProvider.ts
@@ -1,0 +1,27 @@
+import { BehaviorSubject } from 'rxjs';
+import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTracker';
+import { TxSubmitProvider } from '@cardano-sdk/core';
+
+export class TxSubmitProviderStats {
+  readonly submitTx$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+
+  reset() {
+    this.submitTx$.next(CLEAN_FN_STATS);
+  }
+}
+
+/**
+ * Wraps a TxSubmitProvider, tracking # of calls of each function
+ */
+export class TrackedTxSubmitProvider extends ProviderTracker implements TxSubmitProvider {
+  readonly stats = new TxSubmitProviderStats();
+  readonly submitTx: TxSubmitProvider['submitTx'];
+
+  constructor(txSubmitProvider: TxSubmitProvider) {
+    super();
+    txSubmitProvider = txSubmitProvider;
+
+    this.submitTx = (signedTransaction) =>
+      this.trackedCall(() => txSubmitProvider.submitTx(signedTransaction), this.stats.submitTx$);
+  }
+}

--- a/packages/wallet/src/services/ProviderTracker/index.ts
+++ b/packages/wallet/src/services/ProviderTracker/index.ts
@@ -1,0 +1,2 @@
+export * from './ProviderTracker';
+export * from './TrackedTxSubmitProvider';

--- a/packages/wallet/src/services/TrackedWalletProvider.ts
+++ b/packages/wallet/src/services/TrackedWalletProvider.ts
@@ -1,25 +1,18 @@
 import { BehaviorSubject } from 'rxjs';
+import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTracker';
 import { RewardHistoryProps, WalletProvider } from '@cardano-sdk/core';
 
-export interface WalletProviderFnStats {
-  numCalls: number;
-  numResponses: number;
-}
-
-export const CLEAN_FN_STATS = { numCalls: 0, numResponses: 0 };
-
 export class WalletProviderStats {
-  readonly currentWalletProtocolParameters$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly genesisParameters$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly ledgerTip$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly networkInfo$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly queryBlocksByHashes$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly queryTransactionsByAddresses$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly queryTransactionsByHashes$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly rewardsHistory$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly submitTx$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly utxoDelegationAndRewards$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
-  readonly stakePoolStats$ = new BehaviorSubject<WalletProviderFnStats>(CLEAN_FN_STATS);
+  readonly currentWalletProtocolParameters$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly genesisParameters$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly ledgerTip$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly networkInfo$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly queryBlocksByHashes$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly queryTransactionsByAddresses$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly queryTransactionsByHashes$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly rewardsHistory$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly utxoDelegationAndRewards$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly stakePoolStats$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
 
   reset() {
     this.currentWalletProtocolParameters$.next(CLEAN_FN_STATS);
@@ -30,7 +23,6 @@ export class WalletProviderStats {
     this.queryTransactionsByAddresses$.next(CLEAN_FN_STATS);
     this.queryTransactionsByHashes$.next(CLEAN_FN_STATS);
     this.rewardsHistory$.next(CLEAN_FN_STATS);
-    this.submitTx$.next(CLEAN_FN_STATS);
     this.utxoDelegationAndRewards$.next(CLEAN_FN_STATS);
     this.stakePoolStats$.next(CLEAN_FN_STATS);
   }
@@ -39,12 +31,11 @@ export class WalletProviderStats {
 /**
  * Wraps a WalletProvider, tracking # of calls of each function
  */
-export class TrackedWalletProvider implements WalletProvider {
+export class TrackedWalletProvider extends ProviderTracker implements WalletProvider {
   readonly stats = new WalletProviderStats();
   readonly stakePoolStats: WalletProvider['stakePoolStats'];
   readonly ledgerTip: WalletProvider['ledgerTip'];
   readonly networkInfo: WalletProvider['networkInfo'];
-  readonly submitTx: WalletProvider['submitTx'];
   readonly utxoDelegationAndRewards: WalletProvider['utxoDelegationAndRewards'];
   readonly queryTransactionsByAddresses: WalletProvider['queryTransactionsByAddresses'];
   readonly queryTransactionsByHashes: WalletProvider['queryTransactionsByHashes'];
@@ -54,45 +45,33 @@ export class TrackedWalletProvider implements WalletProvider {
   readonly rewardsHistory: WalletProvider['rewardsHistory'];
 
   constructor(walletProvider: WalletProvider) {
+    super();
     walletProvider = walletProvider;
 
     this.stakePoolStats =
       typeof walletProvider.stakePoolStats !== 'undefined'
-        ? () => this.#trackedCall(walletProvider.stakePoolStats!, this.stats.stakePoolStats$)
+        ? () => this.trackedCall(walletProvider.stakePoolStats!, this.stats.stakePoolStats$)
         : undefined;
-    this.ledgerTip = () => this.#trackedCall(walletProvider.ledgerTip, this.stats.ledgerTip$);
-    this.networkInfo = () => this.#trackedCall(walletProvider.networkInfo, this.stats.networkInfo$);
-    this.submitTx = (signedTransaction) =>
-      this.#trackedCall(() => walletProvider.submitTx(signedTransaction), this.stats.submitTx$);
+    this.ledgerTip = () => this.trackedCall(walletProvider.ledgerTip, this.stats.ledgerTip$);
+    this.networkInfo = () => this.trackedCall(walletProvider.networkInfo, this.stats.networkInfo$);
     this.utxoDelegationAndRewards = (addresses, rewardAccount) =>
-      this.#trackedCall(
+      this.trackedCall(
         () => walletProvider.utxoDelegationAndRewards(addresses, rewardAccount),
         this.stats.utxoDelegationAndRewards$
       );
     this.queryTransactionsByAddresses = (addresses) =>
-      this.#trackedCall(
+      this.trackedCall(
         () => walletProvider.queryTransactionsByAddresses(addresses),
         this.stats.queryTransactionsByAddresses$
       );
     this.queryTransactionsByHashes = (hashes) =>
-      this.#trackedCall(() => walletProvider.queryTransactionsByHashes(hashes), this.stats.queryTransactionsByHashes$);
+      this.trackedCall(() => walletProvider.queryTransactionsByHashes(hashes), this.stats.queryTransactionsByHashes$);
     this.queryBlocksByHashes = (hashes) =>
-      this.#trackedCall(() => walletProvider.queryBlocksByHashes(hashes), this.stats.queryBlocksByHashes$);
+      this.trackedCall(() => walletProvider.queryBlocksByHashes(hashes), this.stats.queryBlocksByHashes$);
     this.currentWalletProtocolParameters = () =>
-      this.#trackedCall(walletProvider.currentWalletProtocolParameters, this.stats.currentWalletProtocolParameters$);
-    this.genesisParameters = () => this.#trackedCall(walletProvider.genesisParameters, this.stats.genesisParameters$);
+      this.trackedCall(walletProvider.currentWalletProtocolParameters, this.stats.currentWalletProtocolParameters$);
+    this.genesisParameters = () => this.trackedCall(walletProvider.genesisParameters, this.stats.genesisParameters$);
     this.rewardsHistory = (props: RewardHistoryProps) =>
-      this.#trackedCall(() => walletProvider.rewardsHistory(props), this.stats.rewardsHistory$);
-  }
-
-  #trackedCall<T>(call: () => Promise<T>, tracker: BehaviorSubject<WalletProviderFnStats>) {
-    tracker.next({ ...tracker.value, numCalls: tracker.value.numCalls + 1 });
-    return call().then((result: T) => {
-      tracker.next({
-        ...tracker.value,
-        numResponses: tracker.value.numResponses + 1
-      });
-      return result;
-    });
+      this.trackedCall(() => walletProvider.rewardsHistory(props), this.stats.rewardsHistory$);
   }
 }

--- a/packages/wallet/src/services/index.ts
+++ b/packages/wallet/src/services/index.ts
@@ -6,4 +6,5 @@ export * from './TransactionsTracker';
 export * from './AssetsTracker';
 export * from './types';
 export * from './createNftMetadataProvider';
+export * from './ProviderTracker';
 export * from './TrackedWalletProvider';

--- a/packages/wallet/test/SingleAddressWallet.test.ts
+++ b/packages/wallet/test/SingleAddressWallet.test.ts
@@ -14,12 +14,14 @@ describe('SingleAddressWallet', () => {
   const address = mocks.utxo[0][0].address;
   const rewardAccount = mocks.rewardAccount;
   let keyAgent: KeyManagement.KeyAgent;
-  let walletProvider: mocks.ProviderStub;
+  let txSubmitProvider: mocks.TxSubmitProviderStub;
+  let walletProvider: mocks.WalletProviderStub;
   let assetProvider: mocks.MockAssetProvider;
   let wallet: SingleAddressWallet;
 
   beforeEach(async () => {
     keyAgent = await testKeyAgent();
+    txSubmitProvider = mocks.mockTxSubmitProvider();
     walletProvider = mocks.mockWalletProvider();
     assetProvider = mocks.mockAssetProvider();
     const stakePoolSearchProvider = createStubStakePoolSearchProvider();
@@ -35,7 +37,7 @@ describe('SingleAddressWallet', () => {
     keyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);
     wallet = new SingleAddressWallet(
       { name },
-      { assetProvider, keyAgent, stakePoolSearchProvider, timeSettingsProvider, walletProvider }
+      { assetProvider, keyAgent, stakePoolSearchProvider, timeSettingsProvider, txSubmitProvider, walletProvider }
     );
     keyAgent.knownAddresses.push(groupedAddress);
   });
@@ -170,7 +172,7 @@ describe('SingleAddressWallet', () => {
       const txPending = firstValueFrom(wallet.transactions.outgoing.pending$);
       const txInFlight = firstValueFrom(wallet.transactions.outgoing.inFlight$.pipe(skip(1)));
       await wallet.submitTx(tx);
-      expect(walletProvider.submitTx).toBeCalledTimes(1);
+      expect(txSubmitProvider.submitTx).toBeCalledTimes(1);
       expect(await txSubmitting).toBe(tx);
       expect(await txPending).toBe(tx);
       expect(await txInFlight).toEqual([tx]);

--- a/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
@@ -7,6 +7,7 @@ import {
   poolId2,
   stakePoolSearchProvider,
   timeSettingsProvider,
+  txSubmitProvider,
   walletProvider
 } from '../config';
 import { distinctUntilChanged, filter, firstValueFrom, map, merge, mergeMap, skip, tap, timer } from 'rxjs';
@@ -73,6 +74,7 @@ describe('SingleAddressWallet/delegation', () => {
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
         timeSettingsProvider,
+        txSubmitProvider,
         walletProvider
       }
     );

--- a/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
@@ -1,6 +1,13 @@
 import { Cardano, util } from '@cardano-sdk/core';
 import { SingleAddressWallet } from '../../../src';
-import { assetProvider, keyAgentReady, stakePoolSearchProvider, timeSettingsProvider, walletProvider } from '../config';
+import {
+  assetProvider,
+  keyAgentReady,
+  stakePoolSearchProvider,
+  timeSettingsProvider,
+  txSubmitProvider,
+  walletProvider
+} from '../config';
 import { filter, firstValueFrom, map } from 'rxjs';
 
 describe('SingleAddressWallet/metadata', () => {
@@ -15,6 +22,7 @@ describe('SingleAddressWallet/metadata', () => {
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
         timeSettingsProvider,
+        txSubmitProvider,
         walletProvider
       }
     );

--- a/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
@@ -1,7 +1,14 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Cardano } from '@cardano-sdk/core';
 import { KeyManagement, SingleAddressWallet, Wallet } from '../../../src';
-import { assetProvider, keyAgentReady, stakePoolSearchProvider, timeSettingsProvider, walletProvider } from '../config';
+import {
+  assetProvider,
+  keyAgentReady,
+  stakePoolSearchProvider,
+  timeSettingsProvider,
+  txSubmitProvider,
+  walletProvider
+} from '../config';
 import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
 
 describe('SingleAddressWallet.assets/nft', () => {
@@ -28,6 +35,7 @@ describe('SingleAddressWallet.assets/nft', () => {
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
         timeSettingsProvider,
+        txSubmitProvider,
         walletProvider
       }
     );

--- a/packages/wallet/test/e2e/config.test.ts
+++ b/packages/wallet/test/e2e/config.test.ts
@@ -1,9 +1,10 @@
-import { keyAgentReady, stakePoolSearchProvider, walletProvider } from './config';
+import { keyAgentReady, stakePoolSearchProvider, txSubmitProvider, walletProvider } from './config';
 
 describe('config', () => {
   test('all config variables are set', () => {
     expect(walletProvider).toBeTruthy();
     expect(stakePoolSearchProvider).toBeTruthy();
+    expect(txSubmitProvider).toBeTruthy();
     expect(keyAgentReady).toBeTruthy();
   });
 });

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -1,6 +1,6 @@
 import { Cardano, testnetTimeSettings } from '@cardano-sdk/core';
 import { InMemoryKeyAgent } from '../../src/KeyManagement';
-import { blockfrostAssetProvider, blockfrostWalletProvider } from '@cardano-sdk/blockfrost';
+import { blockfrostAssetProvider, blockfrostTxSubmitProvider, blockfrostWalletProvider } from '@cardano-sdk/blockfrost';
 import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 
 const networkId = Number.parseInt(process.env.NETWORK_ID || '');
@@ -21,6 +21,12 @@ export const assetProvider = (() => {
   const projectId = process.env.BLOCKFROST_API_KEY;
   if (!projectId) throw new Error('BLOCKFROST_API_KEY not set (for assetProvider)');
   return blockfrostAssetProvider({ isTestnet, projectId });
+})();
+
+export const txSubmitProvider = (() => {
+  const projectId = process.env.BLOCKFROST_API_KEY;
+  if (!projectId) throw new Error('BLOCKFROST_API_KEY not set (for txSubmitProvider)');
+  return blockfrostTxSubmitProvider({ isTestnet, projectId });
 })();
 
 export const keyAgentReady = (() => {

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -1,6 +1,11 @@
+import {
+  BlockFrostAPI,
+  blockfrostAssetProvider,
+  blockfrostTxSubmitProvider,
+  blockfrostWalletProvider
+} from '@cardano-sdk/blockfrost';
 import { Cardano, testnetTimeSettings } from '@cardano-sdk/core';
 import { InMemoryKeyAgent } from '../../src/KeyManagement';
-import { blockfrostAssetProvider, blockfrostTxSubmitProvider, blockfrostWalletProvider } from '@cardano-sdk/blockfrost';
 import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 
 const networkId = Number.parseInt(process.env.NETWORK_ID || '');
@@ -12,7 +17,8 @@ export const walletProvider = (() => {
   if (walletProviderName === 'blockfrost') {
     const projectId = process.env.BLOCKFROST_API_KEY;
     if (!projectId) throw new Error('BLOCKFROST_API_KEY not set');
-    return blockfrostWalletProvider({ isTestnet, projectId });
+    const blockfrost = new BlockFrostAPI({ isTestnet, projectId });
+    return blockfrostWalletProvider(blockfrost);
   }
   throw new Error(`WALLET_PROVIDER unsupported: ${walletProviderName}`);
 })();
@@ -20,13 +26,15 @@ export const walletProvider = (() => {
 export const assetProvider = (() => {
   const projectId = process.env.BLOCKFROST_API_KEY;
   if (!projectId) throw new Error('BLOCKFROST_API_KEY not set (for assetProvider)');
-  return blockfrostAssetProvider({ isTestnet, projectId });
+  const blockfrost = new BlockFrostAPI({ isTestnet, projectId });
+  return blockfrostAssetProvider(blockfrost);
 })();
 
 export const txSubmitProvider = (() => {
   const projectId = process.env.BLOCKFROST_API_KEY;
   if (!projectId) throw new Error('BLOCKFROST_API_KEY not set (for txSubmitProvider)');
-  return blockfrostTxSubmitProvider({ isTestnet, projectId });
+  const blockfrost = new BlockFrostAPI({ isTestnet, projectId });
+  return blockfrostTxSubmitProvider(blockfrost);
 })();
 
 export const keyAgentReady = (() => {

--- a/packages/wallet/test/integration/transactionTime.test.ts
+++ b/packages/wallet/test/integration/transactionTime.test.ts
@@ -2,7 +2,7 @@ import { Cardano, createSlotTimeCalc, testnetTimeSettings } from '@cardano-sdk/c
 import { KeyManagement, SingleAddressWallet, SingleAddressWalletProps } from '../../src';
 import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 import { firstValueFrom } from 'rxjs';
-import { mockAssetProvider, mockWalletProvider } from '../mocks';
+import { mockAssetProvider, mockTxSubmitProvider, mockWalletProvider } from '../mocks';
 
 const walletProps: SingleAddressWalletProps = { name: 'some-wallet' };
 const networkId = Cardano.NetworkId.mainnet;
@@ -19,6 +19,7 @@ describe('integration/transactionTime', () => {
       mnemonicWords,
       networkId
     });
+    const txSubmitProvider = mockTxSubmitProvider();
     const walletProvider = mockWalletProvider();
     const stakePoolSearchProvider = createStubStakePoolSearchProvider();
     const timeSettingsProvider = createStubTimeSettingsProvider(testnetTimeSettings);
@@ -28,6 +29,7 @@ describe('integration/transactionTime', () => {
       keyAgent,
       stakePoolSearchProvider,
       timeSettingsProvider,
+      txSubmitProvider,
       walletProvider
     });
   });

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -2,7 +2,7 @@ import { Cardano, testnetTimeSettings } from '@cardano-sdk/core';
 import { KeyManagement, SingleAddressWallet, SingleAddressWalletProps, TransactionFailure } from '../../src';
 import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 import { firstValueFrom } from 'rxjs';
-import { mockAssetProvider, mockWalletProvider } from '../mocks';
+import { mockAssetProvider, mockTxSubmitProvider, mockWalletProvider } from '../mocks';
 
 const walletProps: SingleAddressWalletProps = { name: 'some-wallet' };
 const networkId = Cardano.NetworkId.mainnet;
@@ -19,6 +19,7 @@ describe('integration/withdrawal', () => {
       mnemonicWords,
       networkId
     });
+    const txSubmitProvider = mockTxSubmitProvider();
     const walletProvider = mockWalletProvider();
     const stakePoolSearchProvider = createStubStakePoolSearchProvider();
     const timeSettingsProvider = createStubTimeSettingsProvider(testnetTimeSettings);
@@ -28,6 +29,7 @@ describe('integration/withdrawal', () => {
       keyAgent,
       stakePoolSearchProvider,
       timeSettingsProvider,
+      txSubmitProvider,
       walletProvider
     });
   });

--- a/packages/wallet/test/mocks/index.ts
+++ b/packages/wallet/test/mocks/index.ts
@@ -1,3 +1,4 @@
 export * from './mockWalletProvider';
+export * from './mockTxSubmitProvider';
 export * from './testKeyAgent';
 export * from './mockAssetProvider';

--- a/packages/wallet/test/mocks/mockTxSubmitProvider.ts
+++ b/packages/wallet/test/mocks/mockTxSubmitProvider.ts
@@ -1,0 +1,12 @@
+import { TxSubmitProvider } from '@cardano-sdk/core';
+
+/**
+ * Provider stub for testing
+ *
+ * returns TxSubmitProvider-compatible object
+ */
+export const mockTxSubmitProvider = (): TxSubmitProvider => ({
+  submitTx: jest.fn().mockResolvedValue(void 0)
+});
+
+export type TxSubmitProviderStub = ReturnType<typeof mockTxSubmitProvider>;

--- a/packages/wallet/test/mocks/mockWalletProvider.ts
+++ b/packages/wallet/test/mocks/mockWalletProvider.ts
@@ -204,8 +204,7 @@ export const mockWalletProvider = (): WalletProvider => ({
       retiring: 5
     }
   }),
-  submitTx: jest.fn().mockResolvedValue(void 0),
   utxoDelegationAndRewards: jest.fn().mockResolvedValue({ delegationAndRewards, utxo })
 });
 
-export type ProviderStub = ReturnType<typeof mockWalletProvider>;
+export type WalletProviderStub = ReturnType<typeof mockWalletProvider>;

--- a/packages/wallet/test/services/ProviderStatusTracker.test.ts
+++ b/packages/wallet/test/services/ProviderStatusTracker.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prettier/prettier */
 /* eslint-disable no-multi-spaces */
-import { CLEAN_FN_STATS, SyncStatus, TrackedWalletProvider, WalletProviderFnStats } from '../../src';
+import { CLEAN_FN_STATS, ProviderFnStats, SyncStatus, TrackedWalletProvider } from '../../src';
 import { createProviderStatusTracker } from '../../src/services/ProviderStatusTracker';
 import { createTestScheduler } from '../testScheduler';
 import { mockWalletProvider } from '../mocks';
@@ -10,8 +10,8 @@ describe('syncStatus', () => {
     const walletProvider = new TrackedWalletProvider(mockWalletProvider());
     const timeout = 5000;
     createTestScheduler().run(({ cold, expectObservable }) => {
-      const getWalletProviderSyncRelevantStats = jest.fn().mockReturnValueOnce(
-        cold<WalletProviderFnStats[]>(`abcdef ${timeout}ms g`, {
+      const getProviderSyncRelevantStats = jest.fn().mockReturnValueOnce(
+        cold<ProviderFnStats[]>(`abcdef ${timeout}ms g`, {
           a: [CLEAN_FN_STATS, CLEAN_FN_STATS],                    // Initial state
           b: [{ numCalls: 1, numResponses: 0 }, CLEAN_FN_STATS],  // One provider fn called
           c: [
@@ -39,7 +39,7 @@ describe('syncStatus', () => {
       const tracker = createProviderStatusTracker(
         { walletProvider },
         { consideredOutOfSyncAfter: timeout },
-        { getWalletProviderSyncRelevantStats }
+        { getProviderSyncRelevantStats }
       );
       expectObservable(tracker, `^ ${timeout * 2}ms !`).toBe(`a---e ${timeout - 1}ms f-g`, {
         a: SyncStatus.Syncing,

--- a/packages/wallet/test/services/TrackedTxSubmitProvider.test.ts
+++ b/packages/wallet/test/services/TrackedTxSubmitProvider.test.ts
@@ -1,0 +1,39 @@
+import { BehaviorSubject } from 'rxjs';
+import { CLEAN_FN_STATS, ProviderFnStats, TrackedTxSubmitProvider, TxSubmitProviderStats } from '../../src';
+import { TxSubmitProvider } from '@cardano-sdk/core';
+import { mockTxSubmitProvider } from '../mocks';
+
+describe('TrackedTxSubmitProvider', () => {
+  let txSubmitProvider: TxSubmitProvider;
+  let trackedTxSubmitProvider: TrackedTxSubmitProvider;
+  beforeEach(() => {
+    txSubmitProvider = mockTxSubmitProvider();
+    trackedTxSubmitProvider = new TrackedTxSubmitProvider(txSubmitProvider);
+  });
+
+  describe('wraps underlying provider functions, tracks # of calls/responses and resets on stats.reset()', () => {
+    const testFunctionStats =
+      <T>(
+        call: (txSubmitProvider: TxSubmitProvider) => Promise<T>,
+        selectStats: (stats: TxSubmitProviderStats) => BehaviorSubject<ProviderFnStats>
+        // eslint-disable-next-line unicorn/consistent-function-scoping
+      ) =>
+      async () => {
+        expect(selectStats(trackedTxSubmitProvider.stats).value).toEqual(CLEAN_FN_STATS);
+        const result = call(trackedTxSubmitProvider);
+        expect(selectStats(trackedTxSubmitProvider.stats).value).toEqual({ ...CLEAN_FN_STATS, numCalls: 1 });
+        await result;
+        expect(selectStats(trackedTxSubmitProvider.stats).value).toEqual({ numCalls: 1, numResponses: 1 });
+        trackedTxSubmitProvider.stats.reset();
+        expect(selectStats(trackedTxSubmitProvider.stats).value).toEqual(CLEAN_FN_STATS);
+      };
+
+    test(
+      'submitTx',
+      testFunctionStats(
+        (provider) => provider.submitTx(new Uint8Array()),
+        (stats) => stats.submitTx$
+      )
+    );
+  });
+});

--- a/packages/wallet/test/services/TrackedWalletProvider.test.ts
+++ b/packages/wallet/test/services/TrackedWalletProvider.test.ts
@@ -1,5 +1,5 @@
 import { BehaviorSubject } from 'rxjs';
-import { CLEAN_FN_STATS, TrackedWalletProvider, WalletProviderFnStats, WalletProviderStats } from '../../src';
+import { CLEAN_FN_STATS, ProviderFnStats, TrackedWalletProvider, WalletProviderStats } from '../../src';
 import { WalletProvider } from '@cardano-sdk/core';
 import { mockWalletProvider } from '../mocks';
 
@@ -19,7 +19,7 @@ describe('TrackedWalletProvider', () => {
     const testFunctionStats =
       <T>(
         call: (walletProvider: WalletProvider) => Promise<T>,
-        selectStats: (stats: WalletProviderStats) => BehaviorSubject<WalletProviderFnStats>
+        selectStats: (stats: WalletProviderStats) => BehaviorSubject<ProviderFnStats>
         // eslint-disable-next-line unicorn/consistent-function-scoping
       ) =>
       async () => {
@@ -93,14 +93,6 @@ describe('TrackedWalletProvider', () => {
       testFunctionStats(
         (wp) => wp.rewardsHistory({ stakeAddresses: [] }),
         (stats) => stats.rewardsHistory$
-      )
-    );
-
-    test(
-      'submitTx',
-      testFunctionStats(
-        (wp) => wp.submitTx(new Uint8Array()),
-        (stats) => stats.submitTx$
       )
     );
 


### PR DESCRIPTION
# Context
Given transaction submission is really an independent behaviour,
as evidenced by microservices such as the HTTP submission API,
it's more flexible modelled as an independent provider.

# Proposed Solution
- Separate the function into it's own provider type
- Make an abstract class `ProviderTracker`, and hoist common code. There's likely more optimal ways to go here, but I've tried to keep the refactor as minimal as possible. Open to ideas though.

# Important Changes Introduced
Applicaitons now need to setup an additional provider. A Blockfrost provider (and `cardano-graphql-db-sync`) provider is included in this branch.