### PR TITLE
feat(rabbitmq): TxSubmit via persistent queue

### DIFF
--- a/.versionrc.js
+++ b/.versionrc.js
@@ -36,6 +36,14 @@ const packageMap = [
     type: 'json'
   },
   {
+    filename: 'packages/ogmios/package.json',
+    type: 'json'
+  },
+  {
+    filename: 'packages/rabbitmq/package.json',
+    type: 'json'
+  },
+  {
     filename: 'packages/util-dev/package.json',
     type: 'json'
   },

--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -86,7 +86,9 @@ export class HttpServer extends RunnableModule {
     this.server = await listenPromise(this.app, this.#config.listen);
   }
 
-  shutdownImpl(): Promise<void> {
+  async shutdownImpl(): Promise<void> {
+    for (const service of this.#dependencies.services) await service.close();
+
     return serverClosePromise(this.server);
   }
 }

--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -23,5 +23,9 @@ export abstract class HttpService {
     });
   }
 
+  async close(): Promise<void> {
+    return Promise.resolve();
+  }
+
   protected abstract healthCheck(): Promise<HealthCheckResponse>;
 }

--- a/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
+++ b/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
@@ -3,5 +3,7 @@ export enum ProgramOptionDescriptions {
   DbConnection = 'DB Connection',
   LoggerMinSeverity = 'Log level',
   MetricsEnabled = 'Enable Prometheus Metrics',
-  OgmiosUrl = 'Ogmios URL'
+  OgmiosUrl = 'Ogmios URL',
+  RabbitMQUrl = 'RabbitMQ URL',
+  UseQueue = 'Enables RabbitMQ'
 }

--- a/packages/cardano-services/src/Program/defaults.ts
+++ b/packages/cardano-services/src/Program/defaults.ts
@@ -6,3 +6,5 @@ export const OGMIOS_URL_DEFAULT = (() => {
   const connection = createConnectionObject();
   return connection.address.webSocket;
 })();
+
+export const RABBITMQ_URL_DEFAULT = 'amqp://localhost:5672';

--- a/packages/cardano-services/src/TxSubmit/TxSubmitHttpService.ts
+++ b/packages/cardano-services/src/TxSubmit/TxSubmitHttpService.ts
@@ -24,6 +24,10 @@ export class TxSubmitHttpService extends HttpService {
     this.#txSubmitProvider = txSubmitProvider;
   }
 
+  async close(): Promise<void> {
+    await this.#txSubmitProvider.close?.();
+  }
+
   async healthCheck() {
     return this.#txSubmitProvider.healthCheck();
   }

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -6,6 +6,7 @@ import {
   OGMIOS_URL_DEFAULT,
   ProgramArgs,
   ProgramOptionDescriptions,
+  RABBITMQ_URL_DEFAULT,
   ServiceNames,
   loadHttpServer
 } from './Program';
@@ -40,6 +41,13 @@ program
     (url) => new URL(url),
     new URL(OGMIOS_URL_DEFAULT)
   )
