### PR TITLE
refactor: transactions tracker

### DIFF
--- a/packages/core/src/Address/util.ts
+++ b/packages/core/src/Address/util.ts
@@ -1,4 +1,4 @@
-import { Address, TxAlonzo } from '../Cardano';
+import { Address, TxAlonzo, TxIn } from '../Cardano';
 import { parseCslAddress } from '../CSL';
 
 /**
@@ -15,8 +15,10 @@ export const isAddressWithin =
     addresses.includes(address!);
 
 /**
- * Receives a transaction and a set of addresses to check if the transaction is outgoing,
- * i.e., some of the addresses are included in the transaction inputs
+ * Receives a transaction and a set of addresses to check if
+ * some of them are included in the transaction inputs
+ *
+ * @returns {TxIn[]} array of inputs that contain any of the addresses
  */
-export const isOutgoing = (tx: TxAlonzo, ownAddresses: Address[]): boolean =>
-  tx.body.inputs.some(isAddressWithin(ownAddresses));
+export const inputsWithAddresses = (tx: TxAlonzo, ownAddresses: Address[]): TxIn[] =>
+  tx.body.inputs.filter(isAddressWithin(ownAddresses));

--- a/packages/core/src/Asset/util/index.ts
+++ b/packages/core/src/Asset/util/index.ts
@@ -1,3 +1,5 @@
 export * from './assetId';
 export * from './metadatumToCip25';
 export * from './coalesceTokenMaps';
+export * from './removeNegativesFromTokenMap';
+export * from './subtractTokenMaps';

--- a/packages/core/src/Asset/util/removeNegativesFromTokenMap.ts
+++ b/packages/core/src/Asset/util/removeNegativesFromTokenMap.ts
@@ -1,0 +1,18 @@
+import { TokenMap } from '../../Cardano';
+
+/**
+ * Remove all negative quantities from a TokenMap.
+ * Does not modify the original TokenMap
+ *
+ * @param {TokenMap} assets TokenMap to remove negative quantities
+ * @returns {TokenMap} a copy of `assets` with negative quantities removed, could be empty
+ */
+export const removeNegativesFromTokenMap = (assets: TokenMap): TokenMap => {
+  const result: TokenMap = new Map(assets);
+  for (const [assetId, assetQuantity] of result) {
+    if (assetQuantity < 0) {
+      result.delete(assetId);
+    }
+  }
+  return result;
+};

--- a/packages/core/src/Asset/util/subtractTokenMaps.ts
+++ b/packages/core/src/Asset/util/subtractTokenMaps.ts
@@ -1,0 +1,22 @@
+import { TokenMap } from '../../Cardano';
+import { util } from '../../util';
+
+/**
+ * Subtract asset quantities in order
+ */
+export const subtractTokenMaps = (assets: (TokenMap | undefined)[]): TokenMap | undefined => {
+  if (assets.length <= 0 || !util.isNotNil(assets[0])) return undefined;
+  const result: TokenMap = assets[0];
+  const rest: TokenMap[] = assets.slice(1).filter(util.isNotNil);
+  for (const assetTotals of rest) {
+    for (const [assetId, assetQuantity] of assetTotals.entries()) {
+      const total = result.get(assetId) ?? 0n;
+      const diff = total - assetQuantity;
+      diff === 0n ? result.delete(assetId) : result.set(assetId, diff);
+    }
+  }
+  if (result.size === 0) {
+    return undefined;
+  }
+  return result;
+};

--- a/packages/core/src/Cardano/util/index.ts
+++ b/packages/core/src/Cardano/util/index.ts
@@ -5,3 +5,5 @@ export * from './estimateStakePoolAPY';
 export * from './primitives';
 export * as metadatum from './metadatum';
 export * from './txSubmissionErrors';
+export * from './resolveInputValue';
+export * from './subtractValueQuantities';

