### PR TITLE
Feat/expose unpaginated result count in stake pool search

### DIFF
--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -22,7 +22,7 @@
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
-    "test": "jest -c ./jest.config.js",
+    "test": "jest -c ./jest.config.js -t stakepool",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
     "coverage": "yarn test --coverage",
     "prepack": "yarn build",

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -22,7 +22,7 @@
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
-    "test": "jest -c ./jest.config.js -t stakepool",
+    "test": "jest -c ./jest.config.js",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
     "coverage": "yarn test --coverage",
     "prepack": "yarn build",

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/DbSyncStakePoolSearch.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/DbSyncStakePoolSearch.ts
@@ -1,8 +1,8 @@
 /* eslint-disable sonarjs/no-nested-template-literals */
-import { Cardano, StakePoolQueryOptions, StakePoolSearchProvider, util } from '@cardano-sdk/core';
 import { DbSyncProvider } from '../../DbSyncProvider';
 import { Logger, dummyLogger } from 'ts-log';
 import { Pool } from 'pg';
+import { StakePoolQueryOptions, StakePoolSearchProvider, StakePoolSearchResults, util } from '@cardano-sdk/core';
 import { StakePoolSearchBuilder } from './StakePoolSearchBuilder';
 import { toCoreStakePool } from './mappers';
 
@@ -16,7 +16,7 @@ export class DbSyncStakePoolSearchProvider extends DbSyncProvider implements Sta
     this.#logger = logger;
   }
 
-  public async queryStakePools(options?: StakePoolQueryOptions): Promise<Cardano.StakePool[]> {
+  public async queryStakePools(options?: StakePoolQueryOptions): Promise<StakePoolSearchResults> {
     const { params, query } =
       options?.filters?._condition === 'or'
         ? this.#builder.buildOrQuery(options?.filters)
@@ -27,17 +27,27 @@ export class DbSyncStakePoolSearchProvider extends DbSyncProvider implements Sta
     this.#logger.debug(`${hashesIds.length} pools found`);
     const updatesIds = poolUpdates.map(({ updateId }) => updateId);
     const totalAdaAmount = await this.#builder.getTotalAmountOfAda();
-    const [poolDatas, poolRelays, poolOwners, poolRegistrations, poolRetirements, poolRewards, lastEpoch, poolMetrics] =
-      await Promise.all([
-        this.#builder.queryPoolData(updatesIds),
-        this.#builder.queryPoolRelays(updatesIds),
-        this.#builder.queryPoolOwners(updatesIds),
-        this.#builder.queryRegistrations(hashesIds),
-        this.#builder.queryRetirements(hashesIds),
-        this.#builder.queryPoolRewards(hashesIds, options?.rewardsHistoryLimit),
-        this.#builder.getLastEpoch(),
-        this.#builder.queryPoolMetrics(hashesIds, totalAdaAmount)
-      ]);
+    const [
+      poolDatas,
+      poolRelays,
+      poolOwners,
+      poolRegistrations,
+      poolRetirements,
+      poolRewards,
+      lastEpoch,
+      poolMetrics,
+      totalCount
+    ] = await Promise.all([
+      this.#builder.queryPoolData(updatesIds),
+      this.#builder.queryPoolRelays(updatesIds),
+      this.#builder.queryPoolOwners(updatesIds),
+      this.#builder.queryRegistrations(hashesIds),
+      this.#builder.queryRetirements(hashesIds),
+      this.#builder.queryPoolRewards(hashesIds, options?.rewardsHistoryLimit),
+      this.#builder.getLastEpoch(),
+      this.#builder.queryPoolMetrics(hashesIds, totalAdaAmount),
+      this.#builder.queryTotalCount(query, params)
+    ]);
     return toCoreStakePool({
       lastEpoch,
       poolDatas,
@@ -46,7 +56,8 @@ export class DbSyncStakePoolSearchProvider extends DbSyncProvider implements Sta
       poolRegistrations,
       poolRelays,
       poolRetirements,
-      poolRewards: poolRewards.filter(util.isNotNil)
+      poolRewards: poolRewards.filter(util.isNotNil),
+      totalCount
     });
   }
 }

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.ts
@@ -158,12 +158,7 @@ export class StakePoolSearchBuilder {
     if (filters?.status || filters?.pledgeMet !== undefined)
       subQueries.unshift({ id: { name: 'current_epoch' }, query: findLastEpoch });
     if (subQueries.length > 0) {
-      query =
-        subQueries.length > 1
-          ? buildOrQueryFromClauses(subQueries)
-          : `${subQueries.length > 1 ? `WITH (${subQueries.find((sq) => !sq.id.isPrimary)})` : ''} ${
-              subQueries[0].query
-            } `;
+      query = subQueries.length > 1 ? buildOrQueryFromClauses(subQueries) : subQueries[0].query;
     }
     return { params, query };
   }

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.ts
@@ -11,7 +11,8 @@ import {
   PoolUpdateModel,
   RelayModel,
   SubQuery,
-  TotalAdaModel
+  TotalAdaModel,
+  TotalCountModel
 } from './types';
 import { Logger, dummyLogger } from 'ts-log';
 import { Pool, QueryResult } from 'pg';
