### PR TITLE
Feat/ogmios tx submit provider

### DIFF
--- a/packages/ogmios/.gitignore
+++ b/packages/ogmios/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+secrets
+coverage

--- a/packages/ogmios/LICENSE
+++ b/packages/ogmios/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright © 2021 IOHK
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ogmios/NOTICE
+++ b/packages/ogmios/NOTICE
@@ -1,0 +1,5 @@
+Copyright 2021 IOHK
+
+Licensed under the Apache License, Version 2.0 (the "License”). You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/ogmios/README.md
+++ b/packages/ogmios/README.md
@@ -1,0 +1,1 @@
+# Cardano JS SDK | Ogmios

--- a/packages/ogmios/jest.config.js
+++ b/packages/ogmios/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../test/jest.config');

--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@cardano-sdk/ogmios",
+  "version": "0.2.0",
+  "description": "Ogmios Providers",
+  "engines": {
+    "node": "^14"
+  },
+  "main": "dist/index.js",
+  "repository": "https://github.com/input-output-hk/cardano-js-sdk/packages/ogmios",
+  "author": "Rhys Bartels-Waller",
+  "license": "MPL-2.0",
+  "scripts": {
+    "build": "tsc --build ./src",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
+    "cleanup": "shx rm -rf dist node_modules",
+    "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
+    "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
+    "test": "jest -c ./jest.config.js",
+    "test:e2e": "shx echo 'test:e2e' command not implemented yet",
+    "coverage": "shx echo No coverage report for this package",
+    "prepack": "yarn build"
+  },
+  "devDependencies": {
+    "get-port-please": "^2.4.3",
+    "shx": "^0.3.3",
+    "ws": "^8.5.0"
+  },
+  "dependencies": {
+    "@cardano-ogmios/client": "5.1.0"
+  },
+  "files": [
+    "dist/*",
+    "!dist/tsconfig.tsbuildinfo",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/packages/ogmios/src/.eslintrc.js
+++ b/packages/ogmios/src/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "extends": ["../../../.eslintrc.js"],
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": __dirname
+  }
+}

--- a/packages/ogmios/src/index.ts
+++ b/packages/ogmios/src/index.ts
@@ -1,0 +1,1 @@
+export * from './ogmiosTxSubmitProvider';

--- a/packages/ogmios/src/ogmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/ogmiosTxSubmitProvider.ts
@@ -1,0 +1,54 @@
+import { Buffer } from 'buffer';
+import { Cardano, TxSubmitProvider } from '@cardano-sdk/core';
+import {
+  ConnectionConfig,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  TxSubmission,
+  UnknownResultError,
+  createInteractionContext,
+  createTxSubmissionClient
+} from '@cardano-ogmios/client';
+import { Logger, dummyLogger } from 'ts-log';
+
+/**
+ * Connect to an [Ogmios](https://ogmios.dev/) instance
+ *
+ * @param {ConnectionConfig} connectionConfig Ogmios connection configuration
+ * @param {Logger} logger object implementing the Logger abstract class
+ * @returns {TxSubmitProvider} TxSubmitProvider
+ * @throws {TxSubmission.errors}
+ */
+export const ogmiosTxSubmitProvider = (
+  connectionConfig: ConnectionConfig,
+  logger: Logger = dummyLogger
+): TxSubmitProvider => ({
+  submitTx: async (signedTransaction) => {
+    // The Ogmios client supports opening a long-running ws connection,
+    // however as the provider interface doesn't include shutdown handling,
+    // we're using the one time interaction type for now.
+    try {
+      const interactionContext = await createInteractionContext(
+        (error) => {
+          logger.error({ error: error.name, module: 'ogmiosTxSubmitProvider' }, error.message);
+        },
+        logger.info,
+        {
+          connection: connectionConfig,
+          interactionType: 'OneTime'
+        }
+      );
+      const txSubmissionClient = await createTxSubmissionClient(interactionContext);
+      const txHex = Buffer.from(signedTransaction).toString('hex');
+      return await txSubmissionClient.submitTx(txHex);
+    } catch (error) {
+      // Ogmios throws an array of domain errors, or a single catch-all if the request is malformed.
+      // There's currently no utility to invert this logic to ensure other non-UnknownResultErrors are
+      // also re-thrown as the UnknownTxSubmissionError, but it's a minor issue we can improve on.
+      if (error instanceof UnknownResultError) {
+        throw new Cardano.TxSubmissionErrors.UnknownTxSubmissionError(error);
+      }
+      throw error;
+    }
+  }
+});

