### PR TITLE
refactor(wallet): change transactions history all type to TxAlonzo

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -211,11 +211,7 @@ export class SingleAddressWallet implements Wallet {
       createAssetsTracker({
         assetProvider: this.assetProvider,
         balanceTracker: this.balance,
-        nftMetadataProvider: createNftMetadataProvider(
-          this.walletProvider,
-          // this is not very efficient, consider storing TxAlonzo[] in transactions tracker history
-          this.transactions.history.all$.pipe(map((txs) => txs.map(({ tx }) => tx)))
-        ),
+        nftMetadataProvider: createNftMetadataProvider(this.walletProvider, this.transactions.history.all$),
         retryBackoffConfig
       }),
       stores.assets

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -35,16 +35,6 @@ export interface PollingConfig {
   readonly consideredOutOfSyncAfter?: Milliseconds;
 }
 
-export enum TransactionDirection {
-  Incoming = 'Incoming',
-  Outgoing = 'Outgoing'
-}
-
-export interface DirectionalTransaction {
-  tx: Cardano.TxAlonzo;
-  direction: TransactionDirection;
-}
-
 export interface FailedTx {
   tx: Cardano.NewTxAlonzo;
   reason: TransactionFailure;
@@ -53,7 +43,7 @@ export interface FailedTx {
 
 export interface TransactionsTracker {
   readonly history: {
-    all$: BehaviorObservable<DirectionalTransaction[]>;
+    all$: BehaviorObservable<Cardano.TxAlonzo[]>;
     outgoing$: BehaviorObservable<Cardano.TxAlonzo[]>;
     incoming$: BehaviorObservable<Cardano.TxAlonzo[]>;
   };

--- a/packages/wallet/test/integration/transactionTime.test.ts
+++ b/packages/wallet/test/integration/transactionTime.test.ts
@@ -11,7 +11,7 @@ describe('integration/transactionTime', () => {
   });
 
   it('provides utils necessary for computing transaction time', async () => {
-    const transactions = await firstValueFrom(wallet.transactions.history.incoming$);
+    const transactions = await firstValueFrom(wallet.transactions.history.all$);
     const {
       network: { timeSettings }
     } = await firstValueFrom(wallet.networkInfo$);

--- a/packages/wallet/test/services/TransactionsTracker.test.ts
+++ b/packages/wallet/test/services/TransactionsTracker.test.ts
@@ -1,14 +1,5 @@
-/* eslint-disable no-multi-spaces */
-/* eslint-disable space-in-parens */
-/* eslint-disable prettier/prettier */
 import { Cardano, WalletProvider } from '@cardano-sdk/core';
-import {
-  FailedTx,
-  TransactionDirection,
-  TransactionFailure,
-  createAddressTransactionsProvider,
-  createTransactionsTracker
-} from '../../src';
+import { FailedTx, TransactionFailure, createAddressTransactionsProvider, createTransactionsTracker } from '../../src';
 import { InMemoryTransactionsStore, OrderedCollectionStore } from '../../src/persistence';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { WalletProviderStub, mockWalletProvider, queryTransactionsResult } from '../mocks';
@@ -161,16 +152,8 @@ describe('TransactionsTracker', () => {
         });
         expectObservable(transactionsTracker.history.all$).toBe('a-bc|', {
           a: [],
-          b: [
-            {
-              direction: TransactionDirection.Incoming,
-              tx: incomingTx
-            }
-          ],
-          c: [
-            { direction: TransactionDirection.Outgoing, tx: outgoingTx },
-            { direction: TransactionDirection.Incoming, tx: incomingTx }
-          ]
+          b: [incomingTx],
+          c: [outgoingTx, incomingTx]
         });
       });
     });


### PR DESCRIPTION
# Context
Simplify `SingleAddressWallet.transactions.history.all` by changing it’s type to `Cardano.TxAlonzo[]`

# Proposed Solution
- Use the transaction inspector to identify an outgoing or incoming transaction and get rid of `DirectionalTransaction` type

# Important Changes Introduced
- Changed `transactions.history.all$` type from `DirectionalTransaction` to `TxAlonzo`
- Removed `DirectionalTransaction` and `TransactionDireciton`