### PR TITLE
fix(wallet): queue pouchdb writes

### DIFF
--- a/packages/wallet/src/persistence/pouchdbStores/PouchdbKeyValueStore.ts
+++ b/packages/wallet/src/persistence/pouchdbStores/PouchdbKeyValueStore.ts
@@ -27,7 +27,7 @@ export class PouchdbKeyValueStore<K extends string | Cardano.util.OpaqueString<a
   setAll(docs: KeyValueCollection<K, V>[]): Observable<void> {
     if (this.destroyed) return EMPTY;
     return from(
-      (async (): Promise<void> => {
+      (this.idle = this.idle.then(async (): Promise<void> => {
         try {
           await this.clearDB();
           await this.db.bulkDocs(
@@ -39,7 +39,7 @@ export class PouchdbKeyValueStore<K extends string | Cardano.util.OpaqueString<a
         } catch (error) {
           this.logger.error(`PouchdbDocumentStore(${this.dbName}): failed to setAll`, docs, error);
         }
-      })()
+      }))
     );
   }
 


### PR DESCRIPTION
# Context

When testing in web-extension e2e setup I noticed occasional write failures when setting asset data. Data of each asset is fetched independently and 2 assets can sometimes resolve at roughly the same time, causing 2 simultaneous writes to pouchdb, which results in a conflict error.

# Proposed Solution

Queue pouchdb write operations
