### PR TITLE
Refactor/modularize stake pool queries

### DIFF
--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/DbSyncStakePoolSearch.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/DbSyncStakePoolSearch.ts
@@ -1,254 +1,42 @@
 /* eslint-disable sonarjs/no-nested-template-literals */
-import {
-  Cardano,
-  MultipleChoiceSearchFilter,
-  StakePoolQueryOptions,
-  StakePoolSearchProvider,
-  util
-} from '@cardano-sdk/core';
+import { Cardano, StakePoolQueryOptions, StakePoolSearchProvider, util } from '@cardano-sdk/core';
 import { DbSyncProvider } from '../../DbSyncProvider';
-import {
-  EpochModel,
-  EpochRewardModel,
-  OwnerAddressModel,
-  PoolDataModel,
-  PoolMetricsModel,
-  PoolRegistrationModel,
-  PoolRetirementModel,
-  PoolUpdateModel,
-  RelayModel,
-  SubQuery,
-  TotalAdaModel
-} from './types';
 import { Logger, dummyLogger } from 'ts-log';
-import { Pool, QueryResult } from 'pg';
-import {
-  mapAddressOwner,
-  mapEpochReward,
-  mapPoolData,
-  mapPoolMetrics,
-  mapPoolRegistration,
-  mapPoolRetirement,
-  mapPoolUpdate,
-  mapRelay,
-  toCoreStakePool
-} from './mappers';
-import Queries, {
-  addSentenceToQuery,
-  buildOrQueryFromClauses,
-  findLastEpoch,
-  getIdentifierFullJoinClause,
-  getIdentifierWhereClause,
-  getStatusWhereClause,
-  poolsByPledgeMetSubqueries,
-  withPagination
-} from './queries';
+import { Pool } from 'pg';
+import { SearchStakePoolBuilder } from './SearchStakePoolBuilder';
+import { toCoreStakePool } from './mappers';
 
 export class DbSyncStakePoolSearchProvider extends DbSyncProvider implements StakePoolSearchProvider {
+  #builder: SearchStakePoolBuilder;
   #logger: Logger;
 
-  constructor(db: Pool, logger = dummyLogger) {
+  constructor(db: Pool, builder: SearchStakePoolBuilder, logger = dummyLogger) {
     super(db);
+    this.#builder = builder;
     this.#logger = logger;
   }
 
-  private async queryRetirements(hashesIds: number[]) {
-    this.#logger.debug('About to query pool retirements');
-    const result: QueryResult<PoolRetirementModel> = await this.db.query(Queries.findPoolsRetirements, [hashesIds]);
-    return result.rows.length > 0 ? result.rows.map(mapPoolRetirement) : [];
-  }
-  private async queryRegistrations(hashesIds: number[]) {
-    this.#logger.debug('About to query pool registrations');
-    const result: QueryResult<PoolRegistrationModel> = await this.db.query(Queries.findPoolsRegistrations, [hashesIds]);
-    return result.rows.length > 0 ? result.rows.map(mapPoolRegistration) : [];
-  }
-  private async queryPoolRelays(updatesIds: number[]) {
-    this.#logger.debug('About to query pool relays');
-    const result: QueryResult<RelayModel> = await this.db.query(Queries.findPoolsRelays, [updatesIds]);
-    return result.rows.length > 0 ? result.rows.map(mapRelay) : [];
-  }
-  private async queryPoolOwners(updatesIds: number[]) {
-    this.#logger.debug('About to query pool owners');
-    const result: QueryResult<OwnerAddressModel> = await this.db.query(Queries.findPoolsOwners, [updatesIds]);
-    return result.rows.length > 0 ? result.rows.map(mapAddressOwner) : [];
-  }
-  private async queryPoolRewards(hashesIds: number[], limit?: number) {
-    return Promise.all(
-      hashesIds.map(async (hashId) => {
-        const result: QueryResult<EpochRewardModel> = await this.db.query(Queries.findPoolEpochRewards(limit), [
-          hashId
-        ]);
-        return result.rows.length > 0 ? mapEpochReward(result.rows[0], hashId) : undefined;
-      })
-    );
-  }
-  private async queryPoolData(updatesIds: number[]) {
-    this.#logger.debug('About to query pool data');
-    const result: QueryResult<PoolDataModel> = await this.db.query(Queries.findPoolsData, [updatesIds]);
-    return result.rows.length > 0 ? result.rows.map(mapPoolData) : [];
-  }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async queryPoolHashes(query: string, options?: StakePoolQueryOptions, params: any[] = []) {
-    const queryWithPagination = withPagination(query, options?.pagination);
-    const result: QueryResult<PoolUpdateModel> = await this.db.query(queryWithPagination, params);
-    return result.rows.length > 0 ? result.rows.map(mapPoolUpdate) : [];
-  }
-  private async queryPoolMetrics(hashesIds: number[], totalAdaAmount: string) {
-    this.#logger.debug('About to query pool data');
-    const result: QueryResult<PoolMetricsModel> = await this.db.query(Queries.findPoolsMetrics, [
-      hashesIds,
-      totalAdaAmount
-    ]);
-    return result.rows.length > 0 ? result.rows.map(mapPoolMetrics) : [];
-  }
-  private buildPoolsByIdentifierQuery(
-    identifier: MultipleChoiceSearchFilter<
-      Partial<Pick<Cardano.PoolParameters, 'id'> & Pick<Cardano.StakePoolMetadata, 'name' | 'ticker'>>
-    >
-  ) {
-    const { where, params } = getIdentifierWhereClause(identifier);
-    const whereClause = 'WHERE '.concat(where);
-    const query = `
-    ${Queries.IDENTIFIER_QUERY.SELECT_CLAUSE}
-    ${Queries.IDENTIFIER_QUERY.JOIN_CLAUSE.POOL_UPDATE}
-    ${Queries.IDENTIFIER_QUERY.JOIN_CLAUSE.OFFLINE_METADATA}
-    ${whereClause}
-    `;
-    return { id: { isPrimary: true, name: 'pools_by_identifier' }, params, query };
-  }
-  private buildPoolsByStatusQuery(status: Cardano.StakePoolStatus[]) {
-    const whereClause = getStatusWhereClause(status);
-    const query = `
-    ${Queries.STATUS_QUERY.SELECT_CLAUSE}
-    WHERE ${whereClause}
-    `;
-    return { id: { isPrimary: true, name: 'pools_by_status' }, query };
-  }
-  private buildPoolsByPledgeMetQuery(pledgeMet: boolean) {
-    const subQueries = [...poolsByPledgeMetSubqueries];
-    subQueries.push({
-      id: { isPrimary: true, name: 'pools_by_pledge_met' },
-      query: `
-    ${Queries.POOLS_WITH_PLEDGE_MET.SELECT_CLAUSE} 
-    ${Queries.POOLS_WITH_PLEDGE_MET.JOIN_CLAUSE} 
-    WHERE ${Queries.POOLS_WITH_PLEDGE_MET.WHERE_CLAUSE(pledgeMet)}`
-    });
-    return subQueries;
-  }
-  private async getLastEpoch() {
-    this.#logger.debug('About to query last epoch');
-    const result: QueryResult<EpochModel> = await this.db.query(Queries.findLastEpoch);
-    return result.rows[0].no;
-  }
-  private async getTotalAmountOfAda() {
-    this.#logger.debug('About to get total amount of ada');
-    const result: QueryResult<TotalAdaModel> = await this.db.query(Queries.findTotalAda);
-    return result.rows[0].total_ada;
-  }
-  private async buildOrQuery(filters: StakePoolQueryOptions['filters']) {
-    const subQueries: SubQuery[] = [];
-    const params = [];
-    let query = Queries.findPools;
-    if (filters?.identifier) {
-      const { id: _id, query: _query, params: _params } = this.buildPoolsByIdentifierQuery(filters.identifier);
-      subQueries.push({ id: _id, query: _query });
-      params.push(..._params);
-    }
-    if (filters?.status) {
-      const statusQuery = this.buildPoolsByStatusQuery(filters.status);
-      subQueries.push(statusQuery);
-    }
-    if (filters?.pledgeMet !== undefined) {
-      const pledgeMetQuery = this.buildPoolsByPledgeMetQuery(filters.pledgeMet);
-      subQueries.push(...pledgeMetQuery);
-    }
-    if (filters?.status || filters?.pledgeMet !== undefined)
-      subQueries.unshift({ id: { name: 'current_epoch' }, query: findLastEpoch });
-    if (subQueries.length > 0) {
-      query =
-        subQueries.length > 1
-          ? buildOrQueryFromClauses(subQueries)
-          : `${subQueries.length > 1 ? `WITH (${subQueries.find((sq) => !sq.id.isPrimary)})` : ''} ${
-              subQueries[0].query
-            } `;
-    }
-    return { params, query };
-  }
-  private async buildAndQuery(filters: StakePoolQueryOptions['filters']) {
-    let query = Queries.findPools;
-    let groupByClause = ' GROUP BY ph.id, pu.id ORDER BY ph.id DESC';
-    const params = [];
-    const whereClause = [];
-    if (filters?.pledgeMet !== undefined) {
-      const { WITH_CLAUSE, SELECT_CLAUSE, JOIN_CLAUSE, WHERE_CLAUSE } = Queries.POOLS_WITH_PLEDGE_MET;
-      query = WITH_CLAUSE + SELECT_CLAUSE + JOIN_CLAUSE;
-      whereClause.push(WHERE_CLAUSE(filters.pledgeMet));
-      if (filters.identifier) {
-        query = addSentenceToQuery(query, `${getIdentifierFullJoinClause()}`);
-        const { where, params: identifierParams } = getIdentifierWhereClause(filters.identifier);
-        whereClause.push(where);
-        params.push(...identifierParams);
-      }
-      if (filters.status) {
-        query = addSentenceToQuery(
-          query,
-          `
-          LEFT JOIN pool_retire pr ON 
-            pr.id = (
-              SELECT id
-              FROM pool_retire pr2
-              WHERE pr2.hash_id = ph.id
-              ORDER BY id desc 
-              LIMIT 1
-            )
-          `
-        );
-        whereClause.push(getStatusWhereClause(filters.status, { activeEpoch: 'ph.active_epoch_no' }));
-      }
-      groupByClause = ' GROUP BY ph.id, ph.update_id ORDER BY ph.id DESC';
-    } else if (filters?.status) {
-      query = `${Queries.STATUS_QUERY.WITH_CLAUSE} ${Queries.STATUS_QUERY.SELECT_CLAUSE}`;
-      whereClause.push(getStatusWhereClause(filters.status));
-      if (filters?.identifier) {
-        query = addSentenceToQuery(query, Queries.IDENTIFIER_QUERY.JOIN_CLAUSE.OFFLINE_METADATA);
-        const { where, params: identifierParams } = getIdentifierWhereClause(filters.identifier);
-        whereClause.push(where);
-        params.push(...identifierParams);
-      }
-    } else if (filters?.identifier) {
-      const { where, params: identifierParams } = getIdentifierWhereClause(filters.identifier);
-      query = `
-        ${Queries.IDENTIFIER_QUERY.SELECT_CLAUSE}
-        ${getIdentifierFullJoinClause()}
-        WHERE ${where}
-        `;
-      params.push(...identifierParams);
-    }
-    if (whereClause.length > 0) query = addSentenceToQuery(query, ` WHERE ${whereClause.join(' AND ')}`);
-    query = addSentenceToQuery(query, groupByClause);
-    return { params, query };
-  }
   public async queryStakePools(options?: StakePoolQueryOptions): Promise<Cardano.StakePool[]> {
     const { params, query } =
       options?.filters?._condition === 'or'
-        ? await this.buildOrQuery(options?.filters)
-        : await this.buildAndQuery(options?.filters);
+        ? await this.#builder.buildOrQuery(options?.filters)
+        : await this.#builder.buildAndQuery(options?.filters);
     this.#logger.debug('About to query pool hashes');
-    const poolUpdates = await this.queryPoolHashes(query, options, params);
+    const poolUpdates = await this.#builder.queryPoolHashes(query, options, params);
     const hashesIds = poolUpdates.map(({ id }) => id);
     this.#logger.debug(`${hashesIds.length} pools found`);
     const updatesIds = poolUpdates.map(({ updateId }) => updateId);
-    const totalAdaAmount = await this.getTotalAmountOfAda();
+    const totalAdaAmount = await this.#builder.getTotalAmountOfAda();
     const [poolDatas, poolRelays, poolOwners, poolRegistrations, poolRetirements, poolRewards, lastEpoch, poolMetrics] =
       await Promise.all([
-        this.queryPoolData(updatesIds),
-        this.queryPoolRelays(updatesIds),
-        this.queryPoolOwners(updatesIds),
-        this.queryRegistrations(hashesIds),
-        this.queryRetirements(hashesIds),
-        this.queryPoolRewards(hashesIds, options?.rewardsHistoryLimit),
-        this.getLastEpoch(),
-        this.queryPoolMetrics(hashesIds, totalAdaAmount)
+        this.#builder.queryPoolData(updatesIds),
+        this.#builder.queryPoolRelays(updatesIds),
+        this.#builder.queryPoolOwners(updatesIds),
+        this.#builder.queryRegistrations(hashesIds),
+        this.#builder.queryRetirements(hashesIds),
+        this.#builder.queryPoolRewards(hashesIds, options?.rewardsHistoryLimit),
+        this.#builder.getLastEpoch(),
+        this.#builder.queryPoolMetrics(hashesIds, totalAdaAmount)
       ]);
     return toCoreStakePool({
       lastEpoch,

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/SearchStakePoolBuilder.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/SearchStakePoolBuilder.ts
@@ -1,0 +1,224 @@
+/* eslint-disable sonarjs/no-nested-template-literals */
+import { Cardano, MultipleChoiceSearchFilter, StakePoolQueryOptions } from '@cardano-sdk/core';
+import {
+  EpochModel,
+  EpochRewardModel,
+  OwnerAddressModel,
+  PoolDataModel,
+  PoolMetricsModel,
+  PoolRegistrationModel,
+  PoolRetirementModel,
+  PoolUpdateModel,
+  RelayModel,
+  SubQuery,
+  TotalAdaModel
+} from './types';
+import { Logger, dummyLogger } from 'ts-log';
+import { Pool, QueryResult } from 'pg';
+import {
+  mapAddressOwner,
+  mapEpochReward,
+  mapPoolData,
+  mapPoolMetrics,
+  mapPoolRegistration,
+  mapPoolRetirement,
+  mapPoolUpdate,
+  mapRelay
+} from './mappers';
+import Queries, {
+  addSentenceToQuery,
+  buildOrQueryFromClauses,
+  findLastEpoch,
+  getIdentifierFullJoinClause,
+  getIdentifierWhereClause,
+  getStatusWhereClause,
+  poolsByPledgeMetSubqueries,
+  withPagination
+} from './queries';
+
+export class SearchStakePoolBuilder {
+  #db: Pool;
+  #logger: Logger;
+  constructor(db: Pool, logger = dummyLogger) {
+    this.#db = db;
+    this.#logger = logger;
+  }
+  public async queryRetirements(hashesIds: number[]) {
+    this.#logger.debug('About to query pool retirements');
+    const result: QueryResult<PoolRetirementModel> = await this.#db.query(Queries.findPoolsRetirements, [hashesIds]);
+    return result.rows.length > 0 ? result.rows.map(mapPoolRetirement) : [];
+  }
+  public async queryRegistrations(hashesIds: number[]) {
+    this.#logger.debug('About to query pool registrations');
+    const result: QueryResult<PoolRegistrationModel> = await this.#db.query(Queries.findPoolsRegistrations, [
+      hashesIds
+    ]);
+    return result.rows.length > 0 ? result.rows.map(mapPoolRegistration) : [];
+  }
+  public async queryPoolRelays(updatesIds: number[]) {
+    this.#logger.debug('About to query pool relays');
+    const result: QueryResult<RelayModel> = await this.#db.query(Queries.findPoolsRelays, [updatesIds]);
+    return result.rows.length > 0 ? result.rows.map(mapRelay) : [];
+  }
+  public async queryPoolOwners(updatesIds: number[]) {
+    this.#logger.debug('About to query pool owners');
+    const result: QueryResult<OwnerAddressModel> = await this.#db.query(Queries.findPoolsOwners, [updatesIds]);
+    return result.rows.length > 0 ? result.rows.map(mapAddressOwner) : [];
+  }
+  public async queryPoolRewards(hashesIds: number[], limit?: number) {
+    return Promise.all(
+      hashesIds.map(async (hashId) => {
+        const result: QueryResult<EpochRewardModel> = await this.#db.query(Queries.findPoolEpochRewards(limit), [
+          hashId
+        ]);
+        return result.rows.length > 0 ? mapEpochReward(result.rows[0], hashId) : undefined;
+      })
+    );
+  }
+  public async queryPoolData(updatesIds: number[]) {
+    this.#logger.debug('About to query pool data');
+    const result: QueryResult<PoolDataModel> = await this.#db.query(Queries.findPoolsData, [updatesIds]);
+    return result.rows.length > 0 ? result.rows.map(mapPoolData) : [];
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async queryPoolHashes(query: string, options?: StakePoolQueryOptions, params: any[] = []) {
+    const queryWithPagination = withPagination(query, options?.pagination);
+    const result: QueryResult<PoolUpdateModel> = await this.#db.query(queryWithPagination, params);
+    return result.rows.length > 0 ? result.rows.map(mapPoolUpdate) : [];
+  }
+  public async queryPoolMetrics(hashesIds: number[], totalAdaAmount: string) {
+    this.#logger.debug('About to query pool data');
+    const result: QueryResult<PoolMetricsModel> = await this.#db.query(Queries.findPoolsMetrics, [
+      hashesIds,
+      totalAdaAmount
+    ]);
+    return result.rows.length > 0 ? result.rows.map(mapPoolMetrics) : [];
+  }
+  public buildPoolsByIdentifierQuery(
+    identifier: MultipleChoiceSearchFilter<
+      Partial<Pick<Cardano.PoolParameters, 'id'> & Pick<Cardano.StakePoolMetadata, 'name' | 'ticker'>>
+    >
+  ) {
+    const { where, params } = getIdentifierWhereClause(identifier);
+    const whereClause = 'WHERE '.concat(where);
+    const query = `
+    ${Queries.IDENTIFIER_QUERY.SELECT_CLAUSE}
+    ${Queries.IDENTIFIER_QUERY.JOIN_CLAUSE.POOL_UPDATE}
+    ${Queries.IDENTIFIER_QUERY.JOIN_CLAUSE.OFFLINE_METADATA}
+    ${whereClause}
+    `;
+    return { id: { isPrimary: true, name: 'pools_by_identifier' }, params, query };
+  }
+  public buildPoolsByStatusQuery(status: Cardano.StakePoolStatus[]) {
+    const whereClause = getStatusWhereClause(status);
+    const query = `
+    ${Queries.STATUS_QUERY.SELECT_CLAUSE}
+    WHERE ${whereClause}
+    `;
+    return { id: { isPrimary: true, name: 'pools_by_status' }, query };
+  }
+  public buildPoolsByPledgeMetQuery(pledgeMet: boolean) {
+    const subQueries = [...poolsByPledgeMetSubqueries];
+    subQueries.push({
+      id: { isPrimary: true, name: 'pools_by_pledge_met' },
+      query: `
+    ${Queries.POOLS_WITH_PLEDGE_MET.SELECT_CLAUSE} 
+    ${Queries.POOLS_WITH_PLEDGE_MET.JOIN_CLAUSE} 
+    WHERE ${Queries.POOLS_WITH_PLEDGE_MET.WHERE_CLAUSE(pledgeMet)}`
+    });
+    return subQueries;
+  }
+  public async getLastEpoch() {
+    this.#logger.debug('About to query last epoch');
+    const result: QueryResult<EpochModel> = await this.#db.query(Queries.findLastEpoch);
+    return result.rows[0].no;
+  }
+  public async getTotalAmountOfAda() {
+    this.#logger.debug('About to get total amount of ada');
+    const result: QueryResult<TotalAdaModel> = await this.#db.query(Queries.findTotalAda);
+    return result.rows[0].total_ada;
+  }
+  public async buildOrQuery(filters: StakePoolQueryOptions['filters']) {
+    const subQueries: SubQuery[] = [];
+    const params = [];
+    let query = Queries.findPools;
+    if (filters?.identifier) {
+      const { id: _id, query: _query, params: _params } = this.buildPoolsByIdentifierQuery(filters.identifier);
+      subQueries.push({ id: _id, query: _query });
+      params.push(..._params);
+    }
+    if (filters?.status) {
+      const statusQuery = this.buildPoolsByStatusQuery(filters.status);
+      subQueries.push(statusQuery);
+    }
+    if (filters?.pledgeMet !== undefined) {
+      const pledgeMetQuery = this.buildPoolsByPledgeMetQuery(filters.pledgeMet);
+      subQueries.push(...pledgeMetQuery);
+    }
+    if (filters?.status || filters?.pledgeMet !== undefined)
+      subQueries.unshift({ id: { name: 'current_epoch' }, query: findLastEpoch });
+    if (subQueries.length > 0) {
+      query =
+        subQueries.length > 1
+          ? buildOrQueryFromClauses(subQueries)
+          : `${subQueries.length > 1 ? `WITH (${subQueries.find((sq) => !sq.id.isPrimary)})` : ''} ${
+              subQueries[0].query
+            } `;
+    }
+    return { params, query };
+  }
+  public async buildAndQuery(filters: StakePoolQueryOptions['filters']) {
+    let query = Queries.findPools;
+    let groupByClause = ' GROUP BY ph.id, pu.id ORDER BY ph.id DESC';
+    const params = [];
+    const whereClause = [];
+    if (filters?.pledgeMet !== undefined) {
+      const { WITH_CLAUSE, SELECT_CLAUSE, JOIN_CLAUSE, WHERE_CLAUSE } = Queries.POOLS_WITH_PLEDGE_MET;
+      query = WITH_CLAUSE + SELECT_CLAUSE + JOIN_CLAUSE;
+      whereClause.push(WHERE_CLAUSE(filters.pledgeMet));
+      if (filters.identifier) {
+        query = addSentenceToQuery(query, `${getIdentifierFullJoinClause()}`);
+        const { where, params: identifierParams } = getIdentifierWhereClause(filters.identifier);
+        whereClause.push(where);
+        params.push(...identifierParams);
+      }
+      if (filters.status) {
+        query = addSentenceToQuery(
+          query,
+          `
+          LEFT JOIN pool_retire pr ON 
+            pr.id = (
+              SELECT id
+              FROM pool_retire pr2
+              WHERE pr2.hash_id = ph.id
+              ORDER BY id desc 
+              LIMIT 1
+            )
+          `
+        );
+        whereClause.push(getStatusWhereClause(filters.status, { activeEpoch: 'ph.active_epoch_no' }));
+      }
+      groupByClause = ' GROUP BY ph.id, ph.update_id ORDER BY ph.id DESC';
+    } else if (filters?.status) {
+      query = `${Queries.STATUS_QUERY.WITH_CLAUSE} ${Queries.STATUS_QUERY.SELECT_CLAUSE}`;
+      whereClause.push(getStatusWhereClause(filters.status));
+      if (filters?.identifier) {
+        query = addSentenceToQuery(query, Queries.IDENTIFIER_QUERY.JOIN_CLAUSE.OFFLINE_METADATA);
+        const { where, params: identifierParams } = getIdentifierWhereClause(filters.identifier);
+        whereClause.push(where);
+        params.push(...identifierParams);
+      }
+    } else if (filters?.identifier) {
+      const { where, params: identifierParams } = getIdentifierWhereClause(filters.identifier);
+      query = `
+        ${Queries.IDENTIFIER_QUERY.SELECT_CLAUSE}
+        ${getIdentifierFullJoinClause()}
+        WHERE ${where}
+        `;
+      params.push(...identifierParams);
+    }
+    if (whereClause.length > 0) query = addSentenceToQuery(query, ` WHERE ${whereClause.join(' AND ')}`);
+    query = addSentenceToQuery(query, groupByClause);
+    return { params, query };
+  }
+}

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.ts
@@ -36,7 +36,7 @@ import Queries, {
   withPagination
 } from './queries';
 
