### PR TITLE
feat: generic http provider client

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
       "patterns": ["@cardano-sdk/*/src/*"]
     }],
     "new-cap": 0,
+    'jsdoc/require-returns-type': 0,
     "no-unused-expressions": 0,
     "no-useless-constructor": 0,
     "quotes": ["error", "single", { "avoidEscape": true }],

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "config"]
-	path = config
-	url = https://github.com/input-output-hk/cardano-configurations.git

--- a/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
+++ b/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
@@ -22,7 +22,7 @@ export const blockfrostTxSubmitProvider = (blockfrost: BlockFrostAPI): TxSubmitP
     try {
       await blockfrost.txSubmit(signedTransaction);
     } catch (error) {
-      throw new Cardano.TxSubmissionErrors.UnknownTxSubmissionError(error);
+      throw new Cardano.UnknownTxSubmissionError(error);
     }
   };
 

--- a/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostTxSubmitProvider.test.ts
@@ -38,9 +38,7 @@ describe('blockfrostTxSubmitProvider', () => {
       BlockFrostAPI.prototype.txSubmit = jest.fn().mockRejectedValue(innerError);
       const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
       const provider = blockfrostTxSubmitProvider(blockfrost);
-      await expect(provider.submitTx(null as any)).rejects.toThrowError(
-        Cardano.TxSubmissionErrors.UnknownTxSubmissionError
-      );
+      await expect(provider.submitTx(null as any)).rejects.toThrowError(Cardano.UnknownTxSubmissionError);
     });
   });
 });

--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -28,6 +28,8 @@
   "devDependencies": {
     "@cardano-sdk/cardano-services-client": "0.2.0",
     "@types/validator": "^13.7.1",
+    "express": "^4.17.3",
+    "get-port-please": "^2.4.3",
     "shx": "^0.3.3"
   },
   "dependencies": {

--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -30,6 +30,7 @@
     "@types/validator": "^13.7.1",
     "express": "^4.17.3",
     "get-port-please": "^2.4.3",
+    "serialize-error": "^8",
     "shx": "^0.3.3"
   },
   "dependencies": {
@@ -37,8 +38,7 @@
     "@cardano-sdk/core": "0.2.0",
     "class-validator": "^0.13.1",
     "got": "^11",
-    "json-bigint": "~1.0.0",
-    "serialize-error": "^8"
+    "json-bigint": "~1.0.0"
   },
   "files": [
     "dist/*",

--- a/packages/cardano-services-client/src/HttpProvider.ts
+++ b/packages/cardano-services-client/src/HttpProvider.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ProviderError, ProviderFailure, util } from '@cardano-sdk/core';
+import got, { HTTPError, Options, OptionsOfJSONResponseBody, RequestError } from 'got';
+
+export type HttpProviderConfigPaths<T> = { [methodName in keyof T]: string };
+
+export interface HttpProviderConfig<T> {
+  /**
+   * Example: "http://localhost:3000"
+   */
+  baseUrl: string;
+  /**
+   * A mapping between provider method names and url paths.
+   * Paths have to use /leadingSlash
+   */
+  paths: HttpProviderConfigPaths<T>;
+  /**
+   * Additional request options passed to got
+   */
+  gotOptions?: Options;
+  /**
+   * Custom error handling: Either:
+   * - interpret error as valid response by mapping it to response type and returning it
+   * - map error to a new Error type by throwing it
+   *
+   * @param error response body parsed as JSON
+   * @param method provider method name
+   */
+  mapError?: (error: unknown, method: keyof T) => unknown;
+}
+
+/**
+ * Creates a HTTP client for specified provider type, following some conventions:
+ * - All methods use POST requests
+ * - Arguments are serialized using core toSerializableObject and sent as JSON {args: unknown[]} in request body
+ * - Server is expected to use the following core utils:
+ *   - fromSerializableObject after deserializing args
+ *   - toSerializableObject before serializing response body
+ *
+ * @returns provider that fetches data over http
+ */
+export const createHttpProvider = <T extends object>({
+  baseUrl,
+  gotOptions,
+  mapError,
+  paths
+}: HttpProviderConfig<T>): T =>
+  new Proxy<T>({} as T, {
+    // eslint-disable-next-line sonarjs/cognitive-complexity
+    get(_, prop) {
+      const method = prop as keyof T;
+      const path = paths[method];
+      if (!path)
+        throw new ProviderError(ProviderFailure.NotImplemented, `HttpProvider missing path for '${prop.toString()}'`);
+      return async (...args: any[]) => {
+        try {
+          const req: OptionsOfJSONResponseBody = {
+            ...gotOptions,
+            isStream: false,
+            json: { args },
+            parseJson: (obj) => util.fromSerializableObject(JSON.parse(obj)),
+            resolveBodyOnly: false,
+            responseType: 'json',
+            stringifyJson: (obj) => JSON.stringify(util.toSerializableObject(obj)),
+            url: baseUrl + path
+          };
+          return (await got.post(req).json()) || undefined;
+        } catch (error) {
+          if (error instanceof RequestError) {
+            if (error instanceof HTTPError) {
+              if (mapError) return mapError(error.response.body, method);
+              throw new ProviderError(ProviderFailure.Unknown, error.response.body);
+            }
+            if (mapError) return mapError(null, method);
+            if (['ENOTFOUND', 'ECONNREFUSED'].includes(error.code)) {
+              throw new ProviderError(ProviderFailure.ConnectionFailure, error, error.code);
+            }
+          }
+          throw new ProviderError(ProviderFailure.Unknown, error);
+        }
+      };
+    }
+  });

