### PR TITLE
fix(wallet): Ledger transaction submission bug fix

### DIFF
--- a/packages/wallet/src/KeyManagement/LedgerKeyAgent.ts
+++ b/packages/wallet/src/KeyManagement/LedgerKeyAgent.ts
@@ -12,7 +12,7 @@ import {
 import { KeyAgentBase } from './KeyAgentBase';
 import { TxInternals } from '../Transaction';
 import { txToLedger } from './util';
-import LedgerConnection, { GetVersionResponse, HARDENED, utils } from '@cardano-foundation/ledgerjs-hw-app-cardano';
+import LedgerConnection, { GetVersionResponse, utils } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid-noevents';
 import TransportWebHID from '@ledgerhq/hw-transport-webhid';
 import type LedgerTransport from '@ledgerhq/hw-transport';
@@ -243,7 +243,7 @@ export class LedgerKeyAgent extends KeyAgentBase {
         await Promise.all(
           result.witnesses.map(async (witness) => {
             const publicKey = await this.derivePublicKey({
-              index: HARDENED - witness.path[2],
+              index: witness.path[4],
               role: witness.path[3]
             });
             const signature = Cardano.Ed25519Signature(witness.witnessSignatureHex);

--- a/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
@@ -1,7 +1,7 @@
 import * as mocks from '../mocks';
 import { AssetId, createStubStakePoolSearchProvider } from '@cardano-sdk/util-dev';
 import { Cardano } from '@cardano-sdk/core';
-import { CommunicationType, TransportType } from '../../src/KeyManagement/types';
+import { CommunicationType, LedgerTransportType } from '../../src/KeyManagement/types';
 import { KeyManagement, SingleAddressWallet } from '../../src';
 import DeviceConnection from '@cardano-foundation/ledgerjs-hw-app-cardano';
 
@@ -36,6 +36,18 @@ describe('LedgerKeyAgent', () => {
       { assetProvider, keyAgent, networkInfoProvider, stakePoolSearchProvider, txSubmitProvider, walletProvider }
     );
     keyAgent.knownAddresses.push(groupedAddress);
+  });
+
+  it('can be created with any account index', async () => {
+    const ledgerKeyAgentWithRandomIndex = await KeyManagement.LedgerKeyAgent.createWithDevice({
+      accountIndex: 5,
+      communicationType: CommunicationType.Node,
+      deviceConnection: keyAgent.deviceConnection,
+      networkId: Cardano.NetworkId.testnet
+    });
+    expect(ledgerKeyAgentWithRandomIndex).toBeInstanceOf(KeyManagement.LedgerKeyAgent);
+    expect(ledgerKeyAgentWithRandomIndex.accountIndex).toEqual(5);
+    expect(ledgerKeyAgentWithRandomIndex.extendedAccountPublicKey).not.toEqual(keyAgent.extendedAccountPublicKey);
   });
 
   test('__typename', () => {
@@ -118,7 +130,7 @@ describe('LedgerKeyAgent', () => {
   });
 
   describe('create device connection with transport', () => {
-    let transport: TransportType;
+    let transport: LedgerTransportType;
     beforeAll(async () => {
       transport = await KeyManagement.LedgerKeyAgent.createTransport({
         communicationType: CommunicationType.Node


### PR DESCRIPTION
# Context
Bugfix for transaction signing with Ledger devices when the account index is different than zero.

# Proposed Solution
[JIRA ticket](https://input-output.atlassian.net/browse/ADP-1800)
Wallet user can create a single account / address wallet with any account index, and perform all wallet actions using it. In this particular case to sign and send transactions using Ledger.

# Important Changes Introduced
- Fixed witnesses preparation in LedgerKeyAgent