### PR TITLE
fix: Core TokenMap to CSL multiasset insert de-dupe  

### DIFF
--- a/packages/core/src/CSL/coreToCsl/coreToCsl.ts
+++ b/packages/core/src/CSL/coreToCsl/coreToCsl.ts
@@ -44,14 +44,28 @@ import { SerializationError } from '../../errors';
 import { SerializationFailure } from '../..';
 import { parseCslAddress } from '../parseCslAddress';
 
-export const tokenMap = (assets: Cardano.TokenMap) => {
+export const tokenMap = (map: Cardano.TokenMap) => {
   const multiasset = MultiAsset.new();
-  for (const assetId of assets.keys()) {
-    const { scriptHash, assetName } = Asset.util.parseAssetId(assetId);
-    const assetsObj = Assets.new();
-    const amount = BigNum.from_str(assets.get(assetId)!.toString());
-    assetsObj.insert(assetName, amount);
-    multiasset.insert(scriptHash, assetsObj);
+  const policyMap: Map<string, { assetsMap: Map<AssetName, BigNum>; scriptHash: ScriptHash }> = new Map();
+
+  for (const assetId of map.keys()) {
+    const { assetName, scriptHash } = Asset.util.parseAssetId(assetId);
+    const policyId = Asset.util.policyIdFromAssetId(assetId).toString();
+    const amount = BigNum.from_str(map.get(assetId)!.toString());
+    if (!policyMap.has(policyId)) {
+      policyMap.set(policyId, { assetsMap: new Map([[assetName, amount]]), scriptHash });
+    } else {
+      const { assetsMap } = policyMap.get(policyId)!;
+      policyMap.set(policyId, { assetsMap: assetsMap.set(assetName, amount), scriptHash });
+    }
+  }
+
+  for (const { assetsMap, scriptHash } of policyMap.values()) {
+    const assets = Assets.new();
+    for (const [assetName, amount] of assetsMap.entries()) {
+      assets.insert(assetName, amount);
+    }
+    multiasset.insert(scriptHash, assets);
   }
   return multiasset;
 };

--- a/packages/core/test/CSL/coreToCsl.test.ts
+++ b/packages/core/test/CSL/coreToCsl.test.ts
@@ -31,7 +31,7 @@ describe('coreToCsl', () => {
       const value = coreToCsl.value(valueWithAssets);
       expect(value.coin().to_str()).toEqual(valueWithAssets.coins.toString());
       const multiasset = value.multiasset()!;
-      expect(multiasset.len()).toBe(2);
+      expect(multiasset.len()).toBe(3);
       for (const [assetId, expectedAssetQuantity] of valueWithAssets.assets!.entries()) {
         const { scriptHash, assetName } = Asset.util.parseAssetId(assetId);
         const assetQuantity = BigInt(multiasset.get(scriptHash)!.get(assetName)!.to_str());
@@ -40,15 +40,18 @@ describe('coreToCsl', () => {
       expect(value).toBeInstanceOf(CSL.Value);
     });
   });
-  it('tokenMap', () => {
-    const multiasset = coreToCsl.tokenMap(txOut.value.assets!);
-    expect(multiasset).toBeInstanceOf(CSL.MultiAsset);
-    expect(multiasset.len()).toBe(2);
-    for (const [assetId, expectedAssetQuantity] of txOut.value.assets!.entries()) {
-      const { scriptHash, assetName } = Asset.util.parseAssetId(assetId);
-      const assetQuantity = BigInt(multiasset.get(scriptHash)!.get(assetName)!.to_str());
-      expect(assetQuantity).toBe(expectedAssetQuantity);
-    }
+  describe('tokenMap', () => {
+    it('inserts a single multiasset per asset policy', () => {
+      const multiasset = coreToCsl.tokenMap(txOut.value.assets!);
+      expect(multiasset).toBeInstanceOf(CSL.MultiAsset);
+      const scriptHashes = multiasset.keys();
+      expect(scriptHashes.len()).toBe(3);
+      for (const [assetId, expectedAssetQuantity] of txOut.value.assets!.entries()) {
+        const { scriptHash, assetName } = Asset.util.parseAssetId(assetId);
+        const assetQuantity = BigInt(multiasset.get(scriptHash)!.get(assetName)!.to_str());
+        expect(assetQuantity).toBe(expectedAssetQuantity);
+      }
+    });
   });
   it('txBody', () => {
     const cslBody = coreToCsl.txBody(txBody);

--- a/packages/core/test/CSL/testData.ts
+++ b/packages/core/test/CSL/testData.ts
@@ -32,7 +32,9 @@ export const poolParameters: Cardano.PoolParameters = {
 
 export const mintTokenMap = new Map([
   [Cardano.AssetId('2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740'), 20n],
-  [Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'), -50n]
+  [Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'), -50n],
+  [Cardano.AssetId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373'), 40n],
+  [Cardano.AssetId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373504154415445'), 30n]
 ]);
 
 export const valueCoinOnly = { coins: 100_000n };
@@ -116,7 +118,7 @@ export const tx: Cardano.NewTxAlonzo = {
     }
   },
   body: txBody,
-  id: Cardano.TransactionId('6108081a4c302b22548ac0d3651e43802341c7729791c4f5243fcc6e7c2e8635'),
+  id: Cardano.TransactionId('de9d33f66cffff721673219b19470aec81d96bc9253182369e41eec58389a448'),
   witness: {
     signatures: new Map([[Cardano.Ed25519PublicKey(vkey), Cardano.Ed25519Signature(signature)]])
   }

--- a/packages/core/test/CSL/testData.ts
+++ b/packages/core/test/CSL/testData.ts
@@ -39,7 +39,9 @@ export const valueCoinOnly = { coins: 100_000n };
 export const valueWithAssets = {
   assets: new Map([
     [Cardano.AssetId('2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740'), 20n],
-    [Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'), 50n]
+    [Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'), 50n],
+    [Cardano.AssetId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373'), 40n],
+    [Cardano.AssetId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373504154415445'), 30n]
   ]),
   coins: 10n
 };
@@ -114,7 +116,7 @@ export const tx: Cardano.NewTxAlonzo = {
     }
   },
   body: txBody,
-  id: Cardano.TransactionId('e3a443363eb6ee3d67c5e75ec10b931603787581a948d68fa3b2cd3ff2e0d2ad'),
+  id: Cardano.TransactionId('6108081a4c302b22548ac0d3651e43802341c7729791c4f5243fcc6e7c2e8635'),
   witness: {
     signatures: new Map([[Cardano.Ed25519PublicKey(vkey), Cardano.Ed25519Signature(signature)]])
   }


### PR DESCRIPTION
# Context
ADP-1763

# Proposed Solution
remove duplicated insert when assets from the same policy are present in the token map

# Important Info
Conversion back to core types test is failing. Currently investigating