--- a/packages/ogmios/src/tsconfig.json
+++ b/packages/ogmios/src/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/",
+    "rootDir": "."
+  },
+  "references": [{ "path": "../../core/src" }]
+}

--- a/packages/ogmios/test/.eslintrc.js
+++ b/packages/ogmios/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "extends": ["../../../test/.eslintrc.js"],
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": __dirname
+  }
+}

--- a/packages/ogmios/test/mocks/mockOgmiosServer.ts
+++ b/packages/ogmios/test/mocks/mockOgmiosServer.ts
@@ -1,0 +1,89 @@
+import { Server, createServer } from 'http';
+import { SubmitFail, SubmitSuccess } from '@cardano-ogmios/schema';
+import WebSocket from 'ws';
+
+const HEALTH_RESPONSE_BODY = {
+  connectionStatus: 'connected',
+  currentEpoch: 192,
+  currentEra: 'Alonzo',
+  lastKnownTip: {
+    blockNo: 3_391_731,
+    hash: '9ef43ab6e234fcf90d103413096c7da752da2f45b15e1259f43d476afd12932c',
+    slot: 52_819_355
+  },
+  lastTipUpdate: '2022-03-13T16:22:51.423778138Z',
+  metrics: {
+    activeConnections: 0,
+    runtimeStats: {
+      cpuTime: 1_346_462_892,
+      currentHeapSize: 331,
+      gcCpuTime: 1_217_193_590,
+      maxHeapSize: 367
+    },
+    sessionDurations: {
+      max: 0,
+      mean: 0,
+      min: 0
+    },
+    totalConnections: 0,
+    totalMessages: 0,
+    totalUnrouted: 0
+  },
+  networkSynchronization: 1,
+  slotInEpoch: 244_955,
+  startTime: '2022-03-13T16:18:59.932519677Z'
+};
+
+export interface MockOgmiosServerConfig {
+  submitTx: {
+    response: {
+      success: boolean;
+      failWith?: {
+        type: 'eraMismatch';
+      };
+    };
+  };
+}
+
+export const createMockOgmiosServer = (config: MockOgmiosServerConfig): Server => {
+  const server = createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+
+    if (req.method !== 'GET' || req.url !== '/health') {
+      res.statusCode = 405;
+      res.end('{"error":"METHOD_NOT_ALLOWED"}');
+      return;
+    }
+
+    res.end(JSON.stringify(HEALTH_RESPONSE_BODY));
+  });
+  const wss = new WebSocket.Server({
+    server
+  });
+  wss.on('connection', (ws) => {
+    ws.on('message', (data) => {
+      const { methodname, mirror } = JSON.parse(data as string);
+      if (methodname === 'SubmitTx') {
+        let result: SubmitSuccess | SubmitFail;
+        if (config.submitTx.response.success) {
+          result = 'SubmitSuccess';
+        } else if (config.submitTx.response.failWith?.type === 'eraMismatch') {
+          result = { SubmitFail: [{ eraMismatch: { ledgerEra: 'Shelley', queryEra: 'Alonzo' } }] };
+        } else {
+          throw new Error('Unknown mock response');
+        }
+        ws.send(
+          JSON.stringify({
+            methodname: 'SubmitTx',
+            reflection: mirror,
+            result,
+            servicename: 'ogmios',
+            type: 'jsonwsp/response',
+            version: '1.0'
+          })
+        );
+      }
+    });
+  });
+  return server;
+};