--- a/packages/core/src/Cardano/util/resolveInputValue.ts
+++ b/packages/core/src/Cardano/util/resolveInputValue.ts
@@ -1,0 +1,13 @@
+import { TxAlonzo, TxIn, Value } from '../types';
+
+/**
+ * Resolves the value of an input by looking for the matching output in a list of transactions
+ *
+ * @param {TxIn} input input to resolve value for
+ * @param {TxAlonzo[]} transactions list of transactions to find the matching output
+ * @returns {Value | undefined} input value or undefined if not found
+ */
+export const resolveInputValue = (input: TxIn, transactions: TxAlonzo[]): Value | undefined => {
+  const tx = transactions.find((transaction) => transaction.id === input.txId);
+  return tx?.body.outputs[input.index]?.value;
+};

--- a/packages/core/src/Cardano/util/subtractValueQuantities.ts
+++ b/packages/core/src/Cardano/util/subtractValueQuantities.ts
@@ -1,0 +1,10 @@
+import { Asset, BigIntMath } from '../..';
+import { Value } from '../types';
+
+/**
+ * Subtract all quantities
+ */
+export const subtractValueQuantities = (quantities: Value[]) => ({
+  assets: Asset.util.subtractTokenMaps(quantities.map(({ assets }) => assets)),
+  coins: BigIntMath.subtract(quantities.map(({ coins }) => coins))
+});

--- a/packages/core/src/util/BigIntMath.ts
+++ b/packages/core/src/util/BigIntMath.ts
@@ -10,6 +10,10 @@ export const BigIntMath = {
     }
     return max;
   },
+  subtract(arr: bigint[]): bigint {
+    if (arr.length === 0) return 0n;
+    return arr.reduce((result, num) => result - num);
+  },
   sum(arr: bigint[]): bigint {
     return arr.reduce((result, num) => result + num, 0n);
   }

--- a/packages/core/test/Address/util.test.ts
+++ b/packages/core/test/Address/util.test.ts
@@ -44,7 +44,7 @@ describe('Address', () => {
       });
     });
 
