### PR TITLE
feat: additional output validation

### DIFF
--- a/packages/cip2/src/selectionConstraints.ts
+++ b/packages/cip2/src/selectionConstraints.ts
@@ -67,7 +67,7 @@ const getTxSize = (tx: CSL.Transaction) => tx.to_bytes().length;
  * that adjust selection based on selection limit. RRRI implementation uses this after selecting all the inputs
  * and throws MaximumInputCountExceeded if the constraint returns a limit higher than number of selected utxo.
  *
- * @returns {ComputeSelectionLimit} constraint that returns txSize <= maxTxSize ? utxo[].length : utxo[].length+1
+ * @returns {ComputeSelectionLimit} constraint that returns txSize <= maxTxSize ? utxo[].length : utxo[].length-1
  */
 export const computeSelectionLimit =
   (maxTxSize: ProtocolParametersRequiredByInputSelection['maxTxSize'], buildTx: BuildTx): ComputeSelectionLimit =>
@@ -77,7 +77,7 @@ export const computeSelectionLimit =
     if (txSize <= maxTxSize) {
       return selectionSkeleton.inputs.size;
     }
-    return selectionSkeleton.inputs.size + 1;
+    return selectionSkeleton.inputs.size - 1;
   };
 
 export const defaultSelectionConstraints = ({

--- a/packages/cip2/test/selectionConstraints.test.ts
+++ b/packages/cip2/test/selectionConstraints.test.ts
@@ -90,7 +90,7 @@ describe('defaultSelectionConstraints', () => {
         protocolParameters
       });
       expect(await constraints.computeSelectionLimit({ inputs: new Set([1, 2]) as any } as SelectionSkeleton)).toEqual(
-        3
+        1
       );
     });
   });

--- a/packages/wallet/src/KeyManagement/types.ts
+++ b/packages/wallet/src/KeyManagement/types.ts
@@ -89,10 +89,14 @@ export type TransportType = TransportWebHID | TransportNodeHid;
  */
 export type GetPassword = (noCache?: true) => Promise<Uint8Array>;
 
-export type InputAddressResolver = (txIn: Cardano.NewTxIn) => Cardano.Address | null;
+/**
+ * @param txIn transaction input to resolve address from
+ * @returns input owner address
+ */
+export type ResolveInputAddress = (txIn: Cardano.NewTxIn) => Cardano.Address | null;
 
 export interface SignTransactionOptions {
-  inputAddressResolver: InputAddressResolver;
+  inputAddressResolver: ResolveInputAddress;
   additionalKeyPaths?: AccountKeyDerivationPath[];
 }
 

--- a/packages/wallet/src/KeyManagement/util/mapHardwareSigningData.ts
+++ b/packages/wallet/src/KeyManagement/util/mapHardwareSigningData.ts
@@ -32,7 +32,7 @@ import {
   utils
 } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { CSL, Cardano, cslToCore, util } from '@cardano-sdk/core';
-import { GroupedAddress, InputAddressResolver } from '../types';
+import { GroupedAddress, ResolveInputAddress } from '../types';
 import { HwMappingError } from '../errors';
 import { concat, uniq } from 'lodash-es';
 
@@ -40,7 +40,7 @@ export interface TxToLedgerProps {
   cslTxBody: CSL.TransactionBody;
   networkId: Cardano.NetworkId;
   accountIndex: number;
-  inputAddressResolver: InputAddressResolver;
+  inputAddressResolver: ResolveInputAddress;
   knownAddresses: GroupedAddress[];
 }
 
