### PR TITLE
Feat/Tx Submit HTTP with provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/parser": "^4.29.0",
     "dotenv": "^10.0.0",
     "eslint": "^7.32.0",
-    "eslint-import-resolver-typescript": "^2.4.0",
+    "eslint-import-resolver-typescript": "^2.7.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-jest": "^24.4.0",

--- a/packages/cardano-graphql-services/package.json
+++ b/packages/cardano-graphql-services/package.json
@@ -30,11 +30,17 @@
   "devDependencies": {
     "@cardano-sdk/util-dev": "0.2.0",
     "@graphql-tools/utils": "~8.6.1",
+    "@types/express": "^4.17.13",
+    "cbor": "^8.1.0",
+    "get-port-please": "^2.4.3",
+    "got": "^11",
     "npm-run-all": "^4.1.5",
     "shx": "^0.3.3"
   },
   "dependencies": {
     "@cardano-sdk/core": "0.2.0",
+    "body-parser": "^1.19.2",
+    "express": "^4.17.3",
     "graphql-request": "npm:graphql-request-configurable-serializer@4.0.0",
     "reflect-metadata": "~0.1.13",
     "ts-log": "^2.2.4",

--- a/packages/cardano-graphql-services/package.json
+++ b/packages/cardano-graphql-services/package.json
@@ -34,7 +34,6 @@
     "shx": "^0.3.3"
   },
   "dependencies": {
-    "@cardano-ogmios/client": "~5.1.0",
     "@cardano-sdk/core": "0.2.0",
     "graphql-request": "npm:graphql-request-configurable-serializer@4.0.0",
     "reflect-metadata": "~0.1.13",

--- a/packages/cardano-graphql-services/package.json
+++ b/packages/cardano-graphql-services/package.json
@@ -6,6 +6,9 @@
     "node": "^14"
   },
   "main": "dist/index.js",
+  "bin": {
+    "tx-submit": "./dist/TxSubmit/cli.js"
+  },
   "repository": "https://github.com/input-output-hk/cardano-js-sdk/packages/cardano-graphql-services",
   "contributors": [
     "Martynas Kazlauskas <martynas.kazlauskas@iohk.io>",
@@ -25,7 +28,9 @@
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
     "coverage": "yarn test --coverage",
     "prepack": "yarn build",
-    "test:debug": "DEBUG=true yarn test"
+    "test:debug": "DEBUG=true yarn test",
+    "run:tx-submit": "ts-node --transpile-only src/TxSubmit/run.ts",
+    "cli:tx-submit": "ts-node --transpile-only src/TxSubmit/cli.ts"
   },
   "devDependencies": {
     "@cardano-sdk/util-dev": "0.2.0",
@@ -35,14 +40,25 @@
     "get-port-please": "^2.4.3",
     "got": "^11",
     "npm-run-all": "^4.1.5",
-    "shx": "^0.3.3"
+    "shx": "^0.3.3",
+    "wait-on": "^6.0.1"
   },
   "dependencies": {
     "@cardano-sdk/core": "0.2.0",
+    "@cardano-sdk/ogmios": "0.2.0",
+    "@types/bunyan": "^1.8.8",
+    "@types/death": "^1.1.2",
+    "@types/wait-on": "^5.3.1",
     "body-parser": "^1.19.2",
+    "bunyan": "^1.8.15",
+    "commander": "^9.1.0",
+    "death": "^1.1.0",
+    "debug": "^4.3.4",
+    "envalid": "^7.3.0",
     "express": "^4.17.3",
     "graphql-request": "npm:graphql-request-configurable-serializer@4.0.0",
     "reflect-metadata": "~0.1.13",
+    "serialize-error": "^8",
     "ts-log": "^2.2.4",
     "type-graphql": "~1.1.1"
   },

--- a/packages/cardano-graphql-services/src/Http/HttpServer.ts
+++ b/packages/cardano-graphql-services/src/Http/HttpServer.ts
@@ -1,0 +1,34 @@
+import { RunnableModule } from '../RunnableModule';
+import { dummyLogger } from 'ts-log';
+import { listenPromise, serverClosePromise } from '../util';
+import express from 'express';
+import http from 'http';
+import net from 'net';
+
+export type HttpServerConfig = {
+  router: express.Router;
+  name: string;
+  listen: net.ListenOptions;
+};
+
+export abstract class HttpServer extends RunnableModule {
+  public app: express.Application;
+  public server: http.Server;
+
+  protected constructor(public config: HttpServerConfig, logger = dummyLogger) {
+    super(config.name, logger);
+  }
+
+  protected async initializeImpl(): Promise<void> {
+    this.app = express();
+    this.app.use(this.config.router);
+  }
+
+  protected async startImpl(): Promise<void> {
+    this.server = await listenPromise(this.app, this.config.listen);
+  }
+
+  protected shutdownImpl(): Promise<void> {
+    return serverClosePromise(this.server);
+  }
+}

--- a/packages/cardano-graphql-services/src/Http/index.ts
+++ b/packages/cardano-graphql-services/src/Http/index.ts
@@ -1,0 +1,1 @@
+export * from './HttpServer';

--- a/packages/cardano-graphql-services/src/TxSubmit/TxSubmitHttpServer.ts
+++ b/packages/cardano-graphql-services/src/TxSubmit/TxSubmitHttpServer.ts
@@ -1,0 +1,79 @@
+import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { ErrorObject, serializeError } from 'serialize-error';
+import { HttpServer } from '../Http';
+import { Logger, dummyLogger } from 'ts-log';
+import bodyParser, { Options } from 'body-parser';
+import express, { Router } from 'express';
+import net from 'net';
+
+export interface TxSubmitServerDependencies {
+  txSubmitProvider: TxSubmitProvider;
+  logger?: Logger;
+}
+
+export interface TxSubmitHttpServerConfig {
+  listen: net.ListenOptions;
+  bodyParser?: {
+    limit?: Options['limit'];
+  };
+}
+
+export class TxSubmitHttpServer extends HttpServer {
+  #txSubmitProvider: TxSubmitProvider;
+
+  private constructor(config: TxSubmitHttpServerConfig, router: Router, dependencies: TxSubmitServerDependencies) {
+    super({ listen: config.listen, name: 'TxSubmitServer', router }, dependencies.logger);
+    this.#txSubmitProvider = dependencies.txSubmitProvider;
+  }
+  static create(
+    config: TxSubmitHttpServerConfig,
+    { txSubmitProvider, logger = dummyLogger }: TxSubmitServerDependencies
+  ) {
+    const router = express.Router();
+    router.use(bodyParser.raw({ limit: config.bodyParser?.limit || '500kB', type: 'application/cbor' }));
+    router.get('/health', async (req, res) => {
+      logger.debug('/health', { ip: req.ip });
+      let body: { ok: boolean } | Error['message'];
+      try {
+        body = await txSubmitProvider.healthCheck();
+      } catch (error) {
+        logger.error(error);
+        body = error instanceof ProviderError ? error.message : 'Unknown error';
+        res.statusCode = 500;
+      }
+      res.send(body);
+    });
+    router.post('/submit', async (req, res) => {
+      if (req.header('Content-Type') !== 'application/cbor') {
+        res.statusCode = 400;
+        return res.send('Must use application/cbor Content-Type header');
+      }
+      logger.debug('/submit', { ip: req.ip });
+      let body: Error['message'] | undefined;
+      try {
+        await txSubmitProvider.submitTx(new Uint8Array(req.body));
+        body = undefined;
+      } catch (error) {
+        if (!(await txSubmitProvider.healthCheck()).ok) {
+          res.statusCode = 503;
+          body = JSON.stringify(serializeError(new ProviderError(ProviderFailure.Unhealthy, error)));
+        } else {
+          res.statusCode = Cardano.util.asTxSubmissionError(error) ? 400 : 500;
+          body = JSON.stringify(
+            Array.isArray(error) ? error.map<ErrorObject>((e) => serializeError(e)) : serializeError(error)
+          );
+        }
+        logger.error(body);
+      }
+      res.send(body);
+    });
+    return new TxSubmitHttpServer(config, router, { logger, txSubmitProvider });
+  }
+
+  async initializeImpl(): Promise<void> {
+    if (!(await this.#txSubmitProvider.healthCheck()).ok) {
+      throw new ProviderError(ProviderFailure.Unhealthy);
+    }
+    await super.initializeImpl();
+  }
+}

--- a/packages/cardano-graphql-services/src/TxSubmit/cli.ts
+++ b/packages/cardano-graphql-services/src/TxSubmit/cli.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/* eslint-disable import/imports-first */
+require('../../scripts/patchRequire');
+import { Command } from 'commander';
+import { InvalidLoggerLevel } from '../errors';
+import { LogLevel, createLogger } from 'bunyan';
+import { TxSubmitHttpServer } from './TxSubmitHttpServer';
+import { URL } from 'url';
+import { loggerMethodNames } from '../util';
+import { ogmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
+import onDeath from 'death';
+const clear = require('clear');
+const packageJson = require('../../package.json');
+clear();
+// eslint-disable-next-line no-console
+console.log('Tx Submit CLI');
+
+const program = new Command('tx-submit');
+
+program.description('Submit transactions to the Cardano network').version(packageJson.version);
+
+program
+  .command('start-server')
+  .description('Start the HTTP server')
+  .option('--api-url <apiUrl>', 'Server URL', (url) => new URL(url))
+  .option('--ogmios-url <ogmiosUrl>', 'Ogmios URL', (url) => new URL(url))
+  .option('--logger-min-severity <level>', 'Log level', (level) => {
+    if (!loggerMethodNames.includes(level)) {
+      throw new InvalidLoggerLevel(level);
+    }
+    return level;
+  })
+  .action(
+    async ({ apiUrl, loggerMinSeverity, ogmiosUrl }: { apiUrl: URL; loggerMinSeverity: string; ogmiosUrl: URL }) => {
+      const logger = createLogger({ level: loggerMinSeverity as LogLevel, name: 'tx-submit-http-server' });
+      const txSubmitProvider = ogmiosTxSubmitProvider({
+        host: ogmiosUrl?.hostname,
+        port: ogmiosUrl ? Number.parseInt(ogmiosUrl.port) : undefined,
+        tls: ogmiosUrl?.protocol === 'wss'
+      });
+      const server = TxSubmitHttpServer.create(
+        {
+          listen: {
+            host: apiUrl.hostname,
+            port: Number.parseInt(apiUrl.port)
+          }
+        },
+        {
+          logger,
+          txSubmitProvider
+        }
+      );
+      await server.initialize();
+      await server.start();
+      onDeath(async () => {
+        await server.shutdown();
+        process.exit(1);
+      });
+    }
+  );
+
+if (process.argv.slice(2).length === 0) {
+  program.outputHelp();
+  process.exit(1);
+} else {
+  program.parseAsync(process.argv).catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    process.exit(0);
+  });
+}

--- a/packages/cardano-graphql-services/src/TxSubmit/index.ts
+++ b/packages/cardano-graphql-services/src/TxSubmit/index.ts
@@ -1,0 +1,1 @@
+export * from './TxSubmitHttpServer';

--- a/packages/cardano-graphql-services/src/TxSubmit/run.ts
+++ b/packages/cardano-graphql-services/src/TxSubmit/run.ts
@@ -1,0 +1,43 @@
+/* eslint-disable import/imports-first */
+require('../../scripts/patchRequire');
+import * as envalid from 'envalid';
+import { LogLevel, createLogger } from 'bunyan';
+import { Logger } from 'ts-log';
+import { TxSubmitHttpServer } from '../TxSubmit';
+import { URL } from 'url';
+import { loggerMethodNames } from '../util';
+import { ogmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
+import onDeath from 'death';
+
+// Todo: Hoist some to ogmios package, import and merge here and in wallet e2e tests
+const envSpecs = {
+  API_URL: envalid.url({ default: 'http://localhost:3000' }),
+  LOGGER_MIN_SEVERITY: envalid.str({ choices: loggerMethodNames as string[], default: 'info' }),
+  OGMIOS_URL: envalid.url({ default: 'ws://localhost:1337' })
+};
+
+void (async () => {
+  const env = envalid.cleanEnv(process.env, envSpecs);
+  const apiUrl = new URL(env.API_URL);
+  const ogmiosUrl = new URL(env.OGMIOS_URL);
+  const logger: Logger = createLogger({
+    level: env.LOGGER_MIN_SEVERITY as LogLevel,
+    name: 'tx-submit-http-server'
+  });
+  const txSubmitProvider = await ogmiosTxSubmitProvider({
+    host: ogmiosUrl?.hostname,
+    port: ogmiosUrl ? Number.parseInt(ogmiosUrl.port) : undefined,
+    tls: ogmiosUrl?.protocol === 'wss'
+  });
+  const server = TxSubmitHttpServer.create(
+    { listen: { host: apiUrl.hostname, port: Number.parseInt(apiUrl.port) } },
+    { logger, txSubmitProvider }
+  );
+  await server.initialize();
+  await server.start();
+  onDeath(async () => {
+    await server.shutdown();
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  });
+})();

--- a/packages/cardano-graphql-services/src/errors/InvalidLoggerLevel.ts
+++ b/packages/cardano-graphql-services/src/errors/InvalidLoggerLevel.ts
@@ -1,0 +1,8 @@
+import { CustomError } from 'ts-custom-error';
+
+export class InvalidLoggerLevel extends CustomError {
+  public constructor(value: string) {
+    super();
+    this.message = `${value} is an invalid logger level`;
+  }
+}

--- a/packages/cardano-graphql-services/src/errors/index.ts
+++ b/packages/cardano-graphql-services/src/errors/index.ts
@@ -1,1 +1,2 @@
+export * from './InvalidLoggerLevel';
 export * from './InvalidModuleState';

--- a/packages/cardano-graphql-services/src/index.ts
+++ b/packages/cardano-graphql-services/src/index.ts
@@ -1,2 +1,3 @@
 export * from './Http';
 export * from './RunnableModule';
+export * from './TxSubmit';

--- a/packages/cardano-graphql-services/src/index.ts
+++ b/packages/cardano-graphql-services/src/index.ts
@@ -1,1 +1,2 @@
+export * from './Http';
 export * from './RunnableModule';

--- a/packages/cardano-graphql-services/src/tsconfig.json
+++ b/packages/cardano-graphql-services/src/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "."
   },
   "references": [
-    { "path": "../../core/src" }
+    { "path": "../../core/src" },
+    { "path": "../../ogmios/src" }
   ]
 }

--- a/packages/cardano-graphql-services/src/util/http.ts
+++ b/packages/cardano-graphql-services/src/util/http.ts
@@ -1,0 +1,20 @@
+import { Application } from 'express';
+import { ListenOptions } from 'net';
+import http from 'http';
+
+export const listenPromise = (
+  serverLike: http.Server | Application,
+  listenOptions: ListenOptions = {}
+): Promise<http.Server> =>
+  new Promise((resolve, reject) => {
+    const server = serverLike.listen(listenOptions, () => resolve(server)) as http.Server;
+    server.on('error', reject);
+  });
+
+export const serverClosePromise = (server: http.Server): Promise<void> =>
+  new Promise((resolve, reject) => {
+    server.on('close', resolve);
+    server.close((error) => {
+      if (error !== undefined) reject(error);
+    });
+  });

--- a/packages/cardano-graphql-services/src/util/index.ts
+++ b/packages/cardano-graphql-services/src/util/index.ts
@@ -1,1 +1,2 @@
+export * from './http';
 export * from './logging';

--- a/packages/cardano-graphql-services/src/util/logging.ts
+++ b/packages/cardano-graphql-services/src/util/logging.ts
@@ -1,13 +1,13 @@
 import { Logger } from 'ts-log';
 
+export const loggerMethodNames = ['debug', 'error', 'fatal', 'info', 'trace', 'warn'] as (keyof Logger)[];
+
 /**
  * Appends an object containing module metadata to each log entry
  *
  */