--- a/packages/cardano-services-client/src/StakePoolSearchProvider/index.ts
+++ b/packages/cardano-services-client/src/StakePoolSearchProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './stakePoolSearchHttpProvider';

--- a/packages/cardano-services-client/src/StakePoolSearchProvider/stakePoolSearchHttpProvider.ts
+++ b/packages/cardano-services-client/src/StakePoolSearchProvider/stakePoolSearchHttpProvider.ts
@@ -1,0 +1,20 @@
+import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { StakePoolSearchProvider } from '@cardano-sdk/core';
+
+export const defaultStakePoolSearchProviderPaths: HttpProviderConfigPaths<StakePoolSearchProvider> = {
+  queryStakePools: '/search'
+};
+
+/**
+ * Connect to a StakePoolSearchHttpServer instance
+ *
+ * @param {string} baseUrl server root url, w/o trailing /
+ */
+export const stakePoolSearchHttpProvider = (
+  baseUrl: string,
+  paths = defaultStakePoolSearchProviderPaths
+): StakePoolSearchProvider =>
+  createHttpProvider<StakePoolSearchProvider>({
+    baseUrl,
+    paths
+  });

--- a/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
@@ -1,52 +1,55 @@
-import {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  Cardano,
-  ProviderError,
-  ProviderFailure,
-  TxSubmitProvider
-} from '@cardano-sdk/core';
-import { deserializeError } from 'serialize-error';
-import got from 'got';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import type ConnectionConfig from '@cardano-sdk/cardano-graphql-services';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+
+export const defaultTxSubmitProviderPaths: HttpProviderConfigPaths<TxSubmitProvider> = {
+  healthCheck: '/health',
+  submitTx: '/submit'
+};
+
+const toTxSubmissionError = (error: any): Cardano.TxSubmissionError | null => {
+  if (typeof error === 'object' && typeof error?.name === 'string' && typeof error?.message === 'string') {
+    const rawError = error as Cardano.TxSubmissionError;
+    const txSubmissionErrorName = rawError.name as keyof typeof Cardano.TxSubmissionErrors;
+    const ErrorClass = Cardano.TxSubmissionErrors[txSubmissionErrorName];
+    if (ErrorClass) {
+      Object.setPrototypeOf(error, ErrorClass.prototype);
+      return error;
+    }
+    return new Cardano.UnknownTxSubmissionError(error);
+  }
+  return null;
+};
 
 /**
  * Connect to a TxSubmitHttpServer instance
  *
- * @param {ConnectionConfig} connectionConfig Service connection configuration
+ * @param {string} baseUrl server root url, w/o trailing /
  * @returns {TxSubmitProvider} TxSubmitProvider
- * @throws {Cardano.TxSubmissionErrors}
+ * @throws {ProviderError} if reason === ProviderFailure.BadRequest then
+ * innerError is set to either one of Cardano.TxSubmissionErrors or Cardano.UnknownTxSubmissionError
  */
