### PR TITLE
feat(rabbitmq): TxSubmit via persistent queue - Part 2

### DIFF
--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -28,6 +28,8 @@
     "test:debug": "DEBUG=true yarn test",
     "run:http-server": "ts-node --transpile-only src/run.ts",
     "run:http-server:debug": "npx nodemon --legacy-watch --exec 'node -r ts-node/register --inspect=0.0.0.0:9229 src/run.ts'",
+    "run:tx-worker": "ts-node --transpile-only src/startWorker.ts",
+    "run:tx-worker:debug": "npx nodemon --legacy-watch --exec 'node -r ts-node/register --inspect=0.0.0.0:9229 src/startWorker.ts'",
     "cli": "ts-node --transpile-only src/cli.ts"
   },
   "devDependencies": {

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -7,7 +7,7 @@
   },
   "main": "dist/index.js",
   "bin": {
-    "tx-submit": "./dist/TxSubmit/cli.js"
+    "cardano-services": "./dist/cli.js"
   },
   "repository": "https://github.com/input-output-hk/cardano-js-sdk/packages/cardano-services",
   "contributors": [

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@cardano-sdk/core": "0.2.0",
     "@cardano-sdk/ogmios": "0.2.0",
+    "@cardano-sdk/rabbitmq": "0.2.0",
     "@types/bunyan": "^1.8.8",
     "@types/death": "^1.1.2",
     "@types/wait-on": "^5.3.1",

--- a/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
+++ b/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
@@ -1,9 +1,11 @@
-export enum ProgramOptionDescriptions {
+import { CommonOptionDescriptions } from '../ProgramsCommon';
+
+enum HttpServerOptionDescriptions {
   ApiUrl = 'API URL',
   DbConnection = 'DB Connection',
-  LoggerMinSeverity = 'Log level',
   MetricsEnabled = 'Enable Prometheus Metrics',
-  OgmiosUrl = 'Ogmios URL',
-  RabbitMQUrl = 'RabbitMQ URL',
   UseQueue = 'Enables RabbitMQ'
 }
+
+export type ProgramOptionDescriptions = CommonOptionDescriptions | HttpServerOptionDescriptions;
+export const ProgramOptionDescriptions = { ...CommonOptionDescriptions, ...HttpServerOptionDescriptions };

--- a/packages/cardano-services/src/Program/defaults.ts
+++ b/packages/cardano-services/src/Program/defaults.ts
@@ -1,10 +1,3 @@
-import { createConnectionObject } from '@cardano-sdk/ogmios';
+export { OGMIOS_URL_DEFAULT, RABBITMQ_URL_DEFAULT } from '../ProgramsCommon';
 
 export const API_URL_DEFAULT = 'http://localhost:3000';
-
-export const OGMIOS_URL_DEFAULT = (() => {
-  const connection = createConnectionObject();
-  return connection.address.webSocket;
-})();
-
-export const RABBITMQ_URL_DEFAULT = 'amqp://localhost:5672';

--- a/packages/cardano-services/src/ProgramsCommon/CommonOptionDescriptions.ts
+++ b/packages/cardano-services/src/ProgramsCommon/CommonOptionDescriptions.ts
@@ -1,0 +1,5 @@
+export enum CommonOptionDescriptions {
+  LoggerMinSeverity = 'Log level',
+  OgmiosUrl = 'Ogmios URL',
+  RabbitMQUrl = 'RabbitMQ URL'
+}

--- a/packages/cardano-services/src/ProgramsCommon/defaults.ts
+++ b/packages/cardano-services/src/ProgramsCommon/defaults.ts
@@ -1,0 +1,8 @@
+import { createConnectionObject } from '@cardano-sdk/ogmios';
+
+export const OGMIOS_URL_DEFAULT = (() => {
+  const connection = createConnectionObject();
+  return connection.address.webSocket;
+})();
+
+export const RABBITMQ_URL_DEFAULT = 'amqp://localhost:5672';

--- a/packages/cardano-services/src/ProgramsCommon/index.ts
+++ b/packages/cardano-services/src/ProgramsCommon/index.ts
@@ -1,0 +1,3 @@
+export * from './CommonOptionDescriptions';
+export * from './defaults';
+export * from './options';

--- a/packages/cardano-services/src/ProgramsCommon/options.ts
+++ b/packages/cardano-services/src/ProgramsCommon/options.ts
@@ -1,0 +1,12 @@
+import { LogLevel } from 'bunyan';
+
+/**
+ * Common options for programs:
+ * - HTTP server
+ * - RabbitMQ worker
+ */
+export interface CommonProgramOptions {
+  loggerMinSeverity?: LogLevel;
+  ogmiosUrl?: URL;
+  rabbitmqUrl?: URL;
+}

--- a/packages/cardano-services/src/TxWorker/TxWorkerOptionDescriptions.ts
+++ b/packages/cardano-services/src/TxWorker/TxWorkerOptionDescriptions.ts
@@ -1,0 +1,5 @@
+export enum TxWorkerOptionDescriptions {
+  Parallel = 'Parallel mode',
+  ParallelTxs = 'Parallel transactions',
+  PollingCycle = 'Polling cycle'
+}

--- a/packages/cardano-services/src/TxWorker/defaults.ts
+++ b/packages/cardano-services/src/TxWorker/defaults.ts
@@ -1,0 +1,7 @@
+export { OGMIOS_URL_DEFAULT, RABBITMQ_URL_DEFAULT } from '../ProgramsCommon';
+
+export const PARALLEL_MODE_DEFAULT = false;
+
+export const PARALLEL_TXS_DEFAULT = 3;
+
+export const POLLING_CYCLE_DEFAULT = 500;

--- a/packages/cardano-services/src/TxWorker/errors/WrongTxWorkerOption.ts
+++ b/packages/cardano-services/src/TxWorker/errors/WrongTxWorkerOption.ts
@@ -1,0 +1,10 @@
+import { CustomError } from 'ts-custom-error';
+import { ServiceNames } from '../../Program';
+import { TxWorkerOptionDescriptions } from '../TxWorkerOptionDescriptions';
+
+export class WrongProgramOption extends CustomError {
+  public constructor(service: ServiceNames, option: TxWorkerOptionDescriptions, expected: string[]) {
+    super();
+    this.message = `${service} requires a valid ${option} program option. Expected: ${expected.join(', ')}`;
+  }
+}

--- a/packages/cardano-services/src/TxWorker/errors/index.ts
+++ b/packages/cardano-services/src/TxWorker/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './WrongTxWorkerOption';

--- a/packages/cardano-services/src/TxWorker/index.ts
+++ b/packages/cardano-services/src/TxWorker/index.ts
@@ -1,0 +1,4 @@
+export * from './defaults';
+export * from './errors';
+export * from './loadTxWorker';
+export * from './TxWorkerOptionDescriptions';

--- a/packages/cardano-services/src/TxWorker/loadTxWorker.ts
+++ b/packages/cardano-services/src/TxWorker/loadTxWorker.ts
@@ -1,0 +1,23 @@
+import { CommonOptionDescriptions, CommonProgramOptions } from '../ProgramsCommon';
+import { MissingProgramOption, ServiceNames } from '../Program';
+import { TxSubmitWorker, TxSubmitWorkerConfig } from '@cardano-sdk/rabbitmq';
+import { createLogger } from 'bunyan';
+import { ogmiosTxSubmitProvider, urlToConnectionConfig } from '@cardano-sdk/ogmios';
+
+export type TxWorkerOptions = CommonProgramOptions &
+  Pick<TxSubmitWorkerConfig, 'parallel' | 'parallelTxs' | 'pollingCycle'>;
+
+export interface TxWorkerArgs {
+  options: TxWorkerOptions;
+}
+
+export const loadTxWorker = async (args: TxWorkerArgs) => {
+  const { loggerMinSeverity, ogmiosUrl, rabbitmqUrl } = args.options;
+  const txSubmitProvider = ogmiosTxSubmitProvider(urlToConnectionConfig(ogmiosUrl));
+  const logger = createLogger({ level: loggerMinSeverity, name: 'tx-worker' });
+
+  // Ensure rabbitmqUrl is not undefined
+  if (!rabbitmqUrl) throw new MissingProgramOption(ServiceNames.TxSubmit, CommonOptionDescriptions.RabbitMQUrl);
+
+  return new TxSubmitWorker({ ...args.options, rabbitmqUrl }, { logger, txSubmitProvider });
+};

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -11,7 +11,17 @@ import {
   loadHttpServer
 } from './Program';
 import { Command } from 'commander';
+import { CommonOptionDescriptions } from './ProgramsCommon';
 import { InvalidLoggerLevel } from './errors';
+import {
+  PARALLEL_MODE_DEFAULT,
+  PARALLEL_TXS_DEFAULT,
+  POLLING_CYCLE_DEFAULT,
+  TxWorkerOptionDescriptions,
+  TxWorkerOptions,
+  WrongProgramOption,
+  loadTxWorker
+} from './TxWorker';
 import { URL } from 'url';
 import { loggerMethodNames } from './util';
 import onDeath from 'death';
@@ -22,43 +32,48 @@ clear();
 // eslint-disable-next-line no-console
 console.log('Cardano Services CLI');
 
+const commonOptions = (command: Command) =>
+  command
+    .option(
+      '--logger-min-severity <level>',
+      CommonOptionDescriptions.LoggerMinSeverity,
+      (level) => {
+        if (!loggerMethodNames.includes(level)) {
+          throw new InvalidLoggerLevel(level);
+        }
+        return level;
+      },
+      'info'
+    )
+    .option(
+      '--ogmios-url <ogmiosUrl>',
+      CommonOptionDescriptions.OgmiosUrl,
+      (url) => new URL(url),
+      new URL(OGMIOS_URL_DEFAULT)
+    )
+    .option(
+      '--rabbitmq-url <rabbitMQUrl>',
+      CommonOptionDescriptions.RabbitMQUrl,
+      (url) => new URL(url),
+      new URL(RABBITMQ_URL_DEFAULT)
+    );
+
 const program = new Command('cardano-services');
 
 program.version(packageJson.version);
 
-program
-  .command('start-server')
-  .description('Start the HTTP server')
-  .argument('<serviceNames...>', `List of services to attach: ${Object.values(ServiceNames).toString()}`)
+commonOptions(
+  program
+    .command('start-server')
+    .description('Start the HTTP server')
+    .argument('<serviceNames...>', `List of services to attach: ${Object.values(ServiceNames).toString()}`)
+)
   .option('--api-url <apiUrl>', ProgramOptionDescriptions.ApiUrl, (url) => new URL(url), new URL(API_URL_DEFAULT))
   .option('--enable-metrics <metricsEnabled>', ProgramOptionDescriptions.MetricsEnabled, false)
   .option('--db-connection-string <dbConnectionString>', ProgramOptionDescriptions.DbConnection, (url) =>
     new URL(url).toString()
   )
-  .option(
-    '--ogmios-url <ogmiosUrl>',
-    ProgramOptionDescriptions.OgmiosUrl,
-    (url) => new URL(url),
-    new URL(OGMIOS_URL_DEFAULT)
-  )
-  .option(
-    '--rabbitmq-url <rabbitMQUrl>',
-    ProgramOptionDescriptions.RabbitMQUrl,
-    (url) => new URL(url),
-    new URL(RABBITMQ_URL_DEFAULT)
-  )
   .option('--use-queue', ProgramOptionDescriptions.UseQueue, () => true, false)
-  .option(
-    '--logger-min-severity <level>',
-    ProgramOptionDescriptions.LoggerMinSeverity,
-    (level) => {
-      if (!loggerMethodNames.includes(level)) {
-        throw new InvalidLoggerLevel(level);
-      }
-      return level;
-    },
-    'info'
-  )
   .action(async (serviceNames: ServiceNames[], options: { apiUrl: URL } & HttpServerOptions) => {
     const { apiUrl, ...rest } = options;
     const server = await loadHttpServer({ apiUrl: apiUrl || API_URL_DEFAULT, options: rest, serviceNames });
@@ -66,6 +81,41 @@ program
     await server.start();
     onDeath(async () => {
       await server.shutdown();
+      process.exit(1);
+    });
+  });
+
+commonOptions(program.command('start-worker').description('Start RabbitMQ worker'))
+  .option(
+    '--parallel [parallel]',
+    TxWorkerOptionDescriptions.Parallel,
+    (parallel) => {
+      // for compatibility: accepting same values as envalid in startWorker.ts
+      if (['0', 'f', 'false'].includes(parallel)) return false;
+      if (['1', 't', 'true'].includes(parallel)) return true;
+      throw new WrongProgramOption(ServiceNames.TxSubmit, TxWorkerOptionDescriptions.Parallel, ['false', 'true']);
+    },
+    PARALLEL_MODE_DEFAULT
+  )
+  .option(
+    '--parallel-txs <parallelTxs>',
+    TxWorkerOptionDescriptions.ParallelTxs,
+    (parallelTxs) => Number.parseInt(parallelTxs, 10),
+    PARALLEL_TXS_DEFAULT
+  )
+  .option(
+    '--polling-cycle <pollingCycle>',
+    TxWorkerOptionDescriptions.PollingCycle,
+    (pollingCycle) => Number.parseInt(pollingCycle, 10),
+    POLLING_CYCLE_DEFAULT
+  )
+  .action(async (options: TxWorkerOptions) => {
+    // eslint-disable-next-line no-console
+    console.log(`RabbitMQ transactions worker: ${options.parallel ? 'parallel' : 'serial'} mode`);
+    const txWorker = await loadTxWorker({ options });
+    await txWorker.start();
+    onDeath(async () => {
+      await txWorker.stop();
       process.exit(1);
     });
   });

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -3,8 +3,8 @@
 require('../scripts/patchRequire');
 import {
   API_URL_DEFAULT,
+  HttpServerOptions,
   OGMIOS_URL_DEFAULT,
-  ProgramArgs,
   ProgramOptionDescriptions,
   RABBITMQ_URL_DEFAULT,
   ServiceNames,
@@ -59,7 +59,7 @@ program
     },
     'info'
   )
-  .action(async (serviceNames: ServiceNames[], options: { apiUrl: URL } & NonNullable<ProgramArgs['options']>) => {
+  .action(async (serviceNames: ServiceNames[], options: { apiUrl: URL } & HttpServerOptions) => {
     const { apiUrl, ...rest } = options;
     const server = await loadHttpServer({ apiUrl: apiUrl || API_URL_DEFAULT, options: rest, serviceNames });
     await server.initialize();

--- a/packages/cardano-services/src/index.ts
+++ b/packages/cardano-services/src/index.ts
@@ -3,5 +3,6 @@ export * from './Program';
 export * from './RunnableModule';
 export * from './StakePoolSearch';
 export * from './TxSubmit';
+export * from './TxWorker';
 export * from './Utxo';
 export * as errors from './errors';

--- a/packages/cardano-services/src/startWorker.ts
+++ b/packages/cardano-services/src/startWorker.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/* eslint-disable import/imports-first */
+require('../scripts/patchRequire');
+import * as envalid from 'envalid';
+import { LogLevel } from 'bunyan';
+import {
+  OGMIOS_URL_DEFAULT,
+  PARALLEL_MODE_DEFAULT,
+  PARALLEL_TXS_DEFAULT,
+  POLLING_CYCLE_DEFAULT,
+  RABBITMQ_URL_DEFAULT,
+  loadTxWorker
+} from './TxWorker';
+import { URL } from 'url';
+import { config } from 'dotenv';
+import { loggerMethodNames } from './util';
+import onDeath from 'death';
+
+const envSpecs = {
+  LOGGER_MIN_SEVERITY: envalid.str({ choices: loggerMethodNames as string[], default: 'info' }),
+  OGMIOS_URL: envalid.url({ default: OGMIOS_URL_DEFAULT }),
+  PARALLEL: envalid.bool({ default: PARALLEL_MODE_DEFAULT }),
+  PARALLEL_TXS: envalid.num({ default: PARALLEL_TXS_DEFAULT }),
+  POLLING_CYCLE: envalid.num({ default: POLLING_CYCLE_DEFAULT }),
+  RABBITMQ_URL: envalid.url({ default: RABBITMQ_URL_DEFAULT })
+};
+
+void (async () => {
+  config();
+  const env = envalid.cleanEnv(process.env, envSpecs);
+
+  try {
+    const worker = await loadTxWorker({
+      options: {
+        loggerMinSeverity: env.LOGGER_MIN_SEVERITY as LogLevel,
+        ogmiosUrl: new URL(env.OGMIOS_URL),
+        parallel: env.PARALLEL,
+        parallelTxs: env.PARALLEL_TXS,
+        pollingCycle: env.POLLING_CYCLE,
+        rabbitmqUrl: new URL(env.RABBITMQ_URL)
+      }
+    });
+    await worker.start();
+    onDeath(async () => {
+      await worker.stop();
+      // eslint-disable-next-line unicorn/no-process-exit
+      process.exit(1);
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(error);
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(1);
+  }
+})();

--- a/packages/cardano-services/test/entrypoints.txWorker.test.ts
+++ b/packages/cardano-services/test/entrypoints.txWorker.test.ts
@@ -1,0 +1,195 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { BAD_CONNECTION_URL, enqueueFakeTx, removeAllMessagesFromQueue } from '@cardano-sdk/rabbitmq/test/utils';
+import { ChildProcess, fork } from 'child_process';
+import { createConnectionObject } from '@cardano-ogmios/client';
+import { createHealthyMockOgmiosServer, ogmiosServerReady } from './util';
+import { getRandomPort } from 'get-port-please';
+import { listenPromise, serverClosePromise } from '../src/util';
+import http from 'http';
+import path from 'path';
+
+const exePath = (name: 'cli' | 'startWorker') => path.join(__dirname, '..', 'dist', `${name}.js`);
+
+describe('tx-worker entrypoints', () => {
+  let commonArgs: string[];
+  let commonEnv: Record<string, string>;
+  let hook: () => void;
+  let hookLogs: string[];
+  let hookPromise: Promise<void>;
+  let loggerHookCounter: number;
+  let ogmiosServer: http.Server;
+  let proc: ChildProcess;
+
+  const resetHook = () => (hook = jest.fn());
+
+  const loggerHook = (): [() => void, Promise<void>] => {
+    let resolver: () => void;
+
+    const promise = new Promise<void>((resolve) => (resolver = resolve));
+    const loggingHook = async () => {
+      const counter = ++loggerHookCounter;
+
+      hookLogs.push(`Processing tx ${counter}`);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      hookLogs.push(`Processed tx ${counter}`);
+      if (counter === 2) resolver();
+    };
+
+    return [loggingHook, promise];
+  };
+
+  beforeAll(async () => {
+    resetHook();
+    const port = await getRandomPort();
+    const ogmiosConnection = createConnectionObject({ port });
+    ogmiosServer = createHealthyMockOgmiosServer(() => hook());
+    await listenPromise(ogmiosServer, { port });
+    await ogmiosServerReady(ogmiosConnection);
+    commonArgs = ['start-worker', '--logger-min-severity', 'error', '--ogmios-url', ogmiosConnection.address.webSocket];
+    commonEnv = { LOGGER_MIN_SEVERITY: 'error', OGMIOS_URL: ogmiosConnection.address.webSocket };
+  });
+
+  afterAll(async () => await serverClosePromise(ogmiosServer));
+
+  beforeEach(async () => {
+    await removeAllMessagesFromQueue();
+    await enqueueFakeTx();
+    await enqueueFakeTx();
+    hookLogs = [];
+    loggerHookCounter = 0;
+  });
+
+  afterEach((done) => {
+    resetHook();
+    if (proc?.kill()) proc.on('close', done);
+    else done();
+  });
+
+  // Tests without any assertion fail if they get timeout
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  describe('with a working RabbitMQ server', () => {
+    describe('worker starts', () => {
+      it('cli:start-worker', (done) => {
+        proc = fork(exePath('cli'), commonArgs, { stdio: 'pipe' });
+        proc.stdout!.on('data', (data) => (data.toString().match('RabbitMQ transactions worker') ? done() : null));
+      });
+
+      it('startWorker', (done) => {
+        hook = done;
+        proc = fork(exePath('startWorker'), { env: commonEnv, stdio: 'pipe' });
+      });
+    });
+
+    describe('transaction are actually submitted', () => {
+      it('cli:start-worker submits transactions', () =>
+        new Promise<void>(async (resolve) => {
+          hook = resolve;
+          proc = fork(exePath('cli'), commonArgs, { stdio: 'pipe' });
+        }));
+
+      it('startWorker submits transactions', () =>
+        new Promise<void>(async (resolve) => {
+          hook = resolve;
+          proc = fork(exePath('startWorker'), { env: commonEnv, stdio: 'pipe' });
+        }));
+    });
+
+    describe('parallel option', () => {
+      describe('without parallel option', () => {
+        it('cli:start-worker starts in serial mode', (done) => {
+          proc = fork(exePath('cli'), commonArgs, { stdio: 'pipe' });
+          proc.stdout!.on('data', (data) => (data.toString().match('serial mode') ? done() : null));
+        });
+
+        it('startWorker starts in serial mode', async () => {
+          [hook, hookPromise] = loggerHook();
+          proc = fork(exePath('startWorker'), { env: commonEnv, stdio: 'pipe' });
+          await hookPromise;
+          expect(hookLogs).toEqual(['Processing tx 1', 'Processed tx 1', 'Processing tx 2', 'Processed tx 2']);
+        });
+      });
+
+      describe('with bad parallel option', () => {
+        it('cli:start-worker exits with code 0', (done) => {
+          expect.assertions(2);
+          proc = fork(exePath('cli'), [...commonArgs, '--parallel', 'test'], { stdio: 'pipe' });
+          proc.stderr!.on('data', (data) =>
+            expect(data.toString()).toMatch('tx-submit requires a valid Parallel mode')
+          );
+          proc.on('exit', (code) => {
+            expect(code).toBe(0);
+            done();
+          });
+        });
+
+        it('startWorker exits with code 1', (done) => {
+          expect.assertions(1);
+          proc = fork(exePath('startWorker'), { env: { ...commonEnv, PARALLEL: 'test' }, stdio: 'pipe' });
+          proc.on('exit', (code) => {
+            expect(code).toBe(1);
+            done();
+          });
+        });
+      });
+
+      describe('with parallel option set to false', () => {
+        it('worker starts in serial mode', (done) => {
+          proc = fork(exePath('cli'), [...commonArgs, '--parallel', 'false'], { stdio: 'pipe' });
+          proc.stdout!.on('data', (data) => (data.toString().match('serial mode') ? done() : null));
+        });
+
+        it('startWorker starts in serial mode', async () => {
+          [hook, hookPromise] = loggerHook();
+          proc = fork(exePath('startWorker'), { env: { ...commonEnv, PARALLEL: 'false' }, stdio: 'pipe' });
+          await hookPromise;
+          expect(hookLogs).toEqual(['Processing tx 1', 'Processed tx 1', 'Processing tx 2', 'Processed tx 2']);
+        });
+      });
+
+      describe('with parallel option set to true', () => {
+        it('worker starts in parallel mode', (done) => {
+          proc = fork(exePath('cli'), [...commonArgs, '--parallel', 'true'], { stdio: 'pipe' });
+          proc.stdout!.on('data', (data) => (data.toString().match('parallel mode') ? done() : null));
+        });
+
+        it('startWorker starts in parallel mode', async () => {
+          [hook, hookPromise] = loggerHook();
+          proc = fork(exePath('startWorker'), { env: { ...commonEnv, PARALLEL: 'true' }, stdio: 'pipe' });
+          await hookPromise;
+          expect(hookLogs).toEqual(['Processing tx 1', 'Processing tx 2', 'Processed tx 1', 'Processed tx 2']);
+        });
+      });
+
+      describe('default parallel option value', () => {
+        it('worker starts in parallel mode', (done) => {
+          proc = fork(exePath('cli'), [...commonArgs, '--parallel'], { stdio: 'pipe' });
+          proc.stdout!.on('data', (data) => (data.toString().match('parallel mode') ? done() : null));
+        });
+      });
+    });
+  });
+
+  describe('without a working RabbitMQ server', () => {
+    it('cli:start-worker exits with code 0', (done) => {
+      expect.assertions(2);
+      proc = fork(exePath('cli'), [...commonArgs, '--rabbitmq-url', BAD_CONNECTION_URL.toString()], { stdio: 'pipe' });
+      proc.stderr!.on('data', (data) => expect(data.toString()).toMatch('ECONNREFUSED'));
+      proc.on('exit', (code) => {
+        expect(code).toBe(0);
+        done();
+      });
+    });
+
+    it('startWorker exits with code 1', (done) => {
+      expect.assertions(1);
+      proc = fork(exePath('startWorker'), {
+        env: { ...commonEnv, RABBITMQ_URL: BAD_CONNECTION_URL.toString() },
+        stdio: 'pipe'
+      });
+      proc.on('exit', (code) => {
+        expect(code).toBe(1);
+        done();
+      });
+    });
+  });
+});

--- a/packages/cardano-services/test/util.ts
+++ b/packages/cardano-services/test/util.ts
@@ -11,10 +11,11 @@ export const serverReady = (apiUrl: string, statusCodeMatch = 404): Promise<void
 
 export const ogmiosServerReady = (connection: Connection): Promise<void> => serverReady(connection.address.http, 405);
 
-export const createHealthyMockOgmiosServer = () =>
+export const createHealthyMockOgmiosServer = (submitTxHook?: () => void) =>
   createMockOgmiosServer({
     healthCheck: { response: { networkSynchronization: 0.999, success: true } },
-    submitTx: { response: { success: true } }
+    submitTx: { response: { success: true } },
+    submitTxHook
   });
 
 export const createUnhealthyMockOgmiosServer = () =>

--- a/packages/ogmios/src/ogmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/ogmiosTxSubmitProvider.ts
@@ -59,3 +59,15 @@ export const ogmiosTxSubmitProvider = (
     }
   }
 });
+
+/**
+ * Converts an Ogmios connection URL to a Ogmios ConnectionConfig Object
+ *
+ * @param {URL} connectionURL Ogmios connection URL
+ * @returns {ConnectionConfig} the ConnectionConfig Object
+ */
+export const urlToConnectionConfig = (connectionURL?: URL): ConnectionConfig => ({
+  host: connectionURL?.hostname,
+  port: connectionURL ? Number.parseInt(connectionURL.port) : undefined,
+  tls: connectionURL?.protocol === 'wss'
+});

--- a/packages/ogmios/test/mocks/mockOgmiosServer.ts
+++ b/packages/ogmios/test/mocks/mockOgmiosServer.ts
@@ -105,3 +105,12 @@ export const createMockOgmiosServer = (config: MockOgmiosServerConfig): Server =
   });
   return server;
 };
+
+export const listenPromise = (server: Server, port: number, hostname?: string): Promise<Server> =>
+  new Promise((resolve, reject) => {
+    server.listen(port, hostname, () => resolve(server));
+    server.on('error', reject);
+  });
+
+export const serverClosePromise = (server: Server): Promise<void> =>
+  new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));

