### PR TITLE
fix(wallet): add missing cleanup for SingleAddressWallet

### DIFF
--- a/packages/wallet/src/KeyManagement/types.ts
+++ b/packages/wallet/src/KeyManagement/types.ts
@@ -1,5 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
 import { Observable } from 'rxjs';
+import { Shutdown } from '@cardano-sdk/util';
 import { TxInternals } from '../Transaction';
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid-noevents';
 import TransportWebHID from '@ledgerhq/hw-transport-webhid';
@@ -150,4 +151,4 @@ export interface KeyAgent {
 
 export type AsyncKeyAgent = Pick<KeyAgent, 'deriveAddress' | 'signBlob' | 'signTransaction'> & {
   knownAddresses$: Observable<GroupedAddress[]>;
-};
+} & Shutdown;

--- a/packages/wallet/src/KeyManagement/util/createAsyncKeyAgent.ts
+++ b/packages/wallet/src/KeyManagement/util/createAsyncKeyAgent.ts
@@ -13,6 +13,9 @@ export const createAsyncKeyAgent = (keyAgent: KeyAgent): AsyncKeyAgent => {
       return address;
     },
     knownAddresses$,
+    shutdown() {
+      knownAddresses$.complete();
+    },
     signBlob: keyAgent.signBlob.bind(keyAgent),
     signTransaction: keyAgent.signTransaction.bind(keyAgent)
   };

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -97,7 +97,7 @@ export class SingleAddressWallet implements ObservableWallet {
     submitting$: new Subject<Cardano.NewTxAlonzo>()
   };
   readonly keyAgent: AsyncKeyAgent;
-  readonly currentEpoch$: BehaviorObservable<EpochInfo>;
+  readonly currentEpoch$: TrackerSubject<EpochInfo>;
   readonly txSubmitProvider: TrackedTxSubmitProvider;
   readonly walletProvider: TrackedWalletProvider;
   readonly utxoProvider: TrackedUtxoProvider;
@@ -330,6 +330,15 @@ export class SingleAddressWallet implements ObservableWallet {
     this.txSubmitProvider.stats.shutdown();
     this.networkInfoProvider.stats.shutdown();
     this.stakePoolProvider.stats.shutdown();
+    this.utxoProvider.stats.shutdown();
+    this.keyAgent.shutdown();
+    this.currentEpoch$.complete();
+    this.delegation.shutdown();
+    this.assets$.complete();
+    this.syncStatus.shutdown();
+    this.#newTransactions.failedToSubmit$.complete();
+    this.#newTransactions.pending$.complete();
+    this.#newTransactions.submitting$.complete();
   }
 
   #prepareTx(props: InitializeTxProps) {

--- a/packages/wallet/src/services/EpochTracker.ts
+++ b/packages/wallet/src/services/EpochTracker.ts
@@ -1,12 +1,12 @@
-import { BehaviorObservable, TrackerSubject } from '@cardano-sdk/util-rxjs';
 import { Cardano, EpochInfo, NetworkInfo, createSlotEpochInfoCalc } from '@cardano-sdk/core';
 import { Observable, distinctUntilChanged, map, switchMap } from 'rxjs';