@@ -88,7 +88,7 @@ const bytesToIp = (bytes?: Uint8Array) => {
 
 const prepareLedgerInputs = (
   inputs: CSL.TransactionInputs,
-  inputAddressResolver: InputAddressResolver,
+  inputAddressResolver: ResolveInputAddress,
   knownAddresses: GroupedAddress[]
 ): TxInput[] => {
   const ledgerInputs = [];

--- a/packages/wallet/src/KeyManagement/util/ownSignatureKeyPaths.ts
+++ b/packages/wallet/src/KeyManagement/util/ownSignatureKeyPaths.ts
@@ -1,4 +1,4 @@
-import { AccountKeyDerivationPath, GroupedAddress, InputAddressResolver, KeyRole } from '../types';
+import { AccountKeyDerivationPath, GroupedAddress, KeyRole, ResolveInputAddress } from '../types';
 import { Cardano, util } from '@cardano-sdk/core';
 import { uniq } from 'lodash-es';
 
@@ -10,7 +10,7 @@ import { uniq } from 'lodash-es';
 export const ownSignatureKeyPaths = (
   txBody: Cardano.NewTxBodyAlonzo,
   knownAddresses: GroupedAddress[],
-  resolveInputAddress: InputAddressResolver
+  resolveInputAddress: ResolveInputAddress
 ): AccountKeyDerivationPath[] => {
   const paymentKeyPaths = uniq(
     txBody.inputs

--- a/packages/wallet/src/KeyManagement/util/stubSignTransaction.ts
+++ b/packages/wallet/src/KeyManagement/util/stubSignTransaction.ts
@@ -1,5 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
-import { GroupedAddress, InputAddressResolver } from '../types';
+import { GroupedAddress, ResolveInputAddress } from '../types';
 import { ownSignatureKeyPaths } from './ownSignatureKeyPaths';
 
 const randomHexChar = () => Math.floor(Math.random() * 16).toString(16);
@@ -8,7 +8,7 @@ const randomPublicKey = () => Cardano.Ed25519PublicKey(Array.from({ length: 64 }
 export const stubSignTransaction = (
   txBody: Cardano.NewTxBodyAlonzo,
   knownAddresses: GroupedAddress[],
-  inputAddressResolver: InputAddressResolver
+  inputAddressResolver: ResolveInputAddress
 ): Cardano.Signatures =>
   new Map(
     ownSignatureKeyPaths(txBody, knownAddresses, inputAddressResolver).map(() => [

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -198,7 +198,7 @@ export const createWalletApi = (
             body: coreTx,
             hash
           },
-          { inputAddressResolver: wallet.inputAddressResolver }
+          { inputAddressResolver: wallet.util.resolveInputAddress }
         );
 
         const cslWitnessSet = coreToCsl.witnessSet(witnessSet);

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -1,0 +1,47 @@
+import { BigIntMath, Cardano, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { OutputValidation, Wallet } from '../types';
+import { ResolveInputAddress } from '../KeyManagement';
+import { computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit } from '@cardano-sdk/cip2';
+import { firstValueFrom } from 'rxjs';
+import { txInEquals } from './util';
+
+/**
+ * @returns common wallet utility functions that are aware of wallet state and computes useful things
+ */
+export const createWalletUtil = (wallet: Wallet) => {
+  const validateOutput = async (
+    output: Cardano.TxOut,
+    protocolParameters?: Pick<ProtocolParametersRequiredByWallet, 'coinsPerUtxoWord' | 'maxValueSize'>
+  ): Promise<OutputValidation> => {
+    const { coinsPerUtxoWord, maxValueSize } = protocolParameters || (await firstValueFrom(wallet.protocolParameters$));
+    const minimumCoin = BigInt(computeMinimumCoinQuantity(coinsPerUtxoWord)(output.value.assets));
+    return {
+      coinMissing: BigIntMath.max([minimumCoin - output.value.coins, 0n])!,
+      minimumCoin,
+      tokenBundleSizeExceedsLimit: tokenBundleSizeExceedsLimit(maxValueSize)(output.value.assets)
+    };
+  };
+  const resolveInputAddress: ResolveInputAddress = (input: Cardano.NewTxIn) =>
+    wallet.utxo.available$.value?.find(([txIn]) => txInEquals(txIn, input))?.[1].address || null;
+
+  return {
+    resolveInputAddress,
+    /**
+     * @returns Validates that token bundle size is within limits and computes minimum coin quantity
+     */
+    validateOutput,
+    /**
+     * @returns For every output, validates that token bundle size is within limits and computes minimum coin quantity
+     */
+    validateOutputs: async (outputs: Iterable<Cardano.TxOut>): Promise<Map<Cardano.TxOut, OutputValidation>> => {
+      const protocolParameters = await firstValueFrom(wallet.protocolParameters$);
+      const validations = new Map<Cardano.TxOut, OutputValidation>();
+      for (const output of outputs) {
+        validations.set(output, await validateOutput(output, protocolParameters));
+      }
+      return validations;
+    }
+  };
+};
+
+export type WalletUtil = ReturnType<typeof createWalletUtil>;

--- a/packages/wallet/src/services/index.ts
+++ b/packages/wallet/src/services/index.ts
@@ -7,3 +7,4 @@ export * from './AssetsTracker';
 export * from './types';
 export * from './createNftMetadataProvider';
 export * from './ProviderTracker';
+export * from './WalletUtil';

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,5 +1,12 @@
 import { Asset, Cardano, NetworkInfo, ProtocolParametersRequiredByWallet, TimeSettings } from '@cardano-sdk/core';
-import { Balance, BehaviorObservable, DelegationTracker, TransactionalTracker, TransactionsTracker } from './services';
+import {
+  Balance,
+  BehaviorObservable,
+  DelegationTracker,
+  TransactionalTracker,
+  TransactionsTracker,
+  WalletUtil
+} from './services';
 import { Cip30DataSignature } from '@cardano-sdk/cip30';
 import { Cip30SignDataRequest } from './KeyManagement/cip8';
 import { GroupedAddress } from './KeyManagement';
@@ -23,11 +30,12 @@ export interface FinalizeTxProps {
 
 export type Assets = Map<Cardano.AssetId, Asset.AssetInfo>;
 
-export interface MinimumCoinQuantity {
+export interface OutputValidation {
   minimumCoin: Cardano.Lovelace;
   coinMissing: Cardano.Lovelace;
+  tokenBundleSizeExceedsLimit: boolean;
 }
-export type MinimumCoinQuantityPerOutput = Map<Cardano.TxOut, MinimumCoinQuantity>;
+export type MinimumCoinQuantityPerOutput = Map<Cardano.TxOut, OutputValidation>;
 
 export interface InitializeTxPropsValidationResult {
   minimumCoinQuantities: MinimumCoinQuantityPerOutput;
@@ -75,10 +83,7 @@ export interface Wallet {
   readonly addresses$: BehaviorObservable<GroupedAddress[]>;
   readonly assets$: BehaviorObservable<Assets>;
   readonly syncStatus: SyncStatus;
-  /**
-   * Compute minimum coin quantity for each transaction output
-   */
-  validateInitializeTxProps(props: InitializeTxProps): Promise<InitializeTxPropsValidationResult>;
+  readonly util: WalletUtil;
   /**
    * @throws InputSelectionError
    */

--- a/packages/wallet/test/KeyManagement/InMemoryKeyAgent.test.ts
+++ b/packages/wallet/test/KeyManagement/InMemoryKeyAgent.test.ts
@@ -83,7 +83,7 @@ describe('InMemoryKeyAgent', () => {
       { index: 0, role: 2 }
     ]);
     const body = {} as unknown as Cardano.TxBodyAlonzo;
-    const inputAddressResolver = {} as KeyManagement.InputAddressResolver;
+    const inputAddressResolver = {} as KeyManagement.ResolveInputAddress;
     const options = { inputAddressResolver } as KeyManagement.SignTransactionOptions;
     const witnessSet = await keyAgent.signTransaction(
       {

--- a/packages/wallet/test/KeyManagement/util/stubSignTransaction.test.ts
+++ b/packages/wallet/test/KeyManagement/util/stubSignTransaction.test.ts
@@ -1,5 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
-import { GroupedAddress, InputAddressResolver } from '../../../src/KeyManagement';
+import { GroupedAddress, ResolveInputAddress } from '../../../src/KeyManagement';
 import { stubSignTransaction } from '../../../src/KeyManagement/util';
 
 jest.mock('../../../src/KeyManagement/util/ownSignatureKeyPaths');
@@ -7,7 +7,7 @@ const { ownSignatureKeyPaths } = jest.requireMock('../../../src/KeyManagement/ut
 
 describe('KeyManagement.util.stubSignTransaction', () => {
   it('returns as many signatures as number of keys returned by ownSignaturePaths', () => {
-    const inputAddressResolver = {} as InputAddressResolver; // not called
+    const inputAddressResolver = {} as ResolveInputAddress; // not called
     const txBody = {} as Cardano.TxBodyAlonzo;
     const knownAddresses = [{} as GroupedAddress];
     ownSignatureKeyPaths.mockReturnValueOnce([{}]).mockReturnValueOnce([{}, {}]);

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -94,7 +94,7 @@ const assertWalletProperties = async (
   // timeSettings$
   expect(await firstValueFrom(wallet.timeSettings$)).toEqual(testnetTimeSettings);
   // inputAddressResolver
-  expect(typeof wallet.inputAddressResolver).toBe('function');
+  expect(typeof wallet.util).toBe('object');
 };
 
 const assertWalletProperties2 = async (wallet: Wallet) => {

--- a/packages/wallet/test/SingleAddressWallet/methods.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/methods.test.ts
@@ -10,6 +10,24 @@ import { waitForWalletStateSettle } from '../util';
 jest.mock('../../src/KeyManagement/cip8/cip30signData');
 const { cip30signData } = jest.requireMock('../../src/KeyManagement/cip8/cip30signData');
 
+const outputs = [
+  {
+    address: Cardano.Address(
+      'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w'
+    ),
+    value: { coins: 11_111_111n }
+  },
+  {
+    address: Cardano.Address(
+      'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+    ),
+    value: {
+      assets: new Map([[AssetId.TSLA, 6n]]),
+      coins: 5n
+    }
+  }
+];
+
 describe('SingleAddressWallet methods', () => {
   const address = mocks.utxo[0][0].address!;
   let txSubmitProvider: mocks.TxSubmitProviderStub;
@@ -44,35 +62,46 @@ describe('SingleAddressWallet methods', () => {
     wallet.shutdown();
   });
 
-  describe('creating transactions', () => {
-    const outputs = [
-      {
-        address: Cardano.Address(
-          'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w'
-        ),
-        value: { coins: 11_111_111n }
-      },
-      {
-        address: Cardano.Address(
-          'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
-        ),
-        value: {
-          assets: new Map([[AssetId.TSLA, 6n]]),
-          coins: 5n
-        }
-      }
-    ];
-    const props = {
-      inputs: new Set<Cardano.TxIn>([utxo[1][0]]),
-      outputs: new Set<Cardano.TxOut>(outputs)
-    };
+  describe('util', () => {
+    describe('validateOutput', () => {
+      it('without assets', async () => {
+        const validation = await wallet.util.validateOutput(outputs[0]);
+        expect(validation.coinMissing).toBe(0n);
+        expect(validation.minimumCoin).toBeGreaterThan(0n);
+        expect(validation.tokenBundleSizeExceedsLimit).toBe(false);
+      });
 
-    describe('validateTx', () => {
+      it('with assets', async () => {
+        const validation = await wallet.util.validateOutput(outputs[1]);
+        expect(validation.coinMissing).toBe(validation.minimumCoin - outputs[1].value.coins);
+        expect(validation.minimumCoin).toBeGreaterThan(0n);
+        expect(validation.tokenBundleSizeExceedsLimit).toBe(false);
+      });
+
+      it('token bundle size exceeds limit', async () => {
+        const generateAssetId = () =>
+          Cardano.AssetId(
+            [...Array.from({ length: 56 })].map(() => Math.floor(Math.random() * 16).toString(16)).join('')
+          );
+        const output: Cardano.TxOut = {
+          address: outputs[1].address,
+          value: {
+            assets: new Map<Cardano.AssetId, bigint>(Array.from({ length: 100 }).map(() => [generateAssetId(), 1234n])),
+            coins: 0n
+          }
+        };
+        const validation = await wallet.util.validateOutput(output);
+        expect(validation.coinMissing).toBeGreaterThan(0n);
+        expect(validation.tokenBundleSizeExceedsLimit).toBe(true);
+      });
+    });
+
+    describe('validateOutputs', () => {
       it('returns minimum coin quantity per output', async () => {
-        const { minimumCoinQuantities } = await wallet.validateInitializeTxProps(props);
-        expect(minimumCoinQuantities.size).toBe(2);
-        const outputWithoutAssetsMinimumCoin = minimumCoinQuantities.get(outputs[0])!;
-        const outputWithAssetsMinimumCoin = minimumCoinQuantities.get(outputs[1])!;
+        const outputValidations = await wallet.util.validateOutputs(outputs);
+        expect(outputValidations.size).toBe(2);
+        const outputWithoutAssetsMinimumCoin = outputValidations.get(outputs[0])!;
+        const outputWithAssetsMinimumCoin = outputValidations.get(outputs[1])!;
         expect(outputWithoutAssetsMinimumCoin.minimumCoin).toBeGreaterThan(0n);
         expect(outputWithAssetsMinimumCoin.minimumCoin).toBeGreaterThan(outputWithoutAssetsMinimumCoin.minimumCoin);
         expect(outputWithoutAssetsMinimumCoin.coinMissing).toBe(0n);
@@ -81,6 +110,29 @@ describe('SingleAddressWallet methods', () => {
         );
       });
     });
+
+    describe('resolveInputAddress', () => {
+      it('returns input address for wallet-owned utxo', async () => {
+        const utxoSet = await firstValueFrom(wallet.utxo.available$);
+        expect(typeof wallet.util.resolveInputAddress(utxoSet[0][0])).toBe('string');
+      });
+
+      it('returns null for non-wallet-owned utxo', async () => {
+        expect(
+          wallet.util.resolveInputAddress({
+            index: 9,
+            txId: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
+          })
+        ).toBe(null);
+      });
+    });
+  });
+
+  describe('creating transactions', () => {
+    const props = {
+      inputs: new Set<Cardano.TxIn>([utxo[1][0]]),
+      outputs: new Set<Cardano.TxOut>(outputs)
+    };
 
     it('initializeTx', async () => {
       mocks.getPassword.mockClear();


### PR DESCRIPTION
# Context

Wallets might want to validate some transaction properties before building it. We currently have `Wallet.validateInitializeTxProps`, which was originally designed as a general validation function that could be called prior to calling `Wallet.initializeTx` to ensure that `initializeTx` will succeed, as well as providing additional context about any validation errors. Problem with this approach is that one of the potential errors is the overall transaction size being too large. To perform this validation, you have to run input selection algorithm, which has randomness involved and could therefore select a different number of inputs, resulting in a different transaction size when you later call `initializeTx`. Therefore, it is way more practical to keep validation of transaction size as an exception of `initializeTx` (currently as `MaximumInputCountExceeded` error).

# Proposed Solution

- Since it's not practical to implement assurance of valid InitializeTxProps prior to actually calling `initializeTx`, get rid of `Wallet.validateInitializeTxProps` by splitting it into more atomic validation functions, moving it under `Wallet.util`:
  - Wallet.util.validateOutput
  - Wallet.util.validateOutputs
- Validate token bundle (value) size of an output
- In addition, hoist `SingleAddressWallet.resolveInputAddress` to `Wallet.util.resolveInputAddress` since it fits nicely under this newly created scope, simplifying the root Wallet interface a little bit.

# Important Changes Introduced

- rename type of validation result to OutputValidation
- rename InputAddressResolver to ResolveInputAddress since it's a function, not an object
- [fix(cip2): computeSelectionLimit constraint logic error](https://github.com/input-output-hk/cardano-js-sdk/commit/cbcf9b5ee23964389f671cdab835c47a72427e1b)