@@ -32,6 +33,7 @@ import Queries, {
   getIdentifierFullJoinClause,
   getIdentifierWhereClause,
   getStatusWhereClause,
+  getTotalCountQueryFromQuery,
   poolsByPledgeMetSubqueries,
   withPagination
 } from './queries';
@@ -215,5 +217,11 @@ export class StakePoolSearchBuilder {
     if (whereClause.length > 0) query = addSentenceToQuery(query, ` WHERE ${whereClause.join(' AND ')}`);
     query = addSentenceToQuery(query, groupByClause);
     return { params, query };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public async queryTotalCount(query: string, _params: any[]) {
+    this.#logger.debug('About to get total count of pools');
+    const result: QueryResult<TotalCountModel> = await this.#db.query(getTotalCountQueryFromQuery(query), _params);
+    return result.rows[0].total_count;
   }
 }

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/mappers.ts
@@ -1,4 +1,4 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, StakePoolSearchResults } from '@cardano-sdk/core';
 import {
   EpochReward,
   EpochRewardModel,
@@ -43,6 +43,7 @@ interface ToCoreStakePoolInput {
   poolRewards: EpochReward[];
   lastEpoch: number;
   poolMetrics: PoolMetrics[];
+  totalCount: number;
 }
 
 export const toCoreStakePool = ({
@@ -53,9 +54,10 @@ export const toCoreStakePool = ({
   poolRetirements,
   poolRewards,
   lastEpoch,
-  poolMetrics
-}: ToCoreStakePoolInput): Cardano.StakePool[] =>
-  poolDatas.map((poolData) => {
+  poolMetrics,
+  totalCount
+}: ToCoreStakePoolInput): StakePoolSearchResults => ({
+  pageResults: poolDatas.map((poolData) => {
     const registrations = poolRegistrations.filter((r) => r.hashId === poolData.hashId);
     const retirements = poolRetirements.filter((r) => r.hashId === poolData.hashId);
     const toReturn: Cardano.StakePool = {
@@ -80,7 +82,9 @@ export const toCoreStakePool = ({
     if (poolData.metadata) toReturn.metadata = poolData.metadata;
     if (poolData.metadataJson) toReturn.metadataJson = poolData.metadataJson;
     return toReturn;
-  });
+  }),
+  totalResultCount: Number(totalCount)
+});
 
 export const mapPoolUpdate = (poolUpdateModel: PoolUpdateModel): PoolUpdate => ({
   id: poolUpdateModel.id,

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/queries.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/queries.ts
@@ -682,6 +682,12 @@ export const buildOrQueryFromClauses = (clauses: SubQuery[]) => {
     `;
 };
 
+export const getTotalCountQueryFromQuery = (query: string) => `
+SELECT 
+  COUNT(1) AS total_count
+FROM (${query}) as query
+`;
+
 const Queries = {
   IDENTIFIER_QUERY,
   POOLS_WITH_PLEDGE_MET,

--- a/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/types.ts
+++ b/packages/cardano-services/src/StakePoolSearch/DbSyncStakePoolSearchProvider/types.ts
@@ -132,3 +132,7 @@ export interface PoolMetrics {
   hashId: number;
   metrics: Cardano.StakePoolMetrics;
 }
+
+export interface TotalCountModel {
+  total_count: number;
+}

--- a/packages/cardano-services/src/StakePoolSearch/StakePoolSearchHttpService.ts
+++ b/packages/cardano-services/src/StakePoolSearch/StakePoolSearchHttpService.ts
@@ -1,8 +1,8 @@
 import * as OpenApiValidator from 'express-openapi-validator';
-import { Cardano, ProviderError, ProviderFailure, StakePoolQueryOptions } from '@cardano-sdk/core';
 import { DbSyncStakePoolSearchProvider } from './DbSyncStakePoolSearchProvider';
 import { HttpServer, HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
+import { ProviderError, ProviderFailure, StakePoolQueryOptions, StakePoolSearchResults } from '@cardano-sdk/core';
 import { ServiceNames } from '../Program';
 import { providerHandler } from '../util';
 import express from 'express';
@@ -36,7 +36,7 @@ export class StakePoolSearchHttpService extends HttpService {
     // Add initial healthCheck of the provider when implemented
     router.post(
       '/search',
-      providerHandler<[StakePoolQueryOptions], Cardano.StakePool[]>(async ([stakePoolOptions], _, res) => {
+      providerHandler<[StakePoolQueryOptions], StakePoolSearchResults>(async ([stakePoolOptions], _, res) => {
         try {
           return HttpServer.sendJSON(res, await stakePoolSearchProvider.queryStakePools(stakePoolOptions));
         } catch (error) {

--- a/packages/cardano-services/src/StakePoolSearch/openApi.json
+++ b/packages/cardano-services/src/StakePoolSearch/openApi.json
@@ -29,10 +29,19 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SearchStakePoolResponse"
+                  "type": "object",
+                  "properties": {
+                    "pageResults": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SearchStakePool"
+                      }
+                    },
+                    "totalResultCount": {
+                      "type": "number"
+                    }
                   }
+                  
                 }
               }
             }
@@ -76,7 +85,7 @@
           }
         }
       },
-      "SearchStakePoolResponse": {
+      "SearchStakePool": {
         "required": ["cost", "id", "margin", "owners", "pledge", "relays", "vrf"],
         "type": "object",
         "properties": {
@@ -96,7 +105,7 @@
             "$ref": "#/components/schemas/Fraction"
           },
           "metadataJson": {
-            "$ref": "#/components/schemas/SearchStakePoolResponse_metadataJson"
+            "$ref": "#/components/schemas/MetadataJson"
           },
           "relays": {
             "type": "array",
@@ -328,7 +337,7 @@
           }
         }
       },
-      "SearchStakePoolResponse_metadataJson": {
+      "MetadataJson": {
         "type": "object",
         "properties": {
           "hash": {

--- a/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.test.ts
+++ b/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/StakePoolSearchBuilder.test.ts
@@ -180,19 +180,25 @@ describe('StakePoolSearchBuilder', () => {
     });
   });
   describe('buildOrQuery', () => {
-    it('buildOrQuery & queryPoolHashes', async () => {
+    it('buildOrQuery, queryPoolHashes & queryTotalCount', async () => {
       const builtQuery = builder.buildOrQuery(filters);
-      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      const { query, params } = builtQuery;
+      const poolHashes = await builder.queryPoolHashes(query, params);
+      const totalCount = await builder.queryTotalCount(query, params);
       expect(builtQuery).toMatchSnapshot();
       expect(poolHashes).toMatchSnapshot();
+      expect(totalCount).toMatchSnapshot();
     });
   });
   describe('buildAndQuery', () => {
-    it('buildAndQuery & queryPoolHashes', async () => {
+    it('buildAndQuery, queryPoolHashes & queryTotalCount', async () => {
       const builtQuery = builder.buildAndQuery(filters);
-      const poolHashes = await builder.queryPoolHashes(builtQuery.query, builtQuery.params);
+      const { query, params } = builtQuery;
+      const poolHashes = await builder.queryPoolHashes(query, params);
+      const totalCount = await builder.queryTotalCount(query, params);
       expect(builtQuery).toMatchSnapshot();
       expect(poolHashes).toMatchSnapshot();
+      expect(totalCount).toMatchSnapshot();
     });
   });
 });

--- a/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/__snapshots__/StakePoolSearchBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/__snapshots__/StakePoolSearchBuilder.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StakePoolSearchBuilder buildAndQuery buildAndQuery & queryPoolHashes 1`] = `
+exports[`StakePoolSearchBuilder buildAndQuery buildAndQuery, queryPoolHashes & queryTotalCount 1`] = `
 Object {
   "params": Array [
     "%(CL)%",
@@ -137,7 +137,7 @@ Object {
 }
 `;
 
-exports[`StakePoolSearchBuilder buildAndQuery buildAndQuery & queryPoolHashes 2`] = `
+exports[`StakePoolSearchBuilder buildAndQuery buildAndQuery, queryPoolHashes & queryTotalCount 2`] = `
 Array [
   Object {
     "id": "15",
@@ -146,7 +146,9 @@ Array [
 ]
 `;
 
-exports[`StakePoolSearchBuilder buildOrQuery buildOrQuery & queryPoolHashes 1`] = `
+exports[`StakePoolSearchBuilder buildAndQuery buildAndQuery, queryPoolHashes & queryTotalCount 3`] = `"1"`;
+
+exports[`StakePoolSearchBuilder buildOrQuery buildOrQuery, queryPoolHashes & queryTotalCount 1`] = `
 Object {
   "params": Array [
     "%(CL)%",
@@ -314,7 +316,7 @@ Object {
 }
 `;
 
-exports[`StakePoolSearchBuilder buildOrQuery buildOrQuery & queryPoolHashes 2`] = `
+exports[`StakePoolSearchBuilder buildOrQuery buildOrQuery, queryPoolHashes & queryTotalCount 2`] = `
 Array [
   Object {
     "id": "2056",
@@ -350,6 +352,8 @@ Array [
   },
 ]
 `;
+
+exports[`StakePoolSearchBuilder buildOrQuery buildOrQuery, queryPoolHashes & queryTotalCount 3`] = `"8"`;
 
 exports[`StakePoolSearchBuilder buildPoolsByIdentifierQuery buildPoolsByIdentifierQuery 1`] = `
 Object {

--- a/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/mappers.test.ts
+++ b/packages/cardano-services/test/StakePoolSeach/DbSyncStakePoolSearchProvider/mappers.test.ts
@@ -208,7 +208,7 @@ describe('mappers', () => {
       },
       vrf: poolDatas[0].vrfKeyHash
     };
-
+    const totalCount = 1;
     it('toCoreStakePool with retiring status', () => {
       expect(
         toCoreStakePool({
@@ -219,9 +219,10 @@ describe('mappers', () => {
           poolRegistrations,
           poolRelays,
           poolRetirements,
-          poolRewards
+          poolRewards,
+          totalCount
         })
-      ).toStrictEqual([stakePool]);
+      ).toStrictEqual({ pageResults: [stakePool], totalResultCount: totalCount });
     });
     it('toCoreStakePool with retired status', () => {
       expect(
@@ -233,9 +234,13 @@ describe('mappers', () => {
           poolRegistrations,
           poolRelays,
           poolRetirements,
-          poolRewards
+          poolRewards,
+          totalCount
         })
-      ).toStrictEqual([{ ...stakePool, status: Cardano.StakePoolStatus.Retired }]);
+      ).toStrictEqual({
+        pageResults: [{ ...stakePool, status: Cardano.StakePoolStatus.Retired }],
+        totalResultCount: totalCount
+      });
     });
     it('toCoreStakePool with activating status', () => {
       const _retirements = [
@@ -250,18 +255,22 @@ describe('mappers', () => {
           poolRegistrations,
           poolRelays,
           poolRetirements: _retirements,
-          poolRewards
+          poolRewards,
+          totalCount
         })
-      ).toEqual([
-        {
-          ...stakePool,
-          status: Cardano.StakePoolStatus.Activating,
-          transactions: {
-            registration: poolRegistrations.map((r) => r.transactionId),
-            retirement: _retirements.map((r) => r.transactionId)
+      ).toEqual({
+        pageResults: [
+          {
+            ...stakePool,
+            status: Cardano.StakePoolStatus.Activating,
+            transactions: {
+              registration: poolRegistrations.map((r) => r.transactionId),
+              retirement: _retirements.map((r) => r.transactionId)
+            }
           }
-        }
-      ]);
+        ],
+        totalResultCount: totalCount
+      });
     });
     it('toCoreStakePool with active status', () => {
       const _retirements = [
@@ -276,18 +285,22 @@ describe('mappers', () => {
           poolRegistrations,
           poolRelays,
           poolRetirements: _retirements,
-          poolRewards
+          poolRewards,
+          totalCount
         })
-      ).toEqual([
-        {
-          ...stakePool,
-          status: Cardano.StakePoolStatus.Active,
-          transactions: {
-            registration: poolRegistrations.map((r) => r.transactionId),
-            retirement: _retirements.map((r) => r.transactionId)
+      ).toEqual({
+        pageResults: [
+          {
+            ...stakePool,
+            status: Cardano.StakePoolStatus.Active,
+            transactions: {
+              registration: poolRegistrations.map((r) => r.transactionId),
+              retirement: _retirements.map((r) => r.transactionId)
+            }
           }
-        }
-      ]);
+        ],
+        totalResultCount: totalCount
+      });
     });
   });
 });

--- a/packages/cardano-services/test/StakePoolSeach/StakePoolSearchHttpService.test.ts
+++ b/packages/cardano-services/test/StakePoolSeach/StakePoolSearchHttpService.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
 // import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
-import { Cardano, StakePoolQueryOptions, StakePoolSearchProvider } from '@cardano-sdk/core';
+import { Cardano, StakePoolQueryOptions, StakePoolSearchProvider, StakePoolSearchResults } from '@cardano-sdk/core';
 import { DbSyncStakePoolSearchProvider, HttpServer, HttpServerConfig, StakePoolSearchHttpService } from '../../src';
 import { Pool } from 'pg';
 import { getPort } from 'get-port-please';
@@ -49,7 +49,7 @@ describe('StakePoolSearchHttpService', () => {
       .post(`${apiUrlBase}/search`, {
         json: { args: [arg] }
       })
-      .json() as Promise<Cardano.StakePool[]>;
+      .json() as Promise<StakePoolSearchResults>;
 
   describe('healthy state', () => {
     beforeAll(async () => {
@@ -117,7 +117,8 @@ describe('StakePoolSearchHttpService', () => {
             }
           };
           const response = await provider.queryStakePools(options);
-          expect(response).toHaveLength(2);
+          expect(response.pageResults).toHaveLength(2);
+          expect(response.totalResultCount).toEqual(2);
         });
       });
 
@@ -127,34 +128,34 @@ describe('StakePoolSearchHttpService', () => {
           const reqWithPagination = { pagination: { limit: 2, startAt: 1 } };
           const response = await doServerRequest(req);
           const responseWithPagination = await doServerRequest(reqWithPagination);
-          expect(response.length).toEqual(8);
-          expect(responseWithPagination.length).toEqual(2);
-          expect(response[0]).not.toEqual(responseWithPagination[0]);
+          expect(response.pageResults.length).toEqual(8);
+          expect(responseWithPagination.pageResults.length).toEqual(2);
+          expect(response.pageResults[0]).not.toEqual(responseWithPagination.pageResults[0]);
         });
         it('should paginate response with or condition', async () => {
           const req = { filters: { _condition: 'or' } };
           const reqWithPagination = { ...req, pagination: { limit: 2, startAt: 1 } };
           const response = await doServerRequest(req);
           const responseWithPagination = await doServerRequest(reqWithPagination);
-          expect(response.length).toEqual(8);
-          expect(responseWithPagination.length).toEqual(2);
-          expect(response[0]).not.toEqual(responseWithPagination[0]);
+          expect(response.pageResults.length).toEqual(8);
+          expect(responseWithPagination.pageResults.length).toEqual(2);
+          expect(response.pageResults[0]).not.toEqual(responseWithPagination.pageResults[0]);
         });
         it('should paginate rewards response', async () => {
           const req = { pagination: { limit: 1, startAt: 1 } };
           const reqWithRewardsPagination = { pagination: { limit: 1, startAt: 1 }, rewardsHistoryLimit: 0 };
           const response = await doServerRequest(req);
           const responseWithPagination = await doServerRequest(reqWithRewardsPagination);
-          expect(response[0].epochRewards.length).toEqual(1);
-          expect(responseWithPagination[0].epochRewards.length).toEqual(0);
+          expect(response.pageResults[0].epochRewards.length).toEqual(1);
+          expect(responseWithPagination.pageResults[0].epochRewards.length).toEqual(0);
         });
         it('should paginate rewards response with or condition', async () => {
           const req = { filters: { _condition: 'or' }, pagination: { limit: 1, startAt: 1 } };
           const reqWithRewardsPagination = { pagination: { limit: 1, startAt: 1 }, rewardsHistoryLimit: 0 };
           const response = await doServerRequest(req);
           const responseWithPagination = await doServerRequest(reqWithRewardsPagination);
-          expect(response[0].epochRewards.length).toEqual(1);
-          expect(responseWithPagination[0].epochRewards.length).toEqual(0);
+          expect(response.pageResults[0].epochRewards.length).toEqual(1);
+          expect(responseWithPagination.pageResults[0].epochRewards.length).toEqual(0);
         });
       });
 
@@ -207,7 +208,7 @@ describe('StakePoolSearchHttpService', () => {
             }
           };
           const response = await doServerRequest(req);
-          expect(response).toEqual([]);
+          expect(response.pageResults).toEqual([]);
         });
       });
       describe('search pools by status', () => {

--- a/packages/cardano-services/test/StakePoolSeach/__snapshots__/StakePoolSearchHttpService.test.ts.snap
+++ b/packages/cardano-services/test/StakePoolSeach/__snapshots__/StakePoolSearchHttpService.test.ts.snap
@@ -1,8634 +1,8753 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by identifier filter and condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "22614171623274",
+        },
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "1010000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-]
+  ],
+  "totalResultCount": 1,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by identifier filter or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 4,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, active,  or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "1010000000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "10000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 7,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status activating, and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status activating, and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status activating, or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "1010000000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "10000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 5,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status active, and condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "4321000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "500000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-]
+  ],
+  "totalResultCount": 2,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status retired, and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status retired, and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status retired, or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "1010000000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
-    "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 7,
-    },
-    "metadataJson": Object {
-      "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
-      "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "999999828559",
+        "value": "10000000000",
       },
-      "saturation": "0.01189867476975633141",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
+      "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 7,
+      },
+      "metadataJson": Object {
+        "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
+        "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "999999828559",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1000000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
-    "status": "retired",
-    "transactions": Object {
-      "registration": Array [
-        "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
-      ],
-      "retirement": Array [
-        "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
-      ],
-    },
-    "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.01189867476975633141",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "999999828559",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1000000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
+        ],
+        "retirement": Array [
+          "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 6,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status retiring, and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status retiring, and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet false, status retiring, or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "1010000000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "10000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 5,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, active,  or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 6,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status activating, and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status activating, and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status activating, or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 6,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status active, and condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "1010000000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 2,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status retired, and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status retired, and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status retired, or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
-    "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 7,
-    },
-    "metadataJson": Object {
-      "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
-      "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "999999828559",
+        "value": "1010000000000",
       },
-      "saturation": "0.01189867476975633141",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
+      "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 7,
+      },
+      "metadataJson": Object {
+        "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
+        "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "999999828559",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1000000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
-    "status": "retired",
-    "transactions": Object {
-      "registration": Array [
-        "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
-      ],
-      "retirement": Array [
-        "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
-      ],
-    },
-    "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.01189867476975633141",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "999999828559",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1000000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
+        ],
+        "retirement": Array [
+          "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 7,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status retiring, and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status retiring, and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status retiring, or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "1010000000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "10000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 7,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet, multiple status, and condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 4,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet, multiple status, or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "1010000000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
-    "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 7,
-    },
-    "metadataJson": Object {
-      "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
-      "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "999999828559",
+        "value": "10000000000",
       },
-      "saturation": "0.01189867476975633141",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
+      "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 7,
+      },
+      "metadataJson": Object {
+        "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
+        "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "999999828559",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1000000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
-    "status": "retired",
-    "transactions": Object {
-      "registration": Array [
-        "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
-      ],
-      "retirement": Array [
-        "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
-      ],
-    },
-    "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.01189867476975633141",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "999999828559",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1000000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
+        ],
+        "retirement": Array [
+          "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 8,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters activating with and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters activating with and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters activating with or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 4,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters active with and condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 4,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters active with or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 6,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters retired with and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters retired with and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters retired with or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
-    "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 7,
-    },
-    "metadataJson": Object {
-      "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
-      "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "999999828559",
+        "value": "1010000000000",
       },
-      "saturation": "0.01189867476975633141",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
+      "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 7,
+      },
+      "metadataJson": Object {
+        "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
+        "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "999999828559",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1000000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
-    "status": "retired",
-    "transactions": Object {
-      "registration": Array [
-        "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
-      ],
-      "retirement": Array [
-        "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
-      ],
-    },
-    "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.01189867476975633141",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "999999828559",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1000000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
+        ],
+        "retirement": Array [
+          "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 5,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters retiring with and condition 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters retiring with and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by multiple filters identifier & status filters retiring with or condition 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "340000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
-    },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "1010000000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "10000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "500000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 5,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by pledge met search by pledge met on false 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "345000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
-      },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-      ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
-    },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
         },
       },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "10000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "500000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "70000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-]
+  ],
+  "totalResultCount": 3,
+}
 `;
 
-exports[`StakePoolSearchHttpService healthy state /search search pools by status search by activating status 1`] = `Array []`;
+exports[`StakePoolSearchHttpService healthy state /search search pools by status search by activating status 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by status search by active status 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-    "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-    "margin": Object {
-      "denominator": 40,
-      "numerator": 3,
-    },
-    "metadataJson": Object {
-      "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-      "url": "https://visionstaking.ch/poolmeta.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "997623150",
+        "value": "340000000",
       },
-      "saturation": "0.000011870395439702300648",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "997623150",
         },
+        "saturation": "0.000011870395439702300648",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-    "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-    "margin": Object {
-      "denominator": 20,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "What's past is prologue",
-      "homepage": "https://clio.one",
-      "name": "CLIO1",
-      "ticker": "CLIO1",
-    },
-    "metadataJson": Object {
-      "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-      "url": "https://clio.one/metadata/clio1_testnet.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "22614171623274",
+        "value": "10000000",
       },
-      "saturation": "0.13455157254951724331",
-      "size": Object {
-        "active": "0.00000000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "11308112212955",
-        },
-      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
-    "owners": Array [
-      "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1010000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-        "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "4321000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "22614171623274",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.13455157254951724331",
+        "size": Object {
+          "active": "0.00000000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11308112212955",
+          },
         },
       },
-    ],
-    "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-    "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-    "margin": Object {
-      "denominator": 25,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "The pool that tests all the pools",
-      "homepage": "https://teststakepool.com",
-      "name": "TestPool",
-      "ticker": "TEST",
-    },
-    "metadataJson": Object {
-      "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-      "url": "https://git.io/JJyYy",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "199806239",
+        "value": "1010000000000",
       },
-      "saturation": "0.000002377429862418156568",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "199806239",
         },
+        "saturation": "0.000002377429862418156568",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "70000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-    "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-    "margin": Object {
-      "denominator": 10000,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Our Amsterdam Node",
-      "homepage": "https://twitter.com/A92Syed",
-      "name": "THE AMSTERDAM NODE",
-      "ticker": "AMS",
-    },
-    "metadataJson": Object {
-      "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-      "url": "https://git.io/JJ1dz",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "487464117",
+        "value": "70000000000",
       },
-      "saturation": "0.000005800177984497762235",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "487464117",
         },
+        "saturation": "0.000005800177984497762235",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "500000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "retirement": Array [],
-    },
-    "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-    "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Big Dragon Farts",
-      "homepage": "https://example.com",
-      "name": "Farts",
-      "ticker": "TINY",
-    },
-    "metadataJson": Object {
-      "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-      "url": "https://tinyurl.com/biggerfarts",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "pledge": Object {
         "__type": "bigint",
-        "value": "1988240000",
+        "value": "500000000",
       },
-      "saturation": "0.000005914356295018239663",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "live": Object {
-          "__type": "bigint",
-          "value": "497060000",
-        },
-      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
-    "owners": Array [
-      "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-        "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-        "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-        "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
       ],
-      "retirement": Array [],
-    },
-    "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-  },
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "340000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
-          "value": "0",
+          "value": "1988240000",
         },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
+        "saturation": "0.000005914356295018239663",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
         },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
         },
       },
-    ],
-    "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-    "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-    "margin": Object {
-      "denominator": 1000,
-      "numerator": 27,
-    },
-    "metadata": Object {
-      "description": "Pool a of the banderini devtest staking pools",
-      "homepage": "http://www.banderini.net",
-      "name": "banderini-devtest-a",
-      "ticker": "BANDA",
-    },
-    "metadataJson": Object {
-      "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-      "url": "https://git.io/JJ7wm",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
         "__type": "bigint",
-        "value": "495463149",
+        "value": "400000000",
       },
-      "saturation": "0.000005895355881056029525",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
       },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "495463149",
         },
+        "saturation": "0.000005895355881056029525",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "100000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-    "status": "active",
-    "transactions": Object {
-      "registration": Array [
-        "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "retirement": Array [],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
-    "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-  },
-]
+  ],
+  "totalResultCount": 6,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by status search by retired status 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "400000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
-    "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 7,
-    },
-    "metadataJson": Object {
-      "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
-      "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "999999828559",
+        "value": "400000000",
       },
-      "saturation": "0.01189867476975633141",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
+      "id": "pool1y25deq9kldy9y9gfvrpw8zt05zsrfx84zjhugaxrx9ftvwdpua2",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 7,
+      },
+      "metadataJson": Object {
+        "hash": "67b52f96eb40fcc18fa9cd8b9d7dd620811756f1029411d105de2eaf79655fa4",
+        "url": "https://explorer.cardano-testnet.iohkdev.io/p/1.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "999999828559",
         },
+        "saturation": "0.01189867476975633141",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "999999828559",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "1000000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
-    "status": "retired",
-    "transactions": Object {
-      "registration": Array [
-        "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
+      "owners": Array [
+        "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "retirement": Array [
-        "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
-      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "1000000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz8tusy3ruaw9ekplepacer4v6hpmpcp6ngp3gwj5ve3yjchsqqxn",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7",
+        ],
+        "retirement": Array [
+          "c27b294bb3dfbdfeda19b7f0254b23f91e3a48a2111c52dd99da6f1c8c3ff74f",
+        ],
+      },
+      "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
-    "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
-  },
-]
+  ],
+  "totalResultCount": 1,
+}
 `;
 
 exports[`StakePoolSearchHttpService healthy state /search search pools by status search by retiring status 1`] = `
-Array [
-  Object {
-    "cost": Object {
-      "__type": "bigint",
-      "value": "345000000",
-    },
-    "epochRewards": Array [
-      Object {
-        "activeStake": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "epoch": 175,
-        "epochLength": 431949000,
-        "memberROI": 0,
-        "operatorFees": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-        "totalRewards": Object {
-          "__type": "bigint",
-          "value": "0",
-        },
-      },
-    ],
-    "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-    "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-    "margin": Object {
-      "denominator": 100,
-      "numerator": 1,
-    },
-    "metadata": Object {
-      "description": "Testnet Only",
-      "homepage": "https://git.io/JWPBE",
-      "name": "July 2021",
-      "ticker": "JUL21",
-    },
-    "metadataJson": Object {
-      "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-      "url": "https://git.io/JWP02",
-    },
-    "metrics": Object {
-      "blocksCreated": "0",
-      "delegators": "1",
-      "livePledge": Object {
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
         "__type": "bigint",
-        "value": "1642425776",
+        "value": "345000000",
       },
-      "saturation": "0.000019542693492507578990",
-      "size": Object {
-        "active": "0.0000000000000000000000000000",
-        "live": "1.00000000000000000000",
-      },
-      "stake": Object {
-        "active": Object {
-          "__type": "bigint",
-          "value": "0",
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 175,
+          "epochLength": 431949000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
         },
-        "live": Object {
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
           "__type": "bigint",
           "value": "1642425776",
         },
+        "saturation": "0.000019542693492507578990",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1642425776",
+          },
+        },
       },
-    },
-    "owners": Array [
-      "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    ],
-    "pledge": Object {
-      "__type": "bigint",
-      "value": "10000000000",
-    },
-    "relays": Array [],
-    "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-    "status": "retiring",
-    "transactions": Object {
-      "registration": Array [
-        "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "retirement": Array [
-        "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retiring",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
+      },
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
-    "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-  },
-]
+  ],
+  "totalResultCount": 1,
+}
 `;

--- a/packages/core/src/Provider/StakePoolSearchProvider/types/StakePoolSearchProvider.ts
+++ b/packages/core/src/Provider/StakePoolSearchProvider/types/StakePoolSearchProvider.ts
@@ -41,11 +41,16 @@ export interface StakePoolQueryOptions {
   };
 }
 
+export interface StakePoolSearchResults {
+  pageResults: Cardano.StakePool[];
+  totalResultCount: number;
+}
+
 export interface StakePoolSearchProvider {
   /**
    * @param {StakePoolQueryOptions} options query options
    * @returns Stake pools
    * @throws ProviderError
    */
-  queryStakePools: (options?: StakePoolQueryOptions) => Promise<Cardano.StakePool[]>;
+  queryStakePools: (options?: StakePoolQueryOptions) => Promise<StakePoolSearchResults>;
 }

--- a/packages/util-dev/src/createStubStakePoolSearchProvider.ts
+++ b/packages/util-dev/src/createStubStakePoolSearchProvider.ts
@@ -46,7 +46,7 @@ export const createStubStakePoolSearchProvider = (
     if (delayMs) await delay(delayMs);
     const identifierFilters = options?.filters?.identifier;
     const filterValues = identifierFilters ? identifierFilters.values : [];
-    return stakePools.filter(({ id, metadata }) =>
+    const pageResults = stakePools.filter(({ id, metadata }) =>
       filterValues.some(
         (value) =>
           (value.id && id.includes(value.id.toString())) ||
@@ -54,5 +54,9 @@ export const createStubStakePoolSearchProvider = (
           (value.ticker && metadata?.ticker.includes(value.ticker))
       )
     );
+    return {
+      pageResults,
+      totalResultCount: pageResults.length
+    };
   }
 });

--- a/packages/util-dev/test/createStubStakePoolSearchProvider.test.ts
+++ b/packages/util-dev/test/createStubStakePoolSearchProvider.test.ts
@@ -16,24 +16,27 @@ describe('createStubStakePoolSearchProvider', () => {
       const stakePools = await provider.queryStakePools({
         filters: { identifier: { values: [{ id: 'd-to-matc' as unknown as Cardano.PoolId }] } }
       });
-      expect(stakePools).toHaveLength(1);
-      expect(stakePools[0].id).toBe(ID_TO_MATCH);
+      expect(stakePools.pageResults).toHaveLength(1);
+      expect(stakePools.totalResultCount).toEqual(1);
+      expect(stakePools.pageResults[0].id).toBe(ID_TO_MATCH);
     });
 
     it('matches by name', async () => {
       const stakePools = await provider.queryStakePools({
         filters: { identifier: { values: [{ name: 'ool1' }] } }
       });
-      expect(stakePools).toHaveLength(1);
-      expect(stakePools[0].id).toBe(ID_TO_MATCH);
+      expect(stakePools.pageResults).toHaveLength(1);
+      expect(stakePools.totalResultCount).toEqual(1);
+      expect(stakePools.pageResults[0].id).toBe(ID_TO_MATCH);
     });
 
     it('matches by ticker', async () => {
       const stakePools = await provider.queryStakePools({
         filters: { identifier: { values: [{ ticker: 'TIC' }] } }
       });
-      expect(stakePools).toHaveLength(1);
-      expect(stakePools[0].id).toBe(ID_TO_MATCH);
+      expect(stakePools.pageResults).toHaveLength(1);
+      expect(stakePools.totalResultCount).toEqual(1);
+      expect(stakePools.pageResults[0].id).toBe(ID_TO_MATCH);
     });
   });
 });

--- a/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
@@ -22,13 +22,15 @@ export const createQueryStakePoolsProvider =
       store.getValues(poolIds),
       coldObservableProvider(
         () =>
-          stakePoolSearchProvider.queryStakePools({
-            filters: { identifier: { values: poolIds.map((poolId) => ({ id: poolId })) } }
-          }),
+          stakePoolSearchProvider
+            .queryStakePools({
+              filters: { identifier: { values: poolIds.map((poolId) => ({ id: poolId })) } }
+            })
+            .then(({ pageResults }) => pageResults),
         retryBackoffConfig
       ).pipe(
-        tap((stakePools) => {
-          for (const stakePool of stakePools) {
+        tap((pageResults) => {
+          for (const stakePool of pageResults) {
             store.setValue(stakePool.id, stakePool);
           }
         })


### PR DESCRIPTION
# Context

Let the consumer of StakePoolSearch service know the total amount of stake pools that satisfies the given search.

# Proposed Solution

- [x] Modify StakePoolProvider interface
- [x] Add total count query, mapper and types
- [x] Modify corresponding returning types 
- [x] Modify openApi.json schema

# Important Changes Introduced
n/a

Depends on #242