-export class SearchStakePoolBuilder {
+export class StakePoolSearchBuilder {
   #db: Pool;
   #logger: Logger;
   constructor(db: Pool, logger = dummyLogger) {
@@ -81,8 +81,8 @@ export class SearchStakePoolBuilder {
     return result.rows.length > 0 ? result.rows.map(mapPoolData) : [];
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async queryPoolHashes(query: string, options?: StakePoolQueryOptions, params: any[] = []) {
-    const queryWithPagination = withPagination(query, options?.pagination);
+  public async queryPoolHashes(query: string, params: any[] = [], pagination?: StakePoolQueryOptions['pagination']) {
+    const queryWithPagination = withPagination(query, pagination);
     const result: QueryResult<PoolUpdateModel> = await this.#db.query(queryWithPagination, params);
     return result.rows.length > 0 ? result.rows.map(mapPoolUpdate) : [];
   }
@@ -138,7 +138,7 @@ export class SearchStakePoolBuilder {
     const result: QueryResult<TotalAdaModel> = await this.#db.query(Queries.findTotalAda);
     return result.rows[0].total_ada;
   }
-  public async buildOrQuery(filters: StakePoolQueryOptions['filters']) {
+  public buildOrQuery(filters: StakePoolQueryOptions['filters']) {
     const subQueries: SubQuery[] = [];
     const params = [];
     let query = Queries.findPools;
@@ -167,7 +167,7 @@ export class SearchStakePoolBuilder {
     }
     return { params, query };
   }
-  public async buildAndQuery(filters: StakePoolQueryOptions['filters']) {
+  public buildAndQuery(filters: StakePoolQueryOptions['filters']) {
     let query = Queries.findPools;
     let groupByClause = ' GROUP BY ph.id, pu.id ORDER BY ph.id DESC';
     const params = [];

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/index.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/index.ts
@@ -1,3 +1,4 @@
 export * from './DbSyncStakePoolSearch';
 export * from './mappers';
 export * from './types';
+export * from './StakePoolSearchBuilder';

--- a/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.test.ts
+++ b/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.test.ts
@@ -3,13 +3,8 @@ import { Pool } from 'pg';
 import { StakePoolSearchBuilder } from '../../../src';
 
 describe('StakePoolSearchBuilder', () => {
-  let dbConnection: Pool;
-  let builder: StakePoolSearchBuilder;
-
-  beforeAll(async () => {
-    dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });
-    builder = new StakePoolSearchBuilder(dbConnection);
-  });
+  const dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });
+  const builder = new StakePoolSearchBuilder(dbConnection);
 
   afterAll(async () => {
     await dbConnection.end();
@@ -86,25 +81,79 @@ describe('StakePoolSearchBuilder', () => {
     });
   });
   describe('buildPoolsByStatusQuery', () => {
+    const buildPoolsByStatusQuerySpy = jest.spyOn(builder, 'buildPoolsByStatusQuery');
+    afterEach(() => jest.clearAllMocks());
+    afterAll(() => buildPoolsByStatusQuerySpy.mockRestore());
+
     it('activating', async () => {
-      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Activating]);
+      const activatingStatus = [Cardano.StakePoolStatus.Activating];
+      const poolsByStatusQuery = builder.buildPoolsByStatusQuery(activatingStatus);
+
+      const _filters: StakePoolQueryOptions['filters'] = {
+        status: activatingStatus
+      };
+      const builtQuery = builder.buildOrQuery(_filters);
+      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
+      expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
+      expect(poolHashes).toMatchSnapshot();
     });
     it('active', async () => {
-      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Active]);
+      const activeStatus = [Cardano.StakePoolStatus.Active];
+      const poolsByStatusQuery = builder.buildPoolsByStatusQuery(activeStatus);
+
+      const _filters: StakePoolQueryOptions['filters'] = {
+        status: activeStatus
+      };
+      const builtQuery = builder.buildOrQuery(_filters);
+      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
+      expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
+      expect(poolHashes).toMatchSnapshot();
     });
     it('retiring', async () => {
-      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Retiring]);
+      const retiringStatus = [Cardano.StakePoolStatus.Retiring];
+      const poolsByStatusQuery = builder.buildPoolsByStatusQuery(retiringStatus);
+
+      const _filters: StakePoolQueryOptions['filters'] = {
+        status: retiringStatus
+      };
+      const builtQuery = builder.buildOrQuery(_filters);
+      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
+      expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
+      expect(poolHashes).toMatchSnapshot();
     });
     it('retired', async () => {
-      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Retired]);
+      const retiredStatus = [Cardano.StakePoolStatus.Retired];
+      const poolsByStatusQuery = builder.buildPoolsByStatusQuery(retiredStatus);
+
+      const _filters: StakePoolQueryOptions['filters'] = {
+        status: retiredStatus
+      };
+      const builtQuery = builder.buildOrQuery(_filters);
+      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
+      expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
+      expect(poolHashes).toMatchSnapshot();
     });
     it('active,activating,retiring,retired', async () => {
-      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery(Object.values(Cardano.StakePoolStatus));
+      const poolStatus = Object.values(Cardano.StakePoolStatus);
+      const poolsByStatusQuery = builder.buildPoolsByStatusQuery(poolStatus);
+
+      const _filters: StakePoolQueryOptions['filters'] = {
+        status: poolStatus
+      };
+      const builtQuery = builder.buildOrQuery(_filters);
+      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
+      expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
+      expect(poolHashes).toMatchSnapshot();
     });
   });
   describe('buildPoolsByPledgeMetQuery', () => {

--- a/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.test.ts
+++ b/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.test.ts
@@ -1,0 +1,149 @@
+import { Cardano, StakePoolQueryOptions } from '@cardano-sdk/core';
+import { Pool } from 'pg';
+import { StakePoolSearchBuilder } from '../../../src';
+
+describe('StakePoolSearchBuilder', () => {
+  let dbConnection: Pool;
+  let builder: StakePoolSearchBuilder;
+
+  beforeAll(async () => {
+    dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });
+    builder = new StakePoolSearchBuilder(dbConnection);
+  });
+
+  afterAll(async () => {
+    await dbConnection.end();
+  });
+
+  const filters: StakePoolQueryOptions['filters'] = {
+    _condition: 'or',
+    identifier: {
+      _condition: 'and',
+      values: [
+        { name: 'CL' },
+        { ticker: 'CLIO' },
+        { id: Cardano.PoolId('pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70') }
+      ]
+    },
+    pledgeMet: true,
+    status: Object.values(Cardano.StakePoolStatus)
+  };
+
+  describe('queryRetirements', () => {
+    it('queryRetirements', async () => {
+      const retirements = await builder.queryRetirements([1, 2, 3]);
+      expect(retirements).toMatchSnapshot();
+    });
+  });
+  describe('queryRegistrations', () => {
+    it('queryRegistrations', async () => {
+      const registrations = await builder.queryRegistrations([1, 2, 3]);
+      expect(registrations).toMatchSnapshot();
+    });
+  });
+  describe('queryPoolRewards', () => {
+    it('queryPoolRewards', async () => {
+      const epochRewards = await builder.queryPoolRewards([1, 2, 3]);
+      expect(epochRewards).toMatchSnapshot();
+    });
+  });
+  describe('queryPoolRelays', () => {
+    it('queryPoolRelays', async () => {
+      // todo: change ids
+      const relays = await builder.queryPoolRelays([1, 2, 3]);
+      expect(relays).toEqual([]);
+    });
+  });
+  describe('queryPoolOwners', () => {
+    it('queryPoolOwners', async () => {
+      const owners = await builder.queryPoolOwners([1, 2, 3]);
+      expect(owners).toMatchSnapshot();
+    });
+  });
+  describe('queryPoolMetrics', () => {
+    it('queryPoolMetrics', async () => {
+      const totalAda = '42021479194505231';
+      const metrics = await builder.queryPoolMetrics([1, 2, 3], totalAda);
+      expect(metrics).toMatchSnapshot();
+    });
+  });
+  describe('queryPoolData', () => {
+    it('queryPoolData', async () => {
+      const poolDatas = await builder.queryPoolData([1, 6]);
+      expect(poolDatas).toMatchSnapshot();
+    });
+  });
+  describe('getTotalAmountOfAda', () => {
+    it('getTotalAmountOfAda', async () => {
+      const totalAdaAmount = await builder.getTotalAmountOfAda();
+      expect(totalAdaAmount).toMatchSnapshot();
+    });
+  });
+  describe('getLastEpoch', () => {
+    it('getLastEpoch', async () => {
+      const lastEpoch = await builder.getLastEpoch();
+      expect(lastEpoch).toMatchSnapshot();
+    });
+  });
+  describe('buildPoolsByStatusQuery', () => {
+    it('activating', async () => {
+      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Activating]);
+      expect(poolsByStatusQuery).toMatchSnapshot();
+    });
+    it('active', async () => {
+      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Active]);
+      expect(poolsByStatusQuery).toMatchSnapshot();
+    });
+    it('retiring', async () => {
+      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Retiring]);
+      expect(poolsByStatusQuery).toMatchSnapshot();
+    });
+    it('retired', async () => {
+      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery([Cardano.StakePoolStatus.Retired]);
+      expect(poolsByStatusQuery).toMatchSnapshot();
+    });
+    it('active,activating,retiring,retired', async () => {
+      const poolsByStatusQuery = await builder.buildPoolsByStatusQuery(Object.values(Cardano.StakePoolStatus));
+      expect(poolsByStatusQuery).toMatchSnapshot();
+    });
+  });
+  describe('buildPoolsByPledgeMetQuery', () => {
+    it('pledgeMet true', async () => {
+      const poolsByPledgeQuery = await builder.buildPoolsByPledgeMetQuery(true);
+      expect(poolsByPledgeQuery).toMatchSnapshot();
+    });
+    it('pledgeMet false', async () => {
+      const poolsByPledgeQuery = await builder.buildPoolsByPledgeMetQuery(false);
+      expect(poolsByPledgeQuery).toMatchSnapshot();
+    });
+  });
+  describe('buildPoolsByIdentifierQuery', () => {
+    it('buildPoolsByIdentifierQuery', async () => {
+      const poolsByIdentifierQuery = await builder.buildPoolsByIdentifierQuery({
+        _condition: 'and',
+        values: [
+          { name: 'CL' },
+          { ticker: 'CLIO' },
+          { id: Cardano.PoolId('pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70') }
+        ]
+      });
+      expect(poolsByIdentifierQuery).toMatchSnapshot();
+    });
+  });
+  describe('buildOrQuery', () => {
+    it('buildOrQuery & queryPoolHashes', async () => {
+      const builtQuery = builder.buildOrQuery(filters);
+      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      expect(builtQuery).toMatchSnapshot();
+      expect(poolHashes).toMatchSnapshot();
+    });
+  });
+  describe('buildAndQuery', () => {
+    it('buildAndQuery & queryPoolHashes', async () => {
+      const builtQuery = builder.buildAndQuery(filters);
+      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      expect(builtQuery).toMatchSnapshot();
+      expect(poolHashes).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/__snapshots__/StakePoolSearchBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/__snapshots__/StakePoolSearchBuilder.test.ts.snap
@@ -706,6 +706,8 @@ Object {
 }
 `;
 
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery activating 2`] = `Array []`;
+
 exports[`StakePoolSearchBuilder buildPoolsByStatusQuery active 1`] = `
 Object {
   "id": Object {
@@ -739,6 +741,35 @@ Object {
           AND COALESCE(pr.retiring_epoch,0) < pu.active_epoch_no))
     ",
 }
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery active 2`] = `
+Array [
+  Object {
+    "id": "2055",
+    "updateId": "2068",
+  },
+  Object {
+    "id": "20",
+    "updateId": "20",
+  },
+  Object {
+    "id": "16",
+    "updateId": "16",
+  },
+  Object {
+    "id": "15",
+    "updateId": "309",
+  },
+  Object {
+    "id": "14",
+    "updateId": "14",
+  },
+  Object {
+    "id": "6",
+    "updateId": "6",
+  },
+]
 `;
 
 exports[`StakePoolSearchBuilder buildPoolsByStatusQuery active,activating,retiring,retired 1`] = `
@@ -779,6 +810,43 @@ Object {
 }
 `;
 
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery active,activating,retiring,retired 2`] = `
+Array [
+  Object {
+    "id": "2056",
+    "updateId": "2885",
+  },
+  Object {
+    "id": "2055",
+    "updateId": "2068",
+  },
+  Object {
+    "id": "20",
+    "updateId": "20",
+  },
+  Object {
+    "id": "16",
+    "updateId": "16",
+  },
+  Object {
+    "id": "15",
+    "updateId": "309",
+  },
+  Object {
+    "id": "14",
+    "updateId": "14",
+  },
+  Object {
+    "id": "6",
+    "updateId": "6",
+  },
+  Object {
+    "id": "1",
+    "updateId": "1",
+  },
+]
+`;
+
 exports[`StakePoolSearchBuilder buildPoolsByStatusQuery retired 1`] = `
 Object {
   "id": Object {
@@ -814,6 +882,15 @@ Object {
 }
 `;
 
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery retired 2`] = `
+Array [
+  Object {
+    "id": "1",
+    "updateId": "1",
+  },
+]
+`;
+
 exports[`StakePoolSearchBuilder buildPoolsByStatusQuery retiring 1`] = `
 Object {
   "id": Object {
@@ -847,6 +924,15 @@ Object {
           AND COALESCE(pr.retiring_epoch,0) > pu.active_epoch_no))
     ",
 }
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery retiring 2`] = `
+Array [
+  Object {
+    "id": "2056",
+    "updateId": "2885",
+  },
+]
 `;
 
 exports[`StakePoolSearchBuilder getLastEpoch getLastEpoch 1`] = `175`;

--- a/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/__snapshots__/StakePoolSearchBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/__snapshots__/StakePoolSearchBuilder.test.ts.snap
@@ -1,0 +1,964 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StakePoolSearchBuilder buildAndQuery buildAndQuery & queryPoolHashes 1`] = `
+Object {
+  "params": Array [
+    "%(CL)%",
+    "%(CLIO)%",
+    "%(pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70)%",
+  ],
+  "query": "WITH 
+    current_epoch AS (
+ SELECT 
+  \\"no\\"
+ FROM epoch
+ ORDER BY id DESC 
+ LIMIT 1
+),
+     pools_delegated AS (
+    SELECT 
+      ph.id,
+      ph.view,
+      pu.id AS update_id,
+      pu.active_epoch_no,
+      pu.pledge,
+      sa.id AS stake_address_id
+    FROM pool_hash ph 
+    JOIN pool_update pu
+      ON pu.id = (
+        SELECT id
+        FROM pool_update pu2
+        WHERE pu2.hash_id = ph.id
+        ORDER BY id DESC
+        LIMIT 1
+      ) 
+    JOIN stake_address sa ON
+      sa.hash_raw = pu.reward_addr 
+    JOIN delegation d1 on
+      sa.id = d1.addr_id 
+    WHERE NOT EXISTS
+      (SELECT TRUE
+        FROM delegation d2
+        WHERE d2.addr_id=d1.addr_id 
+          AND d2.tx_id>d1.tx_id)
+    AND NOT EXISTS
+      (SELECT TRUE
+        FROM stake_deregistration
+        WHERE stake_deregistration.addr_id=d1.addr_id
+          AND stake_deregistration.tx_id>d1.tx_id)
+    ), pool_owner_rewards AS (
+  SELECT 
+    COALESCE(SUM(r.amount),0) AS total_amount,
+    sa.id AS stake_address_id,
+    r.pool_id
+  FROM reward r
+  JOIN stake_address sa ON 
+      sa.id = r.addr_id
+  WHERE sa.id in (SELECT stake_address_id FROM pools_delegated) and
+    r.spendable_epoch <= (SELECT \\"no\\" FROM current_epoch)
+  GROUP BY r.pool_id, sa.id), pool_owner_withdraws AS ( 
+  SELECT 
+    COALESCE(SUM(w.amount),0)  AS total_amount,
+    sa.id AS stake_address_id
+  FROM withdrawal w
+  JOIN tx ON tx.id = w.tx_id AND 
+    tx.valid_contract = TRUE
+  JOIN stake_address sa ON sa.id = w.addr_id
+  JOIN pools_delegated pool on pool.stake_address_id = sa.id 
+  GROUP BY sa.id), reward_acc_balance AS (
+  SELECT 
+    (r.total_amount - w.total_amount)  AS total_amount,
+    r.stake_address_id,
+    r.pool_id 
+  FROM pool_owner_rewards r
+  JOIN pool_owner_withdraws w 
+    on r.stake_address_id = w.stake_address_id ), owners_utxo AS (
+  SELECT
+    tx_out.value AS value,
+    o.pool_hash_id 
+  FROM tx_out
+  JOIN pool_owner o on 
+    o.addr_id = tx_out.stake_address_id and 
+    o.pool_hash_id in (SELECT id FROM pools_delegated)
+  LEFT JOIN tx_in ON 
+    tx_out.tx_id = tx_in.tx_out_id AND 
+    tx_out.index::smallint = tx_in.tx_out_index::smallint
+  LEFT JOIN tx AS tx_in_tx ON 
+    tx_in_tx.id = tx_in.tx_in_id AND
+      tx_in_tx.valid_contract = TRUE
+  JOIN tx AS tx_out_tx ON
+    tx_out_tx.id = tx_out.tx_id AND
+      tx_out_tx.valid_contract = TRUE
+  WHERE 
+    tx_in_tx.id IS NULL), owners_balance AS (
+  SELECT 
+    SUM(value) AS total_amount,
+    pool_hash_id
+  FROM owners_utxo 
+  GROUP BY pool_hash_id)
+      
+    SELECT
+        ph.id,
+        ph.update_id
+    FROM pools_delegated AS ph
+    LEFT JOIN owners_balance o_balance ON 
+        ph.id = o_balance.pool_hash_id
+    LEFT JOIN reward_acc_balance r_balance ON
+        r_balance.pool_id = ph.id
+ 
+    JOIN pool_update pu
+      ON pu.id = (
+        SELECT id
+        FROM pool_update pu2
+        WHERE pu2.hash_id = ph.id
+        ORDER BY id DESC
+        LIMIT 1
+      ) 
+ 
+    LEFT JOIN pool_offline_data pod 
+      ON pod.pool_id = ph.id
+    
+          LEFT JOIN pool_retire pr ON 
+            pr.id = (
+              SELECT id
+              FROM pool_retire pr2
+              WHERE pr2.hash_id = ph.id
+              ORDER BY id desc 
+              LIMIT 1
+            )
+           WHERE  
+    ((COALESCE(o_balance.total_amount,0) +
+    COALESCE (r_balance.total_amount, 0)) 
+     >= ph.pledge) AND ((pod.\\"json\\" ->>'name')::varchar SIMILAR TO $1 and pod.ticker_name SIMILAR TO $2 and ph.view SIMILAR TO $3) AND ((COALESCE(pr.retiring_epoch,0) > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > ph.active_epoch_no) OR (COALESCE(pr.retiring_epoch,0) <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > ph.active_epoch_no) OR (ph.active_epoch_no > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) <= ph.active_epoch_no) OR (ph.active_epoch_no <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) < ph.active_epoch_no)) GROUP BY ph.id, ph.update_id ORDER BY ph.id DESC",
+}
+`;
+
+exports[`StakePoolSearchBuilder buildAndQuery buildAndQuery & queryPoolHashes 2`] = `
+Array [
+  Object {
+    "id": "15",
+    "updateId": "309",
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder buildOrQuery buildOrQuery & queryPoolHashes 1`] = `
+Object {
+  "params": Array [
+    "%(CL)%",
+    "%(CLIO)%",
+    "%(pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70)%",
+  ],
+  "query": "
+    WITH current_epoch AS (
+ SELECT 
+  \\"no\\"
+ FROM epoch
+ ORDER BY id DESC 
+ LIMIT 1
+), pools_by_identifier AS (
+    
+  SELECT 
+    ph.id,
+    pu.id AS update_id
+  FROM pool_hash ph 
+  
+     
+    JOIN pool_update pu
+      ON pu.id = (
+        SELECT id
+        FROM pool_update pu2
+        WHERE pu2.hash_id = ph.id
+        ORDER BY id DESC
+        LIMIT 1
+      )
+     
+    LEFT JOIN pool_offline_data pod 
+      ON pod.pool_id = ph.id
+    
+    WHERE ((pod.\\"json\\" ->>'name')::varchar SIMILAR TO $1 and pod.ticker_name SIMILAR TO $2 and ph.view SIMILAR TO $3)
+    ), pools_by_status AS (
+    
+    SELECT
+      ph.id,
+      pu.id AS update_id
+    FROM pool_hash ph
+    JOIN pool_update pu
+        ON pu.id = (
+          SELECT id
+          FROM pool_update pu2
+          WHERE pu2.hash_id = ph.id
+          ORDER BY id DESC
+          LIMIT 1
+        )
+    LEFT JOIN pool_retire pr 
+        ON pr.id = (
+          SELECT id
+          FROM pool_retire pr2
+          WHERE pr2.hash_id = ph.id
+          ORDER BY id desc 
+          LIMIT 1
+    )
+  
+    WHERE ((COALESCE(pr.retiring_epoch,0) > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > pu.active_epoch_no) OR (COALESCE(pr.retiring_epoch,0) <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > pu.active_epoch_no) OR (pu.active_epoch_no > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) <= pu.active_epoch_no) OR (pu.active_epoch_no <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) < pu.active_epoch_no))
+    ), pools_delegated AS (
+    SELECT 
+      ph.id,
+      ph.view,
+      pu.id AS update_id,
+      pu.active_epoch_no,
+      pu.pledge,
+      sa.id AS stake_address_id
+    FROM pool_hash ph 
+    JOIN pool_update pu
+      ON pu.id = (
+        SELECT id
+        FROM pool_update pu2
+        WHERE pu2.hash_id = ph.id
+        ORDER BY id DESC
+        LIMIT 1
+      ) 
+    JOIN stake_address sa ON
+      sa.hash_raw = pu.reward_addr 
+    JOIN delegation d1 on
+      sa.id = d1.addr_id 
+    WHERE NOT EXISTS
+      (SELECT TRUE
+        FROM delegation d2
+        WHERE d2.addr_id=d1.addr_id 
+          AND d2.tx_id>d1.tx_id)
+    AND NOT EXISTS
+      (SELECT TRUE
+        FROM stake_deregistration
+        WHERE stake_deregistration.addr_id=d1.addr_id
+          AND stake_deregistration.tx_id>d1.tx_id)
+    ), pool_owner_rewards AS (
+  SELECT 
+    COALESCE(SUM(r.amount),0) AS total_amount,
+    sa.id AS stake_address_id,
+    r.pool_id
+  FROM reward r
+  JOIN stake_address sa ON 
+      sa.id = r.addr_id
+  WHERE sa.id in (SELECT stake_address_id FROM pools_delegated) and
+    r.spendable_epoch <= (SELECT \\"no\\" FROM current_epoch)
+  GROUP BY r.pool_id, sa.id), pool_owner_withdraws AS ( 
+  SELECT 
+    COALESCE(SUM(w.amount),0)  AS total_amount,
+    sa.id AS stake_address_id
+  FROM withdrawal w
+  JOIN tx ON tx.id = w.tx_id AND 
+    tx.valid_contract = TRUE
+  JOIN stake_address sa ON sa.id = w.addr_id
+  JOIN pools_delegated pool on pool.stake_address_id = sa.id 
+  GROUP BY sa.id), reward_acc_balance AS (
+  SELECT 
+    (r.total_amount - w.total_amount)  AS total_amount,
+    r.stake_address_id,
+    r.pool_id 
+  FROM pool_owner_rewards r
+  JOIN pool_owner_withdraws w 
+    on r.stake_address_id = w.stake_address_id ), owners_utxo AS (
+  SELECT
+    tx_out.value AS value,
+    o.pool_hash_id 
+  FROM tx_out
+  JOIN pool_owner o on 
+    o.addr_id = tx_out.stake_address_id and 
+    o.pool_hash_id in (SELECT id FROM pools_delegated)
+  LEFT JOIN tx_in ON 
+    tx_out.tx_id = tx_in.tx_out_id AND 
+    tx_out.index::smallint = tx_in.tx_out_index::smallint
+  LEFT JOIN tx AS tx_in_tx ON 
+    tx_in_tx.id = tx_in.tx_in_id AND
+      tx_in_tx.valid_contract = TRUE
+  JOIN tx AS tx_out_tx ON
+    tx_out_tx.id = tx_out.tx_id AND
+      tx_out_tx.valid_contract = TRUE
+  WHERE 
+    tx_in_tx.id IS NULL), owners_balance AS (
+  SELECT 
+    SUM(value) AS total_amount,
+    pool_hash_id
+  FROM owners_utxo 
+  GROUP BY pool_hash_id), pools_by_pledge_met AS (
+    
+    SELECT
+        ph.id,
+        ph.update_id
+    FROM pools_delegated AS ph 
+    
+    LEFT JOIN owners_balance o_balance ON 
+        ph.id = o_balance.pool_hash_id
+    LEFT JOIN reward_acc_balance r_balance ON
+        r_balance.pool_id = ph.id 
+    WHERE  
+    ((COALESCE(o_balance.total_amount,0) +
+    COALESCE (r_balance.total_amount, 0)) 
+     >= ph.pledge)) 
+    SELECT id, update_id
+    FROM
+    (SELECT id, update_id FROM pools_by_identifier UNION SELECT id, update_id FROM pools_by_status UNION SELECT id, update_id FROM pools_by_pledge_met)
+    AS pools
+    GROUP BY id,update_id
+    ORDER BY id DESC
+    ",
+}
+`;
+
+exports[`StakePoolSearchBuilder buildOrQuery buildOrQuery & queryPoolHashes 2`] = `
+Array [
+  Object {
+    "id": "2056",
+    "updateId": "2885",
+  },
+  Object {
+    "id": "2055",
+    "updateId": "2068",
+  },
+  Object {
+    "id": "20",
+    "updateId": "20",
+  },
+  Object {
+    "id": "16",
+    "updateId": "16",
+  },
+  Object {
+    "id": "15",
+    "updateId": "309",
+  },
+  Object {
+    "id": "14",
+    "updateId": "14",
+  },
+  Object {
+    "id": "6",
+    "updateId": "6",
+  },
+  Object {
+    "id": "1",
+    "updateId": "1",
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByIdentifierQuery buildPoolsByIdentifierQuery 1`] = `
+Object {
+  "id": Object {
+    "isPrimary": true,
+    "name": "pools_by_identifier",
+  },
+  "params": Array [
+    "%(CL)%",
+    "%(CLIO)%",
+    "%(pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70)%",
+  ],
+  "query": "
+    
+  SELECT 
+    ph.id,
+    pu.id AS update_id
+  FROM pool_hash ph 
+  
+     
+    JOIN pool_update pu
+      ON pu.id = (
+        SELECT id
+        FROM pool_update pu2
+        WHERE pu2.hash_id = ph.id
+        ORDER BY id DESC
+        LIMIT 1
+      )
+     
+    LEFT JOIN pool_offline_data pod 
+      ON pod.pool_id = ph.id
+    
+    WHERE ((pod.\\"json\\" ->>'name')::varchar SIMILAR TO $1 and pod.ticker_name SIMILAR TO $2 and ph.view SIMILAR TO $3)
+    ",
+}
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByPledgeMetQuery pledgeMet false 1`] = `
+Array [
+  Object {
+    "id": Object {
+      "name": "pools_delegated",
+    },
+    "query": "
+    SELECT 
+      ph.id,
+      ph.view,
+      pu.id AS update_id,
+      pu.active_epoch_no,
+      pu.pledge,
+      sa.id AS stake_address_id
+    FROM pool_hash ph 
+    JOIN pool_update pu
+      ON pu.id = (
+        SELECT id
+        FROM pool_update pu2
+        WHERE pu2.hash_id = ph.id
+        ORDER BY id DESC
+        LIMIT 1
+      ) 
+    JOIN stake_address sa ON
+      sa.hash_raw = pu.reward_addr 
+    JOIN delegation d1 on
+      sa.id = d1.addr_id 
+    WHERE NOT EXISTS
+      (SELECT TRUE
+        FROM delegation d2
+        WHERE d2.addr_id=d1.addr_id 
+          AND d2.tx_id>d1.tx_id)
+    AND NOT EXISTS
+      (SELECT TRUE
+        FROM stake_deregistration
+        WHERE stake_deregistration.addr_id=d1.addr_id
+          AND stake_deregistration.tx_id>d1.tx_id)
+    ",
+  },
+  Object {
+    "id": Object {
+      "name": "pool_owner_rewards",
+    },
+    "query": "
+  SELECT 
+    COALESCE(SUM(r.amount),0) AS total_amount,
+    sa.id AS stake_address_id,
+    r.pool_id
+  FROM reward r
+  JOIN stake_address sa ON 
+      sa.id = r.addr_id
+  WHERE sa.id in (SELECT stake_address_id FROM pools_delegated) and
+    r.spendable_epoch <= (SELECT \\"no\\" FROM current_epoch)
+  GROUP BY r.pool_id, sa.id",
+  },
+  Object {
+    "id": Object {
+      "name": "pool_owner_withdraws",
+    },
+    "query": " 
+  SELECT 
+    COALESCE(SUM(w.amount),0)  AS total_amount,
+    sa.id AS stake_address_id
+  FROM withdrawal w
+  JOIN tx ON tx.id = w.tx_id AND 
+    tx.valid_contract = TRUE
+  JOIN stake_address sa ON sa.id = w.addr_id
+  JOIN pools_delegated pool on pool.stake_address_id = sa.id 
+  GROUP BY sa.id",
+  },
+  Object {
+    "id": Object {
+      "name": "reward_acc_balance",
+    },
+    "query": "
+  SELECT 
+    (r.total_amount - w.total_amount)  AS total_amount,
+    r.stake_address_id,
+    r.pool_id 
+  FROM pool_owner_rewards r
+  JOIN pool_owner_withdraws w 
+    on r.stake_address_id = w.stake_address_id ",
+  },
+  Object {
+    "id": Object {
+      "name": "owners_utxo",
+    },
+    "query": "
+  SELECT
+    tx_out.value AS value,
+    o.pool_hash_id 
+  FROM tx_out
+  JOIN pool_owner o on 
+    o.addr_id = tx_out.stake_address_id and 
+    o.pool_hash_id in (SELECT id FROM pools_delegated)
+  LEFT JOIN tx_in ON 
+    tx_out.tx_id = tx_in.tx_out_id AND 
+    tx_out.index::smallint = tx_in.tx_out_index::smallint
+  LEFT JOIN tx AS tx_in_tx ON 
+    tx_in_tx.id = tx_in.tx_in_id AND
+      tx_in_tx.valid_contract = TRUE
+  JOIN tx AS tx_out_tx ON
+    tx_out_tx.id = tx_out.tx_id AND
+      tx_out_tx.valid_contract = TRUE
+  WHERE 
+    tx_in_tx.id IS NULL",
+  },
+  Object {
+    "id": Object {
+      "name": "owners_balance",
+    },
+    "query": "
+  SELECT 
+    SUM(value) AS total_amount,
+    pool_hash_id
+  FROM owners_utxo 
+  GROUP BY pool_hash_id",
+  },
+  Object {
+    "id": Object {
+      "isPrimary": true,
+      "name": "pools_by_pledge_met",
+    },
+    "query": "
+    
+    SELECT
+        ph.id,
+        ph.update_id
+    FROM pools_delegated AS ph 
+    
+    LEFT JOIN owners_balance o_balance ON 
+        ph.id = o_balance.pool_hash_id
+    LEFT JOIN reward_acc_balance r_balance ON
+        r_balance.pool_id = ph.id 
+    WHERE  
+    ((COALESCE(o_balance.total_amount,0) +
+    COALESCE (r_balance.total_amount, 0)) 
+    < ph.pledge)",
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByPledgeMetQuery pledgeMet true 1`] = `
+Array [
+  Object {
+    "id": Object {
+      "name": "pools_delegated",
+    },
+    "query": "
+    SELECT 
+      ph.id,
+      ph.view,
+      pu.id AS update_id,
+      pu.active_epoch_no,
+      pu.pledge,
+      sa.id AS stake_address_id
+    FROM pool_hash ph 
+    JOIN pool_update pu
+      ON pu.id = (
+        SELECT id
+        FROM pool_update pu2
+        WHERE pu2.hash_id = ph.id
+        ORDER BY id DESC
+        LIMIT 1
+      ) 
+    JOIN stake_address sa ON
+      sa.hash_raw = pu.reward_addr 
+    JOIN delegation d1 on
+      sa.id = d1.addr_id 
+    WHERE NOT EXISTS
+      (SELECT TRUE
+        FROM delegation d2
+        WHERE d2.addr_id=d1.addr_id 
+          AND d2.tx_id>d1.tx_id)
+    AND NOT EXISTS
+      (SELECT TRUE
+        FROM stake_deregistration
+        WHERE stake_deregistration.addr_id=d1.addr_id
+          AND stake_deregistration.tx_id>d1.tx_id)
+    ",
+  },
+  Object {
+    "id": Object {
+      "name": "pool_owner_rewards",
+    },
+    "query": "
+  SELECT 
+    COALESCE(SUM(r.amount),0) AS total_amount,
+    sa.id AS stake_address_id,
+    r.pool_id
+  FROM reward r
+  JOIN stake_address sa ON 
+      sa.id = r.addr_id
+  WHERE sa.id in (SELECT stake_address_id FROM pools_delegated) and
+    r.spendable_epoch <= (SELECT \\"no\\" FROM current_epoch)
+  GROUP BY r.pool_id, sa.id",
+  },
+  Object {
+    "id": Object {
+      "name": "pool_owner_withdraws",
+    },
+    "query": " 
+  SELECT 
+    COALESCE(SUM(w.amount),0)  AS total_amount,
+    sa.id AS stake_address_id
+  FROM withdrawal w
+  JOIN tx ON tx.id = w.tx_id AND 
+    tx.valid_contract = TRUE
+  JOIN stake_address sa ON sa.id = w.addr_id
+  JOIN pools_delegated pool on pool.stake_address_id = sa.id 
+  GROUP BY sa.id",
+  },
+  Object {
+    "id": Object {
+      "name": "reward_acc_balance",
+    },
+    "query": "
+  SELECT 
+    (r.total_amount - w.total_amount)  AS total_amount,
+    r.stake_address_id,
+    r.pool_id 
+  FROM pool_owner_rewards r
+  JOIN pool_owner_withdraws w 
+    on r.stake_address_id = w.stake_address_id ",
+  },
+  Object {
+    "id": Object {
+      "name": "owners_utxo",
+    },
+    "query": "
+  SELECT
+    tx_out.value AS value,
+    o.pool_hash_id 
+  FROM tx_out
+  JOIN pool_owner o on 
+    o.addr_id = tx_out.stake_address_id and 
+    o.pool_hash_id in (SELECT id FROM pools_delegated)
+  LEFT JOIN tx_in ON 
+    tx_out.tx_id = tx_in.tx_out_id AND 
+    tx_out.index::smallint = tx_in.tx_out_index::smallint
+  LEFT JOIN tx AS tx_in_tx ON 
+    tx_in_tx.id = tx_in.tx_in_id AND
+      tx_in_tx.valid_contract = TRUE
+  JOIN tx AS tx_out_tx ON
+    tx_out_tx.id = tx_out.tx_id AND
+      tx_out_tx.valid_contract = TRUE
+  WHERE 
+    tx_in_tx.id IS NULL",
+  },
+  Object {
+    "id": Object {
+      "name": "owners_balance",
+    },
+    "query": "
+  SELECT 
+    SUM(value) AS total_amount,
+    pool_hash_id
+  FROM owners_utxo 
+  GROUP BY pool_hash_id",
+  },
+  Object {
+    "id": Object {
+      "isPrimary": true,
+      "name": "pools_by_pledge_met",
+    },
+    "query": "
+    
+    SELECT
+        ph.id,
+        ph.update_id
+    FROM pools_delegated AS ph 
+    
+    LEFT JOIN owners_balance o_balance ON 
+        ph.id = o_balance.pool_hash_id
+    LEFT JOIN reward_acc_balance r_balance ON
+        r_balance.pool_id = ph.id 
+    WHERE  
+    ((COALESCE(o_balance.total_amount,0) +
+    COALESCE (r_balance.total_amount, 0)) 
+     >= ph.pledge)",
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery activating 1`] = `
+Object {
+  "id": Object {
+    "isPrimary": true,
+    "name": "pools_by_status",
+  },
+  "query": "
+    
+    SELECT
+      ph.id,
+      pu.id AS update_id
+    FROM pool_hash ph
+    JOIN pool_update pu
+        ON pu.id = (
+          SELECT id
+          FROM pool_update pu2
+          WHERE pu2.hash_id = ph.id
+          ORDER BY id DESC
+          LIMIT 1
+        )
+    LEFT JOIN pool_retire pr 
+        ON pr.id = (
+          SELECT id
+          FROM pool_retire pr2
+          WHERE pr2.hash_id = ph.id
+          ORDER BY id desc 
+          LIMIT 1
+    )
+  
+    WHERE ((pu.active_epoch_no > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) <= pu.active_epoch_no))
+    ",
+}
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery active 1`] = `
+Object {
+  "id": Object {
+    "isPrimary": true,
+    "name": "pools_by_status",
+  },
+  "query": "
+    
+    SELECT
+      ph.id,
+      pu.id AS update_id
+    FROM pool_hash ph
+    JOIN pool_update pu
+        ON pu.id = (
+          SELECT id
+          FROM pool_update pu2
+          WHERE pu2.hash_id = ph.id
+          ORDER BY id DESC
+          LIMIT 1
+        )
+    LEFT JOIN pool_retire pr 
+        ON pr.id = (
+          SELECT id
+          FROM pool_retire pr2
+          WHERE pr2.hash_id = ph.id
+          ORDER BY id desc 
+          LIMIT 1
+    )
+  
+    WHERE ((pu.active_epoch_no <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) < pu.active_epoch_no))
+    ",
+}
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery active,activating,retiring,retired 1`] = `
+Object {
+  "id": Object {
+    "isPrimary": true,
+    "name": "pools_by_status",
+  },
+  "query": "
+    
+    SELECT
+      ph.id,
+      pu.id AS update_id
+    FROM pool_hash ph
+    JOIN pool_update pu
+        ON pu.id = (
+          SELECT id
+          FROM pool_update pu2
+          WHERE pu2.hash_id = ph.id
+          ORDER BY id DESC
+          LIMIT 1
+        )
+    LEFT JOIN pool_retire pr 
+        ON pr.id = (
+          SELECT id
+          FROM pool_retire pr2
+          WHERE pr2.hash_id = ph.id
+          ORDER BY id desc 
+          LIMIT 1
+    )
+  
+    WHERE ((COALESCE(pr.retiring_epoch,0) > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > pu.active_epoch_no) OR (COALESCE(pr.retiring_epoch,0) <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > pu.active_epoch_no) OR (pu.active_epoch_no > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) <= pu.active_epoch_no) OR (pu.active_epoch_no <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) < pu.active_epoch_no))
+    ",
+}
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery retired 1`] = `
+Object {
+  "id": Object {
+    "isPrimary": true,
+    "name": "pools_by_status",
+  },
+  "query": "
+    
+    SELECT
+      ph.id,
+      pu.id AS update_id
+    FROM pool_hash ph
+    JOIN pool_update pu
+        ON pu.id = (
+          SELECT id
+          FROM pool_update pu2
+          WHERE pu2.hash_id = ph.id
+          ORDER BY id DESC
+          LIMIT 1
+        )
+    LEFT JOIN pool_retire pr 
+        ON pr.id = (
+          SELECT id
+          FROM pool_retire pr2
+          WHERE pr2.hash_id = ph.id
+          ORDER BY id desc 
+          LIMIT 1
+    )
+  
+    WHERE ((COALESCE(pr.retiring_epoch,0) <= (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > pu.active_epoch_no))
+    ",
+}
+`;
+
+exports[`StakePoolSearchBuilder buildPoolsByStatusQuery retiring 1`] = `
+Object {
+  "id": Object {
+    "isPrimary": true,
+    "name": "pools_by_status",
+  },
+  "query": "
+    
+    SELECT
+      ph.id,
+      pu.id AS update_id
+    FROM pool_hash ph
+    JOIN pool_update pu
+        ON pu.id = (
+          SELECT id
+          FROM pool_update pu2
+          WHERE pu2.hash_id = ph.id
+          ORDER BY id DESC
+          LIMIT 1
+        )
+    LEFT JOIN pool_retire pr 
+        ON pr.id = (
+          SELECT id
+          FROM pool_retire pr2
+          WHERE pr2.hash_id = ph.id
+          ORDER BY id desc 
+          LIMIT 1
+    )
+  
+    WHERE ((COALESCE(pr.retiring_epoch,0) > (SELECT \\"no\\" FROM current_epoch) 
+          AND COALESCE(pr.retiring_epoch,0) > pu.active_epoch_no))
+    ",
+}
+`;
+
+exports[`StakePoolSearchBuilder getLastEpoch getLastEpoch 1`] = `175`;
+
+exports[`StakePoolSearchBuilder getTotalAmountOfAda getTotalAmountOfAda 1`] = `"42021479194505231"`;
+
+exports[`StakePoolSearchBuilder queryPoolData queryPoolData 1`] = `
+Array [
+  Object {
+    "cost": 340000000n,
+    "hashId": "6",
+    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+    "margin": Object {
+      "denominator": 40,
+      "numerator": 3,
+    },
+    "metadataJson": Object {
+      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+      "url": "https://visionstaking.ch/poolmeta.json",
+    },
+    "pledge": 10000000n,
+    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+    "updateId": "6",
+    "vrfKeyHash": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
+  },
+  Object {
+    "cost": 400000000n,
+    "hashId": "1",
+    "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
+    "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
+    "margin": Object {
+      "denominator": 100,
+      "numerator": 7,
+    },
+    "metadataJson": Object {
+      "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
+      "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
+    },
+    "pledge": 1000000000000n,
+    "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
+    "updateId": "1",
+    "vrfKeyHash": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder queryPoolMetrics queryPoolMetrics 1`] = `
+Array [
+  Object {
+    "hashId": "1",
+    "metrics": Object {
+      "blocksCreated": "0",
+      "delegators": "1",
+      "livePledge": 999999828559n,
+      "saturation": "0.01189867476975633141",
+      "size": Object {
+        "active": "0.0000000000000000000000000000",
+        "live": "1.00000000000000000000",
+      },
+      "stake": Object {
+        "active": 0n,
+        "live": 999999828559n,
+      },
+    },
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder queryPoolOwners queryPoolOwners 1`] = `
+Array [
+  Object {
+    "address": "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
+    "hashId": "1",
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder queryPoolRewards queryPoolRewards 1`] = `
+Array [
+  Object {
+    "epochReward": Object {
+      "activeStake": 0n,
+      "epoch": 175,
+      "epochLength": 431949000,
+      "memberROI": 0,
+      "operatorFees": 0n,
+      "totalRewards": 0n,
+    },
+    "hashId": 1,
+  },
+  undefined,
+  undefined,
+]
+`;
+
+exports[`StakePoolSearchBuilder queryRegistrations queryRegistrations 1`] = `
+Array [
+  Object {
+    "activeEpochNo": "76",
+    "hashId": "1",
+    "transactionId": "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
+  },
+]
+`;
+
+exports[`StakePoolSearchBuilder queryRetirements queryRetirements 1`] = `
+Array [
+  Object {
+    "hashId": "1",
+    "retiringEpoch": 78,
+    "transactionId": "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
+  },
+]
+`;


### PR DESCRIPTION
# Context

In order to improve testing quality, modularize `DbSyncStakePoolSearch` queries

# Proposed Solution

Create a new dependency into `DbSyncStakePoolSearch` called `StakePoolSearchBuilder` with the previous `DbSyncStakePoolSearch's` private methods (query builders and query calls).

# Important Changes Introduced

n/a