### PR TITLE
feat(wallet): add unspendable utxo observable and store

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -188,7 +188,7 @@ export class SingleAddressWallet implements Wallet {
     this.utxo = createUtxoTracker({
       addresses$,
       retryBackoffConfig,
-      store: stores.utxo,
+      stores,
       tipBlockHeight$,
       transactionsInFlight$: this.transactions.outgoing.inFlight$,
       walletProvider: this.walletProvider

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -14,6 +14,7 @@ export class InMemoryAssetsStore extends InMemoryDocumentStore<Assets> {}
 
 export class InMemoryTransactionsStore extends InMemoryCollectionStore<Cardano.TxAlonzo> {}
 export class InMemoryUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}
+export class InMemoryUnspendableUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}
 
 export class InMemoryRewardsHistoryStore extends InMemoryKeyValueStore<Cardano.RewardAccount, EpochRewards[]> {}
 export class InMemoryStakePoolsStore extends InMemoryKeyValueStore<Cardano.PoolId, Cardano.StakePool> {}
@@ -29,6 +30,7 @@ export const createInMemoryWalletStores = (): WalletStores => ({
         this.genesisParameters.destroy(),
         this.networkInfo.destroy(),
         this.protocolParameters.destroy(),
+        this.unspendableUtxo.destroy(),
         this.rewardsBalances.destroy(),
         this.rewardsHistory.destroy(),
         this.stakePools.destroy(),
@@ -48,5 +50,6 @@ export const createInMemoryWalletStores = (): WalletStores => ({
   stakePools: new InMemoryStakePoolsStore(),
   tip: new InMemoryTipStore(),
   transactions: new InMemoryTransactionsStore(),
+  unspendableUtxo: new InMemoryUnspendableUtxoStore(),
   utxo: new InMemoryUtxoStore()
 });

--- a/packages/wallet/src/persistence/pouchdbStores/pouchdbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchdbStores/pouchdbWalletStores.ts
@@ -35,6 +35,7 @@ export const createPouchdbWalletStores = (walletName: string): WalletStores => {
           destroyDocumentsDb,
           this.transactions.destroy(),
           this.utxo.destroy(),
+          this.unspendableUtxo.destroy(),
           this.rewardsHistory.destroy(),
           this.stakePools.destroy(),
           this.rewardsBalances.destroy()
@@ -57,6 +58,7 @@ export const createPouchdbWalletStores = (walletName: string): WalletStores => {
        */
       (blockNo * 100_000 + index).toString()
     ),
+    unspendableUtxo: new PouchdbUtxoStore(`${baseDbName}UnspendableUtxo`),
     utxo: new PouchdbUtxoStore(`${baseDbName}Utxo`)
   };
 };

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -70,6 +70,7 @@ export interface KeyValueStore<K, V> extends Omit<CollectionStore<KeyValueCollec
 export interface WalletStores extends Destroyable {
   tip: DocumentStore<Cardano.Tip>;
   utxo: CollectionStore<Cardano.Utxo>;
+  unspendableUtxo: CollectionStore<Cardano.Utxo>;
   transactions: OrderedCollectionStore<Cardano.TxAlonzo>;
   rewardsHistory: KeyValueStore<Cardano.RewardAccount, EpochRewards[]>;
   rewardsBalances: KeyValueStore<Cardano.RewardAccount, Cardano.Lovelace>;

--- a/packages/wallet/src/services/BalanceTracker.ts
+++ b/packages/wallet/src/services/BalanceTracker.ts
@@ -73,12 +73,24 @@ export const createBalanceTracker = (
       mapToBalances
     )
   );
+
+  const unspendable$ = new TrackerSubject<Balance>(
+    utxoTracker.unspendable$.pipe(
+      map((utxo) => ({
+        ...Cardano.util.coalesceValueQuantities(utxo.map(([_, txOut]) => txOut.value)),
+        deposit: 0n,
+        rewards: 0n
+      }))
+    )
+  );
+
   return {
     available$,
     shutdown() {
       available$.complete();
       total$.complete();
     },
-    total$
+    total$,
+    unspendable$
   };
 };

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -18,10 +18,15 @@ export interface Balance extends Cardano.Value {
 export interface TransactionalObservables<T> {
   total$: BehaviorObservable<T>;
   available$: BehaviorObservable<T>;
+  unspendable$: BehaviorObservable<T>;
 }
 
 export interface TransactionalTracker<T> extends TransactionalObservables<T> {
   shutdown(): void;
+}
+
+export interface UtxoTracker extends TransactionalTracker<Cardano.Utxo[]> {
+  setUnspendable(utxo: Cardano.Utxo[]): void;
 }
 
 export type Milliseconds = number;


### PR DESCRIPTION
# Context

Allow wallet to set unspendable UTxO set, which won't be present in available UTxO or balance for input selection.

Jira Issue: [ADP-1647](https://input-output.atlassian.net/browse/ADP-1647)

# Proposed Solution

- Add `unspendable$` at `UtxoTracker` and `BalanceTracker`
- Add `setUnspendable(utxo: Cardano.Utxo[])` at `UtxoTracker` to update store values
- Filter out unspendable utxo in `available$` utxo in `UtxoTracker`

# Important Changes Introduced

- `UtxoTracker` now has `unspendableStore` and `unspendableUtxoSource$` arguments
- `PersistentCollectionTrackerSubject.next` now also sets all store values 