--- a/packages/ogmios/test/ogmiosTxSubmitProvider.test.ts
+++ b/packages/ogmios/test/ogmiosTxSubmitProvider.test.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable max-len */
+import { Connection, createConnectionObject } from '@cardano-ogmios/client';
+import { TxSubmitProvider } from '@cardano-sdk/core';
+import { createMockOgmiosServer } from './mocks/mockOgmiosServer';
+import { getPort } from 'get-port-please';
+import { ogmiosTxSubmitProvider } from '../src';
+import http from 'http';
+
+const listenPromise = (server: http.Server, port: number, hostname?: string): Promise<http.Server> =>
+  new Promise((resolve, reject) => {
+    server.listen(port, hostname, () => resolve(server));
+    server.on('error', reject);
+  });
+
+const serverClosePromise = (server: http.Server): Promise<void> =>
+  new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error !== undefined) {
+        reject(error);
+      }
+      resolve();
+    });
+  });
+
+describe('ogmiosTxSubmitProvider', () => {
+  let mockServer: http.Server;
+  let connection: Connection;
+  let provider: TxSubmitProvider;
+
+  beforeAll(async () => {
+    connection = createConnectionObject({ port: await getPort() });
+  });
+  describe('submitTx', () => {
+    describe('success', () => {
+      beforeAll(async () => {
+        mockServer = createMockOgmiosServer({ submitTx: { response: { success: true } } });
+        await listenPromise(mockServer, connection.port);
+        provider = ogmiosTxSubmitProvider(connection);
+      });
+
+      afterAll(async () => {
+        await serverClosePromise(mockServer);
+      });
+
+      it('resolves if successful', async () => {
+        try {
+          const res = await provider.submitTx(new Uint8Array());
+          expect(res).toBeUndefined();
+        } catch (error) {
+          expect(error).toBeUndefined();
+        }
+      });
+    });
+
+    describe('failure', () => {
+      afterAll(async () => {
+        await serverClosePromise(mockServer);
+      });
+
+      it('rejects with errors thrown by the service', async () => {
+        mockServer = createMockOgmiosServer({
+          submitTx: { response: { failWith: { type: 'eraMismatch' }, success: false } }
+        });
+        await listenPromise(mockServer, connection.port);
+        provider = ogmiosTxSubmitProvider(connection);
+
+        try {
+          await provider.submitTx(new Uint8Array());
+        } catch (error) {
+          expect(error[0].name).toBe('EraMismatchError');
+        }
+      });
+    });
+  });
+});

--- a/packages/ogmios/test/tsconfig.json
+++ b/packages/ogmios/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "references": [
+    { "path": "../../core/src" },
+    { "path": "../src" }
+  ]
+}

--- a/packages/wallet/.env.example
+++ b/packages/wallet/.env.example
@@ -1,3 +1,4 @@
+TX_SUBMIT_PROVIDER=blockfrost
 WALLET_PROVIDER=blockfrost
 STAKE_POOL_SEARCH_PROVIDER=stub
 TIME_SETTINGS_PROVIDER=stub_testnet
@@ -7,3 +8,6 @@ MNEMONIC_WORDS="actor scout worth mansion thumb device mass pave gospel secret h
 WALLET_PASSWORD=some_password
 POOL_ID_1=pool1euf2nh92ehqfw7rpd4s9qgq34z8dg4pvfqhjmhggmzk95gcd402
 POOL_ID_2=pool1fghrkl620rl3g54ezv56weeuwlyce2tdannm2hphs62syf3vyyh