+import { TrackerSubject } from '@cardano-sdk/util-rxjs';
 import { epochInfoEquals } from './util';
 
 export const currentEpochTracker = (
   tip$: Observable<Cardano.Tip>,
   networkInfo$: Observable<NetworkInfo>
-): BehaviorObservable<EpochInfo> =>
+): TrackerSubject<EpochInfo> =>
   new TrackerSubject(
     networkInfo$.pipe(
       switchMap((networkInfo) => {

--- a/packages/wallet/src/services/ProviderTracker/ProviderStatusTracker.ts
+++ b/packages/wallet/src/services/ProviderTracker/ProviderStatusTracker.ts
@@ -108,6 +108,11 @@ export const createProviderStatusTracker = (
   return {
     isAnyRequestPending$,
     isSettled$,
-    isUpToDate$
+    isUpToDate$,
+    shutdown() {
+      isAnyRequestPending$.complete();
+      isSettled$.complete();
+      isUpToDate$.complete();
+    }
   };
 };

--- a/packages/wallet/src/services/util/persistentTrackerSubjects.ts
+++ b/packages/wallet/src/services/util/persistentTrackerSubjects.ts
@@ -8,6 +8,7 @@ import {
   delay,
   distinctUntilChanged,
   exhaustMap,
+  finalize,
   merge,
   of,
   startWith,
@@ -90,7 +91,7 @@ export class SyncableIntervalPersistentDocumentTrackerSubject<T> extends Persist
         ),
         // Always immediately restart request on external trigger
         externalTrigger$.pipe(switchMap(() => provider$))
-      ),
+      ).pipe(finalize(() => this.#externalTrigger$.complete())),
       store
     );
     this.#externalTrigger$ = externalTrigger$;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -5,6 +5,7 @@ import { Cip30DataSignature } from '@cardano-sdk/cip30';
 import { Cip30SignDataRequest } from './KeyManagement/cip8';
 import { GroupedAddress } from './KeyManagement';
 import { SelectionSkeleton } from '@cardano-sdk/cip2';
+import { Shutdown } from '@cardano-sdk/util';
 import { TxInternals } from './Transaction';
 
 export type InitializeTxProps = {
@@ -38,7 +39,7 @@ export type InitializeTxResult = TxInternals & { inputSelection: SelectionSkelet
 
 export type SignDataProps = Omit<Cip30SignDataRequest, 'keyAgent'>;
 
-export interface SyncStatus {
+export interface SyncStatus extends Shutdown {
   /**
    * Emits:
    * - `true` while waiting for any provider request to resolve

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -81,7 +81,7 @@ export interface ObservableWallet {
    * @throws InputSelectionError
    */
   initializeTx(props: InitializeTxProps): Promise<InitializeTxResult>;
-  finalizeTx(props: TxInternals): Promise<Cardano.NewTxAlonzo>;
+  finalizeTx(props: TxInternals, auxiliaryData?: Cardano.AuxiliaryData): Promise<Cardano.NewTxAlonzo>;
   /**
    * @throws Cip30DataSignError
    */

--- a/packages/wallet/test/KeyManagement/util/createAsyncKeyAgent.test.ts
+++ b/packages/wallet/test/KeyManagement/util/createAsyncKeyAgent.test.ts
@@ -40,4 +40,14 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
     await asyncKeyAgent.deriveAddress(addressDerivationPath);
     await expect(firstValueFrom(asyncKeyAgent.knownAddresses$)).resolves.toEqual(keyAgent.knownAddresses);
   });
+  it('stops emitting addresses$ after shutdown', (done) => {
+    asyncKeyAgent.shutdown();
+    asyncKeyAgent.knownAddresses$.subscribe({
+      complete: done,
+      next: () => {
+        throw new Error('Should not emit');
+      }
+    });
+    void asyncKeyAgent.deriveAddress(addressDerivationPath);
+  });
 });

--- a/packages/wallet/test/services/ProviderTracker/ProviderStatusTracker.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/ProviderStatusTracker.test.ts
@@ -140,4 +140,21 @@ describe('createProviderStatusTracker', () => {
       });
     });
   });
+
+  it('shutdown() completes all observables', () => {
+    createTestScheduler().run(({ cold, expectObservable }) => {
+      const getProviderSyncRelevantStats = jest
+        .fn()
+        .mockReturnValueOnce(cold<ProviderFnStats[]>(`-a-b-c-d-e-f ${timeout}ms g-h-i`, providerFnStats));
+      const tracker = createProviderStatusTracker(
+        { assetProvider, networkInfoProvider, stakePoolProvider, txSubmitProvider, utxoProvider, walletProvider },
+        { consideredOutOfSyncAfter: timeout },
+        { getProviderSyncRelevantStats }
+      );
+      tracker.shutdown();
+      expectObservable(tracker.isUpToDate$).toBe('(a|)', { a: false });
+      expectObservable(tracker.isSettled$).toBe('(a|)', { a: false });
+      expectObservable(tracker.isAnyRequestPending$).toBe('|');
+    });
+  });
 });