+  .option(
+    '--rabbitmq-url <rabbitMQUrl>',
+    ProgramOptionDescriptions.RabbitMQUrl,
+    (url) => new URL(url),
+    new URL(RABBITMQ_URL_DEFAULT)
+  )
+  .option('--use-queue', ProgramOptionDescriptions.UseQueue, () => true, false)
   .option(
     '--logger-min-severity <level>',
     ProgramOptionDescriptions.LoggerMinSeverity,

--- a/packages/cardano-services/src/run.ts
+++ b/packages/cardano-services/src/run.ts
@@ -2,7 +2,7 @@
 /* eslint-disable import/imports-first */
 require('../scripts/patchRequire');
 import * as envalid from 'envalid';
-import { API_URL_DEFAULT, OGMIOS_URL_DEFAULT, ServiceNames, loadHttpServer } from './Program';
+import { API_URL_DEFAULT, OGMIOS_URL_DEFAULT, RABBITMQ_URL_DEFAULT, ServiceNames, loadHttpServer } from './Program';
 import { LogLevel } from 'bunyan';
 import { URL } from 'url';
 import { config } from 'dotenv';
@@ -14,7 +14,9 @@ const envSpecs = {
   DB_CONNECTION_STRING: envalid.str({ default: undefined }),
   LOGGER_MIN_SEVERITY: envalid.str({ choices: loggerMethodNames as string[], default: 'info' }),
   OGMIOS_URL: envalid.url({ default: OGMIOS_URL_DEFAULT }),
-  SERVICE_NAMES: envalid.str({ example: Object.values(ServiceNames).toString() })
+  RABBITMQ_URL: envalid.url({ default: RABBITMQ_URL_DEFAULT }),
+  SERVICE_NAMES: envalid.str({ example: Object.values(ServiceNames).toString() }),
+  USE_QUEUE: envalid.bool({ default: false })
 };
 
 void (async () => {
@@ -22,6 +24,7 @@ void (async () => {
   const env = envalid.cleanEnv(process.env, envSpecs);
   const apiUrl = new URL(env.API_URL);
   const ogmiosUrl = new URL(env.OGMIOS_URL);
+  const rabbitmqUrl = new URL(env.RABBITMQ_URL);
   const dbConnectionString = env.DB_CONNECTION_STRING ? new URL(env.DB_CONNECTION_STRING).toString() : undefined;
   const serviceNames = env.SERVICE_NAMES.split(',') as ServiceNames[];
 
@@ -31,7 +34,9 @@ void (async () => {
       options: {
         dbConnectionString,
         loggerMinSeverity: env.LOGGER_MIN_SEVERITY as LogLevel,
-        ogmiosUrl
+        ogmiosUrl,
+        rabbitmqUrl,
+        useQueue: env.USE_QUEUE
       },
       serviceNames
     });

--- a/packages/cardano-services/src/tsconfig.json
+++ b/packages/cardano-services/src/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "references": [
     { "path": "../../core/src" },
-    { "path": "../../ogmios/src" }
+    { "path": "../../ogmios/src" },
+    { "path": "../../rabbitmq/src" }
   ]
 }

--- a/packages/cardano-services/test/jest-setup/jest-setup.ts
+++ b/packages/cardano-services/test/jest-setup/jest-setup.ts
@@ -1,5 +1,6 @@
 import { parse } from 'pg-connection-string';
 import { setupPostgresContainer } from './docker';
+import { setupRabbitMQContainer } from '@cardano-sdk/rabbitmq/test/jest-setup/docker';
 import dotenv from 'dotenv';
 import path from 'path';
 
@@ -16,4 +17,5 @@ module.exports = async () => {
     password ? password : 'mysecretpassword',
     port ? port : '5432'
   );
+  await setupRabbitMQContainer();
 };

--- a/packages/cardano-services/test/jest-setup/jest-teardown.ts
+++ b/packages/cardano-services/test/jest-setup/jest-teardown.ts
@@ -1,5 +1,7 @@
 import { removePostgresContainer } from './docker';
+import { removeRabbitMQContainer } from '@cardano-sdk/rabbitmq/test/jest-setup/docker';
 
 module.exports = async () => {
   await removePostgresContainer();
+  await removeRabbitMQContainer();
 };

--- a/packages/cardano-services/test/tsconfig.json
+++ b/packages/cardano-services/test/tsconfig.json
@@ -8,7 +8,7 @@
     { "path": "../src" },
     { "path": "../../core/src" },
     { "path": "../../ogmios/test" },
+    { "path": "../../rabbitmq/test" },
     { "path": "../../util-dev/src" }
   ]
 }
-

--- a/packages/core/src/Provider/Provider.ts
+++ b/packages/core/src/Provider/Provider.ts
@@ -3,6 +3,7 @@ export type HealthCheckResponse = {
 };
 
 export interface Provider {
+  close?(): Promise<void>;
   /**
    * @throws ProviderError
    */

--- a/packages/rabbitmq/.gitignore
+++ b/packages/rabbitmq/.gitignore
@@ -1,3 +1,4 @@
-*.d.ts
 node_modules
 dist
+secrets
+coverage

--- a/packages/rabbitmq/LICENSE
+++ b/packages/rabbitmq/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright © 2022 IOHK
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/rabbitmq/NOTICE
+++ b/packages/rabbitmq/NOTICE
@@ -1,0 +1,5 @@
+Copyright 2022 IOHK
+
+Licensed under the Apache License, Version 2.0 (the "License”). You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/packages/rabbitmq/README.md
+++ b/packages/rabbitmq/README.md
@@ -1,0 +1,1 @@
+# Cardano JS SDK | RabbitMQ

--- a/packages/rabbitmq/jest.config.js
+++ b/packages/rabbitmq/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  ...require('../../test/jest.config'),
+  globalSetup: './test/jest-setup/jest-setup.ts',
+  globalTeardown: './test/jest-setup/jest-teardown.ts'
+};

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@cardano-sdk/rabbitmq",
+  "version": "0.2.0",
+  "description": "RabbitMQ Providers",
+  "engines": {
+    "node": "^14"
+  },
+  "main": "dist/index.js",
+  "repository": "https://github.com/input-output-hk/cardano-js-sdk/packages/rabbitmq",
+  "author": "Daniele Ricci",
+  "license": "MPL-2.0",
+  "scripts": {
+    "build": "tsc --build ./src",
+    "coverage": "yarn test --coverage",
+    "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
+    "cleanup": "shx rm -rf dist node_modules",
+    "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
+    "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
+    "test": "jest -c ./jest.config.js",
+    "test:e2e": "shx echo 'test:e2e' command not implemented yet",
+    "prepack": "yarn build"
+  },
+  "devDependencies": {
+    "@types/amqplib": "0.8.2",
+    "shx": "^0.3.3",
+    "ws": "^8.5.0"
+  },
+  "dependencies": {
+    "amqplib": "0.9.0"
+  },
+  "files": [
+    "dist/*",
+    "!dist/tsconfig.tsbuildinfo",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/packages/rabbitmq/src/index.ts
+++ b/packages/rabbitmq/src/index.ts
@@ -1,0 +1,1 @@
+export * from './rabbitmqTxSubmitProvider';

--- a/packages/rabbitmq/src/rabbitmqTxSubmitProvider.ts
+++ b/packages/rabbitmq/src/rabbitmqTxSubmitProvider.ts
@@ -1,0 +1,114 @@
+import { Buffer } from 'buffer';
+import { Cardano, HealthCheckResponse, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { Channel, Connection, connect } from 'amqplib';
+import { Logger, dummyLogger } from 'ts-log';
+
+const queue = 'tx-submit';
+
+/**
+ * Connect to a [RabbitMQ](https://www.rabbitmq.com/) instance
+ */
+export class RabbitMqTxSubmitProvider implements TxSubmitProvider {
+  #channel?: Channel;
+  #connection?: Connection;
+  #connectionURL: URL;
+  #logger: Logger;
+  #queueWasCreated = false;
+
+  /**
+   * @param {URL} connectionURL RabbitMQ connection URL
+   * @param {Logger} logger object implementing the Logger abstract class
+   */
+  constructor(connectionURL: URL, logger: Logger = dummyLogger) {
+    this.#connectionURL = connectionURL;
+    this.#logger = logger;
+  }
+
+  /**
+   * Connects to the RabbitMQ server and create the channel
+   */
+  async #connectAndCreateChannel() {
+    if (this.#connection) return;
+
+    try {
+      this.#connection = await connect(this.#connectionURL.toString());
+    } catch (error) {
+      await this.close();
+      throw new ProviderError(ProviderFailure.ConnectionFailure, error);
+    }
+
+    try {
+      this.#channel = await this.#connection.createChannel();
+    } catch (error) {
+      await this.close();
+      throw new ProviderError(ProviderFailure.ConnectionFailure, error);
+    }
+  }
+
+  /**
+   * Idempotently (channel.assertQueue does the job for us) creates the queue
+   *
+   * @param {boolean} force Forces the creation of the queue just to have a response from the server
+   */
+  async #ensureQueue(force?: boolean) {
+    if (this.#queueWasCreated && !force) return;
+
+    await this.#connectAndCreateChannel();
+    this.#queueWasCreated = true;
+
+    try {
+      await this.#channel!.assertQueue(queue);
+    } catch (error) {
+      await this.close();
+      throw new ProviderError(ProviderFailure.ConnectionFailure, error);
+    }
+  }
+
+  /**
+   * Closes the connection to RabbitMQ and (for interl purposes) it resets the state as well
+   */
+  async close() {
+    try {
+      await this.#connection?.close();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      this.#logger.error({ error: error.name, module: 'rabbitmqTxSubmitProvider' }, error.message);
+    }
+
+    this.#channel = undefined;
+    this.#connection = undefined;
+    this.#queueWasCreated = false;
+  }
+
+  /**
+   * Checks for healthy status
+   *
+   * @returns {HealthCheckResponse} The result of the check
+   */
+  async healthCheck(): Promise<HealthCheckResponse> {
+    let ok = false;
+
+    try {
+      await this.#ensureQueue(true);
+      ok = true;
+    } catch {
+      this.#logger.error({ error: 'Connection error', module: 'rabbitmqTxSubmitProvider' });
+    }
+
+    return { ok };
+  }
+
+  /**
+   * Submit a transaction to RabbitMQ
+   *
+   * @param {Uint8Array} signedTransaction The Uint8Array representation of a signedTransaction
+   */
+  async submitTx(signedTransaction: Uint8Array) {
+    try {
+      await this.#ensureQueue();
+      this.#channel!.sendToQueue(queue, Buffer.from(signedTransaction));
+    } catch (error) {
+      throw Cardano.util.asTxSubmissionError(error) || new Cardano.UnknownTxSubmissionError(error);
+    }
+  }
+}

--- a/packages/rabbitmq/src/tsconfig.json
+++ b/packages/rabbitmq/src/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "outDir": "../dist/",
+    "rootDir": "."
+  },
+  "references": [{ "path": "../../core/src" }]
+}

--- a/packages/rabbitmq/test/jest-setup/docker.ts
+++ b/packages/rabbitmq/test/jest-setup/docker.ts
@@ -1,0 +1,54 @@
+import { connect } from 'amqplib';
+import { imageExists, pullImageAsync } from 'dockerode-utils';
+import Docker from 'dockerode';
+
+const CONTAINER_IMAGE = 'rabbitmq:3.8-alpine';
+const CONTAINER_NAME = 'cardano-rabbitmq-test';
+
+export const removeRabbitMQContainer = async () => {
+  const docker = new Docker();
+
+  try {
+    const container = docker.getContainer(CONTAINER_NAME);
+
+    try {
+      await container.stop();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      // 304 = container already stopped
+      if (error.statusCode !== 304) throw error;
+    }
+    await container.remove({ v: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    // 404 = container not found
+    if (error.statusCode !== 404) throw error;
+  }
+};
+
+export const setupRabbitMQContainer = async () => {
+  const docker = new Docker();
+  const needsToPull = !(await imageExists(docker, CONTAINER_IMAGE));
+
+  if (needsToPull) await pullImageAsync(docker, CONTAINER_IMAGE);
+  await removeRabbitMQContainer();
+
+  const container = await docker.createContainer({
+    HostConfig: { PortBindings: { '5672/tcp': [{ HostPort: '5672/tcp' }] } },
+    Image: CONTAINER_IMAGE,
+    name: CONTAINER_NAME
+  });
+  await container.start();
+
+  // Once the container starts it is not immediately ready to accept connections
+  // this waits for that short delay
+  await new Promise<void>(async (resolve) => {
+    // eslint-disable-next-line no-constant-condition
+    while (true)
+      try {
+        await connect('amqp://localhost');
+        return resolve();
+        // eslint-disable-next-line no-empty
+      } catch {}
+  });
+};

--- a/packages/rabbitmq/test/jest-setup/jest-setup.ts
+++ b/packages/rabbitmq/test/jest-setup/jest-setup.ts
@@ -1,0 +1,3 @@
+import { setupRabbitMQContainer } from './docker';
+
+export default setupRabbitMQContainer;

--- a/packages/rabbitmq/test/jest-setup/jest-teardown.ts
+++ b/packages/rabbitmq/test/jest-setup/jest-teardown.ts
@@ -1,0 +1,3 @@
+import { removeRabbitMQContainer } from './docker';
+
+export default removeRabbitMQContainer;

--- a/packages/rabbitmq/test/rabbitmqTxSubmitProvider.test.ts
+++ b/packages/rabbitmq/test/rabbitmqTxSubmitProvider.test.ts
@@ -1,0 +1,54 @@
+import { ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
+import { RabbitMqTxSubmitProvider } from '../src';
+
+const BAD_CONNECTION_URL = new URL('amqp://localhost:1234');
+const GOOD_CONNECTION_URL = new URL('amqp://localhost');
+
+describe('RabbitMqTxSubmitProvider', () => {
+  let provider: TxSubmitProvider;
+
+  afterEach(() => provider?.close!());
+
+  describe('healthCheck', () => {
+    it('is not ok if cannot connect', async () => {
+      provider = new RabbitMqTxSubmitProvider(BAD_CONNECTION_URL);
+      const res = await provider.healthCheck();
+      expect(res).toEqual({ ok: false });
+    });
+
+    it('is ok if can connect', async () => {
+      provider = new RabbitMqTxSubmitProvider(GOOD_CONNECTION_URL);
+      const resA = await provider.healthCheck();
+      // Call again to cover the idemopotent RabbitMqTxSubmitProvider.#connectAndCreateChannel() operation
+      const resB = await provider.healthCheck();
+      expect(resA).toEqual({ ok: true });
+      expect(resB).toEqual({ ok: true });
+    });
+  });
+
+  const performSubmitTxTest = async (connectionURL: URL) => {
+    try {
+      provider = new RabbitMqTxSubmitProvider(connectionURL);
+      const resA = await provider.submitTx(new Uint8Array());
+      // Called again to cover the idemopotent RabbitMqTxSubmitProvider.#ensureQueue() operation
+      const resB = await provider.submitTx(new Uint8Array());
+      expect(resA).toBeUndefined();
+      expect(resB).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      expect(error.innerError).toBeInstanceOf(ProviderError);
+    }
+  };
+
+  describe('submitTx', () => {
+    it('resolves if successful', async () => {
+      expect.assertions(2);
+      await performSubmitTxTest(GOOD_CONNECTION_URL);
+    });
+
+    it('rejects with errors thrown by the service', async () => {
+      expect.assertions(1);
+      await performSubmitTxTest(BAD_CONNECTION_URL);
+    });
+  });
+});

--- a/packages/rabbitmq/test/tsconfig.json
+++ b/packages/rabbitmq/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noUnusedLocals": false
+  },
+  "references": [{ "path": "../../core/src" }, { "path": "../src" }]
+}

--- a/scripts/pack.sh
+++ b/scripts/pack.sh
@@ -10,5 +10,7 @@ npm pack --cwd ./packages/cip30 && \
 npm pack --cwd ./packages/web-extension && \
 npm pack --cwd ./packages/core && \
 npm pack --cwd ./packages/golden-test-generator && \
+npm pack --cwd ./packages/ogmios && \
+npm pack --cwd ./packages/rabbitmq && \
 npm pack --cwd ./packages/util-dev && \
 npm pack --cwd ./packages/wallet

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,5 +10,7 @@ npm publish --cwd ./packages/cip30 && \
 npm publish --cwd ./packages/web-extension && \
 npm publish --cwd ./packages/core && \
 npm publish --cwd ./packages/golden-test-generator && \
+npm publish --cwd ./packages/ogmios && \
+npm publish --cwd ./packages/rabbitmq && \
 npm publish --cwd ./packages/util-dev && \
 npm publish --cwd ./packages/wallet

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,6 +1234,14 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
+"@types/amqplib@0.8.2":
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/@types/amqplib/-/amqplib-0.8.2.tgz#9c46f2c7fac381e4f81bcb612c00d54549697d22"
+  integrity sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==
+  dependencies:
+    "@types/bluebird" "*"
+    "@types/node" "*"
+
 "@types/aria-query@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.0.tgz#df2d64b5cc73cca0d75e2a7793d6b5c199c2f7b2"
@@ -1271,6 +1279,11 @@
   integrity sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   dependencies:
     "@babel/types" "^7.3.0"
+
+"@types/bluebird@*":
+  version "3.5.36"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.36.tgz#00d9301d4dc35c2f6465a8aec634bb533674c652"
+  integrity sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -1475,7 +1488,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-bigint/-/json-bigint-1.0.1.tgz#201062a6990119a8cc18023cfe1fed12fc2fc8a7"
   integrity sha512-zpchZLNsNuzJHi6v64UBoFWAvQlPhch7XAi36FkH6tL1bbbmimIF+cS7vwkzY4u5RaSWMoflQfu+TshMPPw8uw==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.6", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
@@ -2502,7 +2515,7 @@ ajv-keywords@^5.0.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5, ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2521,6 +2534,17 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
+
+amqplib@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.9.0.tgz#b2b8705bf8ca3579caef244f01a30a568512f0fd"
+  integrity sha512-emwSdJElmSp52JIKehjLNimKqbZcGUBGdcqST9fll+C/Uss8fWoGyyWlwt20f5lD+SDdozoc4WhF3uDCUOL2ww==
+  dependencies:
+    bitsyntax "~0.1.0"
+    bluebird "^3.7.2"
+    buffer-more-ints "~1.0.0"
+    readable-stream "1.x >=1.1.9"
+    url-parse "~1.5.10"
 
 ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
@@ -2989,6 +3013,15 @@ bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.1:
   resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
   integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
 
+bitsyntax@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/bitsyntax/-/bitsyntax-0.1.0.tgz#b0c59acef03505de5a2ed62a2f763c56ae1d6205"
+  integrity sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==
+  dependencies:
+    buffer-more-ints "~1.0.0"
+    debug "~2.6.9"
+    safe-buffer "~5.1.2"
+
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -3028,6 +3061,11 @@ blake2b@2.1.3:
   dependencies:
     blake2b-wasm "^1.1.0"
     nanoassert "^1.0.0"
+
+bluebird@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.0.0, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
@@ -3153,6 +3191,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer-more-ints@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
+  integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
+
 buffer-writer@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
@@ -3202,13 +3245,6 @@ bunyan@^1.8.15:
     mv "~2"
     safe-json-stringify "~1"
 
-bytebuffer@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
-  integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
-  dependencies:
-    long "~3"
-
 busboy@^0.2.11:
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
@@ -3216,6 +3252,13 @@ busboy@^0.2.11:
   dependencies:
     dicer "0.2.5"
     readable-stream "1.1.x"
+
+bytebuffer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bytebuffer/-/bytebuffer-5.0.1.tgz#582eea4b1a873b6d020a48d58df85f0bba6cfddd"
+  integrity sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=
+  dependencies:
+    long "~3"
 
 bytes@3.1.2:
   version "3.1.2"
@@ -3929,7 +3972,7 @@ death@^1.1.0:
   resolved "https://registry.yarnpkg.com/death/-/death-1.1.0.tgz#01aa9c401edd92750514470b8266390c66c67318"
   integrity sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg=
 
-debug@2.6.9, debug@^2.6.9:
+debug@2.6.9, debug@^2.6.9, debug@~2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -6768,7 +6811,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0:
+js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -6782,13 +6825,6 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -7350,6 +7386,11 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
+lodash.zipobject@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
+  integrity sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg=
+
 lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.5, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -7658,6 +7699,11 @@ mkdirp@^0.5.4, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 mocha@^9.0.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.2.tgz#d70db46bdb93ca57402c809333e5a84977a88fb9"
@@ -7687,11 +7733,6 @@ mocha@^9.0.0:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
-
-mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mock-browser@^0.92.14:
   version "0.92.14"
@@ -8308,6 +8349,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
+  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -8316,11 +8362,6 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-path-to-regexp@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
-  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -8766,6 +8807,11 @@ query-selector-shadow-dom@^1.0.0:
   resolved "https://registry.yarnpkg.com/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.0.tgz#8fa7459a4620f094457640e74e953a9dbe61a38e"
   integrity sha512-bK0/0cCI+R8ZmOF1QjT7HupDUYCxbf/9TJgAmSXQxZpftXmTAeil9DRoCnTDkWbvOyZzhcMBwKpptWcdkGFIMg==
 
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -8863,7 +8909,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@1.1.14, readable-stream@1.1.x, readable-stream@^1.0.33:
+readable-stream@1.1.14, readable-stream@1.1.x, "readable-stream@1.x >=1.1.9", readable-stream@^1.0.33:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
   integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
@@ -8882,7 +8928,7 @@ readable-stream@1.1.14, readable-stream@1.1.x, readable-stream@^1.0.33:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^2.0.0, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -9013,6 +9059,11 @@ requireindex@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
   integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
@@ -9215,7 +9266,7 @@ rxjs@^7.2.0, rxjs@^7.4.0, rxjs@^7.5.1, rxjs@^7.5.4, rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1, safe-buffer@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -10384,6 +10435,14 @@ url-join@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+
+url-parse@~1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url-value-parser@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
# Context

We need to submit transactions through a queue.

# Proposed Solution

Implemented a `RabbitMqTxSubmitProvider` to be used (when configured) instead of `ogmiosTxSubmitProvider`.

# Important Changes Introduced

- Added an _empty_ `close` method to the `HttpService` class (and called it at `HttpServer` shutdown); each Service can implement an overloaded method to perform its own required shutdown operations;
- Added an optional `close` method to the `Provider` interface (and called it from `TxSubmitHttpService.close`);
- Added configuration to `cli` and `run` to use the new provider (optionally with a specific URL);
- Minor refactoring to `cli`: removed little code repetition in types, now `ProgramArgs['options']` type is used