--- a/packages/ogmios/test/ogmiosTxSubmitProvider.test.ts
+++ b/packages/ogmios/test/ogmiosTxSubmitProvider.test.ts
@@ -2,26 +2,10 @@
 /* eslint-disable max-len */
 import { Cardano, ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
 import { Connection, createConnectionObject } from '@cardano-ogmios/client';
-import { createMockOgmiosServer } from './mocks/mockOgmiosServer';
+import { createMockOgmiosServer, listenPromise, serverClosePromise } from './mocks/mockOgmiosServer';
 import { getRandomPort } from 'get-port-please';
 import { ogmiosTxSubmitProvider } from '../src';
 import http from 'http';
-
-const listenPromise = (server: http.Server, port: number, hostname?: string): Promise<http.Server> =>
-  new Promise((resolve, reject) => {
-    server.listen(port, hostname, () => resolve(server));
-    server.on('error', reject);
-  });
-
-const serverClosePromise = (server: http.Server): Promise<void> =>
-  new Promise((resolve, reject) => {
-    server.close((error) => {
-      if (error !== undefined) {
-        reject(error);
-      }
-      resolve();
-    });
-  });
 
 describe('ogmiosTxSubmitProvider', () => {
   let mockServer: http.Server;

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -21,13 +21,16 @@
     "prepack": "yarn build"
   },
   "devDependencies": {
-    "@types/amqplib": "0.8.2",
+    "@cardano-sdk/ogmios": "0.2.0",
+    "@types/amqplib": "^0.8.2",
+    "get-port-please": "^2.4.3",
     "shx": "^0.3.3",
     "ws": "^8.5.0"
   },
   "dependencies": {
     "@cardano-sdk/core": "0.2.0",
-    "amqplib": "0.9.0"
+    "amqplib": "^0.9.0",
+    "ts-log": "^2.2.4"
   },
   "files": [
     "dist/*",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -11,7 +11,7 @@
   "license": "MPL-2.0",
   "scripts": {
     "build": "tsc --build ./src",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage --collectCoverageFrom=src/**/*.ts",
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup": "shx rm -rf dist node_modules",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -26,6 +26,7 @@
     "ws": "^8.5.0"
   },
   "dependencies": {
+    "@cardano-sdk/core": "0.2.0",
     "amqplib": "0.9.0"
   },
   "files": [

--- a/packages/rabbitmq/src/TxSubmitWorker.ts
+++ b/packages/rabbitmq/src/TxSubmitWorker.ts
@@ -1,0 +1,282 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+import { Channel, Connection, Message, connect } from 'amqplib';
+import { Logger, dummyLogger } from 'ts-log';
+import { ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { TX_SUBMISSION_QUEUE } from './rabbitmqTxSubmitProvider';
+
+const moduleName = 'TxSubmitWorker';
+
+/**
+ * Configuration options parameters for the TxSubmitWorker
+ */
+export interface TxSubmitWorkerConfig {
+  /**
+   * Instructs the worker to process multiple transactions simultaneously.
+   * Default: false (serial mode)
+   */
+  parallel?: boolean;
+
+  /**
+   * The number of Tx submitted to the txSubmitProvider in parallel.
+   * Ignored in serial mode. Default: 3
+   */
+  parallelTxs?: number;
+
+  /**
+   * The RabbitMQ polling cycle in milliseconds.
+   * Ignored in parallel mode. Default: 500
+   */
+  pollingCycle?: number;
+
+  /**
+   * The RabbitMQ connection URL
+   */
+  rabbitmqUrl: URL;
+}
+
+/**
+ * Dependencies for the TxSubmitWorker
+ */
+export interface TxSubmitWorkerDependencies {
+  /**
+   * The logger. Default: silent
+   */
+  logger?: Logger;
+
+  /**
+   * The provider to use to submit tx
+   */
+  txSubmitProvider: TxSubmitProvider;
+}
+
+/**
+ * Controller class for the transactions submission worker which gets
+ * transactions from RabbitMQ and submit them via the TxSubmitProvider
+ */
+export class TxSubmitWorker {
+  /**
+   * The RabbitMQ channel
+   */
+  #channel?: Channel;
+
+  /**
+   * The configuration options
+   */
+  #config: TxSubmitWorkerConfig;
+
+  /**
+   * The RabbitMQ connection
+   */
+  #connection?: Connection;
+
+  /**
+   * Flag to exit from the infinite loop in case of sequential tx handlig
+   */
+  #continueForever = false;
+
+  /**
+   * The RabbitMQ consumerTag
+   */
+  #consumerTag?: string;
+
+  /**
+   * Internal messages counter
+   */
+  #counter = 0;
+
+  /**
+   *  The dependency objects
+   */
+  #dependencies: TxSubmitWorkerDependencies;
+
+  /**
+   * The function to call to resolve the start method exit Promise
+   */
+  #exitResolver?: () => void;
+
+  /**
+   * The internal worker status
+   */
+  #status: 'connected' | 'connecting' | 'error' | 'idle' = 'idle';
+
+  /**
+   * @param {TxSubmitWorkerConfig} config The configuration options
+   * @param {TxSubmitWorkerDependencies} dependencies The dependency objects
+   */
+  constructor(config: TxSubmitWorkerConfig, dependencies: TxSubmitWorkerDependencies) {
+    this.#config = { parallelTxs: 3, pollingCycle: 500, ...config };
+    this.#dependencies = { logger: dummyLogger, ...dependencies };
+  }
+
+  /**
+   * Get the status of the worker
+   *
+   * @returns the status of the worker
+   */
+  getStatus() {
+    return this.#status;
+  }
+
+  /**
+   * Starts the worker
+   */
+  start() {
+    return new Promise<void>(async (resolve, reject) => {
+      const closeHandler = async (isAsync: boolean, err: unknown) => {
+        if (err) {
+          this.logError(err, isAsync);
+          this.#exitResolver = undefined;
+          this.#status = 'error';
+          await this.stop();
+          reject(err);
+        }
+      };
+
+      try {
+        this.#dependencies.logger!.info(`${moduleName} init: checking tx submission provider health status`);
+
+        const { ok } = await this.#dependencies.txSubmitProvider.healthCheck();
+
+        if (!ok) throw new ProviderError(ProviderFailure.Unhealthy);
+
+        this.#dependencies.logger!.info(`${moduleName} init: opening RabbitMQ connection`);
+        this.#exitResolver = resolve;
+        this.#status = 'connecting';
+        this.#connection = await connect(this.#config.rabbitmqUrl.toString());
+        this.#connection.on('close', (error) => closeHandler(true, error));
+
+        this.#dependencies.logger!.info(`${moduleName} init: opening RabbitMQ channel`);
+        this.#channel = await this.#connection.createChannel();
+        this.#channel.on('close', (error) => closeHandler(true, error));
+
+        this.#dependencies.logger!.info(`${moduleName} init: ensuring RabbitMQ queue`);
+        await this.#channel.assertQueue(TX_SUBMISSION_QUEUE);
+        this.#dependencies.logger!.info(`${moduleName}: init completed`);
+
+        if (this.#config.parallel) {
+          this.#dependencies.logger!.info(`${moduleName}: starting parallel mode`);
+          await this.#channel.prefetch(this.#config.parallelTxs!, true);
+
+          const parallelHandler = (message: Message | null) => (message ? this.submitTx(message) : null);
+          const { consumerTag } = await this.#channel.consume(TX_SUBMISSION_QUEUE, parallelHandler);
+
+          this.#consumerTag = consumerTag;
+          this.#status = 'connected';
+        } else {
+          this.#dependencies.logger!.info(`${moduleName}: starting serial mode`);
+          await this.infiniteLoop();
+        }
+      } catch (error) {
+        await closeHandler(false, error);
+      }
+    });
+  }
+
+  /**
+   * Stops the worker. Once connection shutdown is completed,
+   * the Promise returned by the start method is resolved as well
+   */
+  async stop() {
+    // This method needs to call this.#exitResolver at the end.
+    // Since it may be called more than once simultaneously,
+    // we need to ensure this.#exitResolver is called only once,
+    // so we immediately store its value in a local variable and we reset it
+    const exitResolver = this.#exitResolver;
+    this.#exitResolver = undefined;
+
+    try {
+      this.#dependencies.logger!.info(`${moduleName} shutdown: closing RabbitMQ channel`);
+
+      try {
+        if (this.#consumerTag) {
+          const consumerTag = this.#consumerTag;
+          this.#consumerTag = undefined;
+
+          await this.#channel?.cancel(consumerTag);
+        }
+      } catch (error) {
+        this.logError(error);
+      }
+
+      this.#dependencies.logger!.info(`${moduleName} shutdown: closing RabbitMQ connection`);
+
+      try {
+        await this.#connection?.close();
+      } catch (error) {
+        this.logError(error);
+      }
+
+      this.#dependencies.logger!.info(`${moduleName}: shutdown completed`);
+      this.#channel = undefined;
+      this.#connection = undefined;
+      this.#consumerTag = undefined;
+      this.#continueForever = false;
+      this.#status = 'idle';
+    } finally {
+      // Only logging functions could throw an error here...
+      // Although this is almost impossible, we want to be sure exitResolver is called
+      exitResolver?.();
+    }
+  }
+
+  /**
+   * Wrapper to log errors from try/catch blocks
+   *
+   * @param {any} error the error to log
+   */
+  private logError(error: unknown, isAsync = false) {
+    const errorMessage =
+      // eslint-disable-next-line prettier/prettier
+      error instanceof Error ? error.message : (typeof error === 'string' ? error : JSON.stringify(error));
+    const errorObject = { error: error instanceof Error ? error.name : 'Unknown error', isAsync, module: moduleName };
+
+    this.#dependencies.logger!.error(errorObject, errorMessage);
+    if (error instanceof Error) this.#dependencies.logger!.debug(`${moduleName}:`, error.stack);
+  }
+
+  /**
+   * The infinite loop to perform serial tx submission
+   */
+  private async infiniteLoop() {
+    this.#continueForever = true;
+    this.#status = 'connected';
+
+    while (this.#continueForever) {
+      const message = await this.#channel?.get(TX_SUBMISSION_QUEUE);
+
+      // If there is a message, handle it, otherwise wait #pollingCycle ms
+      await (message
+        ? this.submitTx(message)
+        : new Promise((resolve) => setTimeout(resolve, this.#config.pollingCycle!)));
+    }
+  }
+
+  /**
+   * Submit a tx to the provider and ack (or nack) the message
+   *
+   * @param {Message} message the message containing the transaction
+   */
+  private async submitTx(message: Message) {
+    try {
+      const counter = ++this.#counter;
+      const { content } = message;
+
+      this.#dependencies.logger!.info(`${moduleName}: submitting tx`);
+      this.#dependencies.logger!.debug(`${moduleName}: tx ${counter} dump:`, content.toString('hex'));
+      await this.#dependencies.txSubmitProvider.submitTx(new Uint8Array(content));
+
+      this.#dependencies.logger!.debug(`${moduleName}: ACKing RabbitMQ message ${counter}`);
+      this.#channel?.ack(message);
+    } catch (error) {
+      this.logError(error);
+
+      try {
+        this.#dependencies.logger!.info(`${moduleName}: NACKing RabbitMQ message`);
+        this.#channel?.nack(message);
+        // eslint-disable-next-line no-catch-shadow
+      } catch (error) {
+        this.logError(error);
+      }
+    }
+  }
+}

--- a/packages/rabbitmq/src/index.ts
+++ b/packages/rabbitmq/src/index.ts
@@ -1,1 +1,2 @@
+export * from './TxSubmitWorker';
 export * from './rabbitmqTxSubmitProvider';

--- a/packages/rabbitmq/test/TxSubmitWorker.test.ts
+++ b/packages/rabbitmq/test/TxSubmitWorker.test.ts
@@ -1,0 +1,257 @@
+import { BAD_CONNECTION_URL, GOOD_CONNECTION_URL, enqueueFakeTx, removeAllMessagesFromQueue } from './utils';
+import { TxSubmitProvider } from '@cardano-sdk/core';
+import { TxSubmitWorker } from '../src';
+import {
+  createMockOgmiosServer,
+  listenPromise,
+  serverClosePromise
+} from '@cardano-sdk/ogmios/test/mocks/mockOgmiosServer';
+import { dummyLogger } from 'ts-log';
+import { getRandomPort } from 'get-port-please';
+import { ogmiosTxSubmitProvider, urlToConnectionConfig } from '@cardano-sdk/ogmios';
+import { removeRabbitMQContainer, setupRabbitMQContainer } from './jest-setup/docker';
+import http from 'http';
+
+const logger = dummyLogger;
+
+describe('TxSubmitWorker', () => {
+  let txSubmitProvider: TxSubmitProvider;
+  let port: number;
+
+  beforeAll(async () => {
+    port = await getRandomPort();
+    txSubmitProvider = ogmiosTxSubmitProvider(urlToConnectionConfig(new URL(`http://localhost:${port}/`)));
+  });
+
+  it('is safe to call stop method on an idle worker', async () => {
+    const worker = new TxSubmitWorker({ rabbitmqUrl: GOOD_CONNECTION_URL }, { logger, txSubmitProvider });
+
+    expect(worker).toBeInstanceOf(TxSubmitWorker);
+    expect(worker.getStatus()).toEqual('idle');
+    expect(await worker.stop()).toBeUndefined();
+    expect(worker.getStatus()).toEqual('idle');
+  });
+
+  it('rejects if the TxSubmitProvider is unhealthy on start', async () => {
+    const worker = new TxSubmitWorker({ rabbitmqUrl: GOOD_CONNECTION_URL }, { logger, txSubmitProvider });
+
+    const unhealthyMock = createMockOgmiosServer({
+      healthCheck: { response: { networkSynchronization: 0.8, success: true } },
+      submitTx: { response: { success: true } }
+    });
+
+    await listenPromise(unhealthyMock, port);
+
+    try {
+      const res = await worker.start();
+      expect(res).toBeDefined();
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+
+    await serverClosePromise(unhealthyMock);
+  });
+
+  it('rejects if unable to connect to the RabbitMQ broker', async () => {
+    const worker = new TxSubmitWorker({ rabbitmqUrl: BAD_CONNECTION_URL }, { logger, txSubmitProvider });
+    const healthyMock = createMockOgmiosServer({
+      healthCheck: { response: { networkSynchronization: 1, success: true } },
+      submitTx: { response: { success: true } }
+    });
+
+    await listenPromise(healthyMock, port);
+
+    try {
+      const res = await worker.start();
+      expect(res).toBeDefined();
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+
+    await serverClosePromise(healthyMock);
+  });
+
+  describe('RabbitMQ connection failure while running', () => {
+    const CONTAINER_NAME = 'cardano-rabbitmq-local-test';
+
+    const performTest = async (options: { parallel: boolean }) => {
+      const healthyMock = createMockOgmiosServer({
+        healthCheck: { response: { networkSynchronization: 1, success: true } },
+        submitTx: { response: { success: true } }
+      });
+
+      await listenPromise(healthyMock, port);
+
+      // Set up a new RabbitMQ container to test TxSubmitWorker on RabbitMQ server shut down
+      const rabbitmqPort = await getRandomPort();
+      await setupRabbitMQContainer(CONTAINER_NAME, rabbitmqPort);
+
+      // Actually create the TxSubmitWorker
+      const worker = new TxSubmitWorker(
+        { rabbitmqUrl: new URL(`amqp://localhost:${rabbitmqPort}`), ...options },
+        { logger, txSubmitProvider }
+      );
+      const startPromise = worker.start();
+
+      // Wait until the worker is connected to the RabbitMQ server
+      await new Promise<void>(async (resolve) => {
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        while (worker.getStatus() === 'connecting') await new Promise((resolve) => setTimeout(resolve, 50));
+        resolve();
+      });
+
+      // Stop the RabbitMQ container while the TxSubmitWorker is connected
+      const removeContainerPromise = removeRabbitMQContainer(CONTAINER_NAME);
+      const innerMessage = "CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'";
+      const fullMessage = `Connection closed: 320 (CONNECTION-FORCED) with message "${innerMessage}"`;
+
+      // Test the TxSubmitWorker actually exits with error
+      await expect(startPromise).rejects.toThrow(new Error(fullMessage));
+
+      // Test teardown
+      await serverClosePromise(healthyMock);
+      await removeContainerPromise;
+    };
+
+    it('rejects when configured to process jobs serially', async () => await performTest({ parallel: false }), 20_000);
+    it(
+      'rejects when configured to process jobs in parallel',
+      async () => await performTest({ parallel: true }),
+      20_000
+    );
+  });
+
+  describe('tx submission is retried until success', () => {
+    // First of all we need to remove from the queue every message sent by previous tests/suites
+    beforeAll(removeAllMessagesFromQueue);
+
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const performTest = async (options: { parallel: boolean }) => {
+      const spy = jest.fn();
+      let hookAlreadyCalled = false;
+      let successMockListenPromise = Promise.resolve<http.Server>(new http.Server());
+      let stopPromise = Promise.resolve();
+      // eslint-disable-next-line prefer-const
+      let worker: TxSubmitWorker;
+
+      const successMock = createMockOgmiosServer({
+        healthCheck: { response: { networkSynchronization: 1, success: true } },
+        submitTx: { response: { success: true } },
+        submitTxHook: () => {
+          spy();
+          // Once the transaction is submitted with success we can stop the worker
+          // We wait half a second to be ensure the tx is submitted only once
+          setTimeout(() => (stopPromise = worker.stop()), 500);
+        }
+      });
+
+      const failMock = createMockOgmiosServer({
+        healthCheck: { response: { networkSynchronization: 1, success: true } },
+        submitTx: { response: { failWith: { type: 'eraMismatch' }, success: false } },
+        submitTxHook: () => {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          (async () => {
+            if (hookAlreadyCalled) return;
+
+            // This hook may be called multple times... ensure the core is executed only once
+            hookAlreadyCalled = true;
+
+            // Stop the failing mock and start the succes one
+            await serverClosePromise(failMock);
+            successMockListenPromise = listenPromise(successMock, port);
+          })();
+        }
+      });
+
+      // Start a failing ogmios server
+      await listenPromise(failMock, port);
+
+      // Enqueue a tx
+      const providerClosePromise = enqueueFakeTx();
+
+      // Actually create the TxSubmitWorker
+      worker = new TxSubmitWorker({ rabbitmqUrl: GOOD_CONNECTION_URL, ...options }, { logger, txSubmitProvider });
+      const startPromise = worker.start();
+
+      await expect(startPromise).resolves.toEqual(undefined);
+      await serverClosePromise(successMock);
+      // All these Promises are the return value of async functions called in a not async context,
+      // we need to await for them to perform a correct test teardown
+      await Promise.all([stopPromise, successMockListenPromise, providerClosePromise]);
+      expect(spy).toBeCalledTimes(1);
+    };
+
+    it('when configured to process jobs serially', async () => performTest({ parallel: false }));
+    it('when configured to process jobs in parallel', async () => performTest({ parallel: true }));
+  });
+
+  it('submission is parallelized up to parallelTx Tx simultaneously', async () => {
+    // First of all we need to remove from the queue every message sent by previous tests/suites
+    await removeAllMessagesFromQueue();
+
+    let stopPromise = Promise.resolve();
+
+    const loggedMessages: unknown[][] = [];
+    const testLogger = {
+      debug: (...args: unknown[]) => loggedMessages.push(args),
+      error: jest.fn(),
+      info: jest.fn(),
+      trace: jest.fn(),
+      warn: jest.fn()
+    };
+
+    const worker = new TxSubmitWorker(
+      { parallel: true, parallelTxs: 4, rabbitmqUrl: GOOD_CONNECTION_URL },
+      { logger: testLogger, txSubmitProvider }
+    );
+
+    const mock = createMockOgmiosServer({
+      healthCheck: { response: { networkSynchronization: 1, success: true } },
+      submitTx: { response: { success: true } },
+      submitTxHook: async (data) => {
+        // Wait 100ms * the first byte of the Tx before sending the result
+        await new Promise((resolve) => setTimeout(resolve, 100 * data![0]));
+        // Exit condition: a Tx with length === 2
+        if (data?.length === 2) stopPromise = worker.stop();
+      }
+    });
+
+    await listenPromise(mock, port);
+
+    /*
+     * Tx submission plan, time sample: 100ms
+     * 11111
+     * 226666
+     * 3555
+     * 4447777
+     */
+    await enqueueFakeTx([5]);
+    await enqueueFakeTx([2]);
+    await enqueueFakeTx([1]);
+    await enqueueFakeTx([3]);
+    await enqueueFakeTx([3]);
+    await enqueueFakeTx([4]);
+    await enqueueFakeTx([4, 0]);
+
+    await expect(worker.start()).resolves.toEqual(undefined);
+    await Promise.all([stopPromise, serverClosePromise(mock)]);
+
+    // We check only the relevant messages
+    expect(loggedMessages.filter(([_]) => typeof _ === 'string' && _.match(/(tx \d dump)|ACKing RabbitMQ/))).toEqual([
+      ['TxSubmitWorker: tx 1 dump:', '05'],
+      ['TxSubmitWorker: tx 2 dump:', '02'],
+      ['TxSubmitWorker: tx 3 dump:', '01'],
+      ['TxSubmitWorker: tx 4 dump:', '03'],
+      ['TxSubmitWorker: ACKing RabbitMQ message 3'],
+      ['TxSubmitWorker: tx 5 dump:', '03'],
+      ['TxSubmitWorker: ACKing RabbitMQ message 2'],
+      ['TxSubmitWorker: tx 6 dump:', '04'],
+      ['TxSubmitWorker: ACKing RabbitMQ message 4'],
+      ['TxSubmitWorker: tx 7 dump:', '0400'],
+      ['TxSubmitWorker: ACKing RabbitMQ message 5'],
+      ['TxSubmitWorker: ACKing RabbitMQ message 1'],
+      ['TxSubmitWorker: ACKing RabbitMQ message 6'],
+      ['TxSubmitWorker: ACKing RabbitMQ message 7']
+    ]);
+  });
+});

--- a/packages/rabbitmq/test/jest-setup/jest-setup.ts
+++ b/packages/rabbitmq/test/jest-setup/jest-setup.ts
@@ -1,3 +1,5 @@
 import { setupRabbitMQContainer } from './docker';
 
-export default setupRabbitMQContainer;
+const setupContainer = () => setupRabbitMQContainer();
+
+export default setupContainer;

--- a/packages/rabbitmq/test/jest-setup/jest-teardown.ts
+++ b/packages/rabbitmq/test/jest-setup/jest-teardown.ts
@@ -1,3 +1,5 @@
 import { removeRabbitMQContainer } from './docker';
 
-export default removeRabbitMQContainer;
+const removeContainer = () => removeRabbitMQContainer();
+
+export default removeContainer;

--- a/packages/rabbitmq/test/rabbitmqTxSubmitProvider.test.ts
+++ b/packages/rabbitmq/test/rabbitmqTxSubmitProvider.test.ts
@@ -1,8 +1,6 @@
+import { BAD_CONNECTION_URL, GOOD_CONNECTION_URL } from './utils';
 import { ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
 import { RabbitMqTxSubmitProvider } from '../src';
-
-const BAD_CONNECTION_URL = new URL('amqp://localhost:1234');
-const GOOD_CONNECTION_URL = new URL('amqp://localhost');
 
 describe('RabbitMqTxSubmitProvider', () => {
   let provider: TxSubmitProvider;

--- a/packages/rabbitmq/test/tsconfig.json
+++ b/packages/rabbitmq/test/tsconfig.json
@@ -6,6 +6,8 @@
   },
   "references": [
     { "path": "../../core/src" },
+    { "path": "../../ogmios/src" },
+    { "path": "../../ogmios/test" },
     { "path": "../src" }
   ]
 }

--- a/packages/rabbitmq/test/utils.ts
+++ b/packages/rabbitmq/test/utils.ts
@@ -1,0 +1,26 @@
+import { Message, connect } from 'amqplib';
+import { RabbitMqTxSubmitProvider, TX_SUBMISSION_QUEUE } from '../src';
+
+export const BAD_CONNECTION_URL = new URL('amqp://localhost:1234');
+export const GOOD_CONNECTION_URL = new URL('amqp://localhost');
+
+export const enqueueFakeTx = async (data = [0, 1, 2, 3, 23]) => {
+  const rabbitMqTxSubmitProvider = new RabbitMqTxSubmitProvider(GOOD_CONNECTION_URL);
+  await rabbitMqTxSubmitProvider.submitTx(new Uint8Array(data));
+  return rabbitMqTxSubmitProvider.close();
+};
+
+export const removeAllMessagesFromQueue = async () => {
+  const connection = await connect(GOOD_CONNECTION_URL.toString());
+  const channel = await connection.createChannel();
+  await channel.assertQueue(TX_SUBMISSION_QUEUE);
+  let message: Message | false;
+
+  do {
+    message = await channel.get(TX_SUBMISSION_QUEUE);
+    if (message) channel.ack(message);
+  } while (message);
+
+  await channel.close();
+  await connection.close();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,7 +1234,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
 
-"@types/amqplib@0.8.2":
+"@types/amqplib@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@types/amqplib/-/amqplib-0.8.2.tgz#9c46f2c7fac381e4f81bcb612c00d54549697d22"
   integrity sha512-p+TFLzo52f8UanB+Nq6gyUi65yecAcRY3nYowU6MPGFtaJvEDxcnFWrxssSTkF+ts1W3zyQDvgVICLQem5WxRA==
@@ -2535,10 +2535,10 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-amqplib@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.9.0.tgz#b2b8705bf8ca3579caef244f01a30a568512f0fd"
-  integrity sha512-emwSdJElmSp52JIKehjLNimKqbZcGUBGdcqST9fll+C/Uss8fWoGyyWlwt20f5lD+SDdozoc4WhF3uDCUOL2ww==
+amqplib@^0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.9.1.tgz#f2ad6e518a148a761e102bf791314fbe4cb94346"
+  integrity sha512-a1DP0H1LcLSMKPAnhUN2AKbVyEPqEUrUf7O+odhKGxaO+Tf0nWtuD7Zq5P9uZwZteu56OfW9EQozSCTKsAEk5w==
   dependencies:
     bitsyntax "~0.1.0"
     bluebird "^3.7.2"


### PR DESCRIPTION
# Context

We need a worker to consume the messages from the queue to complete [Part 1](https://github.com/input-output-hk/cardano-js-sdk/pull/247)

# Proposed Solution
Added the core of the worker in `@cardano-sdk/rabbitmq/src/TxSubmitWorker.ts`.
Added the entry points in `@cardano-sdk/cardano-services`.

# Important Changes Introduced
- Added `TxSubmitWorker`
- Added `urlToConnectionConfig` to `@cardano-sdk/ogmios` to avoid code repetition
- Exported `listenPromise` and `serverClosePromise` from `@cardano-sdk/ogmios/test` to avoid code repetition
- Added `submitTxHook` to the mock server to catch `submitTx` events
- Integrated `TxSubmitWorker` in `cli.ts`
- Added the `startWorker.ts` entry point