--- a/packages/web-extension/src/messaging/remoteApi.ts
+++ b/packages/web-extension/src/messaging/remoteApi.ts
@@ -3,6 +3,7 @@ import {
   BindRequestHandlerOptions,
   ConsumeRemoteApiOptions,
   EmitMessage,
+  ExposableRemoteApi,
   ExposeApiProps,
   MessengerApiDependencies,
   MethodRequest,
@@ -74,7 +75,7 @@ export const consumeMessengerRemoteApi = <T extends object>(
     {
       get(target, prop) {
         if (prop in target) return (target as any)[prop];
-        const propMetadata = properties[prop as keyof T];
+        const propMetadata = properties[prop as keyof ExposableRemoteApi<T>];
         const propName = prop.toString();
         if (typeof propMetadata === 'object') {
           if ('propType' in propMetadata) {
@@ -229,7 +230,7 @@ export const exposeMessengerApi = <API extends object>(
   const methodHandlerSubscription = bindMessengerRequestHandler(
     {
       handler: async (originalRequest, sender) => {
-        const property = properties[originalRequest.method as keyof API];
+        const property = properties[originalRequest.method as keyof ExposableRemoteApi<API>];
         if (
           typeof property === 'undefined' ||
           (property !== RemoteApiPropertyType.MethodReturningPromise &&

--- a/packages/web-extension/src/messaging/types.ts
+++ b/packages/web-extension/src/messaging/types.ts
@@ -95,8 +95,12 @@ export interface RemoteApiMethod {
 
 export type RemoteApiProperty = RemoteApiPropertyType | RemoteApiMethod;
 
+export type ExposableRemoteApi<T> = Omit<T, 'shutdown'>;
+
 export type RemoteApiProperties<T> = {
-  [key in keyof T]: RemoteApiProperty | Omit<RemoteApiProperties<T[key]>, 'propType' | 'requestOptions'>;
+  [key in keyof ExposableRemoteApi<T>]:
+    | RemoteApiProperty
+    | Omit<RemoteApiProperties<T[key]>, 'propType' | 'requestOptions'>;
 };
 
 export interface ExposeApiProps<API extends object> {

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -1,11 +1,9 @@
 import { ObservableWallet } from '@cardano-sdk/wallet';
 import { RemoteApiProperties, RemoteApiPropertyType } from '../messaging';
 
-export type ExposedObservableWalletProperties = Omit<ObservableWallet, 'shutdown'>;
-
 export const observableWalletChannel = (walletName: string) => `${walletName}$`;
 
-export const observableWalletProperties: RemoteApiProperties<ExposedObservableWalletProperties> = {
+export const observableWalletProperties: RemoteApiProperties<ObservableWallet> = {
   addresses$: RemoteApiPropertyType.Observable,
   assets$: RemoteApiPropertyType.Observable,
   balance: {


### PR DESCRIPTION
# Context

e2e tests do not exit for a long time after passing all tests

# Proposed Solution

Add missing SingleAddressWallet cleanup:
  - add AsyncKeyAgent.shutdown
    - [refactor(web-extension): update types to never expose shutdown()](https://github.com/input-output-hk/cardano-js-sdk/pull/268/commits/590de0724b44b8c1849cec96e5bd786e35d495ca)
  - add ProviderStatusTracker.shutdown
  - add a missing `complete()/shutdown()` calls in SingleAddressWallet.shutdown

# Important Changes

- add a missing optional `auxiliaryData` argument in `ObservableWallet.finalizeTx`