### PR TITLE
feat(cip30): implement ApiError{InternalError}

### DIFF
--- a/packages/cip30/src/WebExtension/index.ts
+++ b/packages/cip30/src/WebExtension/index.ts
@@ -1,2 +1,2 @@
-export * from './handleMessages';
+export { handleMessages } from './handleMessages';
 export * from './webExtensionWalletClient';

--- a/packages/cip30/test/WalletExtension/handleMessages.test.ts
+++ b/packages/cip30/test/WalletExtension/handleMessages.test.ts
@@ -1,0 +1,19 @@
+import { ApiError, TxSignError, TxSignErrorCode } from '../../src/errors';
+import { WalletApi } from '../../src/Wallet';
+import { createListener } from '../../src/WebExtension/handleMessages';
+
+describe('handleMessages', () => {
+  const walletName = 'wallet';
+
+  it('rejects with ApiError for non-cip30 error types', async () => {
+    const signTx = jest.fn().mockRejectedValueOnce(new Error('some other error'));
+    const listener = createListener(walletName, { signTx } as unknown as WalletApi);
+    await expect(() => listener({ arguments: [], method: 'signTx', walletName })).rejects.toThrowError(ApiError);
+  });
+
+  it('rejects with original error if its defined by cip30', async () => {
+    const signTx = jest.fn().mockRejectedValueOnce(new TxSignError(TxSignErrorCode.UserDeclined, ''));
+    const listener = createListener(walletName, { signTx } as unknown as WalletApi);
+    await expect(() => listener({ arguments: [], method: 'signTx', walletName })).rejects.toThrowError(TxSignError);
+  });
+});


### PR DESCRIPTION
# Context

Underlying wallet in cip30 throwing for any reason unspecified in the spec should result in ApiError{InternalError}

# Proposed Solution

try-catch in handleMessages