-    describe('isOutgoing', () => {
+    describe('inputsWithAddresses', () => {
       beforeAll(() => parseCslAddressSpy.mockRestore());
       const tx = {
         body: {
@@ -58,12 +58,18 @@ describe('Address', () => {
         }
       } as Cardano.TxAlonzo;
 
-      it('returns true if any of the addresses are in some of the transaction inputs', () => {
-        expect(Address.util.isOutgoing(tx, addresses)).toBe(true);
+      it('returns the transaction inputs that contain any of the addresses', () => {
+        expect(Address.util.inputsWithAddresses(tx, addresses)).toEqual([
+          {
+            address: addresses[0],
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ]);
       });
 
-      it('returns false if none of the addresses are in the transaction inputs', () => {
-        expect(Address.util.isOutgoing(tx, [addresses[1]])).toBe(false);
+      it('returns an empty array if none of the addresses are in the transaction inputs', () => {
+        expect(Address.util.inputsWithAddresses(tx, [addresses[1]])).toEqual([]);
       });
     });
   });

--- a/packages/core/test/Asset/util/removeNegativesFromTokenMap.test.ts
+++ b/packages/core/test/Asset/util/removeNegativesFromTokenMap.test.ts
@@ -1,0 +1,22 @@
+import { Asset } from '@cardano-sdk/core';
+import { AssetId } from '@cardano-sdk/util-dev';
+
+describe('Asset', () => {
+  describe('util', () => {
+    describe('removeNegativesFromTokenMap', () => {
+      it('should delete tokens with negative quantities from a token map', () => {
+        const asset = new Map([
+          [AssetId.PXL, -100n],
+          [AssetId.Unit, 50n],
+          [AssetId.TSLA, 0n]
+        ]);
+        expect(Asset.util.removeNegativesFromTokenMap(asset)).toEqual(
+          new Map([
+            [AssetId.Unit, 50n],
+            [AssetId.TSLA, 0n]
+          ])
+        );
+      });
+    });
+  });
+});

--- a/packages/core/test/Asset/util/subtractTokenMaps.test.ts
+++ b/packages/core/test/Asset/util/subtractTokenMaps.test.ts
@@ -1,0 +1,53 @@
+import { Asset } from '@cardano-sdk/core';
+import { AssetId } from '@cardano-sdk/util-dev';
+
+describe('Asset', () => {
+  describe('util', () => {
+    describe('subtractTokenMaps', () => {
+      it('should subtract quantities correctly when all assets have the same tokens', () => {
+        const initialAsset = new Map([
+          [AssetId.PXL, 100n],
+          [AssetId.Unit, 50n]
+        ]);
+        const asset2 = new Map([
+          [AssetId.PXL, 23n],
+          [AssetId.Unit, 20n]
+        ]);
+        expect(Asset.util.subtractTokenMaps([initialAsset, asset2])).toEqual(
+          new Map([
+            [AssetId.PXL, 77n],
+            [AssetId.Unit, 30n]
+          ])
+        );
+      });
+      it('should delete tokens from result when quantity is 0', () => {
+        const initialAsset = new Map([
+          [AssetId.PXL, 100n],
+          [AssetId.Unit, 50n]
+        ]);
+        const asset2 = new Map([
+          [AssetId.PXL, 23n],
+          [AssetId.Unit, 50n]
+        ]);
+        expect(Asset.util.subtractTokenMaps([initialAsset, asset2])).toEqual(new Map([[AssetId.PXL, 77n]]));
+      });
+      it('should be able to return negative quantities', () => {
+        const initialAsset = new Map([
+          [AssetId.PXL, 100n],
+          [AssetId.Unit, 50n]
+        ]);
+        const asset2 = new Map([
+          [AssetId.PXL, 173n],
+          [AssetId.Unit, 50n]
+        ]);
+        const asset3 = new Map([[AssetId.TSLA, 44n]]);
+        expect(Asset.util.subtractTokenMaps([initialAsset, asset2, asset3])).toEqual(
+          new Map([
+            [AssetId.PXL, -73n],
+            [AssetId.TSLA, -44n]
+          ])
+        );
+      });
+    });
+  });
+});

--- a/packages/core/test/Cardano/util/coalesceValueQuantities.test.ts
+++ b/packages/core/test/Cardano/util/coalesceValueQuantities.test.ts
@@ -28,4 +28,7 @@ describe('Cardano.util.coalesceValueQuantities', () => {
       coins: 170n
     });
   });
+  it('returns 0 coins on empty array', () => {
+    expect(Cardano.util.coalesceValueQuantities([])).toEqual({ coins: 0n });
+  });
 });

--- a/packages/core/test/Cardano/util/resolveInputValue.test.ts
+++ b/packages/core/test/Cardano/util/resolveInputValue.test.ts
@@ -1,0 +1,42 @@
+import { Cardano } from '../../../src';
+
+describe('Cardano.util.resolveInputValue', () => {
+  const txs: Cardano.TxAlonzo[] = [
+    {
+      body: {
+        outputs: [{ value: { coins: 5_000_000n } }, { value: { coins: 1_000_000n } }, { value: { coins: 9_825_963n } }]
+      },
+      id: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a')
+    } as Cardano.TxAlonzo,
+    {
+      body: { outputs: [{ value: { coins: 3_000_000n } }] },
+      id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
+    } as Cardano.TxAlonzo
+  ];
+  it('should resolve the value for the input from the list of transactions', () => {
+    const input1 = {
+      index: 1,
+      txId: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a')
+    } as Cardano.TxIn;
+    const input2 = {
+      index: 0,
+      txId: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
+    } as Cardano.TxIn;
+    expect(Cardano.util.resolveInputValue(input1, txs)).toEqual({ coins: 1_000_000n });
+    expect(Cardano.util.resolveInputValue(input2, txs)).toEqual({ coins: 3_000_000n });
+  });
+  it('should return undefined if there was no tx with the same id as the input', () => {
+    const input = {
+      index: 0,
+      txId: Cardano.TransactionId('01d7366549986d83edeea262e97b68eca3430d3bb052ed1c37d2202fd5458872')
+    } as Cardano.TxIn;
+    expect(Cardano.util.resolveInputValue(input, txs)).toEqual(undefined);
+  });
+  it('should return undefined if the input could match the transaction but not the output index', () => {
+    const input = {
+      index: 4,
+      txId: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a')
+    } as Cardano.TxIn;
+    expect(Cardano.util.resolveInputValue(input, txs)).toEqual(undefined);
+  });
+});

--- a/packages/core/test/Cardano/util/subtractValueQuantities.test.ts
+++ b/packages/core/test/Cardano/util/subtractValueQuantities.test.ts
@@ -1,0 +1,65 @@
+import { AssetId } from '@cardano-sdk/util-dev';
+import { Cardano } from '@cardano-sdk/core';
+
+describe('Cardano.util.subtractValueQuantities', () => {
+  it('subtracts quantities for coins only', () => {
+    const q1: Cardano.Value = { coins: 100n };
+    const q2: Cardano.Value = { coins: 50n };
+    expect(Cardano.util.subtractValueQuantities([q1, q2])).toEqual({ coins: 50n });
+  });
+  it('subtracts quantities for coin and assets', () => {
+    const q1: Cardano.Value = {
+      assets: new Map([
+        [AssetId.PXL, 100n],
+        [AssetId.TSLA, 50n]
+      ]),
+      coins: 200n
+    };
+    const q2: Cardano.Value = { coins: 100n };
+    const q3: Cardano.Value = {
+      assets: new Map([[AssetId.TSLA, 20n]]),
+      coins: 20n
+    };
+    expect(Cardano.util.subtractValueQuantities([q1, q2, q3])).toEqual({
+      assets: new Map([
+        [AssetId.PXL, 100n],
+        [AssetId.TSLA, 30n]
+      ]),
+      coins: 80n
+    });
+  });
+  it('does not return assets when quantities are zero', () => {
+    const q1: Cardano.Value = {
+      assets: new Map([
+        [AssetId.PXL, 100n],
+        [AssetId.TSLA, 50n]
+      ]),
+      coins: 200n
+    };
+    expect(Cardano.util.subtractValueQuantities([q1, q1])).toEqual({ assets: undefined, coins: 0n });
+  });
+  it('returns negative quantities', () => {
+    const q1: Cardano.Value = {
+      assets: new Map([
+        [AssetId.PXL, 100n],
+        [AssetId.TSLA, 50n]
+      ]),
+      coins: 200n
+    };
+    const q2: Cardano.Value = { coins: 100n };
+    const q3: Cardano.Value = {
+      assets: new Map([[AssetId.TSLA, 200n]]),
+      coins: 200n
+    };
+    expect(Cardano.util.subtractValueQuantities([q1, q2, q3])).toEqual({
+      assets: new Map([
+        [AssetId.PXL, 100n],
+        [AssetId.TSLA, -150n]
+      ]),
+      coins: -100n
+    });
+  });
+  it('returns 0 coins on empty array', () => {
+    expect(Cardano.util.subtractValueQuantities([])).toEqual({ coins: 0n });
+  });
+});

--- a/packages/core/test/util/BigIntMath.test.ts
+++ b/packages/core/test/util/BigIntMath.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import { BigIntMath } from '../../src/util/BigIntMath';
 
 describe('BigIntMath', () => {
@@ -12,5 +13,10 @@ describe('BigIntMath', () => {
   describe('max', () => {
     test('empty array', () => expect(BigIntMath.max([])).toBeNull());
     test('non-empty array', () => expect(BigIntMath.max([-2n, -1n, 0n])).toBe(0n));
+  });
+  describe('subtract', () => {
+    test('empty array', () => expect(BigIntMath.subtract([])).toBe(0n));
+    test('non-empty array', () => expect(BigIntMath.subtract([4n, 3n])).toBe(1n));
+    test('negative result', () => expect(BigIntMath.subtract([4n, 3n, 4n])).toBe(-3n));
   });
 });

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -211,7 +211,7 @@ export class SingleAddressWallet implements Wallet {
       createAssetsTracker({
         assetProvider: this.assetProvider,
         balanceTracker: this.balance,
-        nftMetadataProvider: createNftMetadataProvider(this.walletProvider, this.transactions.history.all$),
+        nftMetadataProvider: createNftMetadataProvider(this.walletProvider, this.transactions.history$),
         retryBackoffConfig
       }),
       stores.assets

--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -53,10 +53,7 @@ export const certificateTransactionsWithEpochs = (
   slotEpochCalc$: Observable<SlotEpochCalc>,
   certificateTypes: Cardano.CertificateType[]
 ): Observable<TxWithEpoch[]> =>
-  combineLatest([
-    transactionsWithCertificates(transactionsTracker.history.outgoing$, certificateTypes),
-    slotEpochCalc$
-  ]).pipe(
+  combineLatest([transactionsWithCertificates(transactionsTracker.history$, certificateTypes), slotEpochCalc$]).pipe(
     map(([transactions, slotEpochCalc]) =>
       transactions.map((tx) => ({ epoch: slotEpochCalc(tx.blockHeader.slot), tx }))
     )

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -47,11 +47,7 @@ export interface FailedTx {
 }
 
 export interface TransactionsTracker {
-  readonly history: {
-    all$: BehaviorObservable<Cardano.TxAlonzo[]>;
-    outgoing$: BehaviorObservable<Cardano.TxAlonzo[]>;
-    incoming$: BehaviorObservable<Cardano.TxAlonzo[]>;
-  };
+  readonly history$: BehaviorObservable<Cardano.TxAlonzo[]>;
   readonly outgoing: {
     readonly inFlight$: BehaviorObservable<Cardano.NewTxAlonzo[]>;
     readonly submitting$: Observable<Cardano.NewTxAlonzo>;
@@ -59,7 +55,6 @@ export interface TransactionsTracker {
     readonly failed$: Observable<FailedTx>;
     readonly confirmed$: Observable<Cardano.NewTxAlonzo>;
   };
-  readonly incoming$: Observable<Cardano.TxAlonzo>;
   shutdown(): void;
 }
 

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -63,8 +63,8 @@ const assertWalletProperties = async (
   );
   expect(wallet.balance.total$.value?.rewards).toBe(mocks.rewardAccountBalance);
   // transactions
-  await firstValueFrom(wallet.transactions.history.all$);
-  expect(wallet.transactions.history.all$.value?.length).toBeGreaterThan(0);
+  await firstValueFrom(wallet.transactions.history$);
+  expect(wallet.transactions.history$.value?.length).toBeGreaterThan(0);
   // tip$
   await firstValueFrom(wallet.tip$);
   expect(wallet.tip$.value).toEqual(mocks.ledgerTip);
@@ -104,7 +104,7 @@ const assertWalletProperties2 = async (wallet: Wallet) => {
     Cardano.util.coalesceValueQuantities(mocks.utxo2.map((utxo) => utxo[1].value)).coins
   );
   expect(wallet.balance.total$.value?.rewards).toBe(mocks.rewardAccountBalance2);
-  expect(wallet.transactions.history.all$.value?.length).toEqual(queryTransactionsResult2.length);
+  expect(wallet.transactions.history$.value?.length).toEqual(queryTransactionsResult2.length);
   expect(wallet.tip$.value).toEqual(mocks.ledgerTip2);
   expect(wallet.networkInfo$.value?.network.timeSettings).toEqual(testnetTimeSettings);
   expect(wallet.currentEpoch$.value?.epochNo).toEqual(currentEpoch.number);

--- a/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
@@ -54,7 +54,7 @@ const createDelegationCertificates = ({
 const waitForTx = async (wallet: Wallet, { hash }: TxInternals) => {
   await firstValueFromTimed(
     combineLatest([
-      wallet.transactions.history.all$.pipe(filter((txs) => txs.some(({ tx: { id } }) => id === hash))),
+      wallet.transactions.history$.pipe(filter((txs) => txs.some(({ tx: { id } }) => id === hash))),
       // test that confirmed$ works
       wallet.transactions.outgoing.confirmed$.pipe(filter(({ id }) => id === hash))
     ]),

--- a/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
@@ -44,7 +44,7 @@ describe('SingleAddressWallet/metadata', () => {
     const outgoingTx = await wallet.finalizeTx(txInternals, auxiliaryData);
     await wallet.submitTx(outgoingTx);
     const loadedTx = await firstValueFrom(
-      wallet.transactions.history.outgoing$.pipe(
+      wallet.transactions.history$.pipe(
         map((txs) => txs.find((tx) => tx.id === outgoingTx.id)),
         filter(util.isNotNil)
       )

--- a/packages/wallet/test/integration/transactionTime.test.ts
+++ b/packages/wallet/test/integration/transactionTime.test.ts
@@ -11,7 +11,7 @@ describe('integration/transactionTime', () => {
   });
 
   it('provides utils necessary for computing transaction time', async () => {
-    const transactions = await firstValueFrom(wallet.transactions.history.all$);
+    const transactions = await firstValueFrom(wallet.transactions.history$);
     const {
       network: { timeSettings }
     } = await firstValueFrom(wallet.networkInfo$);

--- a/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
@@ -50,11 +50,9 @@ describe('DelegationTracker', () => {
         const slotEpochCalc$ = cold('-a', { a: slotEpochCalc });
         const target$ = certificateTransactionsWithEpochs(
           {
-            history: {
-              outgoing$: cold('a--a', {
-                a: transactions
-              })
-            }
+            history$: cold('a--a', {
+              a: transactions
+            })
           } as unknown as TransactionsTracker,
           slotEpochCalc$,
           [Cardano.CertificateType.StakeDelegation, Cardano.CertificateType.StakeKeyDeregistration]

--- a/packages/wallet/test/services/TransactionsTracker.test.ts
+++ b/packages/wallet/test/services/TransactionsTracker.test.ts
@@ -134,7 +134,6 @@ describe('TransactionsTracker', () => {
             transactionsSource$
           }
         );
-        expectObservable(transactionsTracker.incoming$).toBe('--a-|', { a: incomingTx });
         expectObservable(transactionsTracker.outgoing.submitting$).toBe('-a--|', { a: outgoingTx });
         expectObservable(transactionsTracker.outgoing.pending$).toBe('--a-|', { a: outgoingTx });
         expectObservable(transactionsTracker.outgoing.confirmed$, confirmedSubscription).toBe('---a|', {
@@ -142,15 +141,7 @@ describe('TransactionsTracker', () => {
         });
         expectObservable(transactionsTracker.outgoing.inFlight$).toBe('ab-c|', { a: [], b: [outgoingTx], c: [] });
         expectObservable(transactionsTracker.outgoing.failed$).toBe('----|');
-        expectObservable(transactionsTracker.history.incoming$).toBe('a-b-|', {
-          a: [],
-          b: [incomingTx]
-        });
-        expectObservable(transactionsTracker.history.outgoing$).toBe('a--b|', {
-          a: [],
-          b: [outgoingTx]
-        });
-        expectObservable(transactionsTracker.history.all$).toBe('a-bc|', {
+        expectObservable(transactionsTracker.history$).toBe('a-bc|', {
           a: [],
           b: [incomingTx],
           c: [outgoingTx, incomingTx]


### PR DESCRIPTION
# Context

`outgoing$` and `incoming$` transactions definitions are not clear. It's better if we removed them and instead let the sdk user use the transaction inspector to classify transactions as needed.

Thread discussing the issue: https://github.com/input-output-hk/cardano-js-sdk/pull/230#discussion_r855336487

# Proposed Solution
- Remove `history.outgoing$` and `history.incoming$`, replace `history.all$` with just `history$`.
- Improve inspectors to properly tell if a transaction was sent by an address, calculate inputs and outputs total value sent and received and calculate total net value sent and received

# Important Changes Introduced
**TransactionsTracker:**
- `TransactionsTracker.history.outgoing$` and `TransactionsTracker.history.incoming$` were removed 
- `TransactionsTracker.incoming$` was removed
- `TransactionsTracker.history.all$` was removed
- `TransactionsTracker.history` was changed to `TransactionsTracker.history$` and now has what `TransactionsTracker.history.all$` used to have

**TxInspector:**
- `valueSentInspector` and `valueSentInspector were modified to calculate sent and received net values
- `totalAddressInputsValueInspector` and `totalAddressOutputsValueInspector` were added
- `sentInspector` was added
- utility functions needed for the new inspectors were added