-export const moduleLogger = (logger: Logger, module: string): Logger => {
-  const methodNames = ['debug', 'error', 'info', 'trace', 'warn'] as (keyof Logger)[];
-  return <Logger>(<unknown>Object.fromEntries(
-    methodNames.map((method) => [
+export const moduleLogger = (logger: Logger, module: string): Logger => <Logger>(<unknown>Object.fromEntries(
+    loggerMethodNames.map((method) => [
       method,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (...optionalParams: any[]) => {
@@ -21,4 +21,3 @@ export const moduleLogger = (logger: Logger, module: string): Logger => {
       }
     ])
   ));
-};

--- a/packages/cardano-graphql-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-graphql-services/test/Http/HttpServer.test.ts
@@ -1,0 +1,119 @@
+import { HttpServer, RunnableModule } from '../../src';
+import { getRandomPort } from 'get-port-please';
+import express from 'express';
+import got from 'got';
+import net from 'net';
+const bodyParser = require('body-parser');
+
+class SomeHttpServer extends HttpServer {
+  private constructor(config: net.ListenOptions, router: express.Router) {
+    super({ listen: config, name: 'SomeHttpServer', router });
+  }
+  static create(config: net.ListenOptions) {
+    const router = express.Router();
+    router.use(bodyParser.json());
+    router.get('/health', (_req, res) => {
+      res.send({ ok: true });
+    });
+    return new SomeHttpServer(config, router);
+  }
+}
+
+describe('HttpServer', () => {
+  let httpServer: HttpServer;
+  let port: number;
+  let apiUrlBase: string;
+
+  it('Is a runnable module', async () => {
+    port = await getRandomPort();
+    httpServer = SomeHttpServer.create({ host: 'localhost', port });
+    expect(httpServer).toBeInstanceOf(RunnableModule);
+  });
+
+  beforeEach(async () => {
+    port = await getRandomPort();
+    apiUrlBase = `http://localhost:${port}`;
+    httpServer = SomeHttpServer.create({ host: 'localhost', port });
+  });
+
+  describe('initialize', () => {
+    it('initializes the express application', async () => {
+      expect(httpServer.app).not.toBeDefined();
+      await httpServer.initialize();
+      expect(httpServer.app).toBeDefined();
+    });
+  });
+
+  describe('start', () => {
+    beforeEach(async () => {
+      await httpServer.initialize();
+    });
+
+    afterEach(async () => {
+      await httpServer.shutdown();
+    });
+
+    it('starts the express application, attaching the server to the public property', async () => {
+      expect(httpServer.state).toBe('initialized');
+      expect(httpServer.server).not.toBeDefined();
+      await httpServer.start();
+      expect(httpServer.state).toBe('running');
+      expect(httpServer.server).toBeDefined();
+      const addressInfo = httpServer.server.address() as net.AddressInfo;
+      expect(addressInfo.port).toBe(port);
+      expect(addressInfo.address).toBe('127.0.0.1');
+    });
+  });
+
+  describe('shutdown', () => {
+    beforeEach(async () => {
+      await httpServer.initialize();
+      await httpServer.start();
+    });
+
+    it('closes the server', async () => {
+      expect(httpServer.state).toBe('running');
+      const spy = jest.fn();
+      httpServer.server.on('close', spy);
+      await httpServer.shutdown();
+      expect(httpServer.state).toBe('initialized');
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('restarting', () => {
+    beforeEach(async () => {
+      await httpServer.initialize();
+      await httpServer.start();
+    });
+
+    it('can be restarted', async () => {
+      expect(httpServer.state).toBe('running');
+      await httpServer.shutdown();
+      expect(httpServer.state).toBe('initialized');
+      await httpServer.start();
+      expect(httpServer.state).toBe('running');
+      await httpServer.shutdown();
+      expect(httpServer.state).toBe('initialized');
+    });
+  });
+
+  describe('HTTP API', () => {
+    beforeEach(async () => {
+      await httpServer.initialize();
+      await httpServer.start();
+    });
+
+    afterEach(async () => {
+      await httpServer.shutdown();
+    });
+
+    it('health', async () => {
+      const res = await got(`${apiUrlBase}/health`, {
+        headers: { 'Content-Type': 'application/json' }
+      });
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body)).toEqual({ ok: true });
+    });
+  });
+});

--- a/packages/cardano-graphql-services/test/TxSubmit/TxSubmitHttpServer.test.ts
+++ b/packages/cardano-graphql-services/test/TxSubmit/TxSubmitHttpServer.test.ts
@@ -1,0 +1,168 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable max-len */
+import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { TxSubmitHttpServer, TxSubmitHttpServerConfig } from '../../src';
+import { getPort } from 'get-port-please';
+import cbor from 'cbor';
+import got from 'got';
+
+const tx = cbor.encode('#####');
+const BAD_REQUEST_STRING = 'Response code 400 (Bad Request)';
+const APPLICATION_CBOR = 'application/cbor';
+const APPLICATION_JSON = 'application/json';
+
+describe('TxSubmitHttpServer', () => {
+  let txSubmitProvider: TxSubmitProvider;
+  let txSubmitHttpServer: TxSubmitHttpServer;
+  let port: number;
+  let apiUrlBase: string;
+  let config: TxSubmitHttpServerConfig;
+
+  beforeAll(async () => {
+    port = await getPort();
+    apiUrlBase = `http://localhost:${port}`;
+    config = { listen: { port } };
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+  });
+
+  describe('unhealthy TxSubmitProvider', () => {
+    beforeAll(async () => {
+      txSubmitProvider = { healthCheck: jest.fn(() => Promise.resolve({ ok: false })), submitTx: jest.fn() };
+      txSubmitHttpServer = TxSubmitHttpServer.create(config, { txSubmitProvider });
+    });
+
+    it('throws during initialization if the TxSubmitProvider is unhealthy', async () => {
+      await expect(txSubmitHttpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+    });
+  });
+
+  describe('healthy TxSubmitProvider on startup, unhealthy at request time', () => {
+    let isOk: () => boolean;
+    let doSubmitTx: (tx: Uint8Array) => Promise<void>;
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const serverHealth = async () => {
+      const response = await got(`${apiUrlBase}/health`, {
+        headers: { 'Content-Type': APPLICATION_JSON }
+      });
+      return JSON.parse(response.body);
+    };
+
+    beforeAll(async () => {
+      isOk = () => true;
+      txSubmitProvider = { healthCheck: jest.fn(() => Promise.resolve({ ok: isOk() })), submitTx: doSubmitTx };
+      txSubmitHttpServer = TxSubmitHttpServer.create(config, { txSubmitProvider });
+      await expect(await txSubmitHttpServer.initialize()).resolves;
+      await expect(txSubmitHttpServer.start()).resolves;
+      expect(await serverHealth()).toEqual({ ok: true });
+    });
+
+    afterAll(async () => {
+      await txSubmitHttpServer.shutdown();
+    });
+
+    it('returns a ProviderError of failure type Unhealthy if the TxSubmitProvider is unhealthy when submitting', async () => {
+      // Flip to unhealthy state
+      isOk = () => false;
+      doSubmitTx = () => Promise.reject();
+      expect(await serverHealth()).toEqual({ ok: false });
+
+      try {
+        await got.post(`${apiUrlBase}/submit`, {
+          body: Buffer.from(new Uint8Array()).toString(),
+          headers: { 'Content-Type': APPLICATION_CBOR }
+        });
+        throw new Error('fail');
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        const body = JSON.parse(error.response.body);
+        expect(error.response.statusCode).toBe(503);
+        expect(body.name).toBe('ProviderError');
+        expect(body.reason).toBe('UNHEALTHY');
+      }
+    });
+  });
+
+  describe('healthy and successful submission', () => {
+    beforeAll(async () => {
+      txSubmitProvider = { healthCheck: jest.fn(() => Promise.resolve({ ok: true })), submitTx: jest.fn() };
+      txSubmitHttpServer = TxSubmitHttpServer.create(config, { txSubmitProvider });
+      await txSubmitHttpServer.initialize();
+      await txSubmitHttpServer.start();
+    });
+
+    afterAll(async () => {
+      await txSubmitHttpServer.shutdown();
+    });
+
+    describe('/health', () => {
+      it('forwards the txSubmitProvider health response', async () => {
+        const res = await got(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({ ok: true });
+      });
+    });
+
+    describe('/submit', () => {
+      it('returns a 200 coded response with a well formed HTTP request', async () => {
+        expect(
+          (
+            await got.post(`${apiUrlBase}/submit`, {
+              body: tx,
+              headers: { 'Content-Type': APPLICATION_CBOR },
+              method: 'post'
+            })
+          ).statusCode
+        ).toEqual(200);
+        expect(txSubmitProvider.submitTx).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns a 400 coded response if the wrong content type header is used', async () => {
+        try {
+          await got.post(`${apiUrlBase}/submit`, {
+            body: tx,
+            headers: { 'Content-Type': APPLICATION_JSON }
+          });
+          throw new Error('fail');
+        } catch (error: any) {
+          expect(error.response.statusCode).toBe(400);
+          expect(error.message).toBe(BAD_REQUEST_STRING);
+          expect(txSubmitProvider.submitTx).toHaveBeenCalledTimes(0);
+        }
+      });
+    });
+  });
+
+  describe('healthy but failing submission', () => {
+    describe('/submit', () => {
+      // eslint-disable-next-line max-len
+      it('returns a 400 coded response with detail in the body to a transaction containing a domain violation', async () => {
+        const stubErrors = [new Cardano.TxSubmissionErrors.BadInputsError({ badInputs: [] })];
+        txSubmitProvider = {
+          healthCheck: jest.fn(() => Promise.resolve({ ok: true })),
+          submitTx: jest.fn(() => Promise.reject(stubErrors))
+        };
+        txSubmitHttpServer = TxSubmitHttpServer.create(config, { txSubmitProvider });
+        await txSubmitHttpServer.initialize();
+        await txSubmitHttpServer.start();
+        try {
+          await got.post(`${apiUrlBase}/submit`, {
+            body: Buffer.from(new Uint8Array()).toString(),
+            headers: { 'Content-Type': APPLICATION_CBOR }
+          });
+          throw new Error('fail');
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+          expect(error.response.statusCode).toBe(400);
+          expect(JSON.parse(error.response.body)[0].name).toEqual(stubErrors[0].name);
+          expect(txSubmitProvider.submitTx).toHaveBeenCalledTimes(1);
+          await txSubmitHttpServer.shutdown();
+        }
+      });
+    });
+  });
+});

--- a/packages/cardano-graphql-services/test/TxSubmit/entrypoints.test.ts
+++ b/packages/cardano-graphql-services/test/TxSubmit/entrypoints.test.ts
@@ -1,0 +1,157 @@
+import { ChildProcess, fork } from 'child_process';
+import { Connection, ConnectionConfig, createConnectionObject } from '@cardano-ogmios/client';
+import { createMockOgmiosServer } from '@cardano-sdk/ogmios/test/mocks/mockOgmiosServer';
+import { getRandomPort } from 'get-port-please';
+import { listenPromise, serverClosePromise } from '../../src/util';
+import { serverReady } from './util';
+import got from 'got';
+import http from 'http';
+import path from 'path';
+
+const exePath = (name: 'cli' | 'run') => path.join(__dirname, '..', '..', 'dist', 'TxSubmit', `${name}.js`);
+
+describe('entrypoints', () => {
+  let apiPort: number;
+  let apiUrlBase: string;
+  let proc: ChildProcess;
+
+  beforeEach(async () => {
+    apiPort = await getRandomPort();
+    apiUrlBase = `http://localhost:${apiPort}`;
+  });
+  afterEach(() => {
+    if (proc !== undefined) proc.kill();
+  });
+
+  it('CLI version', (done) => {
+    proc = fork(exePath('cli'), ['--version'], {
+      stdio: 'pipe'
+    });
+    proc.stdout!.on('data', (data) => {
+      expect(data.toString()).toBeDefined();
+    });
+    proc.stdout?.on('end', () => {
+      done();
+    });
+  });
+
+  // eslint-disable-next-line sonarjs/no-duplicate-string
+  describe('start-server', () => {
+    let ogmiosServer: http.Server;
+    let ogmiosPort: ConnectionConfig['port'];
+    let ogmiosConnection: Connection;
+    let ogmiosUrl: string;
+
+    beforeAll(async () => {
+      ogmiosPort = await getRandomPort();
+      ogmiosConnection = createConnectionObject({ port: ogmiosPort });
+      ogmiosUrl = `ws://localhost:${ogmiosPort}`;
+    });
+
+    describe('running with a healthy Ogmios', () => {
+      beforeEach(async () => {
+        ogmiosServer = createMockOgmiosServer({
+          healthCheck: { response: { networkSynchronization: 0.999, success: true } },
+          submitTx: { response: { success: true } }
+        });
+        await listenPromise(ogmiosServer, { port: ogmiosConnection.port });
+      });
+
+      afterEach(async () => {
+        await serverClosePromise(ogmiosServer);
+      });
+
+      it('cli:start-server', async () => {
+        proc = fork(exePath('cli'), [
+          'start-server',
+          '--api-url',
+          `${apiUrlBase}`,
+          '--logger-min-severity',
+          'error',
+          '--ogmios-url',
+          `${ogmiosUrl}`
+        ]);
+        await serverReady(apiUrlBase);
+        const res = await got(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': 'application/json' }
+        });
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({ ok: true });
+      });
+
+      it('run', async () => {
+        proc = fork(exePath('run'), {
+          env: {
+            API_URL: apiUrlBase,
+            LOGGER_MIN_SEVERITY: 'error',
+            OGMIOS_URL: ogmiosUrl
+          }
+        });
+        await serverReady(apiUrlBase);
+        const res = await got(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': 'application/json' }
+        });
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(res.body)).toEqual({ ok: true });
+      });
+    });
+
+    describe('startup if Ogmios is unhealthy', () => {
+      let spy: jest.Mock;
+      beforeEach(() => {
+        ogmiosServer = createMockOgmiosServer({
+          healthCheck: { response: { networkSynchronization: 0.8, success: true } },
+          submitTx: { response: { success: false } }
+        });
+        spy = jest.fn();
+      });
+      it('cli:start-server', (done) => {
+        ogmiosServer.listen(ogmiosConnection.port, () => {
+          proc = fork(
+            exePath('cli'),
+            [
+              'start-server',
+              '--api-url',
+              `${apiUrlBase}`,
+              '--logger-min-severity',
+              'error',
+              '--ogmios-url',
+              `${ogmiosUrl}`
+            ],
+            {
+              stdio: 'pipe'
+            }
+          );
+          proc.stderr!.on('data', spy);
+          proc.on('exit', (code) => {
+            expect(code).toBe(0);
+            expect(spy).toHaveBeenCalled();
+            done();
+            ogmiosServer.close();
+          });
+        });
+      });
+
+      it('run', (done) => {
+        ogmiosServer.listen(ogmiosConnection.port, () => {
+          proc = fork(exePath('run'), {
+            env: {
+              API_URL: apiUrlBase,
+              LOGGER_MIN_SEVERITY: 'error',
+              OGMIOS_URL: ogmiosUrl
+            },
+            stdio: 'pipe'
+          });
+          proc.stderr!.on('data', spy);
+          // eslint-disable-next-line sonarjs/no-identical-functions
+          proc.on('exit', (code) => {
+            expect(code).toBe(0);
+            expect(spy).toHaveBeenCalled();
+            done();
+            ogmiosServer.close();
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/cardano-graphql-services/test/TxSubmit/util.ts
+++ b/packages/cardano-graphql-services/test/TxSubmit/util.ts
@@ -1,0 +1,4 @@
+import waitOn from 'wait-on';
+
+export const serverReady = (apiUrlBase: string): Promise<void> =>
+  waitOn({ resources: [`${apiUrlBase}`], validateStatus: (status: number) => status === 404 });

--- a/packages/cardano-graphql-services/test/tsconfig.json
+++ b/packages/cardano-graphql-services/test/tsconfig.json
@@ -6,6 +6,7 @@
   "references": [
     { "path": "../src" },
     { "path": "../../core/src" },
+    { "path": "../../ogmios/test" },
     { "path": "../../util-dev/src" }
   ]
 }

--- a/packages/cardano-graphql-services/test/util/http.test.ts
+++ b/packages/cardano-graphql-services/test/util/http.test.ts
@@ -1,0 +1,45 @@
+import { getPort } from 'get-port-please';
+import { listenPromise, serverClosePromise } from '../../src/util/http';
+import express from 'express';
+import http from 'http';
+
+describe('http utils', () => {
+  describe('listenPromise', () => {
+    let port: number;
+    let server: http.Server;
+
+    afterEach(() => {
+      server.close();
+    });
+
+    it('promisifies express app.listen', async () => {
+      const app = express();
+      port = await getPort();
+      expect((server = await listenPromise(app, { port }))).toBeInstanceOf(http.Server);
+      await expect(listenPromise(app, { port })).rejects.toThrow();
+    });
+
+    it('promisifies server.listen', async () => {
+      server = http.createServer();
+      port = await getPort();
+      server = await listenPromise(server, { port });
+      expect(server).toBeInstanceOf(http.Server);
+      await expect(listenPromise(server, { port })).rejects.toThrow();
+    });
+  });
+
+  describe('serverClosePromise', () => {
+    let port: number;
+    let server: http.Server;
+
+    it('promisifies server.close', async () => {
+      server = http.createServer();
+      port = await getPort();
+      const spy = jest.fn();
+      await listenPromise(server, { port });
+      server.on('close', spy);
+      await expect(await serverClosePromise(server)).resolves;
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cardano-graphql/package.json
+++ b/packages/cardano-graphql/package.json
@@ -27,6 +27,7 @@
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {
+    "@cardano-sdk/cardano-graphql-services": "0.2.0",
     "@graphql-codegen/cli": "~2.5.0",
     "@graphql-codegen/typescript": "~2.4.3",
     "@graphql-codegen/typescript-graphql-request": "~4.3.4",
@@ -39,10 +40,12 @@
     "@cardano-ogmios/client": "~5.1.0",
     "@cardano-sdk/core": "0.2.0",
     "class-validator": "^0.13.1",
+    "got": "^11",
     "graphql": "~15.6.1",
     "graphql-request": "npm:graphql-request-configurable-serializer@4.0.0",
     "graphql-tag": "2.12.5",
-    "json-bigint": "~1.0.0"
+    "json-bigint": "~1.0.0",
+    "serialize-error": "^8"
   },
   "files": [
     "dist/*",

--- a/packages/cardano-graphql/src/TxSubmitProvider/index.ts
+++ b/packages/cardano-graphql/src/TxSubmitProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './txSubmitHttpProvider';

--- a/packages/cardano-graphql/src/TxSubmitProvider/txSubmitHttpProvider.ts
+++ b/packages/cardano-graphql/src/TxSubmitProvider/txSubmitHttpProvider.ts
@@ -1,0 +1,52 @@
+import {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  Cardano,
+  ProviderError,
+  ProviderFailure,
+  TxSubmitProvider
+} from '@cardano-sdk/core';
+import { deserializeError } from 'serialize-error';
+import got from 'got';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import type ConnectionConfig from '@cardano-sdk/cardano-graphql-services';
+
+/**
+ * Connect to a TxSubmitHttpServer instance
+ *
+ * @param {ConnectionConfig} connectionConfig Service connection configuration
+ * @returns {TxSubmitProvider} TxSubmitProvider
+ * @throws {Cardano.TxSubmissionErrors}
+ */
+export const txSubmitHttpProvider = (connectionConfig: { url: string }): TxSubmitProvider => ({
+  async healthCheck() {
+    try {
+      const response = await got.get(`${connectionConfig.url}/health`);
+      return JSON.parse(response.body);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if (error.name === 'RequestError') {
+        return { ok: false };
+      }
+      throw new ProviderError(ProviderFailure.Unknown, error);
+    }
+  },
+  async submitTx(tx: Uint8Array) {
+    try {
+      await got.post(`${connectionConfig.url}/submit`, {
+        body: Buffer.from(tx),
+        headers: { 'Content-Type': 'application/cbor' }
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      const domainErrors = JSON.parse(error?.response?.body || null) as null | string | string[];
+      if (Array.isArray(domainErrors)) {
+        throw domainErrors.map((e: string) => deserializeError(e));
+      } else if (domainErrors !== null) {
+        throw deserializeError(domainErrors);
+      }
+      throw new ProviderError(ProviderFailure.Unknown, error);
+    }
+  }
+});

--- a/packages/cardano-graphql/src/index.ts
+++ b/packages/cardano-graphql/src/index.ts
@@ -2,6 +2,7 @@ export { WalletProvider, StakePoolSearchProvider } from '@cardano-sdk/core';
 export * from './StakePoolSearchProvider';
 export * from './WalletProvider';
 export * from './AssetProvider';
+export * from './TxSubmitProvider';
 export * from './createSDK';
 // Do not export this. Using core types elsewhere in the sdk.
 // export * as Schema from './Schema';

--- a/packages/cardano-graphql/src/tsconfig.json
+++ b/packages/cardano-graphql/src/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "."
   },
   "references": [
+    { "path": "../../cardano-graphql-services/src" },
     { "path": "../../core/src" }
   ]
 }

--- a/packages/cardano-graphql/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
+++ b/packages/cardano-graphql/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
@@ -1,0 +1,62 @@
+import { Cardano } from '@cardano-sdk/core';
+import { serializeError } from 'serialize-error';
+import { txSubmitHttpProvider } from '../../src';
+import got from 'got';
+
+const url = 'http://some-hostname:3000';
+
+describe('txSubmitHttpProvider', () => {
+  describe('healthCheck', () => {
+    it('is not ok if cannot connect', async () => {
+      const provider = txSubmitHttpProvider({ url });
+      await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
+    });
+    describe('mocked', () => {
+      beforeAll(() => {
+        jest.mock('got');
+      });
+
+      afterAll(() => {
+        jest.unmock('got');
+      });
+
+      it('is ok if 200 response body is { ok: true }', async () => {
+        got.get = jest.fn().mockResolvedValue({ body: JSON.stringify({ ok: true }) });
+        const provider = txSubmitHttpProvider({ url });
+        await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
+      });
+
+      it('is not ok if 200 response body is { ok: false }', async () => {
+        got.get = jest.fn().mockResolvedValue({ body: JSON.stringify({ ok: false }) });
+        const provider = txSubmitHttpProvider({ url });
+        await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
+      });
+    });
+  });
+  describe('submitTx', () => {
+    it('resolves if successful', async () => {
+      got.post = jest.fn().mockResolvedValue('');
+      const provider = txSubmitHttpProvider({ url });
+      await expect(provider.submitTx(new Uint8Array())).resolves;
+    });
+    it('rehydrates errors, although only as base Error class', async () => {
+      const errors = [new Cardano.TxSubmissionErrors.BadInputsError({ badInputs: [] })];
+      try {
+        got.post = jest.fn().mockRejectedValue({
+          response: {
+            body: JSON.stringify(errors.map((e) => serializeError(e)))
+          }
+        });
+        const provider = txSubmitHttpProvider({ url });
+        await provider.submitTx(new Uint8Array());
+        throw new Error('fail');
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        // https://github.com/sindresorhus/serialize-error/issues/48
+        // expect(error[0]).toBeInstanceOf(Cardano.TxSubmissionErrors.BadInputsError);
+        expect(error[0]).toBeInstanceOf(Error);
+        expect(error[0].name).toBe('BadInputsError');
+      }
+    });
+  });
+});

--- a/packages/core/src/Cardano/types/TxSubmissionErrors.ts
+++ b/packages/core/src/Cardano/types/TxSubmissionErrors.ts
@@ -1,73 +1,78 @@
 import { CustomError } from 'ts-custom-error';
 import { TxSubmission } from '@cardano-ogmios/client';
 
-export const EraMismatchError = TxSubmission.EraMismatchError;
-export const UnkownResultError = TxSubmission.UnknownResultError;
-
-export const AddressAttributesTooLargeError = TxSubmission.errors.AddressAttributesTooLarge.Error;
-export const AlreadyDelegatingError = TxSubmission.errors.AlreadyDelegating.Error;
-export const BadInputsError = TxSubmission.errors.BadInputs.Error;
-export const CollateralHasNonAdaAssetsError = TxSubmission.errors.CollateralHasNonAdaAssets.Error;
-export const CollateralIsScriptError = TxSubmission.errors.CollateralIsScript.Error;
-export const CollateralTooSmallError = TxSubmission.errors.CollateralTooSmall.Error;
-export const CollectErrorsError = TxSubmission.errors.CollectErrors.Error;
-export const DelegateNotRegisteredError = TxSubmission.errors.DelegateNotRegistered.Error;
-export const DuplicateGenesisVrfError = TxSubmission.errors.DuplicateGenesisVrf.Error;
-export const ExecutionUnitsTooLargeError = TxSubmission.errors.ExecutionUnitsTooLarge.Error;
-export const ExpiredUtxoError = TxSubmission.errors.ExpiredUtxo.Error;
-export const ExtraDataMismatchError = TxSubmission.errors.ExtraDataMismatch.Error;
-export const ExtraRedeemersError = TxSubmission.errors.ExtraRedeemers.Error;
-export const FeeTooSmallError = TxSubmission.errors.FeeTooSmall.Error;
-export const InsufficientFundsForMirError = TxSubmission.errors.InsufficientFundsForMir.Error;
-export const InsufficientGenesisSignaturesError = TxSubmission.errors.InsufficientGenesisSignatures.Error;
-export const InvalidMetadataError = TxSubmission.errors.InvalidMetadata.Error;
-export const InvalidWitnessesError = TxSubmission.errors.InvalidWitnesses.Error;
-export const MirNegativeTransferNotCurrentlyAllowedError =
-  TxSubmission.errors.MirNegativeTransferNotCurrentlyAllowed.Error;
-export const MirProducesNegativeUpdateError = TxSubmission.errors.MirProducesNegativeUpdate.Error;
-export const MirTransferNotCurrentlyAllowedError = TxSubmission.errors.MirTransferNotCurrentlyAllowed.Error;
-export const MissingAtLeastOneInputUtxoError = TxSubmission.errors.MissingAtLeastOneInputUtxo.Error;
-export const MissingCollateralInputsError = TxSubmission.errors.MissingCollateralInputs.Error;
-export const MissingDatumHashesForInputsError = TxSubmission.errors.MissingDatumHashesForInputs.Error;
-export const MissingRequiredDatumsError = TxSubmission.errors.MissingRequiredDatums.Error;
-export const MissingRequiredRedeemersError = TxSubmission.errors.MissingRequiredRedeemers.Error;
-export const MissingRequiredSignaturesError = TxSubmission.errors.MissingRequiredSignatures.Error;
-export const MissingScriptWitnessesError = TxSubmission.errors.MissingScriptWitnesses.Error;
-export const MissingTxMetadataError = TxSubmission.errors.MissingTxMetadata.Error;
-export const MissingTxMetadataHashError = TxSubmission.errors.MissingTxMetadataHash.Error;
-export const MissingVkWitnessesError = TxSubmission.errors.MissingVkWitnesses.Error;
-export const NetworkMismatchError = TxSubmission.errors.NetworkMismatch.Error;
-export const NonGenesisVotersError = TxSubmission.errors.NonGenesisVoters.Error;
-export const OutputTooSmallError = TxSubmission.errors.OutputTooSmall.Error;
-export const OutsideForecastError = TxSubmission.errors.OutsideForecast.Error;
-export const OutsideOfValidityIntervalError = TxSubmission.errors.OutsideOfValidityInterval.Error;
-export const PoolCostTooSmallError = TxSubmission.errors.PoolCostTooSmall.Error;
-export const PoolMetadataHashTooBigError = TxSubmission.errors.PoolMetadataHashTooBig.Error;
-export const ProtocolVersionCannotFollowError = TxSubmission.errors.ProtocolVersionCannotFollow.Error;
-export const RewardAccountNotEmptyError = TxSubmission.errors.RewardAccountNotEmpty.Error;
-export const RewardAccountNotExistingError = TxSubmission.errors.RewardAccountNotExisting.Error;
-export const ScriptWitnessNotValidatingError = TxSubmission.errors.ScriptWitnessNotValidating.Error;
-export const StakeKeyAlreadyRegisteredError = TxSubmission.errors.StakeKeyAlreadyRegistered.Error;
-export const StakeKeyNotRegisteredError = TxSubmission.errors.StakeKeyNotRegistered.Error;
-export const StakePoolNotRegisteredError = TxSubmission.errors.StakePoolNotRegistered.Error;
-export const TooLateForMirError = TxSubmission.errors.TooLateForMir.Error;
-export const TooManyAssetsInOutputError = TxSubmission.errors.TooManyAssetsInOutput.Error;
-export const TooManyCollateralInputsError = TxSubmission.errors.TooManyCollateralInputs.Error;
-export const TriesToForgeAdaError = TxSubmission.errors.TriesToForgeAda.Error;
-export const TxMetadataHashMismatchError = TxSubmission.errors.TxMetadataHashMismatch.Error;
-export const TxTooLargeError = TxSubmission.errors.TxTooLarge.Error;
-export const UnknownGenesisKeyError = TxSubmission.errors.UnknownGenesisKey.Error;
-export const UnknownOrIncompleteWithdrawalsError = TxSubmission.errors.UnknownOrIncompleteWithdrawals.Error;
-export const UnspendableDatumsError = TxSubmission.errors.UnspendableDatums.Error;
-export const UnspendableScriptInputsError = TxSubmission.errors.UnspendableScriptInputs.Error;
-export const UpdateWrongEpochError = TxSubmission.errors.UpdateWrongEpoch.Error;
-export const ValidationTagMismatchError = TxSubmission.errors.ValidationTagMismatch.Error;
-export const ValueNotConservedError = TxSubmission.errors.ValueNotConserved.Error;
-export const WrongCertificateTypeError = TxSubmission.errors.WrongCertificateType.Error;
-export const WrongPoolCertificateError = TxSubmission.errors.WrongPoolCertificate.Error;
-export const WrongRetirementEpochError = TxSubmission.errors.WrongRetirementEpoch.Error;
 export class UnknownTxSubmissionError extends CustomError {
   constructor(public innerError: unknown) {
     super('Unknown submission error. See "innerError".');
   }
 }
+
+export const TxSubmissionErrors = {
+  AddressAttributesTooLargeError: TxSubmission.errors.AddressAttributesTooLarge.Error,
+  AlreadyDelegatingError: TxSubmission.errors.AlreadyDelegating.Error,
+  BadInputsError: TxSubmission.errors.BadInputs.Error,
+  CollateralHasNonAdaAssetsError: TxSubmission.errors.CollateralHasNonAdaAssets.Error,
+  CollateralIsScriptError: TxSubmission.errors.CollateralIsScript.Error,
+  CollateralTooSmallError: TxSubmission.errors.CollateralTooSmall.Error,
+  CollectErrorsError: TxSubmission.errors.CollectErrors.Error,
+  DelegateNotRegisteredError: TxSubmission.errors.DelegateNotRegistered.Error,
+  DuplicateGenesisVrfError: TxSubmission.errors.DuplicateGenesisVrf.Error,
+  EraMismatchError: TxSubmission.errors.EraMismatch.Error,
+  ExecutionUnitsTooLargeError: TxSubmission.errors.ExecutionUnitsTooLarge.Error,
+  ExpiredUtxoError: TxSubmission.errors.ExpiredUtxo.Error,
+  ExtraDataMismatchError: TxSubmission.errors.ExtraDataMismatch.Error,
+  ExtraRedeemersError: TxSubmission.errors.ExtraRedeemers.Error,
+  FeeTooSmallError: TxSubmission.errors.FeeTooSmall.Error,
+  InsufficientFundsForMirError: TxSubmission.errors.InsufficientFundsForMir.Error,
+  InsufficientGenesisSignaturesError: TxSubmission.errors.InsufficientGenesisSignatures.Error,
+  InvalidMetadataError: TxSubmission.errors.InvalidMetadata.Error,
+  InvalidWitnessesError: TxSubmission.errors.InvalidWitnesses.Error,
+  MirNegativeTransferNotCurrentlyAllowedError: TxSubmission.errors.MirNegativeTransferNotCurrentlyAllowed.Error,
+  MirProducesNegativeUpdateError: TxSubmission.errors.MirProducesNegativeUpdate.Error,
+  MirTransferNotCurrentlyAllowedError: TxSubmission.errors.MirTransferNotCurrentlyAllowed.Error,
+  MissingAtLeastOneInputUtxoError: TxSubmission.errors.MissingAtLeastOneInputUtxo.Error,
+  MissingCollateralInputsError: TxSubmission.errors.MissingCollateralInputs.Error,
+  MissingDatumHashesForInputsError: TxSubmission.errors.MissingDatumHashesForInputs.Error,
+  MissingRequiredDatumsError: TxSubmission.errors.MissingRequiredDatums.Error,
+  MissingRequiredRedeemersError: TxSubmission.errors.MissingRequiredRedeemers.Error,
+  MissingRequiredSignaturesError: TxSubmission.errors.MissingRequiredSignatures.Error,
+  MissingScriptWitnessesError: TxSubmission.errors.MissingScriptWitnesses.Error,
+  MissingTxMetadataError: TxSubmission.errors.MissingTxMetadata.Error,
+  MissingTxMetadataHashError: TxSubmission.errors.MissingTxMetadataHash.Error,
+  MissingVkWitnessesError: TxSubmission.errors.MissingVkWitnesses.Error,
+  NetworkMismatchError: TxSubmission.errors.NetworkMismatch.Error,
+  NonGenesisVotersError: TxSubmission.errors.NonGenesisVoters.Error,
+  OutputTooSmallError: TxSubmission.errors.OutputTooSmall.Error,
+  OutsideForecastError: TxSubmission.errors.OutsideForecast.Error,
+  OutsideOfValidityIntervalError: TxSubmission.errors.OutsideOfValidityInterval.Error,
+  PoolCostTooSmallError: TxSubmission.errors.PoolCostTooSmall.Error,
+  PoolMetadataHashTooBigError: TxSubmission.errors.PoolMetadataHashTooBig.Error,
+  ProtocolVersionCannotFollowError: TxSubmission.errors.ProtocolVersionCannotFollow.Error,
+  RewardAccountNotEmptyError: TxSubmission.errors.RewardAccountNotEmpty.Error,
+  RewardAccountNotExistingError: TxSubmission.errors.RewardAccountNotExisting.Error,
+  ScriptWitnessNotValidatingError: TxSubmission.errors.ScriptWitnessNotValidating.Error,
+  StakeKeyAlreadyRegisteredError: TxSubmission.errors.StakeKeyAlreadyRegistered.Error,
+  StakeKeyNotRegisteredError: TxSubmission.errors.StakeKeyNotRegistered.Error,
+  StakePoolNotRegisteredError: TxSubmission.errors.StakePoolNotRegistered.Error,
+  TooLateForMirError: TxSubmission.errors.TooLateForMir.Error,
+  TooManyAssetsInOutputError: TxSubmission.errors.TooManyAssetsInOutput.Error,
+  TooManyCollateralInputsError: TxSubmission.errors.TooManyCollateralInputs.Error,
+  TriesToForgeAdaError: TxSubmission.errors.TriesToForgeAda.Error,
+  TxMetadataHashMismatchError: TxSubmission.errors.TxMetadataHashMismatch.Error,
+  TxTooLargeError: TxSubmission.errors.TxTooLarge.Error,
+  UnknownGenesisKeyError: TxSubmission.errors.UnknownGenesisKey.Error,
+  UnknownOrIncompleteWithdrawalsError: TxSubmission.errors.UnknownOrIncompleteWithdrawals.Error,
+  UnknownTxSubmissionError,
+  UnspendableDatumsError: TxSubmission.errors.UnspendableDatums.Error,
+  UnspendableScriptInputsError: TxSubmission.errors.UnspendableScriptInputs.Error,
+  UpdateWrongEpochError: TxSubmission.errors.UpdateWrongEpoch.Error,
+  ValidationTagMismatchError: TxSubmission.errors.ValidationTagMismatch.Error,
+  ValueNotConservedError: TxSubmission.errors.ValueNotConserved.Error,
+  WrongCertificateTypeError: TxSubmission.errors.WrongCertificateType.Error,
+  WrongPoolCertificateError: TxSubmission.errors.WrongPoolCertificate.Error,
+  WrongRetirementEpochError: TxSubmission.errors.WrongRetirementEpoch.Error
+};
+
+type TxSubmissionErrorName = keyof typeof TxSubmissionErrors;
+type TxSubmissionErrorClass = typeof TxSubmissionErrors[TxSubmissionErrorName];
+export type TxSubmissionError = InstanceType<TxSubmissionErrorClass>;

--- a/packages/core/src/Cardano/types/index.ts
+++ b/packages/core/src/Cardano/types/index.ts
@@ -1,5 +1,4 @@
 import * as Ogmios from '@cardano-ogmios/schema';
-import { CustomError } from 'ts-custom-error';
 import { util } from '../../util';
 
 export { Epoch, Slot, ExUnits } from '@cardano-ogmios/schema';
@@ -17,10 +16,8 @@ export * from './Block';
 export * from './Asset';
 export * from './AuxiliaryData';
 export * from './Key';
-export * as TxSubmissionErrors from './TxSubmissionErrors';
+export * from './TxSubmissionErrors';
 export * as NativeScriptType from './NativeScriptType';
-
-export type TxSubmissionError = CustomError;
 
 export type ProtocolParametersAlonzo = util.OptionalUndefined<
   util.RecursivelyReplaceNullWithUndefined<Ogmios.ProtocolParametersAlonzo>

--- a/packages/core/src/Cardano/util/index.ts
+++ b/packages/core/src/Cardano/util/index.ts
@@ -4,3 +4,4 @@ export * from './computeImplicitCoin';
 export * from './estimateStakePoolAPY';
 export * from './primitives';
 export * as metadatum from './metadatum';
+export * from './txSubmissionErrors';

--- a/packages/core/src/Cardano/util/txSubmissionErrors.ts
+++ b/packages/core/src/Cardano/util/txSubmissionErrors.ts
@@ -1,0 +1,26 @@
+import { TxSubmissionError, TxSubmissionErrors } from '../types';
+
+/**
+ * Tests the provided error for an instanceof match in the TxSubmissionErrors object
+ *
+ * @param {TxSubmissionError} error the error under test
+ */
+export const isTxSubmissionError = (error: unknown): error is TxSubmissionError =>
+  Object.values(TxSubmissionErrors).some((TxSubmitError) => error instanceof TxSubmitError);
+
+/**
+ * Attempts to convert the provided error or array of errors into TxSubmissionError object
+ *
+ * @param {any} error the error or array of errors under test
+ */
+export const asTxSubmissionError = (error: unknown): TxSubmissionError | null => {
+  if (Array.isArray(error)) {
+    for (const err of error) {
+      if (isTxSubmissionError(err)) {
+        return err;
+      }
+    }
+    return null;
+  }
+  return isTxSubmissionError(error) ? error : null;
+};

--- a/packages/core/src/Provider/Provider.ts
+++ b/packages/core/src/Provider/Provider.ts
@@ -1,4 +1,7 @@
 export interface Provider {
+  /**
+   * @throws ProviderError
+   */
   healthCheck(): Promise<{
     ok: boolean;
   }>;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -4,7 +4,8 @@ export enum ProviderFailure {
   NotFound = 'NOT_FOUND',
   Unknown = 'UNKNOWN',
   InvalidResponse = 'INVALID_RESPONSE',
-  NotImplemented = 'NOT_IMPLEMENTED'
+  NotImplemented = 'NOT_IMPLEMENTED',
+  Unhealthy = 'UNHEALTHY'
 }
 
 const formatMessage = (reason: string, detail?: string) => reason + (detail ? ` (${detail})` : '');

--- a/packages/core/test/Cardano/util/txSubmissionErrors.test.ts
+++ b/packages/core/test/Cardano/util/txSubmissionErrors.test.ts
@@ -1,0 +1,46 @@
+import { TxSubmissionError, TxSubmissionErrors, util } from '../../../src/Cardano';
+
+const badInputsError = new TxSubmissionErrors.BadInputsError({ badInputs: [] });
+const addressAttributesTooLargeError = new TxSubmissionErrors.AddressAttributesTooLargeError({
+  addressAttributesTooLarge: []
+});
+const someOtherError = new Error('some other error') as unknown as TxSubmissionError;
+const someString = 'some string' as unknown as TxSubmissionError;
+
+describe('txSubmissionErrors', () => {
+  describe('isTxSubmissionError', () => {
+    it('is true if the value is a tx submission error', () => {
+      expect(util.isTxSubmissionError(badInputsError)).toBe(true);
+    });
+
+    it('is false if a single generic error is not a tx submission error', () => {
+      expect(util.isTxSubmissionError(someOtherError)).toBe(false);
+    });
+
+    it('is false if a non-error value is passed', () => {
+      expect(util.isTxSubmissionError(someString)).toBe(false);
+    });
+  });
+
+  describe('hasTxSubmissionError', () => {
+    it('is true if the value is a tx submission error', () => {
+      expect(util.asTxSubmissionError(badInputsError)).toBeTruthy();
+    });
+
+    it('is false if a single generic error is not a tx submission error', () => {
+      expect(util.asTxSubmissionError(someOtherError)).toBe(null);
+    });
+
+    it('is false if a non-error value is passed', () => {
+      expect(util.asTxSubmissionError(someString)).toBe(null);
+    });
+
+    it('is true if all values in an array are tx submission error', () => {
+      expect(util.asTxSubmissionError([badInputsError, addressAttributesTooLargeError])).toBeTruthy();
+    });
+
+    it('is true if at least one value in an array is a tx submission error', () => {
+      expect(util.asTxSubmissionError([badInputsError, someOtherError])).toBeTruthy();
+    });
+  });
+});

--- a/packages/ogmios/src/ogmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/ogmiosTxSubmitProvider.ts
@@ -5,7 +5,6 @@ import {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   TxSubmission,
-  UnknownResultError,
   createConnectionObject,
   createInteractionContext,
   createTxSubmissionClient,
@@ -56,13 +55,7 @@ export const ogmiosTxSubmitProvider = (
       const txHex = Buffer.from(signedTransaction).toString('hex');
       return await txSubmissionClient.submitTx(txHex);
     } catch (error) {
-      // Ogmios throws an array of domain errors, or a single catch-all if the request is malformed.
-      // There's currently no utility to invert this logic to ensure other non-UnknownResultErrors are
-      // also re-thrown as the UnknownTxSubmissionError, but it's a minor issue we can improve on.
-      if (error instanceof UnknownResultError) {
-        throw new Cardano.TxSubmissionErrors.UnknownTxSubmissionError(error);
-      }
-      throw error;
+      throw Cardano.util.asTxSubmissionError(error) || new Cardano.TxSubmissionErrors.UnknownTxSubmissionError(error);
     }
   }
 });

--- a/packages/ogmios/test/ogmiosTxSubmitProvider.test.ts
+++ b/packages/ogmios/test/ogmiosTxSubmitProvider.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
+import { Cardano, ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
 import { Connection, createConnectionObject } from '@cardano-ogmios/client';
-import { ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
 import { createMockOgmiosServer } from './mocks/mockOgmiosServer';
-import { getPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import { ogmiosTxSubmitProvider } from '../src';
 import http from 'http';
 
@@ -29,7 +29,7 @@ describe('ogmiosTxSubmitProvider', () => {
   let provider: TxSubmitProvider;
 
   beforeAll(async () => {
-    connection = createConnectionObject({ port: await getPort() });
+    connection = createConnectionObject({ port: await getRandomPort() });
   });
   describe('healthCheck', () => {
     afterEach(async () => {
@@ -100,7 +100,7 @@ describe('ogmiosTxSubmitProvider', () => {
     });
 
     describe('failure', () => {
-      afterAll(async () => {
+      afterEach(async () => {
         await serverClosePromise(mockServer);
       });
 
@@ -110,12 +110,9 @@ describe('ogmiosTxSubmitProvider', () => {
         });
         await listenPromise(mockServer, connection.port);
         provider = ogmiosTxSubmitProvider(connection);
-
-        try {
-          await provider.submitTx(new Uint8Array());
-        } catch (error: any) {
-          expect(error[0].name).toBe('EraMismatchError');
-        }
+        await expect(provider.submitTx(new Uint8Array())).rejects.toThrowError(
+          Cardano.TxSubmissionErrors.EraMismatchError
+        );
       });
     });
   });

--- a/packages/wallet/.env.example
+++ b/packages/wallet/.env.example
@@ -10,3 +10,4 @@ WALLET_PASSWORD=some_password
 POOL_ID_1=pool1euf2nh92ehqfw7rpd4s9qgq34z8dg4pvfqhjmhggmzk95gcd402
 POOL_ID_2=pool1fghrkl620rl3g54ezv56weeuwlyce2tdannm2hphs62syf3vyyh
 OGMIOS_URL=ws://localhost:1337
+LOGGER_MIN_SEVERITY=debug

--- a/packages/wallet/.env.example
+++ b/packages/wallet/.env.example
@@ -1,4 +1,5 @@
 TX_SUBMIT_PROVIDER=blockfrost
+TX_SUBMIT_HTTP_URL=http://localhost:3000
 WALLET_PROVIDER=blockfrost
 STAKE_POOL_SEARCH_PROVIDER=stub
 TIME_SETTINGS_PROVIDER=stub_testnet
@@ -8,6 +9,4 @@ MNEMONIC_WORDS="actor scout worth mansion thumb device mass pave gospel secret h
 WALLET_PASSWORD=some_password
 POOL_ID_1=pool1euf2nh92ehqfw7rpd4s9qgq34z8dg4pvfqhjmhggmzk95gcd402
 POOL_ID_2=pool1fghrkl620rl3g54ezv56weeuwlyce2tdannm2hphs62syf3vyyh
-OGMIOS_HOST=localhost
-OGMIOS_PORT=1337
-OGMIOS_TLS=0
+OGMIOS_URL=ws://localhost:1337

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -27,6 +27,7 @@
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {
+    "@cardano-sdk/cardano-graphql": " 0.2.0",
     "@cardano-sdk/util-dev": " 0.2.0",
     "@cardano-sdk/ogmios": " 0.2.0",
     "@types/node-hid": "1.3.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -27,22 +27,23 @@
     "test:debug": "DEBUG=true yarn test"
   },
   "devDependencies": {
+    "@cardano-ogmios/client": "^5.2.0",
     "@cardano-sdk/cardano-graphql": " 0.2.0",
-    "@cardano-sdk/util-dev": " 0.2.0",
     "@cardano-sdk/ogmios": " 0.2.0",
-    "@types/node-hid": "1.3.1",
-    "@types/pbkdf2": "^3.1.0",
-    "@types/w3c-web-hid": "^1.0.2",
+    "@cardano-sdk/util-dev": " 0.2.0",
     "@types/node-hid": "^1.3.1",
+    "@types/pbkdf2": "^3.1.0",
     "@types/pouchdb": "^6.4.0",
+    "@types/w3c-web-hid": "^1.0.2",
+    "bunyan": "^1.8.15",
     "envalid": "^7.3.0",
-    "shx": "^0.3.3"
+    "shx": "^0.3.3",
+    "wait-on": "^6.0.1"
   },
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "4.0.0",
     "@cardano-sdk/cip2": " 0.2.0",
     "@cardano-sdk/core": " 0.2.0",
-    "@ledgerhq/hw-transport-webhid": "6.24.1",
     "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.24.1",
     "@ledgerhq/hw-transport-webhid": "6.24.1",

--- a/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
@@ -70,12 +70,12 @@ describe('SingleAddressWallet/delegation', () => {
     wallet = new SingleAddressWallet(
       { name: 'Test Wallet' },
       {
-        assetProvider,
+        assetProvider: await assetProvider,
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
         timeSettingsProvider,
-        txSubmitProvider,
-        walletProvider
+        txSubmitProvider: await txSubmitProvider,
+        walletProvider: await walletProvider
       }
     );
     [{ rewardAccount }] = await firstValueFrom(wallet.addresses$);

--- a/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
@@ -18,12 +18,12 @@ describe('SingleAddressWallet/metadata', () => {
     wallet = new SingleAddressWallet(
       { name: 'Test Wallet' },
       {
-        assetProvider,
+        assetProvider: await assetProvider,
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
         timeSettingsProvider,
-        txSubmitProvider,
-        walletProvider
+        txSubmitProvider: await txSubmitProvider,
+        walletProvider: await walletProvider
       }
     );
     ownAddress = (await firstValueFrom(wallet.addresses$))[0].address;

--- a/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
@@ -38,12 +38,12 @@ describe('SingleAddressWallet.assets/nft', () => {
         name: 'Test Wallet'
       },
       {
-        assetProvider,
+        assetProvider: await assetProvider,
         keyAgent,
         stakePoolSearchProvider,
         timeSettingsProvider,
-        txSubmitProvider,
-        walletProvider
+        txSubmitProvider: await txSubmitProvider,
+        walletProvider: await walletProvider
       }
     );
   });

--- a/packages/wallet/test/e2e/SingleAddressWallet/pouchdbWalletStores.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/pouchdbWalletStores.test.ts
@@ -26,13 +26,13 @@ describe('SingleAddressWallet/pouchdbWalletStores', () => {
     new SingleAddressWallet(
       { name: walletName },
       {
-        assetProvider,
+        assetProvider: await assetProvider,
         keyAgent: await keyAgentReady,
         stakePoolSearchProvider,
         stores,
         timeSettingsProvider,
-        txSubmitProvider,
-        walletProvider
+        txSubmitProvider: await txSubmitProvider,
+        walletProvider: await walletProvider
       }
     );
 

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -85,7 +85,7 @@ export const txSubmitProvider = (async () => {
     case 'ogmios': {
       logger.debug('TxSubmitProvider:ogmios - Initializing');
       const connectionConfig = {
-        host: ogmiosUrl.host,
+        host: ogmiosUrl.hostname,
         port: ogmiosUrl.port ? Number.parseInt(ogmiosUrl.port) : undefined,
         tls: ogmiosUrl?.protocol === 'wss'
       };

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as envalid from 'envalid';
 import {
   BlockFrostAPI,
@@ -7,11 +8,16 @@ import {
 } from '@cardano-sdk/blockfrost';
 import { Cardano, testnetTimeSettings } from '@cardano-sdk/core';
 import { InMemoryKeyAgent } from '../../src/KeyManagement';
+import { LogLevel, createLogger } from 'bunyan';
+import { Logger } from 'ts-log';
 import { URL } from 'url';
+import { createConnectionObject } from '@cardano-ogmios/client';
 import { createStubStakePoolSearchProvider, createStubTimeSettingsProvider } from '@cardano-sdk/util-dev';
 import { ogmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
 import { txSubmitHttpProvider } from '@cardano-sdk/cardano-graphql';
+import waitOn from 'wait-on';
 
+const loggerMethodNames = ['debug', 'error', 'fatal', 'info', 'trace', 'warn'] as (keyof Logger)[];
 const networkIdOptions = [0, 1];
 const stakePoolSearchProviderOptions = ['stub'];
 const timeSettingsProviderOptions = ['stub_testnet'];
@@ -20,6 +26,7 @@ const walletProviderOptions = ['blockfrost'];
 
 const env = envalid.cleanEnv(process.env, {
   BLOCKFROST_API_KEY: envalid.str(),
+  LOGGER_MIN_SEVERITY: envalid.str({ choices: loggerMethodNames as string[], default: 'info' }),
   MNEMONIC_WORDS: envalid.makeValidator<string[]>((input) => {
     const words = input.split(' ');
     if (words.length === 0) throw new Error('MNEMONIC_WORDS not set');
@@ -38,35 +45,65 @@ const env = envalid.cleanEnv(process.env, {
 });
 const isTestnet = env.NETWORK_ID === 0;
 
-export const walletProvider = (() => {
+const logger = createLogger({
+  level: env.LOGGER_MIN_SEVERITY as LogLevel,
+  name: 'wallet e2e tests'
+});
+
+const waitOnBlockfrost = (blockfrost: BlockFrostAPI) =>
+  waitOn({ resources: [blockfrost.apiUrl], validateStatus: (status) => status === 403 });
+
+export const walletProvider = (async () => {
   if (env.WALLET_PROVIDER === 'blockfrost') {
+    logger.debug('WalletProvider:blockfrost - Initializing');
     const blockfrost = new BlockFrostAPI({ isTestnet, projectId: env.BLOCKFROST_API_KEY });
+    await waitOnBlockfrost(blockfrost);
+    logger.debug('WalletProvider:blockfrost - Responding');
     return blockfrostWalletProvider(blockfrost);
   }
   throw new Error(`WALLET_PROVIDER unsupported: ${env.WALLET_PROVIDER}`);
 })();
 
-export const assetProvider = (() => {
+export const assetProvider = (async () => {
   const blockfrost = new BlockFrostAPI({ isTestnet, projectId: env.BLOCKFROST_API_KEY });
+  logger.debug('AssetProvider:blockfrost - Initializing');
+  await waitOnBlockfrost(blockfrost);
+  logger.debug('AssetProvider:blockfrost - Responding');
   return blockfrostAssetProvider(blockfrost);
 })();
 
-export const txSubmitProvider = (() => {
+export const txSubmitProvider = (async () => {
   const ogmiosUrl = new URL(env.OGMIOS_URL);
   switch (env.TX_SUBMIT_PROVIDER) {
     case 'blockfrost': {
+      logger.debug('TxSubmitProvider:blockfrost - Initializing');
       const blockfrost = new BlockFrostAPI({ isTestnet, projectId: env.BLOCKFROST_API_KEY });
+      await waitOnBlockfrost(blockfrost);
+      logger.debug('TxSubmitProvider:blockfrost - Responding');
       return blockfrostTxSubmitProvider(blockfrost);
     }
     case 'ogmios': {
-      return ogmiosTxSubmitProvider({
+      logger.debug('TxSubmitProvider:ogmios - Initializing');
+      const connectionConfig = {
         host: ogmiosUrl.host,
         port: ogmiosUrl.port ? Number.parseInt(ogmiosUrl.port) : undefined,
         tls: ogmiosUrl?.protocol === 'wss'
+      };
+      const connection = createConnectionObject(connectionConfig);
+      const provider = ogmiosTxSubmitProvider(connectionConfig);
+      await waitOn({
+        resources: [connection.address.http],
+        validateStatus: (status) => status === 404
       });
+      logger.debug('TxSubmitProvider:ogmios - Responding');
+      return provider;
     }
     case 'http': {
-      return txSubmitHttpProvider({ url: env.TX_SUBMIT_HTTP_URL });
+      logger.debug('TxSubmitProvider:http - Initializing');
+      const provider = await txSubmitHttpProvider({ url: env.TX_SUBMIT_HTTP_URL });
+      await waitOn({ resources: [`${env.TX_SUBMIT_HTTP_URL}/health`] });
+      logger.debug('TxSubmitProvider:http - Responding');
+      return provider;
     }
     default: {
       throw new Error(`TX_SUBMIT_PROVIDER unsupported: ${env.TX_SUBMIT_PROVIDER}`);

--- a/packages/wallet/test/tsconfig.json
+++ b/packages/wallet/test/tsconfig.json
@@ -8,6 +8,7 @@
     { "path": "../../util-dev/src" },
     { "path": "../../cip2/src" },
     { "path": "../../core/src" },
+    { "path": "../../cardano-graphql/src" },
     { "path": "../../ogmios/src" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -654,6 +654,21 @@
     ts-custom-error "^3.2.0"
     ws "^7.4.6"
 
+"@cardano-ogmios/client@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@cardano-ogmios/client/-/client-5.2.0.tgz#f15ef9a66878848904a3c34c98517d7426bf5543"
+  integrity sha512-HZyrOXbbOICI4EnnBYTRCxOxLyXGfs1Y884Rz7T2e1ES4dA8YtOfTwcRWhwZUEfzHBj0QCRap6lvcoc4lcP0qQ==
+  dependencies:
+    "@cardano-ogmios/schema" "5.2.0"
+    "@cardanosolutions/json-bigint" "^1.0.0"
+    "@types/json-bigint" "^1.0.1"
+    cross-fetch "^3.1.4"
+    fastq "^1.11.0"
+    isomorphic-ws "^4.0.1"
+    nanoid "^3.1.31"
+    ts-custom-error "^3.2.0"
+    ws "^7.4.6"
+
 "@cardano-ogmios/schema@4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@cardano-ogmios/schema/-/schema-4.1.0.tgz#d0fb5823d71fd7741801f56880a3fedbc43be081"
@@ -663,6 +678,11 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@cardano-ogmios/schema/-/schema-5.1.0.tgz#8b6095675c15909e5253712bf758e5001677a2e3"
   integrity sha512-xxke4wNhtRUv42meo69cK0+PraFcpDx3d+SDdtUSjUvKpQVbfuZKgkp+y30nuP6Al6qJ6qiS/wI8WM5bdNKzzg==
+
+"@cardano-ogmios/schema@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@cardano-ogmios/schema/-/schema-5.2.0.tgz#2877c552cbec7c26245a26dd75bcf2fe9aee21aa"
+  integrity sha512-4Ouhy3wrG/Qxi8VPig6UJZ13LRm4aCuy7kyiEHmAll83TCEnMTJwjdIOJIfhv7OO62dWsYi1LjgkK+FWy9yvKg==
 
 "@cardanosolutions/json-bigint@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1696,6 +1696,27 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+<<<<<<< HEAD
+=======
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/cacheable-request@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
+  integrity sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 "@types/cli-progress@^3.9.2":
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.9.2.tgz#6ca355f96268af39bee9f9307f0ac96145639c26"
@@ -1703,7 +1724,18 @@
   dependencies:
     "@types/node" "*"
 
+<<<<<<< HEAD
 "@types/debug@*":
+=======
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/debug@*", "@types/debug@^4.1.4":
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -1717,6 +1749,33 @@
   dependencies:
     "@types/node" "*"
 
+<<<<<<< HEAD
+=======
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.28"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
+  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@^4.17.13":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
+  integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/flat-cache@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/flat-cache/-/flat-cache-2.0.0.tgz#64e5d3b426c392b603a208a55bdcc7d920ce6e57"
+  integrity sha512-fHeEsm9hvmZ+QHpw6Fkvf19KIhuqnYLU6vtWLjd5BsMd/qVi7iTkMioDZl0mQmfNRA1A6NwvhrSRNr9hGYZGww==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 "@types/fs-extra@^9.0.12":
   version "9.0.13"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
@@ -1817,7 +1876,16 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
   integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==
 
+<<<<<<< HEAD
 "@types/minimatch@*":
+=======
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
@@ -2028,14 +2096,55 @@
     "@types/pouchdb-replication" "*"
 
 "@types/prettier@^2.1.5":
+<<<<<<< HEAD
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
   integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
+=======
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
+  integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/sarif@^2.1.3":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.4.tgz#471c5788199d22f572f255de9a8166a30abf1245"
+  integrity sha512-4xKHMdg3foh3Va1fxTzY1qt8QVqmaJpGWsVvtjQrJBn+/bkig2pWFKJ4FPI2yLI4PAj0SUKiPO4Vd7ggYIMZjQ==
+
+"@types/semver@^7.1.0":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
+  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 
 "@types/semver@^7.3.3":
   version "7.3.9"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
   integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
+"@types/serve-static@*":
+  version "1.13.10"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
+  integrity sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -2223,6 +2332,14 @@ abstract-leveldown@~6.2.1, abstract-leveldown@~6.2.3:
     level-concat-iterator "~2.0.0"
     level-supports "~1.0.0"
     xtend "~4.0.0"
+
+accepts@~1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
+  integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
+  dependencies:
+    mime-types "~2.1.34"
+    negotiator "0.6.3"
 
 acorn-globals@^3.1.0:
   version "3.1.0"
@@ -2417,6 +2534,11 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -2738,6 +2860,35 @@ blake2b@2.1.3:
     blake2b-wasm "^1.1.0"
     nanoassert "^1.0.0"
 
+<<<<<<< HEAD
+=======
+body-parser@1.19.2, body-parser@^1.19.2:
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
+  integrity sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.9.7"
+    raw-body "2.4.3"
+    type-is "~1.6.18"
+
+boolean@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.2.tgz#e30f210a26b02458482a8cc353ab06f262a780c2"
+  integrity sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==
+
+bottleneck@2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2819,6 +2970,19 @@ builtin-modules@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
+<<<<<<< HEAD
+=======
+bytes@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
+  integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
+
+cacheable-lookup@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
+  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -2832,6 +2996,22 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
+<<<<<<< HEAD
+=======
+cacheable-request@^7.0.1, cacheable-request@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
+  integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^6.0.1"
+    responselike "^2.0.0"
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -3243,10 +3423,22 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
+content-disposition@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
 content-type-parser@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
   integrity sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==
+
+content-type@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
 conventional-changelog-angular@^5.0.11:
   version "5.0.13"
@@ -3283,6 +3475,16 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
+
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
+
+cookie@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-js@^3.2.1:
   version "3.21.1"
@@ -3444,6 +3646,7 @@ debounce@^1.2.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
+<<<<<<< HEAD
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -3459,6 +3662,30 @@ debug@^2.6.9:
     ms "2.0.0"
 
 debug@^3.2.7:
+=======
+debug@2.6.9, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -3559,10 +3786,20 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
 dependency-graph@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
   integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
+
+destroy@~1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
 detect-indent@^6.0.0:
   version "6.1.0"
@@ -3689,10 +3926,27 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
+<<<<<<< HEAD
 electron-to-chromium@^1.4.84:
   version "1.4.89"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.89.tgz#33c06592812a17a7131873f4596579084ce33ff8"
   integrity sha512-z1Axg0Fu54fse8wN4fd+GAINdU5mJmLtcl6bqIcYyzNVGONcfHAeeJi88KYMQVKalhXlYuVPzKkFIU5VD0raUw==
+=======
+ee-first@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+electron-to-chromium@^1.3.723:
+  version "1.3.778"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.778.tgz#bf01048736c95b78f2988e88005e0ebb385942a4"
+  integrity sha512-Lw04qJaPtWdq0d7qKHJTgkam+FhFi3hm/scf1EyqJWdjO3ZIGUJhNmZJRXWb7yb/bRYXQyVGSpa9RqVpjjWMQw==
+
+electron-to-chromium@^1.4.76:
+  version "1.4.81"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.81.tgz#a9ce8997232fb9fb0ec53de8931a85b18c0a7383"
+  integrity sha512-Gs7xVpIZ7tYYSDA+WgpzwpPvfGwUk3KSIjJ0akuj5XQHFdyQnsUoM76EA4CIHXNLPiVwTwOFay9RMb0ChG3OBw==
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3718,6 +3972,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+encodeurl@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
 encoding-down@^6.3.0:
   version "6.3.0"
@@ -3810,6 +4069,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-html@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -4142,6 +4406,21 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+<<<<<<< HEAD
+=======
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+event-loop-spinner@^2.0.0, event-loop-spinner@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/event-loop-spinner/-/event-loop-spinner-2.1.0.tgz#75f501d585105c6d57f174073b39af1b6b3a1567"
+  integrity sha512-RJ10wL8/F9AlfBgRCvYctJIXSb9XkVmSCK3GGUvPD3dJrvTjDeDT0tmhcbEC6I2NEjNM9xD38HQJ4F/f/gb4VQ==
+  dependencies:
+    tslib "^2.1.0"
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -4219,6 +4498,42 @@ expect@^27.5.1:
     jest-get-type "^27.5.1"
     jest-matcher-utils "^27.5.1"
     jest-message-util "^27.5.1"
+
+express@^4.17.3:
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.17.3.tgz#f6c7302194a4fb54271b73a1fe7a06478c8f85a1"
+  integrity sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.19.2"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.4.2"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~1.1.2"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "~1.1.2"
+    fresh "0.5.2"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.7"
+    qs "6.9.7"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.17.2"
+    serve-static "1.14.2"
+    setprototypeof "1.2.0"
+    statuses "~1.5.0"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 extend@~3.0.2:
   version "3.0.2"
@@ -4372,7 +4687,24 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+<<<<<<< HEAD
 find-up@^2.1.0:
+=======
+finalhandler@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
+  integrity sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.3"
+    statuses "~1.5.0"
+    unpipe "~1.0.0"
+
+find-up@^2.0.0, find-up@^2.1.0:
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
@@ -4457,6 +4789,16 @@ formdata-node@^4.3.1:
   dependencies:
     node-domexception "1.0.0"
     web-streams-polyfill "4.0.0-beta.1"
+
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
 from2@^2.3.0:
   version "2.3.0"
@@ -4690,6 +5032,43 @@ globby@^11.0.3, globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+<<<<<<< HEAD
+=======
+got@11.8.2, got@^11.7.0:
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
+  integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.1"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
+got@^11:
+  version "11.8.3"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.3.tgz#f496c8fdda5d729a90b4905d2b07dbd148170770"
+  integrity sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -4938,6 +5317,17 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+http-errors@1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.1"
+
 http-proxy-agent@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
@@ -5146,6 +5536,11 @@ invariant@^2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -6641,6 +7036,11 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -6663,6 +7063,11 @@ meow@^8.0.0:
     type-fest "^0.18.0"
     yargs-parser "^20.2.3"
 
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -6678,7 +7083,24 @@ meros@^1.1.4:
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.2.0.tgz#096cdede2eb0b1610b219b1031b935260de1ad08"
   integrity sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==
 
+<<<<<<< HEAD
 micromatch@^4.0.4:
+=======
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
+micromatch@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
+
+micromatch@^4.0.2, micromatch@^4.0.4:
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -6691,12 +7113,41 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+<<<<<<< HEAD
 mime-types@^2.1.12, mime-types@~2.1.19:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+=======
+mime-db@1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
+  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
+  dependencies:
+    mime-db "1.52.0"
+
+mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -6786,7 +7237,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -6839,6 +7290,32 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+<<<<<<< HEAD
+=======
+needle@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
+  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
+needle@^2.3.3, needle@^2.5.0, needle@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.8.0.tgz#1c8ef9c1a2c29dcc1e83d73809d7bc681c80a048"
+  integrity sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
+negotiator@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
+  integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
@@ -7049,6 +7526,13 @@ object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+
+on-finished@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
+  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
+  dependencies:
+    ee-first "1.1.1"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -7275,6 +7759,11 @@ parse5@^1.5.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
   integrity sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=
 
+parseurl@~1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
+  integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
 pascal-case@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
@@ -7332,6 +7821,11 @@ path-root@^0.1.1:
   integrity sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=
   dependencies:
     path-root-regex "^0.1.0"
+
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -7570,6 +8064,22 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+<<<<<<< HEAD
+=======
+proxy-addr@~2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
+
+proxy-from-env@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -7603,6 +8113,11 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
+
 qs@~6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
@@ -7624,6 +8139,21 @@ randombytes@^2.0.1:
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+range-parser@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
+  integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+raw-body@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.3.tgz#8f80305d11c2a0a545c2d9d89d7a0286fcead43c"
+  integrity sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==
+  dependencies:
+    bytes "3.1.2"
+    http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
 
 rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
@@ -7993,7 +8523,18 @@ rxjs@^7.4.0, rxjs@^7.5.1, rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
+<<<<<<< HEAD
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+=======
+rxjs@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
+  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+  dependencies:
+    tslib "~2.1.0"
+
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -8054,6 +8595,25 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+send@0.17.2:
+  version "0.17.2"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.17.2.tgz#926622f76601c41808012c8bf1688fe3906f7820"
+  integrity sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==
+  dependencies:
+    debug "2.6.9"
+    depd "~1.1.2"
+    destroy "~1.0.4"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "1.8.1"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "~2.3.0"
+    range-parser "~1.2.1"
+    statuses "~1.5.0"
+
 sentence-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
@@ -8063,6 +8623,26 @@ sentence-case@^3.0.4:
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
 
+<<<<<<< HEAD
+=======
+serialize-error@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-7.0.1.tgz#f1360b0447f61ffb483ec4157c737fab7d778e18"
+  integrity sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==
+  dependencies:
+    type-fest "^0.13.1"
+
+serve-static@1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.2.tgz#722d6294b1d62626d41b43a013ece4598d292bfa"
+  integrity sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.2"
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -8072,6 +8652,11 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
+
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
@@ -8310,6 +8895,19 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+<<<<<<< HEAD
+=======
+"statuses@>= 1.5.0 < 2", statuses@~1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
+
+stream-buffers@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-3.0.2.tgz#5249005a8d5c2d00b3a32e6e0a6ea209dc4f3521"
+  integrity sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 stream-meter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/stream-meter/-/stream-meter-1.0.4.tgz#52af95aa5ea760a2491716704dbff90f73afdd1d"
@@ -8691,6 +9289,19 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+<<<<<<< HEAD
+=======
+toidentifier@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
+  integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+toml@3.0.0, toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 tough-cookie@^2.3.2, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -8908,6 +9519,14 @@ type-graphql@~1.1.1:
     semver "^7.3.2"
     tslib "^2.0.1"
 
+type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -8986,6 +9605,19 @@ unixify@^1.0.0:
   dependencies:
     normalize-path "^2.1.1"
 
+<<<<<<< HEAD
+=======
+unpipe@1.0.0, unpipe@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+upath@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
+  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
+
+>>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 upper-case-first@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
@@ -9023,6 +9655,11 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+utils-merge@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
 uuid@8.1.0:
   version "8.1.0"
@@ -9075,6 +9712,11 @@ value-or-promise@1.0.11, value-or-promise@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.11.tgz#3e90299af31dd014fe843fe309cefa7c1d94b140"
   integrity sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==
+
+vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 verror@1.10.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,6 +1262,18 @@
     tslib "~2.3.0"
     value-or-promise "1.0.11"
 
+"@hapi/hoek@^9.0.0":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
+  integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1607,6 +1619,23 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sideway/address@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
+  integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1706,6 +1735,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/bunyan@^1.8.8":
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.8.tgz#8d6d33f090f37c07e2a80af30ae728450a101008"
+  integrity sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==
+  dependencies:
+    "@types/node" "*"
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
@@ -1733,6 +1769,11 @@
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
+
+"@types/death@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/death/-/death-1.1.2.tgz#72a37216b23ff7f5b537b17de127c08fd619f478"
+  integrity sha512-Rr5NV/H/zj6zgbh6TCwMEe0NhCVS2QbAor0pikvzGx5fh+xsnmV3KUEq2Vb4vgi9ytBHorva+ryQmij2rrstTQ==
 
 "@types/debug@*", "@types/debug@^4.1.4":
 >>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
@@ -2170,6 +2211,13 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@types/w3c-web-hid/-/w3c-web-hid-1.0.3.tgz#e08587a7d737f8654ea6bc0a88689ce5d3ce2d19"
   integrity sha512-eTQRkPd2JukZfS9+kRtrBAaTCCb6waGh5X8BJHmH1MiVQPLMYwm4+EvhwFfOo9SDna15o9dFAwmWwN6r/YM53A==
+
+"@types/wait-on@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@types/wait-on/-/wait-on-5.3.1.tgz#bc5520d1d8b90b9caab1bef23315685ded73320d"
+  integrity sha512-2FFOKCF/YydrMUaqg+fkk49qf0e5rDgwt6aQsMzFQzbS419h2gNOXyiwp/o2yYy27bi/C1z+HgfncryjGzlvgQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/webextension-polyfill@^0.8.0":
   version "0.8.2"
@@ -2629,6 +2677,13 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
+axios@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
+  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+  dependencies:
+    follow-redirects "^1.14.7"
+
 babel-eslint@10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
@@ -2971,7 +3026,20 @@ builtin-modules@^3.0.0:
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+bunyan@^1.8.15:
+  version "1.8.15"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
+  integrity sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.19.3"
+    mv "~2"
+    safe-json-stringify "~1"
+
+>>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -3070,6 +3138,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+cbor@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
 
 chacha-native@^2.0.0:
   version "2.0.3"
@@ -3391,7 +3466,21 @@ comment-parser@1.2.4:
   resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.4.tgz#489f3ee55dfd184a6e4bffb31baba284453cb760"
   integrity sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==
 
+<<<<<<< HEAD
 common-tags@1.8.2, common-tags@^1.8.0:
+=======
+commander@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.1.0.tgz#a6b263b2327f2e188c6402c42623327909f2dbec"
+  integrity sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==
+
+comment-parser@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.3.tgz#303a7eb99c9b2632efd594e183ccbd32042caf69"
+  integrity sha512-vnqDwBSXSsdAkGS5NjwMIPelE47q+UkEgWKHvCDNhVIIaQSUFY6sNnEYGzdoPGMdpV+7KR3ZkRd7oyWIjtuvJg==
+
+common-tags@1.8.2:
+>>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
@@ -3641,6 +3730,11 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
+death@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/death/-/death-1.1.0.tgz#01aa9c401edd92750514470b8266390c66c67318"
+  integrity sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg=
+
 debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
@@ -3691,6 +3785,13 @@ debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -3898,6 +3999,13 @@ dset@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.1.tgz#07de5af7a8d03eab337ad1a8ba77fe17bba61a8c"
   integrity sha512-hYf+jZNNqJBD2GiMYb+5mqOIX4R4RRHXU3qWMWYN+rqcR2/YpRL2bUHr8C8fU+5DNvqYjJ8YvMGSLuVPWU1cNg==
+
+dtrace-provider@~0.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
+  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  dependencies:
+    nan "^2.14.0"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -4745,6 +4853,11 @@ follow-redirects@^1.14.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+follow-redirects@^1.14.7:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -4980,6 +5093,17 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
   version "7.2.0"
@@ -6290,6 +6414,17 @@ jest@^27.5.0:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
+joi@^17.6.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -7181,7 +7316,18 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+<<<<<<< HEAD
 minimatch@3.0.4:
+=======
+"minimatch@2 || 3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
+>>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -7214,7 +7360,18 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
+<<<<<<< HEAD
 mkdirp@^1.0.4:
+=======
+mkdirp@^0.5.1, mkdirp@~0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
+
+mkdirp@^1.0.3, mkdirp@^1.0.4:
+>>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -7226,6 +7383,11 @@ mock-browser@^0.92.14:
   dependencies:
     jsdom "^9.12.0"
     lodash "^4.5"
+
+moment@^2.19.3:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 ms@2.0.0:
   version "2.0.0"
@@ -7260,7 +7422,16 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.4.0:
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.14.0, nan@^2.4.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
@@ -7291,7 +7462,15 @@ natural-compare@^1.4.0:
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
+=======
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
+
+>>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
 needle@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
@@ -7387,6 +7566,27 @@ node-releases@^2.0.2:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
 
+<<<<<<< HEAD
+=======
+node.extend@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node.extend/-/node.extend-2.0.2.tgz#b4404525494acc99740f3703c496b7d5182cc6cc"
+  integrity sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==
+  dependencies:
+    has "^1.0.3"
+    is "^3.2.1"
+
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
+
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
+  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
+
+>>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -8489,6 +8689,13 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -8533,6 +8740,13 @@ rxjs@^7.4.0:
   dependencies:
     tslib "~2.1.0"
 
+rxjs@^7.5.4:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
 >>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "5.2.1"
@@ -8543,6 +8757,11 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
 safe-regex@^2.1.1:
   version "2.1.1"
@@ -8631,6 +8850,13 @@ serialize-error@^7.0.1:
   integrity sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==
   dependencies:
     type-fest "^0.13.1"
+
+serialize-error@^8:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
+  integrity sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==
+  dependencies:
+    type-fest "^0.20.2"
 
 serve-static@1.14.2:
   version "1.14.2"
@@ -9755,6 +9981,17 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
+
+wait-on@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.1.tgz#16bbc4d1e4ebdd41c5b4e63a2e16dbd1f4e5601e"
+  integrity sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==
+  dependencies:
+    axios "^0.25.0"
+    joi "^17.6.0"
+    lodash "^4.17.21"
+    minimist "^1.2.5"
+    rxjs "^7.5.4"
 
 walker@^1.0.7:
   version "1.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,129 +1043,129 @@
     tslib "~2.3.0"
 
 "@graphql-tools/apollo-engine-loader@^7.0.5":
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.2.4.tgz#b40d001a7f969eb8bf57dc38f66e3ac7c641f9f1"
-  integrity sha512-z7ToKpymqyRRGr2c6x824KTMntxxZaZxinY+kRx67DK/HkXPKr9hLWIjKX4LiRJcMMc/yX85aVXV21l2pGBhvQ==
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-7.2.6.tgz#7194a90e6f57eeb43ed4b908c950aaa19257830c"
+  integrity sha512-QuLiN34syxAtLGrIbkuKP0YGkm5uyly9zAjuG+i+Ae2roZk96qvmz4hf1XUSrf+muzs3IHrcGW+kF43mFyCxag==
   dependencies:
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/utils" "8.6.5"
     cross-undici-fetch "^0.1.19"
     sync-fetch "0.3.1"
     tslib "~2.3.0"
 
-"@graphql-tools/batch-execute@8.3.3":
-  version "8.3.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.3.3.tgz#71088500d5d4865d3530cc15921cc106c41602b1"
-  integrity sha512-22q/uCMUf+z3EWoM3ZM6DopDBGkni2TsfUb/mJIysunh5u8btAuXeju++De7RFwwUw+awdJXfunFQJG+OoH5Dg==
+"@graphql-tools/batch-execute@8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-execute/-/batch-execute-8.4.1.tgz#bc5e96ad22c545676da523bae3c3dc94e57bdf3e"
+  integrity sha512-63+lNWrwXmofjZVa7ML+n9CBviClF3K+RP3Xx3hxGQ8BrhvB1pWS1yzaUZqrkiiKdTu1v3mJGVfmooHwzlyPwQ==
   dependencies:
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/utils" "8.6.5"
     dataloader "2.0.0"
     tslib "~2.3.0"
     value-or-promise "1.0.11"
 
 "@graphql-tools/code-file-loader@^7.0.6":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.2.5.tgz#47b4c1a688dca1b31eef6bc4e9c41f91e8e0a3c4"
-  integrity sha512-3pj10/qyQxjfkweOVUEYYhTRfpMxj/cAgJScurTwRiPPBl/t+9rhSCAmr9f0LYljXP+Qo+k8btW/ru0vyyeLHg==
+  version "7.2.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-7.2.7.tgz#9a1a1979992967abef2d9419771b9fc5ee7f68e7"
+  integrity sha512-bJ1nt0eOIlaNvp1Gi488xR3gLxuIWGGzppLgAhuU22TWhLG4TOixvYa7oCNX04H1EmLZw0n51jS9Y2tdP5yp0w==
   dependencies:
-    "@graphql-tools/graphql-tag-pluck" "7.1.7"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/graphql-tag-pluck" "7.1.9"
+    "@graphql-tools/utils" "8.6.5"
     globby "^11.0.3"
     tslib "~2.3.0"
     unixify "^1.0.0"
 
-"@graphql-tools/delegate@8.5.4":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-8.5.4.tgz#9af9bac0111e90129d963dd1c999ca540b366fcd"
-  integrity sha512-+3BCgSPCp/HoeOBjhz6X7RY7HMCNBanz/wkxo0/e4rk8TqJ3sjZCH470SHvsxCsBIlMwx4FYwkmxePgX/V+0Cg==
+"@graphql-tools/delegate@8.6.1":
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-8.6.1.tgz#d41d664745b3aacd60eaca87ae25a70e60a0a88d"
+  integrity sha512-cah5ZGguJGN+6Ts94guhqWTq+Ymtjc5MLnCNFYOtHoGG82zXUE4ip84samvWUaf/u+kCQEgkA0IFTIvhcjrpGw==
   dependencies:
-    "@graphql-tools/batch-execute" "8.3.3"
-    "@graphql-tools/schema" "8.3.3"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/batch-execute" "8.4.1"
+    "@graphql-tools/schema" "8.3.5"
+    "@graphql-tools/utils" "8.6.5"
     dataloader "2.0.0"
-    graphql-executor "0.0.19"
+    graphql-executor "0.0.21"
     tslib "~2.3.0"
     value-or-promise "1.0.11"
 
 "@graphql-tools/git-loader@^7.0.5":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/git-loader/-/git-loader-7.1.4.tgz#f329e0a3e5c7d9d1e6134cb336883f1c16db8537"
-  integrity sha512-3KSeFzStZeXPZtsviA5YZZbz9fIO+fPNyu3+jOJkMla9Pcz7dv8T9/vCN8aRdPfsD566Av0i1QKWWjSw3hq3HQ==
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/git-loader/-/git-loader-7.1.6.tgz#2a1912a57527a78934d8d8f781d5c9e455b18e9f"
+  integrity sha512-0ctyT/AqpxxgCI7xYOfrSqkzSUq7Vc+xGZDQPPfgBlYV0nHkOtf8Bi80QTwEuMgbfPohMPFtZ83ognkTkPVGXg==
   dependencies:
-    "@graphql-tools/graphql-tag-pluck" "7.1.7"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/graphql-tag-pluck" "7.1.9"
+    "@graphql-tools/utils" "8.6.5"
     is-glob "4.0.3"
     micromatch "^4.0.4"
     tslib "~2.3.0"
     unixify "^1.0.0"
 
 "@graphql-tools/github-loader@^7.0.5":
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/github-loader/-/github-loader-7.2.5.tgz#5aa321bc48c8a52d6fbc5fdb792de2f08781dbd7"
-  integrity sha512-++sYpzAnZ5+VR+aaU6sHafO8/jReBnI7cK/SpW329NBekdIC/JxNaeIGvkXd/6MdP2kjrf9sbfVaEeaw71J+wg==
+  version "7.2.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/github-loader/-/github-loader-7.2.7.tgz#bc2822b9084f6d70c16315e90d465f1a967e40c2"
+  integrity sha512-TsdakaE8Y+y12Td9lDAe0U+9ONBMUgwjvvpxtyUErYicDH4lU4134FpPN03jVCNgYxdeLttLeBK7GXN1x5Pmng==
   dependencies:
-    "@graphql-tools/graphql-tag-pluck" "7.1.7"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/graphql-tag-pluck" "7.1.9"
+    "@graphql-tools/utils" "8.6.5"
     cross-undici-fetch "^0.1.19"
     sync-fetch "0.3.1"
     tslib "~2.3.0"
 
 "@graphql-tools/graphql-file-loader@^7.0.5", "@graphql-tools/graphql-file-loader@^7.3.2":
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.5.tgz#bf3408c5abf4c86d62df8c90c6d71d0454a48187"
-  integrity sha512-TBWDA7EV/cmFFUlN2eT9JqYIkiOGEtwwOgzzPcjM9HlPrbKjQkPIJ9Jaxp7aKWbSGhJ+PnbZ7vFLFLGKsCYOjg==
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.3.7.tgz#f5cb05b0e3cd462d74eae47c5b9c08ed6b989837"
+  integrity sha512-fwXLycYvabPhusGtYuFrOPbjeIvLWr6viGkQc9KmiBm2Z2kZrlNRNUlYkXXRzMoiqRkzqFJYhOgWDE7LsOnbjw==
   dependencies:
-    "@graphql-tools/import" "6.6.7"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/import" "6.6.9"
+    "@graphql-tools/utils" "8.6.5"
     globby "^11.0.3"
     tslib "~2.3.0"
     unixify "^1.0.0"
 
-"@graphql-tools/graphql-tag-pluck@7.1.7":
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.7.tgz#af758fb3e82cf06f9f88187f159e6d1feb22d6bb"
-  integrity sha512-942yDEEJK2qMV9L5fLTZSa/XPTjjOBsNZyYPJD07oca7Cx08b5uajFPu53y+TJeOD/YD+sExGiUw8tUiogdmjg==
+"@graphql-tools/graphql-tag-pluck@7.1.9":
+  version "7.1.9"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-7.1.9.tgz#c56b6ef12cb049ef68b5fd759241d5300e180d20"
+  integrity sha512-Ngdb1I805BNvykBDnqQzCjbeSuGjP6W4Ahqcg9krKipxyzgYQCt6ThpSRFC6c/qG+K0AHXqjnM11fATDlmoKzA==
   dependencies:
     "@babel/parser" "^7.16.8"
     "@babel/traverse" "^7.16.8"
     "@babel/types" "^7.16.8"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/utils" "8.6.5"
     tslib "~2.3.0"
 
-"@graphql-tools/import@6.6.7":
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.6.7.tgz#10be66af927c9293c5720c6a7a5de952bedd4c46"
-  integrity sha512-zzpnVtmdel3mKz6i46GUib4wn0K5dosq4OTBl4avKV6ElvgZTkvsvfSv2aRhbRGIT4VnZPXLfzSnmYd8e+SRLQ==
+"@graphql-tools/import@6.6.9":
+  version "6.6.9"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/import/-/import-6.6.9.tgz#53e1517074c756b5191d23d4f1528246913d44ba"
+  integrity sha512-sKaLqvPmNLQlY4te+nnBhRrf5WBISoiyVkbriCLz0kHw805iHdJaU2KxUoHsRTR7WlYq0g9gzB0oVaRh99Q5aA==
   dependencies:
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/utils" "8.6.5"
     resolve-from "5.0.0"
     tslib "~2.3.0"
 
 "@graphql-tools/json-file-loader@^7.1.2", "@graphql-tools/json-file-loader@^7.3.2":
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.3.5.tgz#ccb6254b65e02fb311f663dbfa8bbb508c6a4c03"
-  integrity sha512-okgpMnxxwqzhMkj3l4+pZYaDVjJeDtxahMjfm5XqUEFoP6b0uEyUkd45/BoRUhmctc9OYomLWFULytyhrkvZOw==
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-7.3.7.tgz#3ddae0b15d3c57d1980fa5203541c2e6cd6a5ff4"
+  integrity sha512-dm0LcfiWYin7cUR4RWC33C9bNppujvSU7hwTH+sHmSguNnat9Kn8dBntVSgrY3qCbKuGfz/PshQHIODXrRwAKg==
   dependencies:
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/utils" "8.6.5"
     globby "^11.0.3"
     tslib "~2.3.0"
     unixify "^1.0.0"
 
 "@graphql-tools/load@^7.3.0", "@graphql-tools/load@^7.4.1":
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.5.3.tgz#e7414d11e53ad8b78d5a74a0bd7ae958fa717a5c"
-  integrity sha512-GYwLyGfX1nKUxg6rnTIdryv9d+ugFRTm2q11+IqNsajwNhxJExkx+e/h81AQR5382sAmPEIT+E1J1VS3xNfjyg==
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-7.5.5.tgz#d61e5bdee59b6c8aa9631f74f0b2a70d512e5b31"
+  integrity sha512-qPasit140nwTbMQbFCfZcgaS7q/0+xMQGdkMGU11rtHt6/jMgJIKDUU8/fJGKltNY3EeHlEdVtZmggZD7Rr6bA==
   dependencies:
-    "@graphql-tools/schema" "8.3.3"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/schema" "8.3.5"
+    "@graphql-tools/utils" "8.6.5"
     p-limit "3.1.0"
     tslib "~2.3.0"
 
-"@graphql-tools/merge@8.2.4", "@graphql-tools/merge@^8.2.1":
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.4.tgz#f903545e5693c75418f95671bca1be6bc51bfa53"
-  integrity sha512-hiNRTsS948F+BB4Q7CZXLaGFOIHQzmimVq3EEI/+PQZsPb7kYDzg0Ow0GyV4conDdEiooLqHf7I1dWzTYwvs0A==
+"@graphql-tools/merge@8.2.6", "@graphql-tools/merge@^8.2.1":
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.6.tgz#7fb615fa9c143c3151ff025e501d52bd48186d19"
+  integrity sha512-dkwTm4czMISi/Io47IVvq2Fl9q4TIGKpJ0VZjuXYdEFkECyH6A5uwxZfPVandZG+gQs8ocFFoa6RisiUJLZrJw==
   dependencies:
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/utils" "8.6.5"
     tslib "~2.3.0"
 
 "@graphql-tools/optimize@^1.0.1":
@@ -1176,12 +1176,12 @@
     tslib "~2.3.0"
 
 "@graphql-tools/prisma-loader@^7.0.6":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-7.1.3.tgz#f712655a44dcb646ec9c59c8ad6fa37c758bf24e"
-  integrity sha512-gXCea/7N30auULj1ele8a3QNDF1pIS635J34IoKb2/B71psFMaFQd2nTIOChypecdAuUFBNR57HYA1sEfXVXBA==
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/prisma-loader/-/prisma-loader-7.1.5.tgz#cf1942054e9f6493643878c5ef9e8d8ba470349f"
+  integrity sha512-QfznQR2NvyWBz4P86IZTiJOM1TMnS+D6VTJIjv/QAhWb6n8eqZFGt243u495bt/3TM4wfjrsvyBgMM0aZ9c4uQ==
   dependencies:
-    "@graphql-tools/url-loader" "7.9.4"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/url-loader" "7.9.6"
+    "@graphql-tools/utils" "8.6.5"
     "@types/js-yaml" "^4.0.0"
     "@types/json-stable-stringify" "^1.0.32"
     "@types/jsonwebtoken" "^8.5.0"
@@ -1202,32 +1202,32 @@
     yaml-ast-parser "^0.0.43"
 
 "@graphql-tools/relay-operation-optimizer@^6.3.7":
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.3.tgz#81bf82ccc7653230d41b850080895cbfb5a6b2d7"
-  integrity sha512-whgh2jlZZ4fbOqCMIfGxEplxNXBOXj1I9A8TMsKFrMaLWcy8q1YjBbNQgr7nTz34SERvlIHinjgLy3QAYiXYLg==
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.4.5.tgz#22a379dba23ce60174c17b36fc1f89c5d26dc78b"
+  integrity sha512-AB/eOfpjteO4Gt0is0U1TseDuFjs/DLV1N0cqF0t6TqQLNVBeWIw7yVb8jw7HIfg3jcKLj++8582lhvCsWMT5g==
   dependencies:
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/utils" "8.6.5"
     relay-compiler "12.0.0"
     tslib "~2.3.0"
 
-"@graphql-tools/schema@8.3.3", "@graphql-tools/schema@^8.1.2":
-  version "8.3.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.3.tgz#b69ea495026976f16e697253f08aa7905e7f6265"
-  integrity sha512-OrRLU9/7UmkDemeyNUy62uH+FofgV3bpVVZJprc9bhe3gZsY7kQNIdY7H1unINlepjLvGOgk7u7iLo2+EhjyWw==
+"@graphql-tools/schema@8.3.5", "@graphql-tools/schema@^8.1.2":
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.5.tgz#ebec0c0c7f53e591d34375d6f81d0660852fcaca"
+  integrity sha512-3mJ/K7TdL+fnEUtCUqF4qkh1fcNMzaxgwKgO9fSYSTS7zyT16hbi5XSulSTshygHgaD2u+MO588iR4ZJcbZcIg==
   dependencies:
-    "@graphql-tools/merge" "8.2.4"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/merge" "8.2.6"
+    "@graphql-tools/utils" "8.6.5"
     tslib "~2.3.0"
     value-or-promise "1.0.11"
 
-"@graphql-tools/url-loader@7.9.4", "@graphql-tools/url-loader@^7.0.11", "@graphql-tools/url-loader@^7.4.2":
-  version "7.9.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.9.4.tgz#443a0953b3e18d22d484eb235bc8ca4c6f087597"
-  integrity sha512-M38H/z1KfG+oBHwVXCce3DyhFEspEn9olNkoW1VLgG1sEBbhWJ9Con44dwcZzkatlKH36mz8hxMDPvFWmAb8sg==
+"@graphql-tools/url-loader@7.9.6", "@graphql-tools/url-loader@^7.0.11", "@graphql-tools/url-loader@^7.4.2":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-7.9.6.tgz#86806e23d413c75da9778acaacf23c7652db6c7e"
+  integrity sha512-atQYq13UocK6vbtIaBaJ3rE1jdab/DrE0UZoEeKtJBEZeZwYiSNmB00xG+aF0GoX6ValcvzTYlY8pRiiOUapig==
   dependencies:
-    "@graphql-tools/delegate" "8.5.4"
-    "@graphql-tools/utils" "8.6.3"
-    "@graphql-tools/wrap" "8.4.6"
+    "@graphql-tools/delegate" "8.6.1"
+    "@graphql-tools/utils" "8.6.5"
+    "@graphql-tools/wrap" "8.4.8"
     "@n1ru4l/graphql-live-query" "^0.9.0"
     "@types/websocket" "^1.0.4"
     "@types/ws" "^8.0.0"
@@ -1244,21 +1244,21 @@
     value-or-promise "^1.0.11"
     ws "^8.3.0"
 
-"@graphql-tools/utils@8.6.3", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.1", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@~8.6.1":
-  version "8.6.3"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.3.tgz#ce9fc9adce4d45b229e314a2261290a88a252aed"
-  integrity sha512-CNyP7Uu7dlVMQ32IpHWOxz4yic9BYXXVkDhG0UdTKSszvzHdgMilemE9MpUrGzzBPsTe3aYTtNGyPUkyh9yTXA==
+"@graphql-tools/utils@8.6.5", "@graphql-tools/utils@^8.1.1", "@graphql-tools/utils@^8.3.0", "@graphql-tools/utils@^8.5.1", "@graphql-tools/utils@^8.5.2", "@graphql-tools/utils@~8.6.1":
+  version "8.6.5"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.5.tgz#ac04571b03f854c7a938b2ab700516a6c6d32335"
+  integrity sha512-mjOtaWiS2WIqRz/cq5gaeM3sVrllcu2xbtHROw1su1v3xWa3D3dKgn8Lrl7+tvWs5WUVySsBss/VZ3WdoPkCrA==
   dependencies:
     tslib "~2.3.0"
 
-"@graphql-tools/wrap@8.4.6":
-  version "8.4.6"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-8.4.6.tgz#25b5e1e917f539b5ada11dc349302b0d380c86bb"
-  integrity sha512-tU+8QCoe8lLXduzEIDVVPX8iY3hT+Jz+SapIcxqLqv/MAdaxtGx2HpLl+vMn8Ba1IPcqAXtomLmDMSXI0mG0jw==
+"@graphql-tools/wrap@8.4.8":
+  version "8.4.8"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-8.4.8.tgz#0539a67ea0cd59703cab6823ac4405b71c719ebc"
+  integrity sha512-5pSEf5fvGrgC+YLvxbkatIdzqaWYHcAx5jYhke+hWMy/bEygy+prTtaf/4rEhTsfwvuT/lGVjBukQTGzCfTMFg==
   dependencies:
-    "@graphql-tools/delegate" "8.5.4"
-    "@graphql-tools/schema" "8.3.3"
-    "@graphql-tools/utils" "8.6.3"
+    "@graphql-tools/delegate" "8.6.1"
+    "@graphql-tools/schema" "8.3.5"
+    "@graphql-tools/utils" "8.6.5"
     tslib "~2.3.0"
     value-or-promise "1.0.11"
 
@@ -1620,9 +1620,9 @@
     any-observable "^0.3.0"
 
 "@sideway/address@^4.1.3":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
-  integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
+  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
@@ -1640,6 +1640,11 @@
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
+"@sindresorhus/is@^4.0.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -1661,6 +1666,13 @@
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
+  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
+  dependencies:
+    defer-to-connect "^2.0.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -1725,8 +1737,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-<<<<<<< HEAD
-=======
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -1752,7 +1762,6 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 "@types/cli-progress@^3.9.2":
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.9.2.tgz#6ca355f96268af39bee9f9307f0ac96145639c26"
@@ -1760,9 +1769,6 @@
   dependencies:
     "@types/node" "*"
 
-<<<<<<< HEAD
-"@types/debug@*":
-=======
 "@types/connect@*":
   version "3.4.35"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
@@ -1775,8 +1781,7 @@
   resolved "https://registry.yarnpkg.com/@types/death/-/death-1.1.2.tgz#72a37216b23ff7f5b537b17de127c08fd619f478"
   integrity sha512-Rr5NV/H/zj6zgbh6TCwMEe0NhCVS2QbAor0pikvzGx5fh+xsnmV3KUEq2Vb4vgi9ytBHorva+ryQmij2rrstTQ==
 
-"@types/debug@*", "@types/debug@^4.1.4":
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
+"@types/debug@*":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
   integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
@@ -1790,8 +1795,6 @@
   dependencies:
     "@types/node" "*"
 
-<<<<<<< HEAD
-=======
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.28"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
@@ -1811,12 +1814,6 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/flat-cache@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/flat-cache/-/flat-cache-2.0.0.tgz#64e5d3b426c392b603a208a55bdcc7d920ce6e57"
-  integrity sha512-fHeEsm9hvmZ+QHpw6Fkvf19KIhuqnYLU6vtWLjd5BsMd/qVi7iTkMioDZl0mQmfNRA1A6NwvhrSRNr9hGYZGww==
-
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 "@types/fs-extra@^9.0.12":
   version "9.0.13"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
@@ -1838,6 +1835,11 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/http-cache-semantics@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
+  integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
@@ -1898,6 +1900,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/keyv@*":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
+  integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ledgerhq__hw-transport@^4.21.3":
   version "4.21.4"
   resolved "https://registry.yarnpkg.com/@types/ledgerhq__hw-transport/-/ledgerhq__hw-transport-4.21.4.tgz#3a78a02d2b51d2b0dd8099412d5567d21118225c"
@@ -1917,16 +1926,12 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.180.tgz#4ab7c9ddfc92ec4a887886483bc14c79fb380670"
   integrity sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==
 
-<<<<<<< HEAD
-"@types/minimatch@*":
-=======
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
-"@types/minimatch@*", "@types/minimatch@^3.0.3":
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
+"@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
@@ -2137,14 +2142,9 @@
     "@types/pouchdb-replication" "*"
 
 "@types/prettier@^2.1.5":
-<<<<<<< HEAD
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
   integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
-=======
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
-  integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
 
 "@types/qs@*":
   version "6.9.7"
@@ -2162,17 +2162,6 @@
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
   dependencies:
     "@types/node" "*"
-
-"@types/sarif@^2.1.3":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@types/sarif/-/sarif-2.1.4.tgz#471c5788199d22f572f255de9a8166a30abf1245"
-  integrity sha512-4xKHMdg3foh3Va1fxTzY1qt8QVqmaJpGWsVvtjQrJBn+/bkig2pWFKJ4FPI2yLI4PAj0SUKiPO4Vd7ggYIMZjQ==
-
-"@types/semver@^7.1.0":
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
-  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 
 "@types/semver@^7.3.3":
   version "7.3.9"
@@ -2460,9 +2449,9 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.1:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d"
-  integrity sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -2915,8 +2904,6 @@ blake2b@2.1.3:
     blake2b-wasm "^1.1.0"
     nanoassert "^1.0.0"
 
-<<<<<<< HEAD
-=======
 body-parser@1.19.2, body-parser@^1.19.2:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.2.tgz#4714ccd9c157d44797b8b5607d72c0b89952f26e"
@@ -2933,17 +2920,6 @@ body-parser@1.19.2, body-parser@^1.19.2:
     raw-body "2.4.3"
     type-is "~1.6.18"
 
-boolean@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.2.tgz#e30f210a26b02458482a8cc353ab06f262a780c2"
-  integrity sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==
-
-bottleneck@2.19.5:
-  version "2.19.5"
-  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
-  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
-
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3025,10 +3001,6 @@ builtin-modules@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
 bunyan@^1.8.15:
   version "1.8.15"
   resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.15.tgz#8ce34ca908a17d0776576ca1b2f6cbd916e93b46"
@@ -3039,7 +3011,6 @@ bunyan@^1.8.15:
     mv "~2"
     safe-json-stringify "~1"
 
->>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -3050,7 +3021,6 @@ cacheable-lookup@^5.0.3:
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
   integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
 
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -3064,9 +3034,7 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-<<<<<<< HEAD
-=======
-cacheable-request@^7.0.1, cacheable-request@^7.0.2:
+cacheable-request@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
   integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
@@ -3079,7 +3047,6 @@ cacheable-request@^7.0.1, cacheable-request@^7.0.2:
     normalize-url "^6.0.1"
     responselike "^2.0.0"
 
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -3461,26 +3428,17 @@ commander@^8.0.0, commander@^8.2.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-comment-parser@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.4.tgz#489f3ee55dfd184a6e4bffb31baba284453cb760"
-  integrity sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==
-
-<<<<<<< HEAD
-common-tags@1.8.2, common-tags@^1.8.0:
-=======
 commander@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.1.0.tgz#a6b263b2327f2e188c6402c42623327909f2dbec"
   integrity sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==
 
-comment-parser@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.3.tgz#303a7eb99c9b2632efd594e183ccbd32042caf69"
-  integrity sha512-vnqDwBSXSsdAkGS5NjwMIPelE47q+UkEgWKHvCDNhVIIaQSUFY6sNnEYGzdoPGMdpV+7KR3ZkRd7oyWIjtuvJg==
+comment-parser@1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.2.4.tgz#489f3ee55dfd184a6e4bffb31baba284453cb760"
+  integrity sha512-pm0b+qv+CkWNriSTMsfnjChF9kH0kxz55y44Wo5le9qLxMj5xDQAaEd9ZN1ovSuk9CsrncWaFwgpOMg7ClJwkw==
 
-common-tags@1.8.2:
->>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
+common-tags@1.8.2, common-tags@^1.8.0:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
@@ -3740,23 +3698,6 @@ debounce@^1.2.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
-<<<<<<< HEAD
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
-  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.2.7:
-=======
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3764,34 +3705,19 @@ debug@2.6.9, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
-
-debug@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
-
-debug@^3.1.0, debug@^3.2.6, debug@^3.2.7:
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
-  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.3.4:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -3825,6 +3751,13 @@ decompress-response@^4.2.0:
   dependencies:
     mimic-response "^2.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
@@ -3856,6 +3789,11 @@ defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
+
+defer-to-connect@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 deferred-leveldown@~5.3.0:
   version "5.3.0"
@@ -4034,27 +3972,15 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-<<<<<<< HEAD
-electron-to-chromium@^1.4.84:
-  version "1.4.89"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.89.tgz#33c06592812a17a7131873f4596579084ce33ff8"
-  integrity sha512-z1Axg0Fu54fse8wN4fd+GAINdU5mJmLtcl6bqIcYyzNVGONcfHAeeJi88KYMQVKalhXlYuVPzKkFIU5VD0raUw==
-=======
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.723:
-  version "1.3.778"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.778.tgz#bf01048736c95b78f2988e88005e0ebb385942a4"
-  integrity sha512-Lw04qJaPtWdq0d7qKHJTgkam+FhFi3hm/scf1EyqJWdjO3ZIGUJhNmZJRXWb7yb/bRYXQyVGSpa9RqVpjjWMQw==
-
-electron-to-chromium@^1.4.76:
-  version "1.4.81"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.81.tgz#a9ce8997232fb9fb0ec53de8931a85b18c0a7383"
-  integrity sha512-Gs7xVpIZ7tYYSDA+WgpzwpPvfGwUk3KSIjJ0akuj5XQHFdyQnsUoM76EA4CIHXNLPiVwTwOFay9RMb0ChG3OBw==
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
+electron-to-chromium@^1.4.84:
+  version "1.4.90"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.90.tgz#4a518590f118828d54fff045728f547fef08143f"
+  integrity sha512-ZwKgSA0mQMyEhz+NR0F8dRzkrCLeHLzLkjx/CWf16+zV85hQ6meXPQbKanvhnpkYb7b2uJNj+enQJ/N877ND4Q==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -4235,16 +4161,16 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
-eslint-import-resolver-typescript@^2.4.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.5.0.tgz#07661966b272d14ba97f597b51e1a588f9722f0a"
-  integrity sha512-qZ6e5CFr+I7K4VVhQu3M/9xGv9/YmwsEXrsm3nimw8vWaVHRDrQRp26BgCypTxBp3vUp4o5aVEJRiy0F2DFddQ==
+eslint-import-resolver-typescript@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.0.tgz#1f9d391b636dccdbaa4a3b1a87eb9a8237e23963"
+  integrity sha512-MNHS3u5pebvROX4MjGP9coda589ZGfL1SqdxUV4kSrcclfDRWvNE2D+eljbnWVMvWDVRgT89nhscMHPKYGcObQ==
   dependencies:
-    debug "^4.3.1"
-    glob "^7.1.7"
-    is-glob "^4.0.1"
-    resolve "^1.20.0"
-    tsconfig-paths "^3.9.0"
+    debug "^4.3.4"
+    glob "^7.2.0"
+    is-glob "^4.0.3"
+    resolve "^1.22.0"
+    tsconfig-paths "^3.14.1"
 
 eslint-module-utils@^2.7.2:
   version "2.7.3"
@@ -4514,21 +4440,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-<<<<<<< HEAD
-=======
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-loop-spinner@^2.0.0, event-loop-spinner@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/event-loop-spinner/-/event-loop-spinner-2.1.0.tgz#75f501d585105c6d57f174073b39af1b6b3a1567"
-  integrity sha512-RJ10wL8/F9AlfBgRCvYctJIXSb9XkVmSCK3GGUvPD3dJrvTjDeDT0tmhcbEC6I2NEjNM9xD38HQJ4F/f/gb4VQ==
-  dependencies:
-    tslib "^2.1.0"
-
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -4795,9 +4711,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-<<<<<<< HEAD
-find-up@^2.1.0:
-=======
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -4811,8 +4724,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-up@^2.0.0, find-up@^2.1.0:
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
+find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
@@ -4848,12 +4760,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@^1.14.0:
-  version "1.14.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
-  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
-
-follow-redirects@^1.14.7:
+follow-redirects@^1.14.0, follow-redirects@^1.14.7:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
@@ -5105,7 +5012,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7:
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -5156,25 +5063,6 @@ globby@^11.0.3, globby@^11.0.4:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-<<<<<<< HEAD
-=======
-got@11.8.2, got@^11.7.0:
-  version "11.8.2"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
-  integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
-  dependencies:
-    "@sindresorhus/is" "^4.0.0"
-    "@szmarczak/http-timer" "^4.0.5"
-    "@types/cacheable-request" "^6.0.1"
-    "@types/responselike" "^1.0.0"
-    cacheable-lookup "^5.0.3"
-    cacheable-request "^7.0.1"
-    decompress-response "^6.0.0"
-    http2-wrapper "^1.0.0-beta.5.2"
-    lowercase-keys "^2.0.0"
-    p-cancelable "^2.0.0"
-    responselike "^2.0.0"
-
 got@^11:
   version "11.8.3"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.3.tgz#f496c8fdda5d729a90b4905d2b07dbd148170770"
@@ -5192,7 +5080,6 @@ got@^11:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -5232,10 +5119,10 @@ graphql-config@^4.1.0:
     minimatch "3.0.4"
     string-env-interpolation "1.0.1"
 
-graphql-executor@0.0.19:
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/graphql-executor/-/graphql-executor-0.0.19.tgz#cab902c91444181944a6bbb3e6cab7107b933f33"
-  integrity sha512-AFOcsk/yMtl9jcO/f/0Our7unWxJ5m3FS5HjWfsXRHCyjjaubXpSHiOZO/hSYv6brayIrupDoVAzCuJpBc3elg==
+graphql-executor@0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/graphql-executor/-/graphql-executor-0.0.21.tgz#5bd5bbb0cffecdad213753d7757618b27750de1d"
+  integrity sha512-XGq8batWbqptkR4PNm7WlbeDya2YEurwQUUH5v0XNxQ1/XguB9nKfJjzPKCNEM6RiB0L3rZ7wAFt3oh6B+ikrQ==
 
 graphql-query-complexity@^0.7.0:
   version "0.7.2"
@@ -5478,6 +5365,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
+  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 https-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -6541,6 +6436,11 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -6681,6 +6581,13 @@ keyv@^3.0.0:
   integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
   dependencies:
     json-buffer "3.0.0"
+
+keyv@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.1.1.tgz#02c538bfdbd2a9308cc932d4096f05ae42bfa06a"
+  integrity sha512-tGv1yP6snQVDSM4X6yxrv2zzq/EvpW+oYiUz6aueW1u9CtS8RzUQYxxmFwgZlO2jSgCxQbchhxaqXXp2hnKGpQ==
+  dependencies:
+    json-buffer "3.0.1"
 
 kind-of@^6.0.3:
   version "6.0.3"
@@ -7218,24 +7125,12 @@ meros@^1.1.4:
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.2.0.tgz#096cdede2eb0b1610b219b1031b935260de1ad08"
   integrity sha512-3QRZIS707pZQnijHdhbttXRWwrHhZJ/gzolneoxKVz9N/xmsvY/7Ls8lpnI9gxbgxjcHsAVEW3mgwiZCo6kkJQ==
 
-<<<<<<< HEAD
-micromatch@^4.0.4:
-=======
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
-  dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
-
-micromatch@^4.0.2, micromatch@^4.0.4:
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
+micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -7248,31 +7143,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-<<<<<<< HEAD
-mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-=======
-mime-db@1.49.0:
-  version "1.49.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.49.0.tgz#f3dfde60c99e9cf3bc9701d687778f537001cbed"
-  integrity sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==
-
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12:
-  version "2.1.31"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
-  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
-  dependencies:
-    mime-db "1.52.0"
-
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7304,6 +7175,11 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -7316,28 +7192,17 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-<<<<<<< HEAD
-minimatch@3.0.4:
-=======
-"minimatch@2 || 3":
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
->>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
+minimatch@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^3.0.0, minimatch@^3.0.4:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -7350,7 +7215,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -7360,21 +7225,17 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-<<<<<<< HEAD
 mkdirp@^1.0.4:
-=======
-mkdirp@^0.5.1, mkdirp@~0.5.1:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
-  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
-  dependencies:
-    minimist "^1.2.5"
-
-mkdirp@^1.0.3, mkdirp@^1.0.4:
->>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mkdirp@~0.5.1:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 mock-browser@^0.92.14:
   version "0.92.14"
@@ -7461,40 +7322,16 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
 ncp@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
-
->>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
-needle@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
-  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
-needle@^2.3.3, needle@^2.5.0, needle@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.8.0.tgz#1c8ef9c1a2c29dcc1e83d73809d7bc681c80a048"
-  integrity sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
 
 negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
@@ -7566,27 +7403,11 @@ node-releases@^2.0.2:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
 
-<<<<<<< HEAD
-=======
-node.extend@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node.extend/-/node.extend-2.0.2.tgz#b4404525494acc99740f3703c496b7d5182cc6cc"
-  integrity sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==
-  dependencies:
-    has "^1.0.3"
-    is "^3.2.1"
-
 nofilter@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
   integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
 
-noop-logger@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
-  integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
-
->>>>>>> d5ab2284 (feat(cardano-graphql-services): add TxSubmitHttpServer)
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -7623,6 +7444,11 @@ normalize-url@^4.1.0:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
   integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
+
+normalize-url@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
+  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 npm-run-all@^4.1.5:
   version "4.1.5"
@@ -7817,6 +7643,11 @@ p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
+p-cancelable@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
+  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -8264,8 +8095,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-<<<<<<< HEAD
-=======
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -8274,12 +8103,6 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
@@ -8332,6 +8155,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 randombytes@^2.0.1:
   version "2.1.0"
@@ -8599,6 +8427,11 @@ requireindex@~1.2.0:
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
   integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
+resolve-alpn@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -8628,7 +8461,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.0.0, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.20.0:
+resolve@^1.0.0, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
@@ -8643,6 +8476,13 @@ responselike@^1.0.2:
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
   dependencies:
     lowercase-keys "^1.0.0"
+
+responselike@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -8723,24 +8563,7 @@ rxjs@6, rxjs@^6.3.3, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.4.0, rxjs@^7.5.1, rxjs@^7.5.5:
-  version "7.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
-  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
-  dependencies:
-    tslib "^2.1.0"
-
-<<<<<<< HEAD
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
-=======
-rxjs@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
-  dependencies:
-    tslib "~2.1.0"
-
-rxjs@^7.5.4:
+rxjs@^7.4.0, rxjs@^7.5.1, rxjs@^7.5.4, rxjs@^7.5.5:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
@@ -8748,7 +8571,6 @@ rxjs@^7.5.4:
     tslib "^2.1.0"
 
 safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -8842,15 +8664,6 @@ sentence-case@^3.0.4:
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
 
-<<<<<<< HEAD
-=======
-serialize-error@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-7.0.1.tgz#f1360b0447f61ffb483ec4157c737fab7d778e18"
-  integrity sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==
-  dependencies:
-    type-fest "^0.13.1"
-
 serialize-error@^8:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-8.1.0.tgz#3a069970c712f78634942ddd50fbbc0eaebe2f67"
@@ -8868,7 +8681,6 @@ serve-static@1.14.2:
     parseurl "~1.3.3"
     send "0.17.2"
 
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -9121,19 +8933,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-<<<<<<< HEAD
-=======
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stream-buffers@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-3.0.2.tgz#5249005a8d5c2d00b3a32e6e0a6ea209dc4f3521"
-  integrity sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==
-
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 stream-meter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/stream-meter/-/stream-meter-1.0.4.tgz#52af95aa5ea760a2491716704dbff90f73afdd1d"
@@ -9515,19 +9319,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-<<<<<<< HEAD
-=======
 toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-toml@3.0.0, toml@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
-  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
-
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 tough-cookie@^2.3.2, tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -9638,14 +9434,14 @@ ts-node@^9, ts-node@^9.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
-tsconfig-paths@^3.12.0, tsconfig-paths@^3.9.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.0.tgz#4fcc48f9ccea8826c41b9ca093479de7f5018976"
-  integrity sha512-cg/1jAZoL57R39+wiw4u/SCC6Ic9Q5NqjBOb+9xISedOYurfog9ZNmKJSxAnb2m/5Bq4lE9lhUcau33Ml8DM0g==
+tsconfig-paths@^3.12.0, tsconfig-paths@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
+  integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==
   dependencies:
     "@types/json5" "^0.0.29"
     json5 "^1.0.1"
-    minimist "^1.2.0"
+    minimist "^1.2.6"
     strip-bom "^3.0.0"
 
 tsconfig@^7.0.0:
@@ -9831,19 +9627,11 @@ unixify@^1.0.0:
   dependencies:
     normalize-path "^2.1.1"
 
-<<<<<<< HEAD
-=======
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-upath@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
-  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
-
->>>>>>> d7cdfafb (feat(cardano-graphql-services): add HttpServer abstract class)
 upper-case-first@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"


### PR DESCRIPTION
# Context
We require a tx submission process that supports both direct submission to the node, or via a persistent queue.

# Proposed Solution
-  Add a HTTP server that interfaces with `TxSubmitProvider`, that can be resolved by a queue message creator, but is immediately compatible with the `OgmiosTxSubmitProvider` for direct submission. The scope of this PR is therefore limited to direct submission.
- Adds a `TxSubmitProvider` to interface with the new HTTP service.

# Important Changes Introduced
- Extends the configuration in the wallet e2e tests to optionally use the new service.

# Testing
You need an instance of `cardano-node` + `ogmios` running on the _testnet_. There's a docker-compose in the root that can be booted with:
```
yarn testnet:up
```
Now run the HTTP server from the repo root with debug logging:
```
yarn --cwd ./packages/cardano-graphql-services cli:tx-submit start-server --api-url http://localhost:3000 --ogmios-url ws://localhost:1338 --logger-min-severity debug
```