### PR TITLE
feat: Implement Network Info

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/cardano-services/config"]
+	path = packages/cardano-services/config
+	url = https://github.com/input-output-hk/cardano-configurations.git

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ A Yarn Workspace maintaining a single version across all packages.
 - [nvm](https://github.com/nvm-sh/nvm)
 - [yarn](https://classic.yarnpkg.com/lang/en/docs/install)
 
+#### Clone
+``` console
+git clone \
+  --recurse-submodules \
+  https://github.com/input-output-hk/cardano-js-sdk.git \
+  && cd cardano-js-sdk
+```
 #### Install and Build
 
 ```console

--- a/packages/blockfrost/src/blockfrostNetworkInfoProvider.ts
+++ b/packages/blockfrost/src/blockfrostNetworkInfoProvider.ts
@@ -1,5 +1,5 @@
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
-import { NetworkInfoProvider, ProviderError, ProviderFailure, testnetTimeSettings } from '@cardano-sdk/core';
+import { Cardano, NetworkInfoProvider, ProviderError, ProviderFailure, testnetTimeSettings } from '@cardano-sdk/core';
 
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
@@ -21,6 +21,7 @@ export const blockfrostNetworkInfoProvider = (blockfrost: BlockFrostAPI): Networ
         total: BigInt(supply.total)
       },
       network: {
+        id: Cardano.NetworkId.testnet,
         magic: 1_097_911_063,
         timeSettings: testnetTimeSettings
       },

--- a/packages/blockfrost/test/blockfrostNetworkInfoProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostNetworkInfoProvider.test.ts
@@ -1,5 +1,5 @@
 import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
-import { NetworkInfo, testnetTimeSettings } from '@cardano-sdk/core';
+import { Cardano, NetworkInfo, testnetTimeSettings } from '@cardano-sdk/core';
 import { blockfrostNetworkInfoProvider } from '../src';
 jest.mock('@blockfrost/blockfrost-js');
 
@@ -34,6 +34,7 @@ describe('blockfrostNetworkInfoProvider', () => {
         total: 40_267_211_394_073_980n
       },
       network: {
+        id: Cardano.NetworkId.testnet,
         magic: 1_097_911_063,
         timeSettings: testnetTimeSettings
       },

--- a/packages/cardano-services-client/src/NetworkInfoProvider/index.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './networkInfoHttpProvider';

--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -1,0 +1,20 @@
+import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { NetworkInfoProvider } from '@cardano-sdk/core';
+
+export const defaultNetworkInfoProviderPaths: HttpProviderConfigPaths<NetworkInfoProvider> = {
+  networkInfo: '/network'
+};
+
+/**
+ * Connect to a Cardano Services HttpServer instance with the service available
+ *
+ * @param {string} baseUrl server root url, w/o trailing /
+ */
+export const networkInfoHttpProvider = (
+  baseUrl: string,
+  paths = defaultNetworkInfoProviderPaths
+): NetworkInfoProvider =>
+  createHttpProvider<NetworkInfoProvider>({
+    baseUrl,
+    paths
+  });

--- a/packages/cardano-services-client/src/index.ts
+++ b/packages/cardano-services-client/src/index.ts
@@ -4,3 +4,4 @@ export * from './TxSubmitProvider';
 export * from './StakePoolProvider';
 export * from './UtxoProvider';
 export * from './ChainHistoryProvider';
+export * from './NetworkInfoProvider';

--- a/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
@@ -1,0 +1,29 @@
+/* eslint-disable max-len */
+import { networkInfoHttpProvider } from '../../src';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+const url = 'http://hostname:3000/network';
+
+describe('networkInfoHttpProvider', () => {
+  let axiosMock: MockAdapter;
+
+  beforeAll(() => {
+    axiosMock = new MockAdapter(axios);
+  });
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  afterAll(() => {
+    axiosMock.restore();
+  });
+
+  describe('networkInfo request', () => {
+    test('utxoByAddresses doesnt throw', async () => {
+      axiosMock.onPost().replyOnce(200, []);
+      const provider = networkInfoHttpProvider(url);
+      await expect(provider.networkInfo()).resolves.toEqual([]);
+    });
+  });
+});

--- a/packages/cardano-services/.env.test
+++ b/packages/cardano-services/.env.test
@@ -1,1 +1,2 @@
 DB_CONNECTION_STRING=postgresql://postgres:doNoUseThisSecret!@127.0.0.1:5433/testnet
+CARDANO_NODE_CONFIG_PATH=./config/network/testnet/cardano-node/config.json

--- a/packages/cardano-services/copy-openApi.sh
+++ b/packages/cardano-services/copy-openApi.sh
@@ -4,3 +4,4 @@ cp ./src/StakePool/openApi.json ./dist/StakePool/openApi.json
 cp ./src/TxSubmit/openApi.json ./dist/TxSubmit/openApi.json
 cp ./src/Utxo/openApi.json ./dist/Utxo/openApi.json
 cp ./src/ChainHistory/openApi.json ./dist/ChainHistory/openApi.json
+cp ./src/NetworkInfo/openApi.json ./dist/NetworkInfo/openApi.json

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -25,6 +25,7 @@
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
     "coverage": "yarn test --coverage",
     "prepack": "yarn build",
+    "pretest": "yarn build",
     "test:debug": "DEBUG=true yarn test",
     "run:http-server": "ts-node --transpile-only src/run.ts",
     "run:http-server:debug": "npx nodemon --legacy-watch --exec 'node -r ts-node/register --inspect=0.0.0.0:9229 src/run.ts'",
@@ -72,7 +73,8 @@
     "pg": "^8.7.3",
     "prom-client": "^14.0.1",
     "reflect-metadata": "~0.1.13",
-    "ts-log": "^2.2.4"
+    "ts-log": "^2.2.4",
+    "json-bigint": "^1.0.0"
   },
   "files": [
     "dist/*",

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
@@ -1,0 +1,45 @@
+import { DbSyncProvider } from '../../DbSyncProvider';
+import { GenesisData } from './types';
+import { Logger, dummyLogger } from 'ts-log';
+import { NetworkInfo, NetworkInfoProvider, timeSettingsConfig } from '@cardano-sdk/core';
+import { NetworkInfoBuilder } from './NetworkInfoBuilder';
+import { Pool } from 'pg';
+import { loadGenesisData, toNetworkInfo } from './mappers';
+
+export class DbSyncNetworkInfoProvider extends DbSyncProvider implements NetworkInfoProvider {
+  #logger: Logger;
+  #builder: NetworkInfoBuilder;
+  #genesisDataReady: Promise<GenesisData>;
+
+  constructor(cardanoNodeConfigPath: string, db: Pool, logger = dummyLogger) {
+    super(db);
+    this.#logger = logger;
+    this.#builder = new NetworkInfoBuilder(db, logger);
+    this.#genesisDataReady = loadGenesisData(cardanoNodeConfigPath);
+  }
+
+  public async networkInfo(): Promise<NetworkInfo> {
+    const { networkMagic, networkId, maxLovelaceSupply } = await this.#genesisDataReady;
+    const timeSettings = timeSettingsConfig[networkMagic];
+
+    this.#logger.debug('About to query network info data');
+
+    const [totalSupply, circulatingSupply, activeStake, liveStake] = await Promise.all([
+      this.#builder.queryTotalSupply(maxLovelaceSupply),
+      this.#builder.queryCirculatingSupply(),
+      this.#builder.queryActiveStake(),
+      this.#builder.queryLiveStake()
+    ]);
+
+    return toNetworkInfo({
+      activeStake,
+      circulatingSupply,
+      liveStake,
+      maxLovelaceSupply,
+      networkId,
+      networkMagic,
+      timeSettings,
+      totalSupply
+    });
+  }
+}

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
@@ -1,0 +1,37 @@
+import { ActiveStakeModel, CirculatingSupplyModel, LiveStakeModel, TotalSupplyModel } from './types';
+import { Cardano } from '@cardano-sdk/core';
+import { Logger, dummyLogger } from 'ts-log';
+import { Pool, QueryResult } from 'pg';
+import Queries from './queries';
+
+export class NetworkInfoBuilder {
+  #db: Pool;
+  #logger: Logger;
+  constructor(db: Pool, logger = dummyLogger) {
+    this.#db = db;
+    this.#logger = logger;
+  }
+
+  public async queryCirculatingSupply() {
+    this.#logger.debug('About to query circulation supply');
+    const result: QueryResult<CirculatingSupplyModel> = await this.#db.query(Queries.findCirculatingSupply);
+    return result.rows[0].circulating_supply;
+  }
+
+  public async queryTotalSupply(maxLovelaceSupply: Cardano.Lovelace) {
+    this.#logger.debug('About to query total supply');
+    const result: QueryResult<TotalSupplyModel> = await this.#db.query(Queries.findTotalSupply, [maxLovelaceSupply]);
+    return result.rows[0].total_supply;
+  }
+  public async queryLiveStake() {
+    this.#logger.debug('About to query live stake');
+    const result: QueryResult<LiveStakeModel> = await this.#db.query(Queries.findLiveStake);
+    return result.rows[0].live_stake;
+  }
+
+  public async queryActiveStake() {
+    this.#logger.debug('About to query active stake');
+    const result: QueryResult<ActiveStakeModel> = await this.#db.query(Queries.findActiveStake);
+    return result.rows[0].active_stake;
+  }
+}

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/index.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './DbSyncNetworkInfoProvider';

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -1,0 +1,63 @@
+import { Cardano, NetworkInfo, ProviderError, ProviderFailure, TimeSettings } from '@cardano-sdk/core';
+import { GenesisData } from './types';
+import JSONbig from 'json-bigint';
+import fs from 'fs';
+import path from 'path';
+
+interface ToNetworkInfoInput {
+  networkMagic: Cardano.NetworkMagic;
+  networkId: Cardano.CardanoNetworkId;
+  timeSettings: TimeSettings[];
+  maxLovelaceSupply: Cardano.Lovelace;
+  circulatingSupply: string;
+  totalSupply: string;
+  activeStake: string;
+  liveStake: string;
+}
+
+export const networkIdMap = {
+  Mainnet: Cardano.NetworkId.mainnet,
+  Testnet: Cardano.NetworkId.testnet
+};
+
+export const toNetworkInfo = ({
+  networkId,
+  networkMagic,
+  timeSettings,
+  circulatingSupply,
+  maxLovelaceSupply,
+  totalSupply,
+  activeStake,
+  liveStake
+}: ToNetworkInfoInput): NetworkInfo => ({
+  lovelaceSupply: {
+    circulating: BigInt(circulatingSupply),
+    max: maxLovelaceSupply,
+    total: BigInt(totalSupply)
+  },
+  network: {
+    id: networkIdMap[networkId],
+    magic: networkMagic,
+    timeSettings
+  },
+  stake: {
+    active: BigInt(activeStake),
+    live: BigInt(liveStake)
+  }
+});
+
+export const loadGenesisData = async (cardanoNodeConfigPath: string): Promise<GenesisData> => {
+  try {
+    const genesisFilePath = require(path.resolve(cardanoNodeConfigPath)).ShelleyGenesisFile;
+    const genesis = JSONbig({ useNativeBigInt: true }).parse(
+      fs.readFileSync(path.resolve(path.dirname(cardanoNodeConfigPath), genesisFilePath), 'utf-8')
+    );
+    return {
+      maxLovelaceSupply: genesis.maxLovelaceSupply,
+      networkId: genesis.networkId,
+      networkMagic: genesis.networkMagic
+    };
+  } catch (error) {
+    throw new ProviderError(ProviderFailure.Unhealthy, error);
+  }
+};

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -1,0 +1,78 @@
+export const findCirculatingSupply = `
+    WITH total_rewards AS (
+        SELECT COALESCE(SUM(amount), 0) as rewards_amount
+        FROM reward
+    ),
+    total_withdrawals AS (
+        SELECT COALESCE(SUM(amount), 0) as withdrawals_amount
+        FROM withdrawal
+    ),
+    total_utxo AS (
+        SELECT COALESCE(SUM(value)) AS utxo_amount
+        FROM tx_out AS tx_outer WHERE
+        NOT exists
+            ( SELECT tx_out.id
+        FROM tx_out
+        JOIN tx_in on
+        tx_out.tx_id = tx_in.tx_out_id AND
+        tx_out.index = tx_in.tx_out_index
+        WHERE tx_outer.id = tx_out.id)
+    )
+    SELECT CAST(utxo_amount + (rewards_amount - withdrawals_amount) AS BIGINT) as circulating_supply
+    FROM total_rewards, total_withdrawals, total_utxo
+`;
+
+export const findTotalSupply = `
+    WITH total_reserves AS (
+        SELECT CAST(COALESCE(SUM(reserves),0) AS BIGINT) as reserves_amount
+        FROM ada_pots
+            WHERE ada_pots.epoch_no = (
+            SELECT no FROM epoch
+            ORDER BY id DESC 
+            LIMIT 1
+        )
+    )
+
+    SELECT CAST($1 - reserves_amount AS BIGINT) as total_supply
+    FROM total_reserves   
+`;
+
+// Live stake is the current epoch’s delegated stake that has yet to be snapshotted
+export const findLiveStake = `
+    WITH current_delegation AS (
+        SELECT DISTINCT ON (delegation.addr_id) delegation.addr_id,
+    delegation.pool_hash_id
+    FROM delegation
+    ORDER BY delegation.addr_id, delegation.slot_no DESC, delegation.pool_hash_id 
+    )
+
+    SELECT CAST(COALESCE(SUM(tx_out.value), 0) AS BIGINT) AS live_stake
+    FROM tx_out 
+    LEFT JOIN tx_in ON tx_out.tx_id = tx_in.tx_out_id AND tx_out.index::smallint = tx_in.tx_out_index::smallint
+    LEFT JOIN current_delegation ON current_delegation.addr_id = tx_out.stake_address_id 
+    LEFT JOIN stake_address ON stake_address.id = current_delegation.addr_id 
+
+    WHERE 
+        tx_in.tx_in_id IS NULL
+`;
+
+// Active stake is the stake snapshot from n-1 epochs, where n = current epoch
+// epoch_stake contains records of completed epochs
+export const findActiveStake = `
+    SELECT CAST(COALESCE(SUM(amount), 0) AS BIGINT) as active_stake
+    FROM epoch_stake
+    WHERE epoch_stake.epoch_no = (
+    SELECT no FROM epoch
+        ORDER BY no DESC
+        LIMIT 1
+    )
+`;
+
+const Queries = {
+  findActiveStake,
+  findCirculatingSupply,
+  findLiveStake,
+  findTotalSupply
+};
+
+export default Queries;

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
@@ -1,0 +1,23 @@
+import { Cardano } from '@cardano-sdk/core';
+
+export interface CirculatingSupplyModel {
+  circulating_supply: string;
+}
+
+export interface TotalSupplyModel {
+  total_supply: string;
+}
+
+export interface ActiveStakeModel {
+  active_stake: string;
+}
+
+export interface LiveStakeModel {
+  live_stake: string;
+}
+
+export interface GenesisData {
+  networkMagic: Cardano.CardanoNetworkMagic;
+  networkId: Cardano.CardanoNetworkId;
+  maxLovelaceSupply: Cardano.Lovelace;
+}

--- a/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
+++ b/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
@@ -1,0 +1,50 @@
+import * as OpenApiValidator from 'express-openapi-validator';
+import { DbSyncNetworkInfoProvider } from './DbSyncNetworkInfoProvider';
+import { HttpService } from '../Http';
+import { Logger, dummyLogger } from 'ts-log';
+import { ServiceNames } from '../Program';
+import { providerHandler } from '../util';
+import express from 'express';
+import path from 'path';
+
+export interface NetworkInfoServiceDependencies {
+  logger?: Logger;
+  networkInfoProvider: DbSyncNetworkInfoProvider;
+}
+
+export class NetworkInfoHttpService extends HttpService {
+  #networkInfoProvider: DbSyncNetworkInfoProvider;
+
+  private constructor(
+    { networkInfoProvider, logger = dummyLogger }: NetworkInfoServiceDependencies,
+    router: express.Router
+  ) {
+    super(ServiceNames.NetworkInfo, router, logger);
+    this.#networkInfoProvider = networkInfoProvider;
+  }
+
+  async healthCheck() {
+    return this.#networkInfoProvider.healthCheck();
+  }
+
+  static create({ logger = dummyLogger, networkInfoProvider }: NetworkInfoServiceDependencies) {
+    const router = express.Router();
+    const apiSpec = path.join(__dirname, 'openApi.json');
+    router.use(
+      OpenApiValidator.middleware({
+        apiSpec,
+        ignoreUndocumented: true,
+        validateRequests: true,
+        validateResponses: true
+      })
+    );
+    router.post(
+      '/network',
+      providerHandler(networkInfoProvider.networkInfo.bind(networkInfoProvider))(
+        HttpService.routeHandler(logger),
+        logger
+      )
+    );
+    return new NetworkInfoHttpService({ logger, networkInfoProvider }, router);
+  }
+}

--- a/packages/cardano-services/src/NetworkInfo/index.ts
+++ b/packages/cardano-services/src/NetworkInfo/index.ts
@@ -1,0 +1,2 @@
+export * from './DbSyncNetworkInfoProvider';
+export * from './NetworkInfoHttpService';

--- a/packages/cardano-services/src/NetworkInfo/openApi.json
+++ b/packages/cardano-services/src/NetworkInfo/openApi.json
@@ -1,0 +1,179 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Network Info",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/network-info/network": {
+      "post": {
+        "summary": "fetch network info",
+        "description": "Fetch Network Info",
+        "operationId": "networkInfo",
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "network info fetched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NetworkInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid request"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Network": {
+        "required": [
+          "id",
+          "magic",
+          "timeSettings"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number",
+            "example": 1
+          },
+          "magic": {
+            "type": "number",
+            "example": 24
+          },
+          "timeSettings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimeSettings"
+            }
+          }
+        }
+      },
+      "Stake": {
+        "required": [
+          "active",
+          "live"
+        ],
+        "type": "object",
+        "properties": {
+          "live": {
+            "$ref": "#/components/schemas/BigInt"
+          },
+          "active": {
+            "$ref": "#/components/schemas/BigInt"
+          }
+        }
+      },
+      "LovelaceSupply": {
+        "required": [
+          "circulating",
+          "max",
+          "total"
+        ],
+        "type": "object",
+        "properties": {
+          "circulating": {
+            "$ref": "#/components/schemas/BigInt"
+          },
+          "max": {
+            "$ref": "#/components/schemas/BigInt"
+          },
+          "total": {
+            "$ref": "#/components/schemas/BigInt"
+          }
+        }
+      },
+      "TimeSettings": {
+        "required": [
+          "epochLength",
+          "fromSlotDate",
+          "fromSlotNo",
+          "slotLength"
+        ],
+        "type": "object",
+        "properties": {
+          "epochLength": {
+            "type": "number",
+            "example": 21600
+          },
+          "fromSlotDate": {
+            "$ref": "#/components/schemas/Date"
+          },
+          "fromSlotNo": {
+            "type": "number",
+            "example": 1200
+          },
+          "slotLength": {
+            "type": "number",
+            "example": 1000
+          }
+        }
+      },
+      "Date": {
+        "required": [
+          "__type",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "number"
+          },
+          "__type": {
+            "type": "string",
+            "enum": [
+              "Date"
+            ]
+          }
+        }
+      },
+      "BigInt": {
+        "required": [
+          "__type",
+          "value"
+        ],
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "example": "112233445566778899"
+          },
+          "__type": {
+            "type": "string",
+            "enum": [
+              "bigint"
+            ]
+          }
+        }
+      },
+      "NetworkInfoResponse": {
+        "type": "object",
+        "properties": {
+          "network": {
+            "$ref": "#/components/schemas/Network"
+          },
+          "stake": {
+            "$ref": "#/components/schemas/Stake"
+          },
+          "lovelaceSupply": {
+            "$ref": "#/components/schemas/LovelaceSupply"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
+++ b/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
@@ -4,7 +4,10 @@ enum HttpServerOptionDescriptions {
   ApiUrl = 'API URL',
   DbConnection = 'DB Connection',
   MetricsEnabled = 'Enable Prometheus Metrics',
-  UseQueue = 'Enables RabbitMQ'
+  OgmiosUrl = 'Ogmios URL',
+  RabbitMQUrl = 'RabbitMQ URL',
+  UseQueue = 'Enables RabbitMQ',
+  CardanoNodeConfigPath = 'Cardano node config path'
 }
 
 export type ProgramOptionDescriptions = CommonOptionDescriptions | HttpServerOptionDescriptions;

--- a/packages/cardano-services/src/Program/ServiceNames.ts
+++ b/packages/cardano-services/src/Program/ServiceNames.ts
@@ -4,6 +4,7 @@
  */
 export enum ServiceNames {
   StakePool = 'stake-pool',
+  NetworkInfo = 'network-info',
   TxSubmit = 'tx-submit',
   Utxo = 'utxo',
   ChainHistory = 'chain-history'

--- a/packages/cardano-services/src/Program/loadHttpServer.ts
+++ b/packages/cardano-services/src/Program/loadHttpServer.ts
@@ -2,6 +2,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider } from '../ChainHistory';
 import { CommonProgramOptions } from '../ProgramsCommon';
+import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../NetworkInfo';
 import { DbSyncStakePoolProvider, StakePoolHttpService } from '../StakePool';
 import { DbSyncUtxoProvider, UtxoHttpService } from '../Utxo';
 import { HttpServer, HttpServerConfig, HttpService } from '../Http';
@@ -11,20 +12,71 @@ import { ProgramOptionDescriptions } from './ProgramOptionDescriptions';
 import { RabbitMqTxSubmitProvider } from '@cardano-sdk/rabbitmq';
 import { ServiceNames } from './ServiceNames';
 import { TxSubmitHttpService } from '../TxSubmit';
-import { createLogger } from 'bunyan';
 import { ogmiosTxSubmitProvider, urlToConnectionConfig } from '@cardano-sdk/ogmios';
+import Logger, { createLogger } from 'bunyan';
 
 export interface HttpServerOptions extends CommonProgramOptions {
   dbConnectionString?: string;
+  cardanoNodeConfigPath?: string;
   metricsEnabled?: boolean;
   useQueue?: boolean;
 }
 
 export interface ProgramArgs {
   apiUrl: URL;
-  serviceNames: (ServiceNames.StakePool | ServiceNames.TxSubmit | ServiceNames.ChainHistory | ServiceNames.Utxo)[];
+  serviceNames: (
+    | ServiceNames.StakePool
+    | ServiceNames.TxSubmit
+    | ServiceNames.ChainHistory
+    | ServiceNames.Utxo
+    | ServiceNames.NetworkInfo
+  )[];
   options?: HttpServerOptions;
 }
+
+const serviceMapFactory = (args: ProgramArgs, logger: Logger, db?: Pool) => ({
+  [ServiceNames.StakePool]: async () => {
+    if (!db) throw new MissingProgramOption(ServiceNames.StakePool, ProgramOptionDescriptions.DbConnection);
+    return await StakePoolHttpService.create({
+      logger,
+      stakePoolProvider: new DbSyncStakePoolProvider(db, logger)
+    });
+  },
+  [ServiceNames.Utxo]: async () => {
+    if (!db) throw new MissingProgramOption(ServiceNames.Utxo, ProgramOptionDescriptions.DbConnection);
+
+    return await UtxoHttpService.create({
+      logger,
+      utxoProvider: new DbSyncUtxoProvider(db, logger)
+    });
+  },
+  [ServiceNames.ChainHistory]: async () => {
+    if (!db) throw new MissingProgramOption(ServiceNames.ChainHistory, ProgramOptionDescriptions.DbConnection);
+
+    return await ChainHistoryHttpService.create({
+      chainHistoryProvider: new DbSyncChainHistoryProvider(db, logger),
+      logger
+    });
+  },
+  [ServiceNames.NetworkInfo]: async () => {
+    if (!db) throw new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.DbConnection);
+    if (args.options?.cardanoNodeConfigPath === undefined)
+      throw new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.CardanoNodeConfigPath);
+
+    return await NetworkInfoHttpService.create({
+      logger,
+      networkInfoProvider: new DbSyncNetworkInfoProvider(args.options?.cardanoNodeConfigPath, db, logger)
+    });
+  },
+  [ServiceNames.TxSubmit]: async () =>
+    await TxSubmitHttpService.create({
+      logger,
+      txSubmitProvider:
+        args.options?.useQueue && args.options?.rabbitmqUrl
+          ? new RabbitMqTxSubmitProvider(args.options.rabbitmqUrl)
+          : ogmiosTxSubmitProvider(urlToConnectionConfig(args.options?.ogmiosUrl))
+    })
+});
 
 export const loadHttpServer = async (args: ProgramArgs): Promise<HttpServer> => {
   const services: HttpService[] = [];
@@ -37,50 +89,16 @@ export const loadHttpServer = async (args: ProgramArgs): Promise<HttpServer> => 
     ? new Pool({ connectionString: args.options.dbConnectionString })
     : undefined;
 
+  const serviceMap = serviceMapFactory(args, logger, db);
+
   for (const serviceName of args.serviceNames) {
-    switch (serviceName) {
-      case ServiceNames.StakePool:
-        if (!db) throw new MissingProgramOption(ServiceNames.StakePool, ProgramOptionDescriptions.DbConnection);
-        services.push(
-          StakePoolHttpService.create({
-            logger,
-            stakePoolProvider: new DbSyncStakePoolProvider(db, logger)
-          })
-        );
-        break;
-      case ServiceNames.TxSubmit:
-        services.push(
-          await TxSubmitHttpService.create({
-            logger,
-            txSubmitProvider:
-              args.options?.useQueue && args.options?.rabbitmqUrl
-                ? new RabbitMqTxSubmitProvider(args.options.rabbitmqUrl)
-                : ogmiosTxSubmitProvider(urlToConnectionConfig(args.options?.ogmiosUrl))
-          })
-        );
-        break;
-      case ServiceNames.ChainHistory:
-        if (!db) throw new MissingProgramOption(ServiceNames.ChainHistory, ProgramOptionDescriptions.DbConnection);
-        services.push(
-          await ChainHistoryHttpService.create({
-            chainHistoryProvider: new DbSyncChainHistoryProvider(db, logger),
-            logger
-          })
-        );
-        break;
-      case ServiceNames.Utxo:
-        if (!db) throw new MissingProgramOption(ServiceNames.Utxo, ProgramOptionDescriptions.DbConnection);
-        services.push(
-          await UtxoHttpService.create({
-            logger,
-            utxoProvider: new DbSyncUtxoProvider(db, logger)
-          })
-        );
-        break;
-      default:
-        throw new UnknownServiceName(serviceName);
+    if (serviceMap[serviceName]) {
+      services.push(await serviceMap[serviceName]());
+    } else {
+      throw new UnknownServiceName(serviceName);
     }
   }
+
   const config: HttpServerConfig = {
     listen: {
       host: args.apiUrl.hostname,

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -73,6 +73,7 @@ commonOptions(
   .option('--db-connection-string <dbConnectionString>', ProgramOptionDescriptions.DbConnection, (url) =>
     new URL(url).toString()
   )
+  .option('--cardano-node-config-path <cardanoNodeConfigPath>', ProgramOptionDescriptions.CardanoNodeConfigPath)
   .option('--use-queue', ProgramOptionDescriptions.UseQueue, () => true, false)
   .action(async (serviceNames: ServiceNames[], options: { apiUrl: URL } & HttpServerOptions) => {
     const { apiUrl, ...rest } = options;

--- a/packages/cardano-services/src/run.ts
+++ b/packages/cardano-services/src/run.ts
@@ -11,6 +11,7 @@ import onDeath from 'death';
 
 const envSpecs = {
   API_URL: envalid.url({ default: API_URL_DEFAULT }),
+  CARDANO_NODE_CONFIG_PATH: envalid.str({ default: undefined }),
   DB_CONNECTION_STRING: envalid.str({ default: undefined }),
   LOGGER_MIN_SEVERITY: envalid.str({ choices: loggerMethodNames as string[], default: 'info' }),
   OGMIOS_URL: envalid.url({ default: OGMIOS_URL_DEFAULT }),
@@ -25,6 +26,7 @@ void (async () => {
   const apiUrl = new URL(env.API_URL);
   const ogmiosUrl = new URL(env.OGMIOS_URL);
   const rabbitmqUrl = new URL(env.RABBITMQ_URL);
+  const cardanoNodeConfigPath = env.CARDANO_NODE_CONFIG_PATH;
   const dbConnectionString = env.DB_CONNECTION_STRING ? new URL(env.DB_CONNECTION_STRING).toString() : undefined;
   const serviceNames = env.SERVICE_NAMES.split(',') as ServiceNames[];
 
@@ -32,6 +34,7 @@ void (async () => {
     const server = await loadHttpServer({
       apiUrl,
       options: {
+        cardanoNodeConfigPath,
         dbConnectionString,
         loggerMinSeverity: env.LOGGER_MIN_SEVERITY as LogLevel,
         ogmiosUrl,

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/ChainHistoryBuilder.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/ChainHistoryBuilder.test.ts
@@ -83,7 +83,7 @@ describe('ChainHistoryBuilder', () => {
 
   describe('queryMultiAssetsByTxOut', () => {
     test('query multi assets by tx output', async () => {
-      const result = await builder.queryMultiAssetsByTxOut([5_396_853n, 5_396_911n, 5_396_912n]);
+      const result = await builder.queryMultiAssetsByTxOut([5_129_575n, 5_129_595n, 5_129_550n]);
       expect(result.size).toEqual(3);
       expect(result).toMatchSnapshot();
     });

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/__snapshots__/ChainHistoryBuilder.test.ts.snap
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/__snapshots__/ChainHistoryBuilder.test.ts.snap
@@ -70,17 +70,14 @@ Map {
 
 exports[`ChainHistoryBuilder queryMultiAssetsByTxOut query multi assets by tx output 1`] = `
 Map {
-  "5396853" => Map {
+  "5129550" => Map {
     "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43" => 10000000n,
     "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54" => 5000000000n,
     "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259" => 1000000000n,
-    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 2000000000n,
+    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 1828882901n,
     "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c" => 15000000n,
   },
-  "5396911" => Map {
-    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 10000000n,
-  },
-  "5396912" => Map {
+  "5129575" => Map {
     "22be35160908d953c25b30d1ad59876cbf073a8b31ef7a4f77468355414141" => 4208n,
     "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54" => 1914111968n,
     "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259" => 1000000000n,
@@ -90,15 +87,22 @@ Map {
     "d311d3488cc4fef19d05634adce8534977a3bc6fc18136ad65df1d4f6c71202e01" => 100000000n,
     "d311d3488cc4fef19d05634adce8534977a3bc6fc18136ad65df1d4f6c712038" => 172696733n,
   },
+  "5129595" => Map {
+    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43" => 10000000n,
+    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54" => 4865509476n,
+    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259" => 1000000000n,
+    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 2000000000n,
+    "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c" => 15000000n,
+  },
 }
 `;
 
 exports[`ChainHistoryBuilder queryProtocolParams query protocol parameters from last epoch 1`] = `
 Object {
   "coinsPerUtxoWord": NaN,
-  "maxCollateralInputs": 1,
+  "maxCollateralInputs": 3,
   "maxTxSize": 16384,
-  "maxValueSize": 1000,
+  "maxValueSize": 5000,
   "minFeeCoefficient": 44,
   "minFeeConstant": 155381,
   "minPoolCost": 340000000,

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Cardano, NetworkInfo, NetworkInfoProvider, testnetTimeSettings } from '@cardano-sdk/core';
+import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../src/NetworkInfo';
+import { HttpServer, HttpServerConfig } from '../../src';
+import { Pool } from 'pg';
+import { getPort } from 'get-port-please';
+import { networkInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
+import axios from 'axios';
+
+const UNSUPPORTED_MEDIA_STRING = 'Request failed with status code 415';
+const APPLICATION_CBOR = 'application/cbor';
+const APPLICATION_JSON = 'application/json';
+
+describe('NetworkInfoHttpService', () => {
+  let dbConnection: Pool;
+  let httpServer: HttpServer;
+  let networkInfoProvider: DbSyncNetworkInfoProvider;
+  let service: NetworkInfoHttpService;
+  let port: number;
+  let apiUrlBase: string;
+  let config: HttpServerConfig;
+  let cardanoNodeConfigPath: string;
+
+  beforeAll(async () => {
+    port = await getPort();
+    config = { listen: { port } };
+    apiUrlBase = `http://localhost:${port}/network-info`;
+    cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
+    dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+  });
+
+  describe('healthy state', () => {
+    beforeAll(async () => {
+      networkInfoProvider = new DbSyncNetworkInfoProvider(cardanoNodeConfigPath, dbConnection);
+      service = NetworkInfoHttpService.create({ networkInfoProvider });
+      httpServer = new HttpServer(config, { services: [service] });
+      await httpServer.initialize();
+      await httpServer.start();
+    });
+
+    afterAll(async () => {
+      await dbConnection.end();
+      await httpServer.shutdown();
+    });
+
+    describe('/health', () => {
+      it('forwards the networkInfoProvider health response', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+
+    describe('/network', () => {
+      it('returns a 200 coded response with a well formed HTTP request', async () => {
+        expect((await axios.post(`${apiUrlBase}/network`, { args: [] })).status).toEqual(200);
+      });
+
+      it('returns a 415 coded response if the wrong content type header is used', async () => {
+        try {
+          await axios.post(`${apiUrlBase}/network`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+        } catch (error: any) {
+          expect(error.response.status).toBe(415);
+          expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+        }
+      });
+
+      describe('with NetworkInfoHttpProvider', () => {
+        let provider: NetworkInfoProvider;
+        beforeEach(() => {
+          provider = networkInfoHttpProvider(apiUrlBase);
+        });
+
+        it('time settings response is an array of network info response', async () => {
+          const testnetNetworkInfo: NetworkInfo['network'] = {
+            id: Cardano.NetworkId.testnet,
+            magic: Cardano.CardanoNetworkMagic.Testnet,
+            timeSettings: testnetTimeSettings
+          };
+
+          const response = await provider.networkInfo();
+          expect(response.network).toEqual(testnetNetworkInfo);
+        });
+
+        it('response is an object of network info', async () => {
+          const response = await provider.networkInfo();
+          expect(response).toMatchSnapshot();
+        });
+      });
+    });
+  });
+});

--- a/packages/cardano-services/test/NetworkInfo/__snapshots__/NetworkInfoHttpService.test.ts.snap
+++ b/packages/cardano-services/test/NetworkInfo/__snapshots__/NetworkInfoHttpService.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "lovelaceSupply": Object {
     "circulating": 69163989759711432n,
     "max": 45000000000000000n,
-    "total": 45000000000000000n,
+    "total": 40342337171803411n,
   },
   "network": Object {
     "id": 0,

--- a/packages/cardano-services/test/NetworkInfo/__snapshots__/NetworkInfoHttpService.test.ts.snap
+++ b/packages/cardano-services/test/NetworkInfo/__snapshots__/NetworkInfoHttpService.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NetworkInfoHttpService healthy state /network with NetworkInfoHttpProvider response is an object of network info 1`] = `
+Object {
+  "lovelaceSupply": Object {
+    "circulating": 69163989759711432n,
+    "max": 45000000000000000n,
+    "total": 45000000000000000n,
+  },
+  "network": Object {
+    "id": 0,
+    "magic": 1097911063,
+    "timeSettings": Array [
+      Object {
+        "epochLength": 21600,
+        "fromSlotDate": 2019-07-24T20:20:16.000Z,
+        "fromSlotNo": 0,
+        "slotLength": 20000,
+      },
+      Object {
+        "epochLength": 432000,
+        "fromSlotDate": 2020-07-28T19:20:16.000Z,
+        "fromSlotNo": 1598400,
+        "slotLength": 1000,
+      },
+    ],
+  },
+  "stake": Object {
+    "active": 14977960053990832n,
+    "live": 69154425288708824n,
+  },
+}
+`;

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
@@ -107,7 +107,7 @@ describe('StakePoolBuilder', () => {
       expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
       expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
-      expect(poolHashes).toHaveLength(1);
+      expect(poolHashes).toHaveLength(0);
     });
     it('active', async () => {
       const activeStatus = [Cardano.StakePoolStatus.Active];
@@ -121,7 +121,7 @@ describe('StakePoolBuilder', () => {
       expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
       expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
-      expect(poolHashes).toHaveLength(6);
+      expect(poolHashes).toHaveLength(7);
     });
     it('retiring', async () => {
       const retiringStatus = [Cardano.StakePoolStatus.Retiring];
@@ -135,7 +135,7 @@ describe('StakePoolBuilder', () => {
       expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
       expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
-      expect(poolHashes).toHaveLength(1);
+      expect(poolHashes).toHaveLength(0);
     });
     it('retired', async () => {
       const retiredStatus = [Cardano.StakePoolStatus.Retired];
@@ -149,7 +149,7 @@ describe('StakePoolBuilder', () => {
       expect(buildPoolsByStatusQuerySpy).toHaveBeenCalledTimes(2);
       expect(buildPoolsByStatusQuerySpy).toHaveReturnedWith(poolsByStatusQuery);
       expect(poolsByStatusQuery).toMatchSnapshot();
-      expect(poolHashes).toHaveLength(1);
+      expect(poolHashes).toHaveLength(2);
     });
     it('active,activating,retiring,retired', async () => {
       const poolStatus = Object.values(Cardano.StakePoolStatus);

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -807,7 +807,7 @@ Object {
 }
 `;
 
-exports[`StakePoolBuilder getLastEpoch getLastEpoch 1`] = `175`;
+exports[`StakePoolBuilder getLastEpoch getLastEpoch 1`] = `183`;
 
 exports[`StakePoolBuilder getTotalAmountOfAda getTotalAmountOfAda 1`] = `"69154425288708824"`;
 
@@ -877,8 +877,8 @@ exports[`StakePoolBuilder queryPoolRewards queryPoolRewards 1`] = `
 Array [
   Object {
     "activeStake": 0n,
-    "epoch": 175,
-    "epochLength": 431949000,
+    "epoch": 183,
+    "epochLength": 431910000,
     "memberROI": 0,
     "operatorFees": 0n,
     "totalRewards": 0n,

--- a/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
@@ -12,10 +12,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -50,15 +50,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -102,10 +102,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -140,15 +140,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -184,10 +184,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -222,15 +222,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -265,10 +265,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -303,15 +303,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -346,10 +346,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -384,15 +384,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -435,10 +435,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -473,15 +473,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -519,8 +519,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -601,10 +601,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -639,15 +639,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -664,7 +664,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -678,16 +678,97 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
+      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "advanced staking",
+        "homepage": "https://nedscave.io",
+        "name": "NEDSCAVE.IO",
+        "ticker": "NEDST",
+      },
+      "metadataJson": Object {
+        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
+        "url": "https://nedscave.io/nedstmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "0",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1099603790",
+        },
+        "saturation": "0.000072460074956593695520",
+        "size": Object {
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -722,15 +803,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -765,10 +846,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -803,15 +884,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -846,10 +927,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -884,15 +965,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -929,8 +1010,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -994,7 +1075,7 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
   ],
-  "totalResultCount": 7,
+  "totalResultCount": 8,
 }
 `;
 
@@ -1017,10 +1098,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1055,15 +1136,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -1099,10 +1180,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1137,15 +1218,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -1162,7 +1243,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -1176,79 +1257,16 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [],
-      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
-      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "advanced staking",
-        "homepage": "https://nedscave.io",
-        "name": "NEDSCAVE.IO",
-        "ticker": "NEDST",
-      },
-      "metadataJson": Object {
-        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
-        "url": "https://nedscave.io/nedstmeta.json",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
-        "saturation": "0.000000000000000000000000000000000000",
-        "size": Object {
-          "active": "0",
-          "live": "0",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
-      "transactions": Object {
-        "registration": Array [
-          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1283,15 +1301,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -1326,10 +1344,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1364,15 +1382,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -1407,10 +1425,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1445,15 +1463,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -1480,7 +1498,7 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
   ],
-  "totalResultCount": 6,
+  "totalResultCount": 5,
 }
 `;
 
@@ -1496,10 +1514,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1534,15 +1552,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -1577,10 +1595,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1615,15 +1633,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -1673,10 +1691,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1711,15 +1729,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -1755,10 +1773,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1793,15 +1811,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -1818,7 +1836,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -1838,10 +1856,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1876,15 +1894,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -1919,10 +1937,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -1957,15 +1975,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -2000,10 +2018,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2038,15 +2056,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -2083,8 +2101,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2173,10 +2191,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2211,15 +2229,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -2255,10 +2273,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2293,15 +2311,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -2318,7 +2336,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -2338,10 +2356,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2376,15 +2394,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -2419,10 +2437,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2457,15 +2475,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -2500,10 +2518,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2538,15 +2556,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -2589,10 +2607,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2627,15 +2645,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -2673,8 +2691,588 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
+      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Big Dragon Farts",
+        "homepage": "https://example.com",
+        "name": "Farts",
+        "ticker": "TINY",
+      },
+      "metadataJson": Object {
+        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
+        "url": "https://tinyurl.com/biggerfarts",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1988240000",
+        },
+        "saturation": "0.000003593840870810890678",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "497060000",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
+          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
+          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
+          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
+      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "advanced staking",
+        "homepage": "https://nedscave.io",
+        "name": "NEDSCAVE.IO",
+        "ticker": "NEDST",
+      },
+      "metadataJson": Object {
+        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
+        "url": "https://nedscave.io/nedstmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "0",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1099603790",
+        },
+        "saturation": "0.000072460074956593695520",
+        "size": Object {
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "400000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "2499703578",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
+      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
+      "margin": Object {
+        "denominator": 10000,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Our Amsterdam Node",
+        "homepage": "https://twitter.com/A92Syed",
+        "name": "THE AMSTERDAM NODE",
+        "ticker": "AMS",
+      },
+      "metadataJson": Object {
+        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
+        "url": "https://git.io/JJ1dz",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "487464117",
+        },
+        "saturation": "0.000021597805798609747488",
+        "size": Object {
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "2499703578",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "487464117",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "500000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "4321000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "1296866803",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
+      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
+      "margin": Object {
+        "denominator": 25,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "The pool that tests all the pools",
+        "homepage": "https://teststakepool.com",
+        "name": "TestPool",
+        "ticker": "TEST",
+      },
+      "metadataJson": Object {
+        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
+        "url": "https://git.io/JJyYy",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "199806239",
+        },
+        "saturation": "0.000010821238378828440746",
+        "size": Object {
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "1296866803",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "199806239",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "70000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "795289068",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
+      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
+      "margin": Object {
+        "denominator": 1000,
+        "numerator": 27,
+      },
+      "metadata": Object {
+        "description": "Pool a of the banderini devtest staking pools",
+        "homepage": "http://www.banderini.net",
+        "name": "banderini-devtest-a",
+        "ticker": "BANDA",
+      },
+      "metadataJson": Object {
+        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
+        "url": "https://git.io/JJ7wm",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "495463149",
+        },
+        "saturation": "0.000009332390599815651490",
+        "size": Object {
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "795289068",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "495463149",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "100000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
+      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
+      "margin": Object {
+        "denominator": 40,
+        "numerator": 3,
+      },
+      "metadataJson": Object {
+        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
+        "url": "https://visionstaking.ch/poolmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "997623150",
+        },
+        "saturation": "0.000007213010200251687547",
+        "size": Object {
+          "active": "0.0000000000000000000000000000",
+          "live": "1.00000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "997623150",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
+    },
+  ],
+  "totalResultCount": 7,
+}
+`;
+
+exports[`StakePoolHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status activating, and condition 1`] = `
+Object {
+  "pageResults": Array [],
+  "totalResultCount": 0,
+}
+`;
+
+exports[`StakePoolHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status activating, or condition 1`] = `
+Object {
+  "pageResults": Array [
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "50147015265584",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
+      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
+      "margin": Object {
+        "denominator": 20,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "What's past is prologue",
+        "homepage": "https://clio.one",
+        "name": "CLIO1",
+        "ticker": "CLIO1",
+      },
+      "metadataJson": Object {
+        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
+        "url": "https://clio.one/metadata/clio1_testnet.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "22615260846603",
+        },
+        "saturation": "0.44434044853455135587",
+        "size": Object {
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "50147015265584",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "11309201436284",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "1010000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
+          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2755,10 +3353,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2793,15 +3391,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -2836,10 +3434,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2874,15 +3472,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -2917,10 +3515,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2955,15 +3553,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -3000,8 +3598,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -3069,568 +3667,6 @@ Object {
 }
 `;
 
-exports[`StakePoolHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status activating, and condition 1`] = `
-Object {
-  "pageResults": Array [],
-  "totalResultCount": 0,
-}
-`;
-
-exports[`StakePoolHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status activating, or condition 1`] = `
-Object {
-  "pageResults": Array [
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
-      "id": "pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70",
-      "margin": Object {
-        "denominator": 20,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "What's past is prologue",
-        "homepage": "https://clio.one",
-        "name": "CLIO1",
-        "ticker": "CLIO1",
-      },
-      "metadataJson": Object {
-        "hash": "47530ba97c12e2ac40462e9c86eeb07ea555877d2a1f9d74b6ff8471839267d8",
-        "url": "https://clio.one/metadata/clio1_testnet.json",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22615260846603",
-        },
-        "saturation": "0.08176773495745114502",
-        "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11309201436284",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
-      "status": "active",
-      "transactions": Object {
-        "registration": Array [
-          "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-          "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
-      "id": "pool168d9plflldfr6mpjg9q2typv2m6a0hx4u5g8kfa486dwkke2uj7",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "Big Dragon Farts",
-        "homepage": "https://example.com",
-        "name": "Farts",
-        "ticker": "TINY",
-      },
-      "metadataJson": Object {
-        "hash": "1de0ed2cce9713054dbe8de942da9ebbe43d75534e4922ddb230ca0f268e203c",
-        "url": "https://tinyurl.com/biggerfarts",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
-        "saturation": "0.000003593840870810890678",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
-      "status": "active",
-      "transactions": Object {
-        "registration": Array [
-          "790665c0eb88f4a182c54393ca5178e53f2726223c8ade82a2b9fae52e2cb7bd",
-          "9a9b18842f679422127cbff3e65d76d3aea114a346f3c8209698e011764e0401",
-          "1725047a83924a285904c8879ebe7cf2a47fd0e20887272cc39b0f6ed4819a9c",
-          "bbef847054cc18a1fb7f37b073b2bc669ba4c3150bf1f8c9b49c0ca2af37c4ba",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [],
-      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
-      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "advanced staking",
-        "homepage": "https://nedscave.io",
-        "name": "NEDSCAVE.IO",
-        "ticker": "NEDST",
-      },
-      "metadataJson": Object {
-        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
-        "url": "https://nedscave.io/nedstmeta.json",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
-        "saturation": "0.000000000000000000000000000000000000",
-        "size": Object {
-          "active": "0",
-          "live": "0",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
-      "transactions": Object {
-        "registration": Array [
-          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
-      "id": "pool1tmn4jxlnp64y7hwwwz62vahtqt2maqqj6xy0qnlrhmlmq3u8q0e",
-      "margin": Object {
-        "denominator": 10000,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "Our Amsterdam Node",
-        "homepage": "https://twitter.com/A92Syed",
-        "name": "THE AMSTERDAM NODE",
-        "ticker": "AMS",
-      },
-      "metadataJson": Object {
-        "hash": "cc019105f084aef2a956b2f7f2c0bf4e747bf7696705312c244620089429df6f",
-        "url": "https://git.io/JJ1dz",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
-        "saturation": "0.000003524460762741604430",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
-      "status": "active",
-      "transactions": Object {
-        "registration": Array [
-          "0d3c928318f489a93b2ceba60f1998594f3626e4018ad19adf0a9615164b5469",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
-      "id": "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg",
-      "margin": Object {
-        "denominator": 25,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "The pool that tests all the pools",
-        "homepage": "https://teststakepool.com",
-        "name": "TestPool",
-        "ticker": "TEST",
-      },
-      "metadataJson": Object {
-        "hash": "2412f77be9b650eff7b015455d15cea355e1782dda2e7d7b1cb34943eefac348",
-        "url": "https://git.io/JJyYy",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
-        "saturation": "0.000001444638128115738435",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
-      "status": "active",
-      "transactions": Object {
-        "registration": Array [
-          "071b93a1a134389c22a1dc43fe747e43d23088448fed2b5ab22564cc0cb8bbc5",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
-      "id": "pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96",
-      "margin": Object {
-        "denominator": 1000,
-        "numerator": 27,
-      },
-      "metadata": Object {
-        "description": "Pool a of the banderini devtest staking pools",
-        "homepage": "http://www.banderini.net",
-        "name": "banderini-devtest-a",
-        "ticker": "BANDA",
-      },
-      "metadataJson": Object {
-        "hash": "4d89054c2962215694a7122dfe41bc728d3ec248f80ea9a2e0d493057d7d2338",
-        "url": "https://git.io/JJ7wm",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
-        "saturation": "0.000003582295326231976177",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
-      "status": "active",
-      "transactions": Object {
-        "registration": Array [
-          "047ee144d7adc5f10a107bf13eab570833bf2fb8bb6b016d030739a4cc585aa7",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
-      "id": "pool126zlx7728y7xs08s8epg9qp393kyafy9rzr89g4qkvv4cv93zem",
-      "margin": Object {
-        "denominator": 40,
-        "numerator": 3,
-      },
-      "metadataJson": Object {
-        "hash": "7feb5bf22fc8c57be71a4b24f68381a7d1051e94290164530da6f7d5682a0024",
-        "url": "https://visionstaking.ch/poolmeta.json",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
-        "saturation": "0.000007213010200251687547",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
-      "status": "active",
-      "transactions": Object {
-        "registration": Array [
-          "78925fad4cce75a22a675ed5e175ecfd40baf7ac51c487c5cdb0fde9a02afa64",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
-    },
-  ],
-  "totalResultCount": 7,
-}
-`;
-
 exports[`StakePoolHttpService healthy state /search search pools by multiple filters identifier & status  & pledgeMet filters pledgeMet true, status active, and condition 1`] = `
 Object {
   "pageResults": Array [
@@ -3643,10 +3679,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -3681,15 +3717,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -3725,10 +3761,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -3763,15 +3799,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -3821,10 +3857,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -3859,15 +3895,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -3905,8 +3941,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -3981,16 +4017,99 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "321928331851",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1791084124",
+        },
+        "saturation": "0.00234055459664021839",
+        "size": Object {
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "321928331851",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1791084124",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
+      },
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4025,15 +4144,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -4068,10 +4187,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4106,15 +4225,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -4149,10 +4268,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4187,15 +4306,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -4232,8 +4351,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4307,8 +4426,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4374,7 +4493,7 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
   ],
-  "totalResultCount": 7,
+  "totalResultCount": 8,
 }
 `;
 
@@ -4397,10 +4516,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4435,15 +4554,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -4481,8 +4600,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4557,99 +4676,16 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
-        "value": "345000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "Testnet Only",
-        "homepage": "https://git.io/JWPBE",
-        "name": "July 2021",
-        "ticker": "JUL21",
-      },
-      "metadataJson": Object {
-        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-        "url": "https://git.io/JWP02",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1791084124",
-        },
-        "saturation": "0.000012949887997207019875",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "1791084124",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
-      "transactions": Object {
-        "registration": Array [
-          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-        ],
-        "retirement": Array [
-          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-        ],
-      },
-      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4684,15 +4720,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -4727,10 +4763,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4765,15 +4801,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -4808,10 +4844,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4846,15 +4882,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -4891,8 +4927,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4956,7 +4992,7 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
   ],
-  "totalResultCount": 7,
+  "totalResultCount": 6,
 }
 `;
 
@@ -4972,10 +5008,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5010,15 +5046,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -5054,10 +5090,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5092,15 +5128,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -5135,10 +5171,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5173,15 +5209,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -5216,10 +5252,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5254,15 +5290,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -5305,10 +5341,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5343,15 +5379,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -5389,8 +5425,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5471,10 +5507,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5509,15 +5545,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -5534,7 +5570,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -5550,7 +5586,25 @@ Object {
         "__type": "bigint",
         "value": "340000000",
       },
-      "epochRewards": Array [],
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
       "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
       "margin": Object {
@@ -5574,15 +5628,15 @@ Object {
           "__type": "bigint",
           "value": "1099603790",
         },
-        "saturation": "0.000000000000000000000000000000000000",
+        "saturation": "0.000072460074956593695520",
         "size": Object {
-          "active": "0",
-          "live": "0",
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "10021869680",
           },
           "live": Object {
             "__type": "bigint",
@@ -5599,7 +5653,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
+      "status": "active",
       "transactions": Object {
         "registration": Array [
           "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
@@ -5617,10 +5671,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5655,15 +5709,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -5698,10 +5752,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5736,15 +5790,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -5779,10 +5833,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5817,15 +5871,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -5862,8 +5916,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5937,8 +5991,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6027,10 +6081,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6065,15 +6119,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -6103,79 +6157,16 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [],
-      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
-      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "advanced staking",
-        "homepage": "https://nedscave.io",
-        "name": "NEDSCAVE.IO",
-        "ticker": "NEDST",
-      },
-      "metadataJson": Object {
-        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
-        "url": "https://nedscave.io/nedstmeta.json",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
-        "saturation": "0.000000000000000000000000000000000000",
-        "size": Object {
-          "active": "0",
-          "live": "0",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
-      "transactions": Object {
-        "registration": Array [
-          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6210,15 +6201,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -6253,10 +6244,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6291,15 +6282,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -6334,10 +6325,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6372,15 +6363,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -6407,7 +6398,7 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
   ],
-  "totalResultCount": 5,
+  "totalResultCount": 4,
 }
 `;
 
@@ -6423,10 +6414,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6461,15 +6452,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -6505,10 +6496,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6543,15 +6534,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -6586,10 +6577,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6624,15 +6615,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -6667,10 +6658,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6705,15 +6696,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -6756,10 +6747,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6794,15 +6785,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -6840,8 +6831,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6916,16 +6907,97 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
+      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "advanced staking",
+        "homepage": "https://nedscave.io",
+        "name": "NEDSCAVE.IO",
+        "ticker": "NEDST",
+      },
+      "metadataJson": Object {
+        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
+        "url": "https://nedscave.io/nedstmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "0",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1099603790",
+        },
+        "saturation": "0.000072460074956593695520",
+        "size": Object {
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -6960,15 +7032,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -7003,10 +7075,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7041,15 +7113,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -7084,10 +7156,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7122,15 +7194,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -7167,8 +7239,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7232,7 +7304,7 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
   ],
-  "totalResultCount": 6,
+  "totalResultCount": 7,
 }
 `;
 
@@ -7255,10 +7327,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7293,15 +7365,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -7331,16 +7403,99 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "321928331851",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1791084124",
+        },
+        "saturation": "0.00234055459664021839",
+        "size": Object {
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "321928331851",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1791084124",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
+      },
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7375,15 +7530,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -7418,10 +7573,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7456,15 +7611,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -7499,10 +7654,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7537,15 +7692,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -7582,8 +7737,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7649,7 +7804,7 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
   ],
-  "totalResultCount": 5,
+  "totalResultCount": 6,
 }
 `;
 
@@ -7672,10 +7827,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7710,15 +7865,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -7748,99 +7903,16 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
-        "value": "345000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "Testnet Only",
-        "homepage": "https://git.io/JWPBE",
-        "name": "July 2021",
-        "ticker": "JUL21",
-      },
-      "metadataJson": Object {
-        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-        "url": "https://git.io/JWP02",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1791084124",
-        },
-        "saturation": "0.000012949887997207019875",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "1791084124",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
-      "transactions": Object {
-        "registration": Array [
-          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-        ],
-        "retirement": Array [
-          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-        ],
-      },
-      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-    },
-    Object {
-      "cost": Object {
-        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7875,15 +7947,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -7918,10 +7990,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7956,15 +8028,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -7999,10 +8071,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8037,15 +8109,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -8072,7 +8144,7 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
   ],
-  "totalResultCount": 5,
+  "totalResultCount": 4,
 }
 `;
 
@@ -8088,10 +8160,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8126,15 +8198,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -8151,7 +8223,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -8171,10 +8243,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8209,15 +8281,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -8252,10 +8324,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8290,15 +8362,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -8331,72 +8403,8 @@ Object {
 
 exports[`StakePoolHttpService healthy state /search search pools by status search by activating status 1`] = `
 Object {
-  "pageResults": Array [
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
-      "epochRewards": Array [],
-      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
-      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "advanced staking",
-        "homepage": "https://nedscave.io",
-        "name": "NEDSCAVE.IO",
-        "ticker": "NEDST",
-      },
-      "metadataJson": Object {
-        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
-        "url": "https://nedscave.io/nedstmeta.json",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
-        "saturation": "0.000000000000000000000000000000000000",
-        "size": Object {
-          "active": "0",
-          "live": "0",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
-      "transactions": Object {
-        "registration": Array [
-          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
-        ],
-        "retirement": Array [],
-      },
-      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
-    },
-  ],
-  "totalResultCount": 1,
+  "pageResults": Array [],
+  "totalResultCount": 0,
 }
 `;
 
@@ -8412,10 +8420,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8450,15 +8458,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -8496,8 +8504,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8572,16 +8580,97 @@ Object {
     Object {
       "cost": Object {
         "__type": "bigint",
+        "value": "340000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
+      "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "advanced staking",
+        "homepage": "https://nedscave.io",
+        "name": "NEDSCAVE.IO",
+        "ticker": "NEDST",
+      },
+      "metadataJson": Object {
+        "hash": "12c0b00572e2450932b531d1efb88a4bbffda986257ed847e6fd2f9fa5bc90cd",
+        "url": "https://nedscave.io/nedstmeta.json",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "0",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1099603790",
+        },
+        "saturation": "0.000072460074956593695520",
+        "size": Object {
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
+      "status": "active",
+      "transactions": Object {
+        "registration": Array [
+          "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
+        ],
+        "retirement": Array [],
+      },
+      "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
+    },
+    Object {
+      "cost": Object {
+        "__type": "bigint",
         "value": "400000000",
       },
       "epochRewards": Array [
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8616,15 +8705,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -8659,10 +8748,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8697,15 +8786,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -8740,10 +8829,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8778,15 +8867,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -8823,8 +8912,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8888,13 +8977,96 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
   ],
-  "totalResultCount": 6,
+  "totalResultCount": 7,
 }
 `;
 
 exports[`StakePoolHttpService healthy state /search search pools by status search by retired status 1`] = `
 Object {
   "pageResults": Array [
+    Object {
+      "cost": Object {
+        "__type": "bigint",
+        "value": "345000000",
+      },
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "321928331851",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
+      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
+      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
+      "margin": Object {
+        "denominator": 100,
+        "numerator": 1,
+      },
+      "metadata": Object {
+        "description": "Testnet Only",
+        "homepage": "https://git.io/JWPBE",
+        "name": "July 2021",
+        "ticker": "JUL21",
+      },
+      "metadataJson": Object {
+        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
+        "url": "https://git.io/JWP02",
+      },
+      "metrics": Object {
+        "blocksCreated": "0",
+        "delegators": "1",
+        "livePledge": Object {
+          "__type": "bigint",
+          "value": "1791084124",
+        },
+        "saturation": "0.00234055459664021839",
+        "size": Object {
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
+        },
+        "stake": Object {
+          "active": Object {
+            "__type": "bigint",
+            "value": "321928331851",
+          },
+          "live": Object {
+            "__type": "bigint",
+            "value": "1791084124",
+          },
+        },
+      },
+      "owners": Array [
+        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      ],
+      "pledge": Object {
+        "__type": "bigint",
+        "value": "10000000000",
+      },
+      "relays": Array [],
+      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
+      "status": "retired",
+      "transactions": Object {
+        "registration": Array [
+          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
+        ],
+        "retirement": Array [
+          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
+        ],
+      },
+      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
+    },
     Object {
       "cost": Object {
         "__type": "bigint",
@@ -8906,8 +9078,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8973,98 +9145,14 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
   ],
-  "totalResultCount": 1,
+  "totalResultCount": 2,
 }
 `;
 
 exports[`StakePoolHttpService healthy state /search search pools by status search by retiring status 1`] = `
 Object {
-  "pageResults": Array [
-    Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
-      "epochRewards": Array [
-        Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "epoch": 175,
-          "epochLength": 431949000,
-          "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-        },
-      ],
-      "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
-      "id": "pool1xv0p9vje3r09tac22mhgnsg08rmfm5qxadggjnfnq3cz52apdew",
-      "margin": Object {
-        "denominator": 100,
-        "numerator": 1,
-      },
-      "metadata": Object {
-        "description": "Testnet Only",
-        "homepage": "https://git.io/JWPBE",
-        "name": "July 2021",
-        "ticker": "JUL21",
-      },
-      "metadataJson": Object {
-        "hash": "d1b06cb907d081513e506471ce960934f859049808023d7176870e302a7c9989",
-        "url": "https://git.io/JWP02",
-      },
-      "metrics": Object {
-        "blocksCreated": "0",
-        "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1791084124",
-        },
-        "saturation": "0.000012949887997207019875",
-        "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
-        },
-        "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "1791084124",
-          },
-        },
-      },
-      "owners": Array [
-        "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
-      "relays": Array [],
-      "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
-      "transactions": Object {
-        "registration": Array [
-          "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-        ],
-        "retirement": Array [
-          "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-        ],
-      },
-      "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
-    },
-  ],
-  "totalResultCount": 1,
+  "pageResults": Array [],
+  "totalResultCount": 0,
 }
 `;
 
@@ -9080,10 +9168,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9118,15 +9206,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -9164,8 +9252,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9246,10 +9334,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9284,15 +9372,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -9309,7 +9397,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -9325,7 +9413,25 @@ Object {
         "__type": "bigint",
         "value": "340000000",
       },
-      "epochRewards": Array [],
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
       "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
       "margin": Object {
@@ -9349,15 +9455,15 @@ Object {
           "__type": "bigint",
           "value": "1099603790",
         },
-        "saturation": "0.000000000000000000000000000000000000",
+        "saturation": "0.000072460074956593695520",
         "size": Object {
-          "active": "0",
-          "live": "0",
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "10021869680",
           },
           "live": Object {
             "__type": "bigint",
@@ -9374,7 +9480,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
+      "status": "active",
       "transactions": Object {
         "registration": Array [
           "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
@@ -9392,10 +9498,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9430,15 +9536,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -9473,10 +9579,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9511,15 +9617,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -9554,10 +9660,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9592,15 +9698,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -9637,8 +9743,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9712,8 +9818,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9795,10 +9901,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9833,15 +9939,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -9879,8 +9985,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9961,10 +10067,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9999,15 +10105,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -10024,7 +10130,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -10048,7 +10154,25 @@ Object {
         "__type": "bigint",
         "value": "340000000",
       },
-      "epochRewards": Array [],
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
       "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
       "margin": Object {
@@ -10072,15 +10196,15 @@ Object {
           "__type": "bigint",
           "value": "1099603790",
         },
-        "saturation": "0.000000000000000000000000000000000000",
+        "saturation": "0.000072460074956593695520",
         "size": Object {
-          "active": "0",
-          "live": "0",
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "10021869680",
           },
           "live": Object {
             "__type": "bigint",
@@ -10097,7 +10221,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
+      "status": "active",
       "transactions": Object {
         "registration": Array [
           "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
@@ -10115,10 +10239,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10153,15 +10277,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -10196,10 +10320,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10234,15 +10358,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -10285,10 +10409,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10323,15 +10447,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -10367,10 +10491,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10405,15 +10529,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -10448,10 +10572,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10486,15 +10610,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -10537,10 +10661,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10575,15 +10699,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -10621,8 +10745,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10703,10 +10827,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10741,15 +10865,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -10766,7 +10890,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -10782,7 +10906,25 @@ Object {
         "__type": "bigint",
         "value": "340000000",
       },
-      "epochRewards": Array [],
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
       "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
       "margin": Object {
@@ -10806,15 +10948,15 @@ Object {
           "__type": "bigint",
           "value": "1099603790",
         },
-        "saturation": "0.000000000000000000000000000000000000",
+        "saturation": "0.000072460074956593695520",
         "size": Object {
-          "active": "0",
-          "live": "0",
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "10021869680",
           },
           "live": Object {
             "__type": "bigint",
@@ -10831,7 +10973,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
+      "status": "active",
       "transactions": Object {
         "registration": Array [
           "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
@@ -10849,10 +10991,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10887,15 +11029,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -10938,10 +11080,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -10976,15 +11118,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -11019,10 +11161,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11057,15 +11199,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -11102,8 +11244,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11177,8 +11319,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11260,10 +11402,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11298,15 +11440,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -11344,8 +11486,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11426,10 +11568,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11464,15 +11606,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -11489,7 +11631,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -11505,7 +11647,25 @@ Object {
         "__type": "bigint",
         "value": "340000000",
       },
-      "epochRewards": Array [],
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
       "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
       "margin": Object {
@@ -11529,15 +11689,15 @@ Object {
           "__type": "bigint",
           "value": "1099603790",
         },
-        "saturation": "0.000000000000000000000000000000000000",
+        "saturation": "0.000072460074956593695520",
         "size": Object {
-          "active": "0",
-          "live": "0",
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "10021869680",
           },
           "live": Object {
             "__type": "bigint",
@@ -11554,7 +11714,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
+      "status": "active",
       "transactions": Object {
         "registration": Array [
           "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
@@ -11572,10 +11732,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11610,15 +11770,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -11653,10 +11813,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11691,15 +11851,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -11734,10 +11894,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11772,15 +11932,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -11817,8 +11977,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11892,8 +12052,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11977,8 +12137,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12052,8 +12212,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12127,10 +12287,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12165,15 +12325,15 @@ Object {
           "__type": "bigint",
           "value": "495463149",
         },
-        "saturation": "0.000003582295326231976177",
+        "saturation": "0.000009332390599815651490",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.61614387139960263961",
+          "live": "0.38385612860039736039",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "795289068",
           },
           "live": Object {
             "__type": "bigint",
@@ -12208,10 +12368,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12246,15 +12406,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -12289,10 +12449,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12327,15 +12487,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -12366,7 +12526,25 @@ Object {
         "__type": "bigint",
         "value": "340000000",
       },
-      "epochRewards": Array [],
+      "epochRewards": Array [
+        Object {
+          "activeStake": Object {
+            "__type": "bigint",
+            "value": "10021869680",
+          },
+          "epoch": 183,
+          "epochLength": 431910000,
+          "memberROI": 0,
+          "operatorFees": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+          "totalRewards": Object {
+            "__type": "bigint",
+            "value": "0",
+          },
+        },
+      ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
       "id": "pool103qt58f9xlsr7y9anz3lnyq6cph4xh2yr4qrrtc356ldzz6ktqz",
       "margin": Object {
@@ -12390,15 +12568,15 @@ Object {
           "__type": "bigint",
           "value": "1099603790",
         },
-        "saturation": "0.000000000000000000000000000000000000",
+        "saturation": "0.000072460074956593695520",
         "size": Object {
-          "active": "0",
-          "live": "0",
+          "active": "1.00000000000000000000",
+          "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "10021869680",
           },
           "live": Object {
             "__type": "bigint",
@@ -12415,7 +12593,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
-      "status": "activating",
+      "status": "active",
       "transactions": Object {
         "registration": Array [
           "aa9073d5bfb1aefdd33a6aeea37688c777de64220e8f7c373ed9651740a1d1ac",
@@ -12433,10 +12611,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12471,15 +12649,15 @@ Object {
           "__type": "bigint",
           "value": "1791084124",
         },
-        "saturation": "0.000012949887997207019875",
+        "saturation": "0.00234055459664021839",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.99446717115003592889",
+          "live": "0.00553282884996407111",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "321928331851",
           },
           "live": Object {
             "__type": "bigint",
@@ -12496,7 +12674,7 @@ Object {
       },
       "relays": Array [],
       "rewardAccount": "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
-      "status": "retiring",
+      "status": "retired",
       "transactions": Object {
         "registration": Array [
           "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
@@ -12518,8 +12696,8 @@ Object {
             "__type": "bigint",
             "value": "0",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12600,10 +12778,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12638,15 +12816,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",
@@ -12690,10 +12868,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12728,15 +12906,15 @@ Object {
           "__type": "bigint",
           "value": "199806239",
         },
-        "saturation": "0.000001444638128115738435",
+        "saturation": "0.000010821238378828440746",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.86649974082983449634",
+          "live": "0.13350025917016550366",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1296866803",
           },
           "live": Object {
             "__type": "bigint",
@@ -12771,10 +12949,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12809,15 +12987,15 @@ Object {
           "__type": "bigint",
           "value": "487464117",
         },
-        "saturation": "0.000003524460762741604430",
+        "saturation": "0.000021597805798609747488",
         "size": Object {
-          "active": "0.0000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.83681394324934275242",
+          "live": "0.16318605675065724758",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "2499703578",
           },
           "live": Object {
             "__type": "bigint",
@@ -12852,10 +13030,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
-          "epoch": 175,
-          "epochLength": 431949000,
+          "epoch": 183,
+          "epochLength": 431910000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12890,15 +13068,15 @@ Object {
           "__type": "bigint",
           "value": "22615260846603",
         },
-        "saturation": "0.08176773495745114502",
+        "saturation": "0.44434044853455135587",
         "size": Object {
-          "active": "0.00000000000000000000000000000000",
-          "live": "1.00000000000000000000",
+          "active": "0.81597953725094421936",
+          "live": "0.18402046274905578064",
         },
         "stake": Object {
           "active": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "50147015265584",
           },
           "live": Object {
             "__type": "bigint",

--- a/packages/core/src/Cardano/NetworkId.ts
+++ b/packages/core/src/Cardano/NetworkId.ts
@@ -3,4 +3,10 @@ export enum NetworkId {
   testnet = 0
 }
 
+export enum CardanoNetworkMagic {
+  Mainnet = 764_824_073,
+  Testnet = 1_097_911_063
+}
+
+export type CardanoNetworkId = keyof typeof CardanoNetworkMagic;
 export type NetworkMagic = number;

--- a/packages/core/src/Provider/NetworkInfoProvider/types.ts
+++ b/packages/core/src/Provider/NetworkInfoProvider/types.ts
@@ -13,6 +13,7 @@ export type StakeSummary = {
 
 export type NetworkInfo = {
   network: {
+    id: Cardano.NetworkId;
     magic: Cardano.NetworkMagic;
     timeSettings: TimeSettings[];
   };

--- a/packages/core/src/util/slotCalc.ts
+++ b/packages/core/src/util/slotCalc.ts
@@ -1,5 +1,5 @@
+import { CardanoNetworkMagic, Epoch, Slot } from '../Cardano';
 import { CustomError } from 'ts-custom-error';
-import { Epoch, Slot } from '../Cardano';
 import { orderBy } from 'lodash-es';
 
 export interface TimeSettings {
@@ -35,12 +35,24 @@ export interface EpochInfo {
 export class TimeSettingsError extends CustomError {}
 
 /**
- * Were valid at 2022-01-14
+ * Were valid at 2022-05-28
  */
+export const mainnetTimeSettings: TimeSettings[] = [
+  { epochLength: 21_600, fromSlotDate: new Date(1_506_192_291_000), fromSlotNo: 0, slotLength: 20_000 },
+  { epochLength: 432_000, fromSlotDate: new Date(1_596_059_091_000), fromSlotNo: 4_492_800, slotLength: 1000 }
+];
+
 export const testnetTimeSettings: TimeSettings[] = [
   { epochLength: 21_600, fromSlotDate: new Date(1_563_999_616_000), fromSlotNo: 0, slotLength: 20_000 },
   { epochLength: 432_000, fromSlotDate: new Date(1_595_964_016_000), fromSlotNo: 1_598_400, slotLength: 1000 }
 ];
+
+export type TimeSettingsMap = { [key in CardanoNetworkMagic]: TimeSettings[] };
+
+export const timeSettingsConfig: TimeSettingsMap = {
+  [CardanoNetworkMagic.Mainnet]: mainnetTimeSettings,
+  [CardanoNetworkMagic.Testnet]: testnetTimeSettings
+};
 
 const createSlotEpochCalcImpl = (timeSettings: TimeSettings[]) => {
   const timeSettingsAsc = orderBy(timeSettings, ({ fromSlotNo }) => fromSlotNo);


### PR DESCRIPTION
# Context

Network settings have data that’s sourced from configuration files, which can be served over the network to clients dynamically upon connection.  Right now we have the [NetworkInfoProvider](https://github.com/input-output-hk/cardano-js-sdk/blob/ad0ffb5a73c4af2b3d1bf4d20506e33d05353c38/packages/core/src/Provider/NetworkInfoProvider/types.ts#L23), with an HTTP service then reading values from the `cardano-db-sync` DB. Our service design means a Node.js application could also bypass the HTTP service to read values straight from the source by wiring up say the NetworkInfoDbSyncProvider.

As a developer wishing to connect dynamically to a network
We need to have the option of using a remote service to access network-specific information.

# Proposed Solution

# Important Changes Introduced

- create **DbSyncNetworkInfoProvider** and **NetworkInfoBuilder**
- add '[cardano-configurations](https://github.com/input-output-hk/cardano-configurations/tree/568756920ef0249b9cee09e0b973c2aacec241de)' as a submodule to `cardano-services`
- implement '[extractGenesisData](https://github.com/input-output-hk/cardano-js-sdk/blob/7608c8baba0b1e9a7320c85af8782f39dac65bce/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts#L39)' method to load genesis configs and extract needed info on provider initialisation
- create [timeSettingsConfig](https://github.com/input-output-hk/cardano-js-sdk/blob/ad0ffb5a73c4af2b3d1bf4d20506e33d05353c38/packages/core/src/util/slotCalc.ts#L52) for mainnet and testnetnet, NetworkMagic mapping
- extend env vars with **CARDANO_NODE_CONFIG_PATH** required for NetworkInfo service in `run.ts` and `cli.ts`
- create **NetworkInfoHttpService** and extend HTTP server with it, attached on demand
- attach **OpenApi** spec and validation on NetworkInfo http service
- create db queries for extract the relevant network information from db-sync
- refactor **loadHttpServer** with factory method (get rid of switch-case) 
- create **networkInfoHttpProvider** in `cardano-services-client`
- cover **UtxoHttpService** with entrypoints (run/cli) tests by request
- extend `NetworkInfo['network']` interface with `id`, align BlockfrostNetworkInfo provider with it
- extend `dump-db-sdk.sh` script with `epoch_stake` & `ada_pots` tables, [testnet-fixture-data.sql](https://github.com/input-output-hk/cardano-js-sdk/pull/255/files#diff-9a85bd87f8e82c4d03799778c134fd9e1f83d9dfcae5d63809e93b6adf56f515) and [testnet-fixture-data.tar](https://github.com/input-output-hk/cardano-js-sdk/pull/255/files#diff-9c2cb12030e8d5ed457fc4f0f33f7051efadca275f237b202c5c75d73f45165b) files are updated accordingly
