### PR TITLE
feat: add Provider interface, use as base for TxSubmitProvider

### DIFF
--- a/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
+++ b/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
@@ -1,5 +1,5 @@
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
-import { Cardano, TxSubmitProvider } from '@cardano-sdk/core';
+import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
 
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
@@ -9,6 +9,15 @@ import { Cardano, TxSubmitProvider } from '@cardano-sdk/core';
  * @throws {Cardano.TxSubmissionErrors.UnknownTxSubmissionError}
  */
 export const blockfrostTxSubmitProvider = (blockfrost: BlockFrostAPI): TxSubmitProvider => {
+  const healthCheck: TxSubmitProvider['healthCheck'] = async () => {
+    try {
+      const result = await blockfrost.health();
+      return { ok: result.is_healthy };
+    } catch (error) {
+      throw new ProviderError(ProviderFailure.Unknown, error);
+    }
+  };
+
   const submitTx: TxSubmitProvider['submitTx'] = async (signedTransaction) => {
     try {
       await blockfrost.txSubmit(signedTransaction);
@@ -18,6 +27,7 @@ export const blockfrostTxSubmitProvider = (blockfrost: BlockFrostAPI): TxSubmitP
   };
 
   return {
+    healthCheck,
     submitTx
   };
 };

--- a/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
@@ -2,12 +2,35 @@
 /* eslint-disable max-len */
 
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { blockfrostTxSubmitProvider } from '../src';
 jest.mock('@blockfrost/blockfrost-js');
 
 describe('blockfrostTxSubmitProvider', () => {
   const apiKey = 'someapikey';
+
+  describe('healthCheck', () => {
+    it('returns ok if the service reports a healthy state', async () => {
+      BlockFrostAPI.prototype.health = jest.fn().mockResolvedValue({ is_healthy: true });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const provider = blockfrostTxSubmitProvider(blockfrost);
+      expect(await provider.healthCheck()).toEqual({ ok: true });
+    });
+    it('returns not ok if the service reports an unhealthy state', async () => {
+      BlockFrostAPI.prototype.health = jest.fn().mockResolvedValue({ is_healthy: false });
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const provider = blockfrostTxSubmitProvider(blockfrost);
+      expect(await provider.healthCheck()).toEqual({ ok: false });
+    });
+    it('throws a typed error if caught during the service interaction', async () => {
+      BlockFrostAPI.prototype.health = jest
+        .fn()
+        .mockRejectedValue(new ProviderError(ProviderFailure.Unknown, new Error('Some error')));
+      const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
+      const provider = blockfrostTxSubmitProvider(blockfrost);
+      await expect(provider.healthCheck()).rejects.toThrowError(ProviderError);
+    });
+  });
 
   describe('submitTx', () => {
     it('wraps error in UnknownTxSubmissionError', async () => {

--- a/packages/core/src/Provider/Provider.ts
+++ b/packages/core/src/Provider/Provider.ts
@@ -1,0 +1,5 @@
+export interface Provider {
+  healthCheck(): Promise<{
+    ok: boolean;
+  }>;
+}

--- a/packages/core/src/Provider/TxSubmitProvider/types.ts
+++ b/packages/core/src/Provider/TxSubmitProvider/types.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import Cardano from '../..';
+import Cardano, { Provider } from '../..';
 
-export interface TxSubmitProvider {
+export interface TxSubmitProvider extends Provider {
   /**
    * @param signedTransaction signed and serialized cbor
    * @throws {Cardano.TxSubmissionError} (see Cardano.TxSubmissionErrors)

--- a/packages/core/src/Provider/index.ts
+++ b/packages/core/src/Provider/index.ts
@@ -1,3 +1,4 @@
+export * from './Provider';
 export * from './StakePoolSearchProvider';
 export * from './WalletProvider';
 export * from './AssetProvider';

--- a/packages/wallet/src/services/ProviderTracker/TrackedTxSubmitProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedTxSubmitProvider.ts
@@ -3,9 +3,11 @@ import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTrac
 import { TxSubmitProvider } from '@cardano-sdk/core';
 
 export class TxSubmitProviderStats {
+  readonly healthCheck$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly submitTx$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
 
   reset() {
+    this.healthCheck$.next(CLEAN_FN_STATS);
     this.submitTx$.next(CLEAN_FN_STATS);
   }
 }
@@ -15,11 +17,14 @@ export class TxSubmitProviderStats {
  */
 export class TrackedTxSubmitProvider extends ProviderTracker implements TxSubmitProvider {
   readonly stats = new TxSubmitProviderStats();
+  readonly healthCheck: TxSubmitProvider['healthCheck'];
   readonly submitTx: TxSubmitProvider['submitTx'];
 
   constructor(txSubmitProvider: TxSubmitProvider) {
     super();
     txSubmitProvider = txSubmitProvider;
+
+    this.healthCheck = () => this.trackedCall(() => txSubmitProvider.healthCheck(), this.stats.healthCheck$);
 
     this.submitTx = (signedTransaction) =>
       this.trackedCall(() => txSubmitProvider.submitTx(signedTransaction), this.stats.submitTx$);

--- a/packages/wallet/test/mocks/mockTxSubmitProvider.ts
+++ b/packages/wallet/test/mocks/mockTxSubmitProvider.ts
@@ -6,6 +6,7 @@ import { TxSubmitProvider } from '@cardano-sdk/core';
  * returns TxSubmitProvider-compatible object
  */
 export const mockTxSubmitProvider = (): TxSubmitProvider => ({
+  healthCheck: jest.fn().mockResolvedValue(true),
   submitTx: jest.fn().mockResolvedValue(void 0)
 });
 

--- a/packages/wallet/test/services/TrackedTxSubmitProvider.test.ts
+++ b/packages/wallet/test/services/TrackedTxSubmitProvider.test.ts
@@ -34,6 +34,14 @@ describe('TrackedTxSubmitProvider', () => {
       };
 
     test(
+      'healthCheck',
+      testFunctionStats(
+        (provider) => provider.healthCheck(),
+        (stats) => stats.healthCheck$
+      )
+    );
+
+    test(
       'submitTx',
       testFunctionStats(
         (provider) => provider.submitTx(new Uint8Array()),


### PR DESCRIPTION
# Context
Checking the health of a service is an important aspect for application logic and system monitoring. All providers have this common model, but we don't currently have a base interface. The service of interest is tx submission due to a dependent chunk of work now on hold awaiting this feature.

# Proposed Solution
Implement a base interface with minimal model for a boolean response, but room for an extension to include other metrics at a later date. I've purposely left the other provider refactors out of this scope to avoid overloading this PR, as it can be completed separately.
