### PR TITLE
refactor(cip30): remove storage.local dependency

### DIFF
--- a/packages/cip30/src/Wallet/Wallet.ts
+++ b/packages/cip30/src/Wallet/Wallet.ts
@@ -1,6 +1,6 @@
 import { APIErrorCode, ApiError } from '../errors';
 import { Logger, dummyLogger } from 'ts-log';
-import { Storage, storage } from 'webextension-polyfill';
+import { Storage } from 'webextension-polyfill';
 import { WalletApi } from './types';
 
 /**
@@ -31,13 +31,11 @@ export type RequestAccess = () => Promise<boolean>;
 
 export type WalletOptions = {
   logger?: Logger;
-  storage?: Storage.LocalStorageArea;
+  storage: Storage.LocalStorageArea;
 };
 
 const defaultOptions = {
-  logger: dummyLogger,
-  persistAllowList: false,
-  storage: storage.local
+  logger: dummyLogger
 };
 
 type WalletStorage = {
@@ -55,7 +53,7 @@ export class Wallet {
   #requestAccess: RequestAccess;
   readonly #options: Required<WalletOptions>;
 
-  constructor(properties: WalletProperties, api: WalletApi, requestAccess: RequestAccess, options?: WalletOptions) {
+  constructor(properties: WalletProperties, api: WalletApi, requestAccess: RequestAccess, options: WalletOptions) {
     this.apiVersion = properties.apiVersion;
     this.enable = this.enable.bind(this);
     this.icon = properties.icon;

--- a/packages/cip30/src/WebExtension/handleMessages.ts
+++ b/packages/cip30/src/WebExtension/handleMessages.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { APIErrorCode, ApiError, DataSignError, PaginateError, TxSendError, TxSignError } from '../errors';
 import { Logger, dummyLogger } from 'ts-log';
+import { Runtime } from 'webextension-polyfill';
 import { WalletApi } from '../Wallet';
-import browser from 'webextension-polyfill';
 
 const cip30errorTypes = [ApiError, DataSignError, PaginateError, TxSendError, TxSignError];
 
@@ -40,8 +40,13 @@ export const createListener =
     }
   };
 
-export const handleMessages = (walletName: string, walletApi: WalletApi, logger: Logger = dummyLogger) => {
+export const handleMessages = (
+  walletName: string,
+  walletApi: WalletApi,
+  logger: Logger = dummyLogger,
+  runtime: Runtime.Static
+) => {
   const listener = createListener(walletName, walletApi, logger);
-  browser.runtime.onMessage.addListener(listener);
-  return () => browser.runtime.onMessage.removeListener(listener);
+  runtime.onMessage.addListener(listener);
+  return () => runtime.onMessage.removeListener(listener);
 };

--- a/packages/cip30/src/WebExtension/sendMessage.ts
+++ b/packages/cip30/src/WebExtension/sendMessage.ts
@@ -1,14 +1,14 @@
 import { Message } from './types';
+import { Runtime } from 'webextension-polyfill';
 import { WalletApi } from '../Wallet';
 import { dummyLogger } from 'ts-log';
-import browser from 'webextension-polyfill';
 
 export const createMessenger =
-  (extensionId: string, logger = dummyLogger) =>
+  (extensionId: string, runtime: Runtime.Static, logger = dummyLogger) =>
   async (msg: Message): Promise<WalletApi[keyof WalletApi]> => {
     logger.debug('sendMessage', msg);
     try {
-      return browser.runtime.sendMessage(extensionId, msg);
+      return runtime.sendMessage(extensionId, msg);
     } catch (error) {
       logger.error('sendMessage', error);
       throw error;

--- a/packages/cip30/src/WebExtension/webExtensionWalletClient.ts
+++ b/packages/cip30/src/WebExtension/webExtensionWalletClient.ts
@@ -1,4 +1,5 @@
 import { Message } from './types';
+import { Runtime } from 'webextension-polyfill';
 import { WalletApi, WalletMethodNames } from '../Wallet';
 import { createMessenger } from './sendMessage';
 import { dummyLogger } from 'ts-log';
@@ -10,9 +11,10 @@ export interface WebExtensionClientProps {
 
 export const createWebExtensionWalletClient = (
   { walletName, walletExtensionId }: WebExtensionClientProps,
+  runtime: Runtime.Static,
   logger = dummyLogger
 ): WalletApi => {
-  const sendMessage = createMessenger(walletExtensionId, logger);
+  const sendMessage = createMessenger(walletExtensionId, runtime, logger);
   return <WalletApi>(
     (<unknown>(
       Object.fromEntries(

--- a/packages/cip30/src/index.ts
+++ b/packages/cip30/src/index.ts
@@ -3,3 +3,4 @@ export * from './Wallet';
 export * from './types';
 export * from './injectWindow';
 export * from './types';
+export * from './WebExtension';

--- a/packages/cip30/test/Wallet.test.ts
+++ b/packages/cip30/test/Wallet.test.ts
@@ -4,11 +4,15 @@
 import * as testWallet from './testWallet';
 import { Cardano } from '@cardano-sdk/core';
 import { Wallet, WalletApi, WalletMethodNames, WalletOptions } from '../src/Wallet';
+import { dummyLogger } from 'ts-log';
 import { mocks } from 'mock-browser';
 import browser from 'webextension-polyfill';
 const window = mocks.MockBrowser.createWindow();
 
-const options: WalletOptions = {};
+const options: Required<WalletOptions> = {
+  logger: dummyLogger,
+  storage: browser.storage.local
+};
 
 if (process.env.DEBUG) {
   options.logger = console;

--- a/packages/cip30/test/injectWindow.test.ts
+++ b/packages/cip30/test/injectWindow.test.ts
@@ -2,6 +2,7 @@ import { ApiError } from '../src/errors';
 import { Wallet } from '../src/Wallet';
 import { WindowMaybeWithCardano, injectWindow } from '../src/injectWindow';
 import { api, properties, requestAccess } from './testWallet';
+import { dummyLogger } from 'ts-log';
 import { mocks } from 'mock-browser';
 import browser from 'webextension-polyfill';
 
@@ -9,10 +10,15 @@ describe('injectWindow', () => {
   let wallet: Wallet;
   let window: ReturnType<typeof mocks.MockBrowser>;
 
+  const options = {
+    logger: dummyLogger,
+    storage: browser.storage.local
+  };
+
   beforeEach(async () => {
     await browser.storage.local.clear();
 
-    wallet = new Wallet(properties, api, requestAccess);
+    wallet = new Wallet(properties, api, requestAccess, options);
     window = mocks.MockBrowser.createWindow();
   });
 
@@ -46,7 +52,7 @@ describe('injectWindow', () => {
 
       window = mocks.MockBrowser.createWindow();
       // re-inject window
-      const newWallet = new Wallet(properties, api, requestAccess);
+      const newWallet = new Wallet(properties, api, requestAccess, options);
       injectWindow(window, newWallet);
 
       expect(await window.cardano[properties.name].isEnabled(firstHostname)).toBe(false);
@@ -64,7 +70,7 @@ describe('injectWindow', () => {
 
       window = mocks.MockBrowser.createWindow();
       // re-inject window
-      const newWallet = new Wallet(properties, api, requestAccess);
+      const newWallet = new Wallet(properties, api, requestAccess, options);
       injectWindow(window, newWallet);
 
       expect(await window.cardano[properties.name].isEnabled(firstHostname)).toBe(true);
@@ -73,7 +79,7 @@ describe('injectWindow', () => {
 
     test('One allowed, one disallowed', async () => {
       const allowAccess = jest.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
-      const nextWallet = new Wallet(properties, api, allowAccess);
+      const nextWallet = new Wallet(properties, api, allowAccess, options);
 
       injectWindow(window, nextWallet);
 

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -37,10 +37,11 @@
     "@types/w3c-web-hid": "^1.0.2",
     "bunyan": "^1.8.15",
     "envalid": "^7.3.0",
-    "shx": "^0.3.3",
     "jest-webextension-mock": "^3.7.19",
     "mock-browser": "^0.92.14",
-    "wait-on": "^6.0.1"
+    "shx": "^0.3.3",
+    "wait-on": "^6.0.1",
+    "webextension-polyfill": "^0.9.0"
   },
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "4.0.0",

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -10,16 +10,17 @@ import {
   TxSendErrorCode,
   TxSignError,
   TxSignErrorCode,
-  WalletApi
+  WalletApi,
+  handleMessages
 } from '@cardano-sdk/cip30';
 import { AuthenticationError } from './KeyManagement/errors';
 import { CSL, Cardano, coreToCsl, cslToCore } from '@cardano-sdk/core';
 import { InputSelectionError } from '@cardano-sdk/cip2';
 import { Logger, dummyLogger } from 'ts-log';
+import { Runtime } from 'webextension-polyfill';
 import { SingleAddressWallet } from '.';
 import { cip30signData } from './KeyManagement/cip8';
 import { firstValueFrom } from 'rxjs';
-import { handleMessages } from '@cardano-sdk/cip30/dist/WebExtension';
 
 export type Cip30WalletDependencies = {
   logger?: Logger;
@@ -245,8 +246,9 @@ export const createWalletApi = (
 export const initialize = (
   wallet: SingleAddressWallet,
   confirmationCallback: CallbackConfirmation,
+  runtime: Runtime.Static,
   { logger = dummyLogger }: Cip30WalletDependencies = {}
 ) => {
   const walletApi = createWalletApi(wallet, confirmationCallback, { logger });
-  return handleMessages(wallet.name, walletApi, logger);
+  return handleMessages(wallet.name, walletApi, logger, runtime);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5191,16 +5191,16 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-bigint@CardanoSolutions/json-bigint#d277387d:
+  version "1.0.0"
+  resolved "https://codeload.github.com/CardanoSolutions/json-bigint/tar.gz/d277387d7750ff4e698677d0aa0db97ebb60c581"
+  dependencies:
+    bignumber.js "^9.0.0"
+
 json-bigint@^1.0.0, json-bigint@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
   integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
-  dependencies:
-    bignumber.js "^9.0.0"
-
-"json-bigint@github:CardanoSolutions/json-bigint#d277387d":
-  version "1.0.0"
-  resolved "https://codeload.github.com/CardanoSolutions/json-bigint/tar.gz/d277387d7750ff4e698677d0aa0db97ebb60c581"
   dependencies:
     bignumber.js "^9.0.0"
 
@@ -7990,6 +7990,11 @@ webextension-polyfill@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz#f80e9f4b7f81820c420abd6ffbebfa838c60e041"
   integrity sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==
+
+webextension-polyfill@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz#de6c1941d0ef1b0858b20e9c7b46bbc042c5a960"
+  integrity sha512-LTtHb0yR49xa9irkstDxba4GATDAcDw3ncnFH9RImoFwDlW47U95ME5sn5IiQX2ghfaECaf6xyXM8yvClIBkkw==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
# Context

The lightwallet application breaks if the `webextension-polyfill` is imported in anything other than the popup

# Proposed Solution
Remove the default import of this package and instead pass in as a required prop

# Important Changes Introduced
