### PR TITLE
ci: update CI upload artifact steps

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -45,24 +45,23 @@ jobs:
         ./scripts/pack.sh
 
     - name: 📤 Upload npm packages
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: cardano-js-sdk-packages
-        path: |
-          ./cardano-js-sdk-golden-test-generator-${{ steps.package-version.outputs.current-version}}.tgz
+        path: ./cardano-sdk-*-${{ steps.package-version.outputs.current-version}}.tgz
           
-    - name: 📦 Package REPL
+    - name: 📦 Package Golden Test Generator
       working-directory: packages/golden-test-generator
       run: yarn pkg
 
     - name: 📤 Upload Golden Test Generator exe - Linux
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: golden-test-generator-linux
-        path: packages/golden-test-generator/build/golden-test-generator-linux
+        path: ./packages/golden-test-generator/build/golden-test-generator-linux
 
     - name: 📤 Upload Golden Test Generator exe - macOS
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: golden-test-generator-macos
-        path: packages/golden-test-generator/build/golden-test-generator-macos
+        path: ./packages/golden-test-generator/build/golden-test-generator-macos


### PR DESCRIPTION
# Context
The workflow has had a failure with the artefact upload for some time now:
![image](https://user-images.githubusercontent.com/303881/172340998-37e68c39-ddbf-4b07-835a-3e9f6eb712c1.png)

# Proposed Solution
- Bump upload-artifact version
- Use the new glob-based matcher to dynamically select both npm packages and GTG executables

# Testing
The changes can be verified by comparing the [last CI run on master ](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/2453480464) with this [branch's run](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/2453386707). Downloading the fixed workflow artifacts and unpacking will demonstrate it.