+OGMIOS_HOST=localhost
+OGMIOS_PORT=1337
+OGMIOS_TLS=0

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -27,7 +27,9 @@
   },
   "devDependencies": {
     "@cardano-sdk/util-dev": " 0.2.0",
+    "@cardano-sdk/ogmios": " 0.2.0",
     "@types/pbkdf2": "^3.1.0",
+    "envalid": "^7.3.0",
     "shx": "^0.3.3"
   },
   "dependencies": {

--- a/packages/wallet/test/README.md
+++ b/packages/wallet/test/README.md
@@ -1,0 +1,7 @@
+# Cardano JS SDK | Wallet | Test
+
+## e2e
+Configuration is managed via ENVs. To run tests locally, make a copy of
+[.env.example](../.env.example) as `.env`, and modify to suit test requirements. See [config.ts](./e2e/config.ts) for 
+`*_PROVIDER` 
+options. 

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -10,42 +10,49 @@ import { InMemoryKeyAgent } from '../../src/KeyManagement';
 import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 import { ogmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
 
-const txSubmitOptions = ['blockfrost', 'ogmios'];
+const networkIdOptions = [0, 1];
+const stakePoolSearchProviderOptions = ['stub'];
+const timeSettingsProviderOptions = ['stub_testnet'];
+const txSubmitProviderOptions = ['blockfrost', 'ogmios'];
+const walletProviderOptions = ['blockfrost'];
 
-const networkId = Number.parseInt(process.env.NETWORK_ID || '');
-if (Number.isNaN(networkId)) throw new Error('NETWORK_ID not set');
-const isTestnet = networkId === 0;
+const env = envalid.cleanEnv(process.env, {
+  BLOCKFROST_API_KEY: envalid.str(),
+  MNEMONIC_WORDS: envalid.makeValidator<string[]>((input) => {
+    const words = input.split(' ');
+    if (words.length === 0) throw new Error('MNEMONIC_WORDS not set');
+    return words;
+  })(),
+  NETWORK_ID: envalid.num({ choices: networkIdOptions }),
+  OGMIOS_HOST: envalid.host(),
+  OGMIOS_PORT: envalid.port(),
+  OGMIOS_TLS: envalid.bool(),
+  POOL_ID_1: envalid.str(),
+  POOL_ID_2: envalid.str(),
+  STAKE_POOL_SEARCH_PROVIDER: envalid.str({ choices: stakePoolSearchProviderOptions }),
+  TIME_SETTINGS_PROVIDER: envalid.str({ choices: timeSettingsProviderOptions }),
+  TX_SUBMIT_PROVIDER: envalid.str({ choices: txSubmitProviderOptions }),
+  WALLET_PASSWORD: envalid.str(),
+  WALLET_PROVIDER: envalid.str({ choices: walletProviderOptions })
+});
+const isTestnet = env.NETWORK_ID === 0;
 
 export const walletProvider = (() => {
-  const walletProviderName = process.env.WALLET_PROVIDER;
-  if (walletProviderName === 'blockfrost') {
-    const projectId = process.env.BLOCKFROST_API_KEY;
-    if (!projectId) throw new Error('BLOCKFROST_API_KEY not set');
-    const blockfrost = new BlockFrostAPI({ isTestnet, projectId });
+  if (env.WALLET_PROVIDER === 'blockfrost') {
+    const blockfrost = new BlockFrostAPI({ isTestnet, projectId: env.BLOCKFROST_API_KEY });
     return blockfrostWalletProvider(blockfrost);
   }
-  throw new Error(`WALLET_PROVIDER unsupported: ${walletProviderName}`);
+  throw new Error(`WALLET_PROVIDER unsupported: ${env.WALLET_PROVIDER}`);
 })();
 
 export const assetProvider = (() => {
-  const projectId = process.env.BLOCKFROST_API_KEY;
-  if (!projectId) throw new Error('BLOCKFROST_API_KEY not set (for assetProvider)');
-  const blockfrost = new BlockFrostAPI({ isTestnet, projectId });
+  const blockfrost = new BlockFrostAPI({ isTestnet, projectId: env.BLOCKFROST_API_KEY });
   return blockfrostAssetProvider(blockfrost);
 })();
 
 export const txSubmitProvider = (() => {
-  const env = envalid.cleanEnv(process.env, {
-    BLOCKFROST_API_KEY: envalid.str(),
-    OGMIOS_HOST: envalid.host(),
-    OGMIOS_PORT: envalid.port(),
-    OGMIOS_TLS: envalid.bool(),
-    TX_SUBMIT_PROVIDER: envalid.str({ choices: txSubmitOptions })
-  });
   if (env.TX_SUBMIT_PROVIDER === 'blockfrost') {
-    const projectId = env.BLOCKFROST_API_KEY;
-    if (!projectId) throw new Error('BLOCKFROST_API_KEY not set (for txSubmitProvider)');
-    const blockfrost = new BlockFrostAPI({ isTestnet, projectId });
+    const blockfrost = new BlockFrostAPI({ isTestnet, projectId: env.BLOCKFROST_API_KEY });
     return blockfrostTxSubmitProvider(blockfrost);
   } else if (env.TX_SUBMIT_PROVIDER === 'ogmios') {
     return ogmiosTxSubmitProvider({ host: env.OGMIOS_HOST, port: env.OGMIOS_PORT, tls: env.OGMIOS_TLS });
@@ -53,36 +60,26 @@ export const txSubmitProvider = (() => {
   throw new Error(`TX_SUBMIT_PROVIDER unsupported: ${env.TX_SUBMIT_PROVIDER}`);
 })();
 
-export const keyAgentReady = (() => {
-  const mnemonicWords = (process.env.MNEMONIC_WORDS || '').split(' ');
-  if (mnemonicWords.length === 0) throw new Error('MNEMONIC_WORDS not set');
-  const password = process.env.WALLET_PASSWORD;
-  if (!password) throw new Error('WALLET_PASSWORD not set');
-  return InMemoryKeyAgent.fromBip39MnemonicWords({
-    getPassword: async () => Buffer.from(password),
-    mnemonicWords,
-    networkId
-  });
-})();
+export const keyAgentReady = (() =>
+  InMemoryKeyAgent.fromBip39MnemonicWords({
+    getPassword: async () => Buffer.from(env.WALLET_PASSWORD),
+    mnemonicWords: env.MNEMONIC_WORDS,
+    networkId: env.NETWORK_ID
+  }))();
 
 export const stakePoolSearchProvider = (() => {
-  const stakePoolSearchProviderName = process.env.STAKE_POOL_SEARCH_PROVIDER;
-  if (stakePoolSearchProviderName === 'stub') {
+  if (env.STAKE_POOL_SEARCH_PROVIDER === 'stub') {
     return createStubStakePoolSearchProvider();
   }
-  throw new Error(`STAKE_POOL_SEARCH_PROVIDER unsupported: ${stakePoolSearchProviderName}`);
+  throw new Error(`STAKE_POOL_SEARCH_PROVIDER unsupported: ${env.STAKE_POOL_SEARCH_PROVIDER}`);
 })();
 
 export const timeSettingsProvider = (() => {
-  const timeSettingsProviderName = process.env.TIME_SETTINGS_PROVIDER;
-  if (timeSettingsProviderName === 'stub_testnet') {
+  if (env.TIME_SETTINGS_PROVIDER === 'stub_testnet') {
     return createStubTimeSettingsProvider(testnetTimeSettings);
   }
-  throw new Error(`TIME_SETTINGS_PROVIDER unsupported: ${timeSettingsProviderName}`);
+  throw new Error(`TIME_SETTINGS_PROVIDER unsupported: ${env.TIME_SETTINGS_PROVIDER}`);
 })();
 
-if (!process.env.POOL_ID_1) throw new Error('POOL_ID_1 not set');
-export const poolId1 = Cardano.PoolId(process.env.POOL_ID_1!);
-
-if (!process.env.POOL_ID_2) throw new Error('POOL_ID_2 not set');
-export const poolId2 = Cardano.PoolId(process.env.POOL_ID_2!);
+export const poolId1 = Cardano.PoolId(env.POOL_ID_1);
+export const poolId2 = Cardano.PoolId(env.POOL_ID_2);

--- a/packages/wallet/test/tsconfig.json
+++ b/packages/wallet/test/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "../src" },
     { "path": "../../util-dev/src" },
     { "path": "../../cip2/src" },
-    { "path": "../../core/src" }
+    { "path": "../../core/src" },
+    { "path": "../../ogmios/src" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5325,6 +5325,11 @@ fs-extra@^9.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-memo@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fs-memo/-/fs-memo-1.2.0.tgz#a2ec3be606b902077adbb37ec529c5ec5fb2e037"
+  integrity sha512-YEexkCpL4j03jn5SxaMHqcO6IuWuqm8JFUYhyCep7Ao89JIYmB8xoKhK7zXXJ9cCaNXpyNH5L3QtAmoxjoHW2w==
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -5394,6 +5399,13 @@ get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
+get-port-please@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/get-port-please/-/get-port-please-2.4.3.tgz#8f054020016bfafb7f65001db501079c02ed59d1"
+  integrity sha512-l5zVrG3mzz+I7MfbPwyJJ4xZKIdQfARpOtsBjUDUZ0iXlF0IXc1wMBg3Jb7G1te7tRzjOxu+MRLpvgxxTdCkwg==
+  dependencies:
+    fs-memo "^1.2.0"
 
 get-random-values@^1.2.2:
   version "1.2.2"
@@ -11241,6 +11253,11 @@ ws@^8.3.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
   integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
+
+ws@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,6 +4562,13 @@ enquirer@^2.3.5, enquirer@^2.3.6:
   dependencies:
     ansi-colors "^4.1.1"
 
+envalid@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/envalid/-/envalid-7.3.0.tgz#9d5eda789216cfdd8c55ff0d6fe30ddff38e52d5"
+  integrity sha512-RWAAXLU+s884YwbVQ+D8OYRIspo7hvF9zPTvjToVzqZknHwycAuGiiHG/XiI1UDY/PeYSlMwQvMUGb25n06iwA==
+  dependencies:
+    tslib "2.3.1"
+
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -10709,15 +10716,15 @@ tslib@2.1.0, tslib@~2.1.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
+tslib@2.3.1, tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1, tslib@^1.10.0, tslib@^1.11.2, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@~2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
# Context
- Ogmios provides a number of useful interfaces we need to integrate with, including transaction submission.
- The core package contains a dependency on Ogmios, given it forms the basis of our integration with `cardano-node`.

# Proposed Solution
I've chosen to source the provider in the core package for now given the existing dependency, with a mock service to facilitate testing. Only a single error path is tested, as the provider is only catching and translating non-domain errors to the [error type](https://github.com/input-output-hk/cardano-js-sdk/blob/7e4a058abd404aad6b96cd66dd1a80948c6abee4/packages/core/src/Cardano/types/TxSubmissionErrors.ts#L69-L73) defined by the SDK, so it would be a lot of mocking and test code for little benefit. The two core package tests demonstrate the two top-level responses, with further test coverage to be handled within the wallet's e2e tests.
 
:pushpin: **feat(core): ogmiosTxSubmitProvider**
- Uses a mock Ogmios server, that we can also use to facilitate chain-sync testing.
- random free port selected within the test

:pushpin: **feat(wallet): ogmiosTxSubmitProvider in e2e tests**
Configuration to select the provider in wallet e2e tests, using envalid for improved
env validation.

:pushpin: r**efactor(wallet): refactor remaining e2e config.ts using envalid**
Also positions the options for easy review when determining config.
Existence checks are not needed since envalid enforces values.