-export const txSubmitHttpProvider = (connectionConfig: { url: string }): TxSubmitProvider => ({
-  async healthCheck() {
-    try {
-      const response = await got.get(`${connectionConfig.url}/health`);
-      return JSON.parse(response.body);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      if (error.name === 'RequestError') {
-        return { ok: false };
+export const txSubmitHttpProvider = (baseUrl: string, paths = defaultTxSubmitProviderPaths): TxSubmitProvider =>
+  createHttpProvider<TxSubmitProvider>({
+    baseUrl,
+    mapError: (error: any, method) => {
+      switch (method) {
+        case 'healthCheck': {
+          if (!error) {
+            return { ok: false };
+          }
+          break;
+        }
+        case 'submitTx': {
+          if (typeof error === 'object') {
+            const txSubmissionError = toTxSubmissionError(error);
+            if (txSubmissionError) {
+              throw new ProviderError(ProviderFailure.BadRequest, txSubmissionError);
+            }
+          }
+        }
       }
       throw new ProviderError(ProviderFailure.Unknown, error);
-    }
-  },
-  async submitTx(tx: Uint8Array) {
-    try {
-      await got.post(`${connectionConfig.url}/submit`, {
-        body: Buffer.from(tx),
-        headers: { 'Content-Type': 'application/cbor' }
-      });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      const domainErrors = JSON.parse(error?.response?.body || null) as null | string | string[];
-      if (Array.isArray(domainErrors)) {
-        throw domainErrors.map((e: string) => deserializeError(e));
-      } else if (domainErrors !== null) {
-        throw deserializeError(domainErrors);
-      }
-      throw new ProviderError(ProviderFailure.Unknown, error);
-    }
-  }
-});
+    },
+    paths
+  });

--- a/packages/cardano-services-client/src/index.ts
+++ b/packages/cardano-services-client/src/index.ts
@@ -1,4 +1,3 @@
 export { TxSubmitProvider } from '@cardano-sdk/core';
+export * from './HttpProvider';
 export * from './TxSubmitProvider';
-// Do not export this. Using core types elsewhere in the sdk.
-// export * as Schema from './Schema';

--- a/packages/cardano-services-client/src/index.ts
+++ b/packages/cardano-services-client/src/index.ts
@@ -1,3 +1,4 @@
 export { TxSubmitProvider } from '@cardano-sdk/core';
 export * from './HttpProvider';
 export * from './TxSubmitProvider';
+export * from './StakePoolSearchProvider';

--- a/packages/cardano-services-client/test/HttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HttpProvider.test.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable sonarjs/cognitive-complexity */
+/* eslint-disable sonarjs/no-duplicate-string */
+import { HttpProviderConfig, createHttpProvider } from '../src';
+import { ProviderError, ProviderFailure, util } from '@cardano-sdk/core';
+import { Server } from 'http';
+import { getPort } from 'get-port-please';
+import express, { RequestHandler } from 'express';
+
+type ComplexArg2 = { map: Map<string, Buffer> };
+type ComplexResponse = Map<bigint, Buffer>[];
+interface TestProvider {
+  noArgsEmptyReturn(): Promise<void>;
+  complexArgsAndReturn(arg1: bigint, arg2: ComplexArg2): Promise<ComplexResponse>;
+}
+
+const createStubHttpProviderServer = async (port: number, path: string, handler: RequestHandler) => {
+  const app = express();
+  app.use(express.json());
+  app.post(path, handler);
+  const server = await new Promise<Server>((resolve) => {
+    const result = app.listen(port, () => resolve(result));
+  });
+  return () => new Promise((resolve) => server.close(resolve));
+};
+
+const stubProviderPaths = {
+  complexArgsAndReturn: '/complex',
+  noArgsEmptyReturn: '/simple'
+};
+
+describe('createHttpServer', () => {
+  let port: number;
+  let baseUrl: string;
+
+  const createTxSubmitProviderClient = (
+    config: Pick<HttpProviderConfig<TestProvider>, 'gotOptions' | 'mapError'> = {}
+  ) =>
+    createHttpProvider<TestProvider>({
+      baseUrl,
+      paths: stubProviderPaths,
+      ...config
+    });
+
+  beforeAll(async () => {
+    port = await getPort();
+    baseUrl = `http://localhost:${port}`;
+  });
+
+  it('attempting to access unimplemented method throws ProviderError', async () => {
+    const provider = createTxSubmitProviderClient();
+    expect(() => (provider as any).doesntExist).toThrowError(ProviderError);
+  });
+
+  describe('method with no args and void return', () => {
+    it('calls http server with empty args in req body and parses the response', async () => {
+      const provider = createTxSubmitProviderClient();
+      const closeServer = await createStubHttpProviderServer(port, stubProviderPaths.noArgsEmptyReturn, (req, res) => {
+        expect(req.body.args).toEqual([]);
+        res.send();
+      });
+      const response = await provider.noArgsEmptyReturn();
+      expect(response).toBe(undefined);
+      await closeServer();
+    });
+  });
+
+  describe('method with complex args and return', () => {
+    it('serializes args and deserializes response using core serializableObject', async () => {
+      const arg1 = 123n;
+      const arg2: ComplexArg2 = { map: new Map([['key', Buffer.from('abc')]]) };
+      const expectedResponse: ComplexResponse = [new Map([[1234n, Buffer.from('response data')]])];
+      const provider = createTxSubmitProviderClient();
+      const closeServer = await createStubHttpProviderServer(
+        port,
+        stubProviderPaths.complexArgsAndReturn,
+        (req, res) => {
+          expect(util.fromSerializableObject(req.body.args)).toEqual([arg1, arg2]);
+          res.send(util.toSerializableObject(expectedResponse));
+        }
+      );
+      const response = await provider.complexArgsAndReturn(arg1, arg2);
+      expect(response).toEqual(expectedResponse);
+      await closeServer();
+    });
+  });
+
+  it('passes through got options', async () => {
+    const provider = createTxSubmitProviderClient({ gotOptions: { headers: { 'custom-header': 'header-value' } } });
+    const closeServer = await createStubHttpProviderServer(port, stubProviderPaths.noArgsEmptyReturn, (req, res) => {
+      expect(req.headers['custom-header']).toBe('header-value');
+      res.send();
+    });
+    await provider.noArgsEmptyReturn();
+    await closeServer();
+  });
+
+  describe('errors', () => {
+    describe('connection errors', () => {
+      it('maps ECONNREFUSED and ENOTFOUND to ProviderError{ConnectionFailure}', async () => {
+        const provider = createTxSubmitProviderClient();
+        try {
+          await provider.noArgsEmptyReturn();
+          throw new Error('Expected to throw');
+        } catch (error) {
+          if (error instanceof ProviderError) {
+            expect(error.reason).toBe(ProviderFailure.ConnectionFailure);
+          } else {
+            throw new TypeError('Invalid error type');
+          }
+        }
+      });
+
+      it('calls mapError with null response when request fails', async () => {
+        const provider = createTxSubmitProviderClient({
+          mapError: (error) => {
+            expect(error).toBeNull();
+            return 'error';
+          }
+        });
+        expect(await provider.noArgsEmptyReturn()).toEqual('error');
+      });
+    });
+
+    describe('HTTPError', () => {
+      let closeServer: Function;
+      const errorJson = { message: 'error' };
+
+      beforeAll(async () => {
+        closeServer = await createStubHttpProviderServer(port, stubProviderPaths.noArgsEmptyReturn, (_, res) => {
+          res.status(500).send(errorJson);
+        });
+      });
+
+      afterAll(() => closeServer());
+
+      it('parses error json and wraps errors in ProviderError', async () => {
+        const provider = createTxSubmitProviderClient();
+        try {
+          await provider.noArgsEmptyReturn();
+          throw new Error('Expected to throw');
+        } catch (error) {
+          if (error instanceof ProviderError) {
+            expect(error.innerError).toEqual(errorJson);
+          } else {
+            throw new TypeError('Expected ProviderError');
+          }
+        }
+      });
+
+      it('supports custom error mapper that maps error into return type', async () => {
+        const provider = createTxSubmitProviderClient({
+          mapError: () => 'result'
+        });
+        expect(await provider.noArgsEmptyReturn()).toEqual('result');
+      });
+
+      it('supports custom error mapper that throws', async () => {
+        const provider = createTxSubmitProviderClient({
+          mapError: (error) => {
+            throw new ProviderError(ProviderFailure.Unhealthy, error, 'bad server');
+          }
+        });
+        try {
+          await provider.noArgsEmptyReturn();
+          throw new Error('Expected to throw');
+        } catch (error) {
+          expect((error as ProviderError).innerError).toBeTruthy();
+          expect((error as ProviderError).reason).toBe(ProviderFailure.Unhealthy);
+          expect((error as ProviderError).detail).toBe('bad server');
+        }
+      });
+    });
+  });
+});

--- a/packages/cardano-services-client/test/StakePoolSearchProvider/stakePoolSearchHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/StakePoolSearchProvider/stakePoolSearchHttpProvider.test.ts
@@ -1,0 +1,20 @@
+import { stakePoolSearchHttpProvider } from '../../src';
+import got from 'got';
+
+const url = 'http://some-hostname:3000';
+
+describe('stakePoolSearchHttpProvider', () => {
+  beforeAll(() => {
+    jest.mock('got');
+  });
+
+  afterAll(() => {
+    jest.unmock('got');
+  });
+
+  test('queryStakePools doesnt throw', async () => {
+    got.post = jest.fn().mockReturnValue({ json: jest.fn().mockResolvedValue([]) });
+    const provider = stakePoolSearchHttpProvider(url);
+    await expect(provider.queryStakePools([])).resolves.toEqual([]);
+  });
+});

--- a/packages/cardano-services-client/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
@@ -1,14 +1,14 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { serializeError } from 'serialize-error';
 import { txSubmitHttpProvider } from '../../src';
-import got from 'got';
+import got, { HTTPError, Response } from 'got';
 
 const url = 'http://some-hostname:3000';
 
 describe('txSubmitHttpProvider', () => {
   describe('healthCheck', () => {
     it('is not ok if cannot connect', async () => {
-      const provider = txSubmitHttpProvider({ url });
+      const provider = txSubmitHttpProvider(url);
       await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
     });
     describe('mocked', () => {
@@ -21,42 +21,63 @@ describe('txSubmitHttpProvider', () => {
       });
 
       it('is ok if 200 response body is { ok: true }', async () => {
-        got.get = jest.fn().mockResolvedValue({ body: JSON.stringify({ ok: true }) });
-        const provider = txSubmitHttpProvider({ url });
+        got.post = jest.fn().mockReturnValue({ json: jest.fn().mockResolvedValue({ ok: true }) });
+        const provider = txSubmitHttpProvider(url);
         await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
       });
 
       it('is not ok if 200 response body is { ok: false }', async () => {
-        got.get = jest.fn().mockResolvedValue({ body: JSON.stringify({ ok: false }) });
-        const provider = txSubmitHttpProvider({ url });
+        got.post = jest.fn().mockReturnValue({ json: jest.fn().mockResolvedValue({ ok: false }) });
+        const provider = txSubmitHttpProvider(url);
         await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
       });
     });
   });
+
   describe('submitTx', () => {
     it('resolves if successful', async () => {
-      got.post = jest.fn().mockResolvedValue('');
-      const provider = txSubmitHttpProvider({ url });
-      await expect(provider.submitTx(new Uint8Array())).resolves;
+      got.post = jest.fn().mockReturnValue({ json: jest.fn().mockResolvedValue('') });
+      const provider = txSubmitHttpProvider(url);
+      await expect(provider.submitTx(new Uint8Array())).resolves.not.toThrow();
     });
-    it('rehydrates errors, although only as base Error class', async () => {
-      const errors = [new Cardano.TxSubmissionErrors.BadInputsError({ badInputs: [] })];
-      try {
-        got.post = jest.fn().mockRejectedValue({
-          response: {
-            body: JSON.stringify(errors.map((e) => serializeError(e)))
+
+    describe('errors', () => {
+      const testError = (bodyError: Error, providerErrorType: unknown) => async () => {
+        const response = {
+          body: serializeError(bodyError)
+        } as Response;
+        const httpError = new HTTPError(response);
+        Object.defineProperty(httpError, 'response', { value: response });
+        try {
+          got.post = jest.fn().mockReturnValue({
+            json: jest.fn().mockRejectedValue(httpError)
+          });
+          const provider = txSubmitHttpProvider(url);
+          await provider.submitTx(new Uint8Array());
+          throw new Error('Expected to throw');
+        } catch (error) {
+          if (error instanceof ProviderError) {
+            expect(error.reason).toBe(ProviderFailure.BadRequest);
+            const innerError = error.innerError as Cardano.TxSubmissionError;
+            expect(innerError).toBeInstanceOf(providerErrorType);
+          } else {
+            throw new TypeError('Expected ProviderError');
           }
-        });
-        const provider = txSubmitHttpProvider({ url });
-        await provider.submitTx(new Uint8Array());
-        throw new Error('fail');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        // https://github.com/sindresorhus/serialize-error/issues/48
-        // expect(error[0]).toBeInstanceOf(Cardano.TxSubmissionErrors.BadInputsError);
-        expect(error[0]).toBeInstanceOf(Error);
-        expect(error[0].name).toBe('BadInputsError');
-      }
+        }
+      };
+
+      it(
+        'rehydrates errors',
+        testError(
+          new Cardano.TxSubmissionErrors.BadInputsError({ badInputs: [] }),
+          Cardano.TxSubmissionErrors.BadInputsError
+        )
+      );
+
+      it(
+        'maps unrecognized errors to UnknownTxSubmissionError',
+        testError(new Error('Unknown error'), Cardano.UnknownTxSubmissionError)
+      );
     });
   });
 });

--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -2,7 +2,7 @@ import { HealthCheckResponse, ProviderError, util } from '@cardano-sdk/core';
 import { Logger, dummyLogger } from 'ts-log';
 import { RunnableModule } from '../RunnableModule';
 import { listenPromise, serverClosePromise } from '../util';
-import bodyParser from 'body-parser';
+import bodyParser, { Options } from 'body-parser';
 import express from 'express';
 import expressPromBundle from 'express-prom-bundle';
 import http from 'http';
@@ -16,6 +16,9 @@ export type HttpServerConfig = {
   metrics?: {
     enabled: boolean;
     options?: expressPromBundle.Opts;
+  };
+  bodyParser?: {
+    limit?: Options['limit'];
   };
   name?: string;
   listen: net.ListenOptions;
@@ -41,7 +44,10 @@ export abstract class HttpServer extends RunnableModule {
     this.app = express();
     // must use this before router
     this.app.use(
-      bodyParser.json({ reviver: (key, value) => (key === '' ? util.fromSerializableObject(value) : value) })
+      bodyParser.json({
+        limit: this.config.bodyParser?.limit || '500kB',
+        reviver: (key, value) => (key === '' ? util.fromSerializableObject(value) : value)
+      })
     );
 
     if (this.config.metrics?.enabled) {

--- a/packages/cardano-services/src/util/index.ts
+++ b/packages/cardano-services/src/util/index.ts
@@ -1,2 +1,3 @@
 export * from './http';
 export * from './logging';
+export * from './provider';

--- a/packages/cardano-services/src/util/provider.ts
+++ b/packages/cardano-services/src/util/provider.ts
@@ -1,0 +1,16 @@
+import express from 'express';
+
+/**
+ * Parse provider method arguments, as sent by createHttpClient<T>.
+ * Arguments themselves are not validated.
+ */
+export const providerHandler =
+  <A1, A2 = unknown>(
+    handler: (args: [A1, A2], req: express.Request, _res: express.Response, _next: express.NextFunction) => void
+  ) =>
+  (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (!Array.isArray(req.body?.args)) {
+      return res.status(400).send('Must use application/json Content-Type header and have {args} in body');
+    }
+    handler(req.body?.args, req, res, next);
+  };

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -1,28 +1,39 @@
-import { HttpServer, HttpServerConfig, HttpServerDependencies, RunnableModule } from '../../src';
+import {
+  APPLICATION_JSON,
+  CONTENT_TYPE,
+  HttpServer,
+  HttpServerConfig,
+  HttpServerDependencies,
+  RunnableModule
+} from '../../src';
 import { getRandomPort } from 'get-port-please';
+import { util } from '@cardano-sdk/core';
 import express from 'express';
 import got from 'got';
 import net from 'net';
 import waitOn from 'wait-on';
 
-const APPLICATION_JSON = 'application/json';
 const onHttpServer = (url: string) => waitOn({ resources: [url], validateStatus: (statusCode) => statusCode === 404 });
 
 class SomeHttpServer extends HttpServer {
   private constructor(config: HttpServerConfig, dependencies: HttpServerDependencies) {
     super({ ...config, name: 'SomeHttpServer' }, dependencies);
   }
-  static create(config: HttpServerConfig) {
+  static create(config: HttpServerConfig, initialize?: (router: express.Router) => void) {
     const router = express.Router();
+    if (initialize) initialize(router);
     return new SomeHttpServer(config, {
       healthCheck: () => Promise.resolve({ ok: true }),
       router
     });
   }
+  publicSendJSON(res: express.Response, obj: unknown) {
+    this.sendJSON(res, obj);
+  }
 }
 
 describe('HttpServer', () => {
-  let httpServer: HttpServer;
+  let httpServer: SomeHttpServer;
   let port: number;
   let apiUrlBase: string;
 
@@ -43,6 +54,44 @@ describe('HttpServer', () => {
       expect(httpServer.app).not.toBeDefined();
       await httpServer.initialize();
       expect(httpServer.app).toBeDefined();
+    });
+
+    it('uses core serializableObject with body parser', async () => {
+      const expectedBody = {
+        bigint: 123n
+      };
+      httpServer = SomeHttpServer.create({ listen: { host: 'localhost', port } }, (router) => {
+        router.post('/echo', (req, res) => {
+          expect(req.body).toEqual(expectedBody);
+          res.send();
+        });
+      });
+      await httpServer.initialize();
+      await httpServer.start();
+      await onHttpServer(apiUrlBase);
+      await got.post(`${apiUrlBase}/echo`, {
+        body: JSON.stringify(util.toSerializableObject(expectedBody)),
+        headers: { [CONTENT_TYPE]: APPLICATION_JSON }
+      });
+      await httpServer.shutdown();
+    });
+  });
+
+  describe('sendJSON', () => {
+    it('sets content-type and transforms the object using toSerializableObj', () => {
+      httpServer = SomeHttpServer.create({ listen: { host: 'localhost', port } });
+      const obj = {
+        bigint: 123n
+      };
+      const res = {
+        header: jest.fn(),
+        send: jest.fn().mockImplementation((json) => {
+          expect(util.fromSerializableObject(JSON.parse(json))).toEqual(obj);
+        })
+      };
+      httpServer.publicSendJSON(res as unknown as express.Response, obj);
+      expect(res.send).toBeCalledTimes(1);
+      expect(res.header).toBeCalledTimes(1);
     });
   });
 
@@ -115,7 +164,7 @@ describe('HttpServer', () => {
       await httpServer.start();
       await onHttpServer(apiUrlBase);
       const res2 = await got(`${apiUrlBase}/metrics`, {
-        headers: { 'Content-Type': APPLICATION_JSON },
+        headers: { [CONTENT_TYPE]: APPLICATION_JSON },
         throwHttpErrors: false
       });
       expect(res2.statusCode).toBe(404);
@@ -127,7 +176,7 @@ describe('HttpServer', () => {
       await httpServer.start();
       await onHttpServer(apiUrlBase);
       const res = await got(`${apiUrlBase}/metrics`, {
-        headers: { 'Content-Type': APPLICATION_JSON }
+        headers: { [CONTENT_TYPE]: APPLICATION_JSON }
       });
       expect(res.statusCode).toBe(200);
       expect(typeof res.body).toBe('string');
@@ -143,7 +192,7 @@ describe('HttpServer', () => {
       await httpServer.start();
       await onHttpServer(apiUrlBase);
       const res = await got(`${apiUrlBase}${metricsPath}`, {
-        headers: { 'Content-Type': APPLICATION_JSON }
+        headers: { [CONTENT_TYPE]: APPLICATION_JSON }
       });
       expect(res.statusCode).toBe(200);
       expect(typeof res.body).toBe('string');
@@ -164,7 +213,7 @@ describe('HttpServer', () => {
 
     it('health', async () => {
       const res = await got(`${apiUrlBase}/health`, {
-        headers: { 'Content-Type': 'application/json' }
+        headers: { [CONTENT_TYPE]: 'application/json' }
       });
       expect(res.statusCode).toBe(200);
       expect(JSON.parse(res.body)).toEqual({ ok: true });

--- a/packages/cardano-services/test/util/provider.test.ts
+++ b/packages/cardano-services/test/util/provider.test.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { providerHandler } from '../../src/util';
+
+describe('util/provider', () => {
+  describe('providerHandler', () => {
+    it('calls handler with {args} from request body, doesnt send any response', () => {
+      const handler = jest.fn().mockImplementation((args) => {
+        expect(args[0]).toBe('arg');
+      });
+      const req = { body: { args: ['arg'] } };
+      const res = { send: jest.fn(), status: jest.fn() };
+      const next = {} as any;
+      providerHandler<string>(handler)(req as any, res as any, next);
+      expect(handler).toBeCalledTimes(1);
+      expect(handler).toBeCalledWith(['arg'], req, res, next);
+      expect(res.send).not.toBeCalled();
+      expect(res.status).not.toBeCalled();
+    });
+
+    it('given invalid request, sends 400 and does not call handler', () => {
+      const handler = jest.fn();
+      const req = { body: { args: {} } };
+      const res: any = {
+        send: jest.fn(),
+        status: jest.fn().mockImplementation(() => res)
+      };
+      const next = {} as any;
+      providerHandler<string>(handler)(req as any, res as any, next);
+      expect(handler).not.toBeCalled();
+      expect(res.status).toBeCalledTimes(1);
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/Cardano/types/TxSubmissionErrors.ts
+++ b/packages/core/src/Cardano/types/TxSubmissionErrors.ts
@@ -63,7 +63,6 @@ export const TxSubmissionErrors = {
   TxTooLargeError: TxSubmission.errors.TxTooLarge.Error,
   UnknownGenesisKeyError: TxSubmission.errors.UnknownGenesisKey.Error,
   UnknownOrIncompleteWithdrawalsError: TxSubmission.errors.UnknownOrIncompleteWithdrawals.Error,
-  UnknownTxSubmissionError,
   UnspendableDatumsError: TxSubmission.errors.UnspendableDatums.Error,
   UnspendableScriptInputsError: TxSubmission.errors.UnspendableScriptInputs.Error,
   UpdateWrongEpochError: TxSubmission.errors.UpdateWrongEpoch.Error,
@@ -76,4 +75,4 @@ export const TxSubmissionErrors = {
 
 type TxSubmissionErrorName = keyof typeof TxSubmissionErrors;
 type TxSubmissionErrorClass = typeof TxSubmissionErrors[TxSubmissionErrorName];
-export type TxSubmissionError = InstanceType<TxSubmissionErrorClass>;
+export type TxSubmissionError = InstanceType<TxSubmissionErrorClass> | UnknownTxSubmissionError;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -5,7 +5,9 @@ export enum ProviderFailure {
   Unknown = 'UNKNOWN',
   InvalidResponse = 'INVALID_RESPONSE',
   NotImplemented = 'NOT_IMPLEMENTED',
-  Unhealthy = 'UNHEALTHY'
+  Unhealthy = 'UNHEALTHY',
+  ConnectionFailure = 'CONNECTION_FAILURE',
+  BadRequest = 'BAD_REQUEST'
 }
 
 const formatMessage = (reason: string, detail?: string) => reason + (detail ? ` (${detail})` : '');

--- a/packages/core/src/util/misc/index.ts
+++ b/packages/core/src/util/misc/index.ts
@@ -1,3 +1,4 @@
 export * from './replaceNullsToUndefineds';
 export * from './isNotNil';
 export * from './bytesToHex';
+export * from './serializableObject';

--- a/packages/core/src/util/misc/serializableObject.ts
+++ b/packages/core/src/util/misc/serializableObject.ts
@@ -1,0 +1,71 @@
+import { transform } from 'lodash-es';
+
+const PLAIN_TYPES = new Set(['boolean', 'number', 'string']);
+
+export const toSerializableObject = (obj: unknown): unknown => {
+  if (PLAIN_TYPES.has(typeof obj)) return obj;
+  if (typeof obj === 'undefined') {
+    return {
+      __type: 'undefined'
+    };
+  }
+  if (typeof obj === 'object') {
+    if (obj === null) return null;
+    if (Array.isArray(obj)) {
+      return obj.map((item) => toSerializableObject(item));
+    }
+    if (ArrayBuffer.isView(obj)) {
+      const arr = new Uint8Array(obj.buffer, obj.byteOffset, obj.byteLength / Uint8Array.BYTES_PER_ELEMENT);
+      const value = Buffer.from(arr).toString('hex');
+      return { __type: 'Buffer', value };
+    }
+    if (obj instanceof Map) {
+      return {
+        __type: 'Map',
+        value: [...obj.entries()].map(([key, value]) => [toSerializableObject(key), toSerializableObject(value)])
+      };
+    }
+    return transform(
+      obj,
+      (result, value, key) => {
+        result[key] = toSerializableObject(value);
+        return result;
+      },
+      {} as Record<string | number | symbol, unknown>
+    );
+  }
+  if (typeof obj === 'bigint')
+    return {
+      __type: 'bigint',
+      value: obj.toString()
+    };
+};
+
+// eslint-disable-next-line sonarjs/cognitive-complexity
+const fromSerializableObjectUnknown = (obj: unknown): unknown => {
+  if (PLAIN_TYPES.has(typeof obj)) return obj;
+  if (typeof obj === 'object') {
+    if (obj === null) return null;
+    if (Array.isArray(obj)) {
+      return obj.map(fromSerializableObjectUnknown);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const docAsAny = obj as any;
+    if (docAsAny.__type === 'undefined') return undefined;
+    if (docAsAny.__type === 'bigint') return BigInt(docAsAny.value);
+    if (docAsAny.__type === 'Buffer') return Buffer.from(docAsAny.value, 'hex');
+    if (docAsAny.__type === 'Map')
+      return new Map(docAsAny.value.map((keyValues: unknown[]) => keyValues.map(fromSerializableObjectUnknown)));
+    return transform(
+      obj,
+      (result, value, key) => {
+        result[key] = fromSerializableObjectUnknown(value);
+        return result;
+      },
+      {} as Record<string | number | symbol, unknown>
+    );
+  }
+};
+
+export const fromSerializableObject = <T>(serializableObject: unknown) =>
+  fromSerializableObjectUnknown(serializableObject) as T;

--- a/packages/core/test/util/serializableObject.test.ts
+++ b/packages/core/test/util/serializableObject.test.ts
@@ -1,0 +1,40 @@
+import { util } from '../../src';
+
+const serializeAndDeserialize = (obj: unknown) =>
+  util.fromSerializableObject(JSON.parse(JSON.stringify(util.toSerializableObject(obj))));
+
+describe('serializableObject', () => {
+  it('supports plain types', () => {
+    expect(serializeAndDeserialize(123)).toEqual(123);
+    expect(serializeAndDeserialize('123')).toEqual('123');
+    expect(serializeAndDeserialize(true)).toEqual(true);
+    expect(serializeAndDeserialize(null)).toEqual(null);
+  });
+
+  it('supports nested arrays', () => {
+    const obj = [123, [456, 789]];
+    expect(serializeAndDeserialize(obj)).toEqual(obj);
+  });
+
+  it('supports nested objects', () => {
+    const obj = {
+      a: {
+        b: {
+          c: 'c',
+          d: 'd'
+        }
+      }
+    };
+    expect(serializeAndDeserialize(obj)).toEqual(obj);
+  });
+
+  it('supports types that are used in SDK, but not natively supported in JSON', () => {
+    const obj = {
+      bigint: 123n,
+      buffer: Buffer.from('data'),
+      map: new Map([['key', 'value']]),
+      undefined
+    };
+    expect(serializeAndDeserialize(obj)).toEqual(obj);
+  });
+});

--- a/packages/ogmios/src/ogmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/ogmiosTxSubmitProvider.ts
@@ -55,7 +55,7 @@ export const ogmiosTxSubmitProvider = (
       const txHex = Buffer.from(signedTransaction).toString('hex');
       return await txSubmissionClient.submitTx(txHex);
     } catch (error) {
-      throw Cardano.util.asTxSubmissionError(error) || new Cardano.TxSubmissionErrors.UnknownTxSubmissionError(error);
+      throw Cardano.util.asTxSubmissionError(error) || new Cardano.UnknownTxSubmissionError(error);
     }
   }
 });

--- a/packages/wallet/src/persistence/pouchdbStores/PouchdbStore.ts
+++ b/packages/wallet/src/persistence/pouchdbStores/PouchdbStore.ts
@@ -43,6 +43,6 @@ export abstract class PouchdbStore<T> {
   }
 
   protected toPouchdbDoc(obj: T): T {
-    return toPouchdbDoc(obj, false) as T;
+    return toPouchdbDoc(obj) as T;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5191,16 +5191,16 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-bigint@CardanoSolutions/json-bigint#d277387d:
+  version "1.0.0"
+  resolved "https://codeload.github.com/CardanoSolutions/json-bigint/tar.gz/d277387d7750ff4e698677d0aa0db97ebb60c581"
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-bigint@^1.0.0, json-bigint@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
   integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
-  dependencies:
-    bignumber.js "^9.0.0"
-
-"json-bigint@github:CardanoSolutions/json-bigint#d277387d":
-  version "1.0.0"
-  resolved "https://codeload.github.com/CardanoSolutions/json-bigint/tar.gz/d277387d7750ff4e698677d0aa0db97ebb60c581"
   dependencies:
     bignumber.js "^9.0.0"
 


### PR DESCRIPTION
# Context

Need to implement a http provider client for every type of provider

# Proposed Solution

- [x] feat(cardano-graphql-services): add generic http provider client that uses Proxy
- [x] refactor(cardano-services-client)!: reimplement txSubmitHttpProvider using createHttpProvider
  - fix TxSubmissionError deserialization into correct error type
  - wrap submitTx errors in ProviderError, simplify to always return 1 obj
  - move serialize-error to devDependencies
- [x] feat(cardano-services-client): add stakePoolSearchHttpProvider
- [x] refactor TxSubmitHttpServer to be compatible with the new generic HttpServer
  - feat(cardano-services): add HttpServer.sendJSON as a generic util that all http provider servers can use. 
    - Update base HttpServer to use core fromSerializableObject when deserializing req body.
  - refactor(cardano-services)!: make TxSubmitHttpServer compatible with createHttpProvider<T>
    - move body size validation to HttpServer
    - add providerHandler util to validate args presence in req body

# Important Changes Introduced

- [x] chore: rm unused .gitmodules
- [x] chore: disable 'jsdoc/require-returns-type' eslint rule
- [x] refactor: hoist pouchdb obj processing to core as serializableObject
- [x] refactor(core): rm UnknownTxSubmissionError from TxSubmissionErrors
  - add ProviderFailure.ConnectionFailure and ProviderFailure.BadRequest
  - refactor: update UnknownTxSubmissionError usages
