### PR TITLE
fix(wallet): added utxoProvider to e2e tests

### DIFF
--- a/packages/wallet/.env.example
+++ b/packages/wallet/.env.example
@@ -13,3 +13,4 @@ POOL_ID_2=pool1fghrkl620rl3g54ezv56weeuwlyce2tdannm2hphs62syf3vyyh
 OGMIOS_URL=ws://localhost:1337
 LOGGER_MIN_SEVERITY=debug
 KEY_AGENT=InMemory
+UTXO_PROVIDER=blockfrost

--- a/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
@@ -11,6 +11,7 @@ import {
   poolId2,
   stakePoolProvider,
   txSubmitProvider,
+  utxoProvider,
   walletProvider
 } from '../config';
 import { combineLatest, filter, firstValueFrom } from 'rxjs';
@@ -73,6 +74,7 @@ const getWallet = async (idx: number) =>
       networkInfoProvider: await networkInfoProvider,
       stakePoolProvider,
       txSubmitProvider: await txSubmitProvider,
+      utxoProvider: await utxoProvider,
       walletProvider: await walletProvider
     }
   );

--- a/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
@@ -6,6 +6,7 @@ import {
   networkInfoProvider,
   stakePoolProvider,
   txSubmitProvider,
+  utxoProvider,
   walletProvider
 } from '../config';
 import { filter, firstValueFrom, map } from 'rxjs';
@@ -23,6 +24,7 @@ describe('SingleAddressWallet/metadata', () => {
         networkInfoProvider: await networkInfoProvider,
         stakePoolProvider,
         txSubmitProvider: await txSubmitProvider,
+        utxoProvider: await utxoProvider,
         walletProvider: await walletProvider
       }
     );

--- a/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
@@ -7,6 +7,7 @@ import {
   networkInfoProvider,
   stakePoolProvider,
   txSubmitProvider,
+  utxoProvider,
   walletProvider
 } from '../config';
 import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
@@ -43,6 +44,7 @@ describe('SingleAddressWallet.assets/nft', () => {
         networkInfoProvider: await networkInfoProvider,
         stakePoolProvider,
         txSubmitProvider: await txSubmitProvider,
+        utxoProvider: await utxoProvider,
         walletProvider: await walletProvider
       }
     );

--- a/packages/wallet/test/e2e/SingleAddressWallet/pouchdbWalletStores.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/pouchdbWalletStores.test.ts
@@ -6,6 +6,7 @@ import {
   networkInfoProvider,
   stakePoolProvider,
   txSubmitProvider,
+  utxoProvider,
   walletProvider
 } from '../config';
 import { filter, firstValueFrom } from 'rxjs';
@@ -30,6 +31,7 @@ describe('SingleAddressWallet/pouchdbWalletStores', () => {
         stakePoolProvider,
         stores,
         txSubmitProvider: await txSubmitProvider,
+        utxoProvider: await utxoProvider,
         walletProvider: await walletProvider
       }
     );

--- a/packages/wallet/test/e2e/config.ts
+++ b/packages/wallet/test/e2e/config.ts
@@ -5,6 +5,7 @@ import {
   blockfrostAssetProvider,
   blockfrostNetworkInfoProvider,
   blockfrostTxSubmitProvider,
+  blockfrostUtxoProvider,
   blockfrostWalletProvider
 } from '@cardano-sdk/blockfrost';
 import { Cardano } from '@cardano-sdk/core';
@@ -26,6 +27,7 @@ const networkIdOptions = [0, 1];
 const stakePoolProviderOptions = ['stub'];
 const networkInfoProviderOptions = ['blockfrost'];
 const txSubmitProviderOptions = ['blockfrost', 'ogmios', 'http'];
+const utxoProviderOptions = ['blockfrost'];
 const walletProviderOptions = ['blockfrost'];
 const assetProviderOptions = ['blockfrost'];
 const keyAgentOptions = ['InMemory', 'Ledger'];
@@ -48,6 +50,7 @@ const env = envalid.cleanEnv(process.env, {
   STAKE_POOL_PROVIDER: envalid.str({ choices: stakePoolProviderOptions }),
   TX_SUBMIT_HTTP_URL: envalid.url(),
   TX_SUBMIT_PROVIDER: envalid.str({ choices: txSubmitProviderOptions }),
+  UTXO_PROVIDER: envalid.str({ choices: utxoProviderOptions }),
   WALLET_PASSWORD: envalid.str(),
   WALLET_PROVIDER: envalid.str({ choices: walletProviderOptions })
 });
@@ -174,6 +177,13 @@ export const networkInfoProvider = (async () => {
     return blockfrostNetworkInfoProvider(await blockfrostApi!);
   }
   throw new Error(`NETWORK_INFO_PROVIDER unsupported: ${env.NETWORK_INFO_PROVIDER}`);
+})();
+
+export const utxoProvider = (async () => {
+  if (env.UTXO_PROVIDER === 'blockfrost') {
+    return blockfrostUtxoProvider(await blockfrostApi!);
+  }
+  throw new Error(`UTXO_PROVIDER unsupported: ${env.UTXO_PROVIDER}`);
 })();
 
 export const poolId1 = Cardano.PoolId(env.POOL_ID_1);


### PR DESCRIPTION
# Context

The `@cardano-sdk/wallet` e2e tests compilation fails due to they are missing the `utxoProvider`.

# Proposed Solution
Added the `utxoProvider` to the e2e tests.

# Important Changes Introduced
None.