### PR TITLE
feat: Cache heavy NetworkInfo db-sync queries

### DIFF
--- a/packages/cardano-services/.env.test
+++ b/packages/cardano-services/.env.test
@@ -1,2 +1,3 @@
 DB_CONNECTION_STRING=postgresql://postgres:doNoUseThisSecret!@127.0.0.1:5433/testnet
 CARDANO_NODE_CONFIG_PATH=./config/network/testnet/cardano-node/config.json
+DB_QUERIES_CACHE_TTL=120

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -86,7 +86,9 @@
     "pg": "^8.7.3",
     "prom-client": "^14.0.1",
     "reflect-metadata": "~0.1.13",
-    "ts-log": "^2.2.4"
+    "ts-log": "^2.2.4",
+    "json-bigint": "^1.0.0",
+    "node-cache": "^5.1.2"
   },
   "files": [
     "dist/*",

--- a/packages/cardano-services/src/ChainHistory/ChainHistoryHttpService.ts
+++ b/packages/cardano-services/src/ChainHistory/ChainHistoryHttpService.ts
@@ -1,5 +1,5 @@
 import * as OpenApiValidator from 'express-openapi-validator';
-import { ChainHistoryProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { ChainHistoryProvider } from '@cardano-sdk/core';
 import { DbSyncChainHistoryProvider } from './DbSyncChainHistory/DbSyncChainHistoryProvider';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
@@ -29,9 +29,7 @@ export class ChainHistoryHttpService extends HttpService {
 
   static async create({ logger = dummyLogger, chainHistoryProvider }: ChainHistoryHttpServiceDependencies) {
     const router = express.Router();
-    if (!(await chainHistoryProvider.healthCheck()).ok) {
-      throw new ProviderError(ProviderFailure.Unhealthy);
-    }
+
     const apiSpec = path.join(__dirname, 'openApi.json');
     router.use(
       OpenApiValidator.middleware({

--- a/packages/cardano-services/src/DbSyncProvider.ts
+++ b/packages/cardano-services/src/DbSyncProvider.ts
@@ -14,4 +14,8 @@ export abstract class DbSyncProvider implements Provider {
     const result = await this.db.query(HEALTH_CHECK_QUERY);
     return { ok: !!result.rowCount };
   }
+
+  public async start(): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -82,6 +82,7 @@ export class HttpServer extends RunnableModule {
 
   async startImpl(): Promise<void> {
     this.server = await listenPromise(this.app, this.#config.listen);
+    for (const service of this.#dependencies.services) await service.start();
   }
 
   async shutdownImpl(): Promise<void> {

--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -25,6 +25,10 @@ export abstract class HttpService {
     });
   }
 
+  async start(): Promise<void> {
+    return Promise.resolve();
+  }
+
   async close(): Promise<void> {
     return Promise.resolve();
   }

--- a/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
+++ b/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
@@ -1,0 +1,87 @@
+import { CACHE_TTL_DEFAULT } from './defaults';
+import NodeCache from 'node-cache';
+
+export type Key = string | number;
+export type DbSyncQuery<T> = () => Promise<T>;
+
+export class InMemoryCache {
+  #cache: NodeCache;
+  #ttlDefault: number;
+
+  constructor(cacheTtlInMins: number = CACHE_TTL_DEFAULT, cache: NodeCache = new NodeCache()) {
+    this.#ttlDefault = cacheTtlInMins * 60;
+    this.#cache = cache;
+  }
+
+  /**
+   * Get a cached key value, if not found execute db query and cache the result with that key
+   *
+   * @param key cache key
+   * @param dbSyncQuery cache key
+   * @param ttl cache duration in seconds
+   * @returns The value stored with the key
+   */
+  public async get<T>(key: Key, dbSyncQuery: DbSyncQuery<T>, ttl = this.#ttlDefault): Promise<T> {
+    const cachedValue: T | undefined = this.#cache.get(key);
+    if (cachedValue) {
+      return cachedValue;
+    }
+
+    const result = await dbSyncQuery();
+    this.#cache.set(key, result, ttl);
+    return result;
+  }
+
+  /**
+   * Get a cached key
+   *
+   * @param key cache key
+   * @returns The value stored in the key
+   */
+  public getVal<T>(key: Key) {
+    return this.#cache.get<T>(key);
+  }
+
+  /**
+   * Set a cached key
+   *
+   * @param key Cache key
+   * @param value A value to cache
+   * @param ttl The time to live in seconds.
+   */
+  public set<T>(key: Key, value: T, ttl: number) {
+    return this.#cache.set<T>(key, value, ttl);
+  }
+
+  /**
+   * Invalidate cached values
+   *
+   * @param keys cache key to delete or a array of cache keys
+   */
+  public invalidate(keys: Key | Key[]) {
+    this.#cache.del(keys);
+  }
+
+  /**
+   * List all keys within this cache
+   *
+   * @returns An array of all keys
+   */
+  public keys() {
+    return this.#cache.keys();
+  }
+
+  /**
+   * Clear the interval timeout which is set on check period option. Default: 600
+   */
+  public shutdown() {
+    this.#cache.close();
+  }
+
+  /**
+   * Clear the whole data and reset the stats
+   */
+  public clear() {
+    this.#cache.flushAll();
+  }
+}

--- a/packages/cardano-services/src/InMemoryCache/defaults.ts
+++ b/packages/cardano-services/src/InMemoryCache/defaults.ts
@@ -1,0 +1,4 @@
+export const CACHE_TTL_DEFAULT = 120;
+export const CACHE_TTL_LOWER_LIMIT = 1;
+export const CACHE_TTL_UPPER_LIMIT = 2880;
+export const UNLIMITED_CACHE_TTL = 0;

--- a/packages/cardano-services/src/InMemoryCache/index.ts
+++ b/packages/cardano-services/src/InMemoryCache/index.ts
@@ -1,0 +1,2 @@
+export * from './InMemoryCache';
+export * from './defaults';

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
@@ -1,21 +1,42 @@
 import { DbSyncProvider } from '../../DbSyncProvider';
 import { GenesisData } from './types';
+import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../InMemoryCache';
 import { Logger, dummyLogger } from 'ts-log';
 import { NetworkInfo, NetworkInfoProvider, timeSettingsConfig } from '@cardano-sdk/core';
 import { NetworkInfoBuilder } from './NetworkInfoBuilder';
+import { NetworkInfoCacheKey } from '.';
 import { Pool } from 'pg';
+import { Shutdown } from '@cardano-sdk/util';
 import { loadGenesisData, toNetworkInfo } from './mappers';
+import { pollDbSync } from './utils';
 
+export interface NetworkInfoProviderProps {
+  cardanoNodeConfigPath: string;
+  dbPollInterval: number;
+}
+export interface NetworkInfoProviderDependencies {
+  db: Pool;
+  cache: InMemoryCache;
+  logger?: Logger;
+}
 export class DbSyncNetworkInfoProvider extends DbSyncProvider implements NetworkInfoProvider {
   #logger: Logger;
+  #cache: InMemoryCache;
   #builder: NetworkInfoBuilder;
   #genesisDataReady: Promise<GenesisData>;
+  #dbPollInterval: number;
+  #pollService: Shutdown | null;
 
-  constructor(cardanoNodeConfigPath: string, db: Pool, logger = dummyLogger) {
+  constructor(
+    { cardanoNodeConfigPath, dbPollInterval }: NetworkInfoProviderProps,
+    { db, cache, logger = dummyLogger }: NetworkInfoProviderDependencies
+  ) {
     super(db);
     this.#logger = logger;
+    this.#cache = cache;
     this.#builder = new NetworkInfoBuilder(db, logger);
     this.#genesisDataReady = loadGenesisData(cardanoNodeConfigPath);
+    this.#dbPollInterval = dbPollInterval;
   }
 
   public async networkInfo(): Promise<NetworkInfo> {
@@ -24,11 +45,15 @@ export class DbSyncNetworkInfoProvider extends DbSyncProvider implements Network
 
     this.#logger.debug('About to query network info data');
 
-    const [totalSupply, circulatingSupply, activeStake, liveStake] = await Promise.all([
-      this.#builder.queryTotalSupply(maxLovelaceSupply),
-      this.#builder.queryCirculatingSupply(),
-      this.#builder.queryActiveStake(),
-      this.#builder.queryLiveStake()
+    const [liveStake, circulatingSupply, activeStake, totalSupply] = await Promise.all([
+      this.#cache.get(NetworkInfoCacheKey.LIVE_STAKE, () => this.#builder.queryLiveStake()),
+      this.#cache.get(NetworkInfoCacheKey.CIRCULATING_SUPPLY, () => this.#builder.queryCirculatingSupply()),
+      this.#cache.get(NetworkInfoCacheKey.ACTIVE_STAKE, () => this.#builder.queryActiveStake(), UNLIMITED_CACHE_TTL),
+      this.#cache.get(
+        NetworkInfoCacheKey.TOTAL_SUPPLY,
+        () => this.#builder.queryTotalSupply(maxLovelaceSupply),
+        UNLIMITED_CACHE_TTL
+      )
     ]);
 
     return toNetworkInfo({
@@ -41,5 +66,16 @@ export class DbSyncNetworkInfoProvider extends DbSyncProvider implements Network
       timeSettings,
       totalSupply
     });
+  }
+
+  async start(): Promise<void> {
+    if (!this.#pollService)
+      this.#pollService = pollDbSync(this.#cache, () => this.#builder.queryLatestEpoch(), this.#dbPollInterval);
+  }
+
+  async close(): Promise<void> {
+    this.#pollService?.shutdown();
+    this.#pollService = null;
+    this.#cache.shutdown();
   }
 }

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
@@ -1,4 +1,4 @@
-import { ActiveStakeModel, CirculatingSupplyModel, LiveStakeModel, TotalSupplyModel } from './types';
+import { ActiveStakeModel, CirculatingSupplyModel, EpochModel, LiveStakeModel, TotalSupplyModel } from './types';
 import { Cardano } from '@cardano-sdk/core';
 import { Logger, dummyLogger } from 'ts-log';
 import { Pool, QueryResult } from 'pg';
@@ -33,5 +33,11 @@ export class NetworkInfoBuilder {
     this.#logger.debug('About to query active stake');
     const result: QueryResult<ActiveStakeModel> = await this.#db.query(Queries.findActiveStake);
     return result.rows[0].active_stake;
+  }
+
+  public async queryLatestEpoch() {
+    this.#logger.debug('About to query the last epoch');
+    const result: QueryResult<EpochModel> = await this.#db.query(Queries.findLatestCompleteEpoch);
+    return result.rows[0].no;
   }
 }

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/index.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/index.ts
@@ -1,1 +1,3 @@
 export * from './DbSyncNetworkInfoProvider';
+export * from './utils';
+export * as NetworkInfoCacheKey from './keys';

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/keys.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/keys.ts
@@ -1,0 +1,5 @@
+export const TOTAL_SUPPLY = 'NetworkInfo_total_supply';
+export const CIRCULATING_SUPPLY = 'NetworkInfo_circulating_supply';
+export const ACTIVE_STAKE = 'NetworkInfo_active_stake';
+export const LIVE_STAKE = 'NetworkInfo_live_stake';
+export const CURRENT_EPOCH = 'NetworkInfo_current_epoch';

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -68,9 +68,17 @@ export const findActiveStake = `
     )
 `;
 
+export const findLatestCompleteEpoch = `
+    SELECT no
+    FROM public.epoch
+    ORDER BY no DESC
+    LIMIT 1
+`;
+
 const Queries = {
   findActiveStake,
   findCirculatingSupply,
+  findLatestCompleteEpoch,
   findLiveStake,
   findTotalSupply
 };

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
@@ -16,6 +16,10 @@ export interface LiveStakeModel {
   live_stake: string;
 }
 
+export interface EpochModel {
+  no: number;
+}
+
 export interface GenesisData {
   networkMagic: Cardano.CardanoNetworkMagic;
   networkId: Cardano.CardanoNetworkId;

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/utils.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/utils.ts
@@ -1,0 +1,26 @@
+import { DbSyncQuery, InMemoryCache, UNLIMITED_CACHE_TTL } from '../../InMemoryCache';
+import { NetworkInfoCacheKey } from '.';
+import { Shutdown } from '@cardano-sdk/util';
+
+export const DB_POLL_INTERVAL_DEFAULT = 10_000;
+
+export const pollDbSync = (cache: InMemoryCache, dbSyncQuery: DbSyncQuery<number>, interval: number): Shutdown => {
+  const executePoll = async () => {
+    const lastEpoch = await dbSyncQuery();
+    const currentEpoch = cache.getVal<number>(NetworkInfoCacheKey.CURRENT_EPOCH);
+    const shouldInvalidateEpochValues = !!(currentEpoch && lastEpoch > currentEpoch);
+
+    if (!currentEpoch || shouldInvalidateEpochValues) {
+      cache.set<number>(NetworkInfoCacheKey.CURRENT_EPOCH, lastEpoch, UNLIMITED_CACHE_TTL);
+      shouldInvalidateEpochValues
+        ? cache.invalidate([NetworkInfoCacheKey.TOTAL_SUPPLY, NetworkInfoCacheKey.ACTIVE_STAKE])
+        : void 0;
+    }
+  };
+
+  const timeout = setInterval(executePoll, interval);
+
+  return {
+    shutdown: () => clearInterval(timeout)
+  };
+};

--- a/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
+++ b/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
@@ -29,6 +29,7 @@ export class NetworkInfoHttpService extends HttpService {
 
   static create({ logger = dummyLogger, networkInfoProvider }: NetworkInfoServiceDependencies) {
     const router = express.Router();
+
     const apiSpec = path.join(__dirname, 'openApi.json');
     router.use(
       OpenApiValidator.middleware({
@@ -46,5 +47,13 @@ export class NetworkInfoHttpService extends HttpService {
       )
     );
     return new NetworkInfoHttpService({ logger, networkInfoProvider }, router);
+  }
+
+  async start(): Promise<void> {
+    await this.#networkInfoProvider.start();
+  }
+
+  async close(): Promise<void> {
+    await this.#networkInfoProvider.close();
   }
 }

--- a/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
+++ b/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
@@ -7,7 +7,9 @@ enum HttpServerOptionDescriptions {
   OgmiosUrl = 'Ogmios URL',
   RabbitMQUrl = 'RabbitMQ URL',
   UseQueue = 'Enables RabbitMQ',
-  CardanoNodeConfigPath = 'Cardano node config path'
+  CardanoNodeConfigPath = 'Cardano node config path',
+  DbQueriesCacheTtl = 'Db queries cache TTL in minutes between 1 and 2880',
+  DbPollInterval = 'Db poll interval'
 }
 
 export type ProgramOptionDescriptions = CommonOptionDescriptions | HttpServerOptionDescriptions;

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -145,5 +145,6 @@ if (process.argv.slice(2).length === 0) {
   program.parseAsync(process.argv).catch((error) => {
     // eslint-disable-next-line no-console
     console.error(error);
+    process.exit(1);
   });
 }

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -8,8 +8,10 @@ import {
   ServiceNames,
   loadHttpServer
 } from './Program';
+import { CACHE_TTL_DEFAULT } from './InMemoryCache';
 import { Command } from 'commander';
 import { CommonOptionDescriptions } from './ProgramsCommon';
+import { DB_POLL_INTERVAL_DEFAULT } from './NetworkInfo';
 import { InvalidLoggerLevel } from './errors';
 import {
   PARALLEL_MODE_DEFAULT,
@@ -21,6 +23,7 @@ import {
   loadTxWorker
 } from './TxWorker';
 import { URL } from 'url';
+import { cacheTtlValidator } from './util/validators';
 import { loggerMethodNames } from './util';
 import clear from 'clear';
 import fs from 'fs';
@@ -76,6 +79,18 @@ commonOptions(
     new URL(url).toString()
   )
   .option('--cardano-node-config-path <cardanoNodeConfigPath>', ProgramOptionDescriptions.CardanoNodeConfigPath)
+  .option(
+    '--db-queries-cache-ttl <dbQueriesCacheTtl>',
+    ProgramOptionDescriptions.DbQueriesCacheTtl,
+    cacheTtlValidator,
+    CACHE_TTL_DEFAULT
+  )
+  .option(
+    '--db-poll-interval <dbPollInterval>',
+    ProgramOptionDescriptions.DbPollInterval,
+    (interval) => Number.parseInt(interval, 10),
+    DB_POLL_INTERVAL_DEFAULT
+  )
   .option('--use-queue', ProgramOptionDescriptions.UseQueue, () => true, false)
   .action(async (serviceNames: ServiceNames[], options: { apiUrl: URL } & HttpServerOptions) => {
     const { apiUrl, ...rest } = options;
@@ -130,6 +145,5 @@ if (process.argv.slice(2).length === 0) {
   program.parseAsync(process.argv).catch((error) => {
     // eslint-disable-next-line no-console
     console.error(error);
-    process.exit(0);
   });
 }

--- a/packages/cardano-services/src/run.ts
+++ b/packages/cardano-services/src/run.ts
@@ -60,5 +60,6 @@ void (async () => {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
+    process.exit(1);
   }
 })();

--- a/packages/cardano-services/src/run.ts
+++ b/packages/cardano-services/src/run.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 import * as envalid from 'envalid';
 import { API_URL_DEFAULT, OGMIOS_URL_DEFAULT, RABBITMQ_URL_DEFAULT, ServiceNames, loadHttpServer } from './Program';
+import { CACHE_TTL_DEFAULT } from './InMemoryCache';
+import { DB_POLL_INTERVAL_DEFAULT } from './NetworkInfo';
 import { LogLevel } from 'bunyan';
 import { URL } from 'url';
+import { cacheTtlValidator } from './util/validators';
 import { config } from 'dotenv';
 import { loggerMethodNames } from './util';
 import onDeath from 'death';
@@ -11,6 +14,8 @@ const envSpecs = {
   API_URL: envalid.url({ default: API_URL_DEFAULT }),
   CARDANO_NODE_CONFIG_PATH: envalid.str({ default: undefined }),
   DB_CONNECTION_STRING: envalid.str({ default: undefined }),
+  DB_POLL_INTERVAL: envalid.num({ default: DB_POLL_INTERVAL_DEFAULT }),
+  DB_QUERIES_CACHE_TTL: envalid.makeValidator(cacheTtlValidator)(envalid.num({ default: CACHE_TTL_DEFAULT })),
   LOGGER_MIN_SEVERITY: envalid.str({ choices: loggerMethodNames as string[], default: 'info' }),
   OGMIOS_URL: envalid.url({ default: OGMIOS_URL_DEFAULT }),
   RABBITMQ_URL: envalid.url({ default: RABBITMQ_URL_DEFAULT }),
@@ -25,6 +30,8 @@ void (async () => {
   const ogmiosUrl = new URL(env.OGMIOS_URL);
   const rabbitmqUrl = new URL(env.RABBITMQ_URL);
   const cardanoNodeConfigPath = env.CARDANO_NODE_CONFIG_PATH;
+  const dbQueriesCacheTtl = env.DB_QUERIES_CACHE_TTL;
+  const dbPollInterval = env.DB_POLL_INTERVAL;
   const dbConnectionString = env.DB_CONNECTION_STRING ? new URL(env.DB_CONNECTION_STRING).toString() : undefined;
   const serviceNames = env.SERVICE_NAMES.split(',') as ServiceNames[];
 
@@ -34,6 +41,8 @@ void (async () => {
       options: {
         cardanoNodeConfigPath,
         dbConnectionString,
+        dbPollInterval,
+        dbQueriesCacheTtl,
         loggerMinSeverity: env.LOGGER_MIN_SEVERITY as LogLevel,
         ogmiosUrl,
         rabbitmqUrl,

--- a/packages/cardano-services/src/util/validators.ts
+++ b/packages/cardano-services/src/util/validators.ts
@@ -1,0 +1,10 @@
+import { CACHE_TTL_LOWER_LIMIT, CACHE_TTL_UPPER_LIMIT } from '../InMemoryCache';
+import { MissingProgramOption, ProgramOptionDescriptions, ServiceNames } from '../Program';
+
+export const cacheTtlValidator = (ttl: string) => {
+  const cacheTtl = Number.parseInt(ttl, 10);
+  if (typeof cacheTtl === 'number' && cacheTtl >= CACHE_TTL_LOWER_LIMIT && cacheTtl <= CACHE_TTL_UPPER_LIMIT) {
+    return cacheTtl;
+  }
+  throw new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.DbQueriesCacheTtl);
+};

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -2,13 +2,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  Cardano,
-  ChainHistoryProvider,
-  ProviderError,
-  ProviderFailure,
-  TransactionsByAddressesArgs
-} from '@cardano-sdk/core';
+import { Cardano, ChainHistoryProvider, TransactionsByAddressesArgs } from '@cardano-sdk/core';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider, HttpServer, HttpServerConfig } from '../../src';
 import { Pool } from 'pg';
 import { chainHistoryHttpProvider } from '@cardano-sdk/cardano-services-client';
@@ -41,20 +35,6 @@ describe('ChainHistoryHttpService', () => {
 
   afterEach(async () => {
     jest.resetAllMocks();
-  });
-
-  describe('unhealthy ChainHistoryProvider', () => {
-    beforeAll(async () => {
-      chainHistoryProvider = {
-        healthCheck: jest.fn(() => Promise.resolve({ ok: false }))
-      } as unknown as DbSyncChainHistoryProvider;
-    });
-
-    it('throws during initialization if the ChainHistoryProvider is unhealthy', async () => {
-      await expect(() => ChainHistoryHttpService.create({ chainHistoryProvider })).rejects.toThrow(
-        new ProviderError(ProviderFailure.Unhealthy)
-      );
-    });
   });
 
   describe('healthy state', () => {

--- a/packages/cardano-services/test/InMemoryCache/InMemoryCache.test.ts
+++ b/packages/cardano-services/test/InMemoryCache/InMemoryCache.test.ts
@@ -1,0 +1,80 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { CACHE_TTL_DEFAULT, InMemoryCache } from '../../src/InMemoryCache';
+import NodeCache from 'node-cache';
+
+jest.mock('node-cache');
+
+describe('InMemoryCache', () => {
+  let nodeCache: NodeCache;
+  let cache: InMemoryCache;
+
+  const CURRENT_EPOCH_KEY = 'NetworkInfo_current_epoch';
+  const TOTAL_STAKE_KEY = 'NetworkInfo_total_stake';
+  const totalStakeCachedValue = 4_500_000_000;
+  const currentEpoch = 250;
+  const cachedValues: any = {
+    [CURRENT_EPOCH_KEY]: currentEpoch,
+    [TOTAL_STAKE_KEY]: totalStakeCachedValue
+  };
+
+  beforeAll(() => {
+    (NodeCache as jest.MockedClass<any>).mockImplementation(() => ({
+      close: jest.fn(),
+      flushAll: jest.fn(),
+      get: jest.fn((key) => cachedValues[key]),
+      getVal: jest.fn((key) => cachedValues[key]),
+      keys: jest.fn(() => [CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]),
+      set: jest.fn(() => true)
+    }));
+    nodeCache = new NodeCache();
+    cache = new InMemoryCache(CACHE_TTL_DEFAULT, nodeCache);
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  it('get with cache hit', async () => {
+    const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve());
+    expect(response).toEqual(totalStakeCachedValue);
+    expect(nodeCache.get).toBeCalled();
+    expect(nodeCache.set).not.toBeCalled();
+  });
+
+  it('get with cache miss', async () => {
+    const cacheMiss = undefined;
+    const dbQueryTotalStakeResponse = '445566778899';
+    (nodeCache as jest.MockedClass<any>).get.mockImplementationOnce(() => cacheMiss);
+
+    const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve(dbQueryTotalStakeResponse));
+    expect(response).toEqual(dbQueryTotalStakeResponse);
+    expect(nodeCache.get).toBeCalled();
+    expect(nodeCache.set).toBeCalled();
+  });
+
+  it('set', async () => {
+    expect(cache.set(CURRENT_EPOCH_KEY, currentEpoch, 120)).toEqual(true);
+    expect(nodeCache.set).toBeCalled();
+  });
+
+  it('getVal', async () => {
+    expect(cache.getVal(TOTAL_STAKE_KEY)).toEqual(totalStakeCachedValue);
+    expect(nodeCache.get).toBeCalled();
+  });
+
+  it('keys', async () => {
+    const keys = cache.keys();
+    expect(keys).toEqual([CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]);
+    expect(nodeCache.keys).toBeCalled();
+  });
+
+  it('shutdown', async () => {
+    cache.shutdown();
+    expect(nodeCache.close).toBeCalled();
+  });
+
+  it('clear', async () => {
+    cache.clear();
+    expect(nodeCache.flushAll).toBeCalled();
+  });
+});

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cardano, NetworkInfo, NetworkInfoProvider, testnetTimeSettings } from '@cardano-sdk/core';
-import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../src/NetworkInfo';
+import { DbSyncNetworkInfoProvider, NetworkInfoCacheKey, NetworkInfoHttpService } from '../../src/NetworkInfo';
 import { HttpServer, HttpServerConfig } from '../../src';
+import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../src/InMemoryCache';
 import { Pool } from 'pg';
+import { doServerRequest, ingestDbData, sleep, wrapWithTransaction } from '../util';
 import { getPort } from 'get-port-please';
 import { networkInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import axios from 'axios';
@@ -12,39 +14,62 @@ const APPLICATION_CBOR = 'application/cbor';
 const APPLICATION_JSON = 'application/json';
 
 describe('NetworkInfoHttpService', () => {
-  let dbConnection: Pool;
   let httpServer: HttpServer;
   let networkInfoProvider: DbSyncNetworkInfoProvider;
   let service: NetworkInfoHttpService;
   let port: number;
   let apiUrlBase: string;
   let config: HttpServerConfig;
-  let cardanoNodeConfigPath: string;
+  let doNetworkInfoRequest: ReturnType<typeof doServerRequest>;
+
+  const dbPollInterval = 2 * 1000;
+  const cache = new InMemoryCache(UNLIMITED_CACHE_TTL);
+  const cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
+  const db = new Pool({ connectionString: process.env.DB_CONNECTION_STRING, max: 1, min: 1 });
 
   beforeAll(async () => {
     port = await getPort();
     config = { listen: { port } };
     apiUrlBase = `http://localhost:${port}/network-info`;
-    cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
-    dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });
-  });
-
-  afterEach(async () => {
-    jest.resetAllMocks();
+    networkInfoProvider = new DbSyncNetworkInfoProvider({ cardanoNodeConfigPath, dbPollInterval }, { cache, db });
+    service = await NetworkInfoHttpService.create({ networkInfoProvider });
+    httpServer = new HttpServer(config, { services: [service] });
+    doNetworkInfoRequest = doServerRequest(apiUrlBase);
   });
 
   describe('healthy state', () => {
+    const dbConnectionQuerySpy = jest.spyOn(db, 'query');
+    const invalidateCacheSpy = jest.spyOn(cache, 'invalidate');
+
+    beforeEach(async () => {
+      await cache.clear();
+      dbConnectionQuerySpy.mockClear();
+      invalidateCacheSpy.mockClear();
+    });
+
     beforeAll(async () => {
-      networkInfoProvider = new DbSyncNetworkInfoProvider(cardanoNodeConfigPath, dbConnection);
-      service = NetworkInfoHttpService.create({ networkInfoProvider });
-      httpServer = new HttpServer(config, { services: [service] });
       await httpServer.initialize();
       await httpServer.start();
     });
 
     afterAll(async () => {
-      await dbConnection.end();
+      await db.end();
       await httpServer.shutdown();
+      await cache.shutdown();
+      jest.clearAllTimers();
+    });
+
+    describe('init', () => {
+      it('should start epoch polling once the db provider is initialized', async () => {
+        expect(cache.getVal(NetworkInfoCacheKey.CURRENT_EPOCH)).toBeUndefined();
+        expect(cache.keys().length).toEqual(0);
+
+        await sleep(dbPollInterval * 2);
+
+        expect(cache.keys().length).toEqual(1);
+        expect(cache.getVal(NetworkInfoCacheKey.CURRENT_EPOCH)).toBeDefined();
+        expect(invalidateCacheSpy).not.toHaveBeenCalled();
+      });
     });
 
     describe('/health', () => {
@@ -58,6 +83,10 @@ describe('NetworkInfoHttpService', () => {
     });
 
     describe('/network', () => {
+      const path = '/network';
+      const DB_POLL_QUERIES_COUNT = 1;
+      const networkInfoTotalQueriesCount = 4;
+
       it('returns a 200 coded response with a well formed HTTP request', async () => {
         expect((await axios.post(`${apiUrlBase}/network`, { args: [] })).status).toEqual(200);
       });
@@ -71,9 +100,74 @@ describe('NetworkInfoHttpService', () => {
         }
       });
 
+      describe('cached', () => {
+        it('should query the DB only once when the response is cached', async () => {
+          await doNetworkInfoRequest<[], NetworkInfo>(path, []);
+          await doNetworkInfoRequest<[], NetworkInfo>(path, []);
+
+          expect(dbConnectionQuerySpy).toHaveBeenCalledTimes(networkInfoTotalQueriesCount);
+          expect(cache.keys().length).toEqual(networkInfoTotalQueriesCount);
+        });
+
+        it('should call db-sync queries again once the cache is cleared', async () => {
+          await doNetworkInfoRequest<[], NetworkInfo>(path, []);
+          await cache.clear();
+          expect(cache.keys().length).toEqual(0);
+
+          await doNetworkInfoRequest<[], NetworkInfo>(path, []);
+          expect(dbConnectionQuerySpy).toBeCalledTimes(networkInfoTotalQueriesCount * 2);
+        });
+
+        it('should not invalidate the epoch values from the cache if there is no epoch rollover', async () => {
+          const currentEpochNo = 183;
+          const totalQueriesCount = networkInfoTotalQueriesCount + DB_POLL_QUERIES_COUNT;
+
+          await doNetworkInfoRequest<[], NetworkInfo>(path, []);
+          expect(cache.getVal(NetworkInfoCacheKey.CURRENT_EPOCH)).toBeUndefined();
+          expect(cache.keys().length).toEqual(networkInfoTotalQueriesCount);
+
+          await sleep(dbPollInterval);
+
+          expect(cache.getVal(NetworkInfoCacheKey.CURRENT_EPOCH)).toEqual(currentEpochNo);
+          expect(cache.keys().length).toEqual(totalQueriesCount);
+          expect(dbConnectionQuerySpy).toBeCalledTimes(totalQueriesCount);
+          expect(invalidateCacheSpy).not.toHaveBeenCalled();
+        });
+
+        it(
+          'should invalidate cached epoch values once the epoch rollover is captured by polling',
+          wrapWithTransaction(async (dbConnection) => {
+            const greaterEpoch = 255;
+
+            await doNetworkInfoRequest<[], NetworkInfo>(path, []);
+
+            await sleep(dbPollInterval);
+            expect(cache.keys().length).toEqual(networkInfoTotalQueriesCount + DB_POLL_QUERIES_COUNT);
+
+            await ingestDbData(
+              dbConnection,
+              'epoch',
+              ['id', 'out_sum', 'fees', 'tx_count', 'blk_count', 'no', 'start_time', 'end_time'],
+              [greaterEpoch, 58_389_393_484_858, 43_424_552, 55_666, 10_000, greaterEpoch, '2022-05-28', '2022-06-02']
+            );
+
+            await sleep(dbPollInterval);
+            expect(invalidateCacheSpy).toHaveBeenCalledWith([
+              NetworkInfoCacheKey.TOTAL_SUPPLY,
+              NetworkInfoCacheKey.ACTIVE_STAKE
+            ]);
+            expect(cache.getVal(NetworkInfoCacheKey.CURRENT_EPOCH)).toEqual(greaterEpoch);
+            expect(cache.keys().length).toEqual(3);
+
+            await sleep(dbPollInterval);
+          }, db)
+        );
+      });
+
       describe('with NetworkInfoHttpProvider', () => {
         let provider: NetworkInfoProvider;
-        beforeEach(() => {
+
+        beforeEach(async () => {
           provider = networkInfoHttpProvider(apiUrlBase);
         });
 
@@ -83,7 +177,6 @@ describe('NetworkInfoHttpService', () => {
             magic: Cardano.CardanoNetworkMagic.Testnet,
             timeSettings: testnetTimeSettings
           };
-
           const response = await provider.networkInfo();
           expect(response.network).toEqual(testnetNetworkInfo);
         });

--- a/packages/cardano-services/test/entrypoints.test.ts
+++ b/packages/cardano-services/test/entrypoints.test.ts
@@ -126,7 +126,7 @@ describe('entrypoints', () => {
           spy = jest.fn();
         });
 
-        it('cli:start-server stake-pool exits with code 0', (done) => {
+        it('cli:start-server stake-pool exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(
             exePath('cli'),
@@ -137,13 +137,13 @@ describe('entrypoints', () => {
           );
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
         });
 
-        it('cli:start-server network-info exits with code 0', (done) => {
+        it('cli:start-server network-info exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(
             exePath('cli'),
@@ -163,7 +163,7 @@ describe('entrypoints', () => {
           );
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
@@ -192,13 +192,13 @@ describe('entrypoints', () => {
           );
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
         });
 
-        it('cli:start-server utxo exits with code 0', (done) => {
+        it('cli:start-server utxo exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(
             exePath('cli'),
@@ -218,13 +218,13 @@ describe('entrypoints', () => {
           );
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
         });
 
-        it('run stake-pool exits with code 0', (done) => {
+        it('run stake-pool exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(exePath('run'), {
             env: {
@@ -236,13 +236,13 @@ describe('entrypoints', () => {
           });
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
         });
 
-        it('run network-info exits with code 0', (done) => {
+        it('run network-info exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(exePath('run'), {
             env: {
@@ -254,7 +254,7 @@ describe('entrypoints', () => {
           });
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
@@ -280,7 +280,7 @@ describe('entrypoints', () => {
           });
         });
 
-        it('run utxo exits with code 0', (done) => {
+        it('run utxo exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(exePath('run'), {
             env: {
@@ -292,7 +292,7 @@ describe('entrypoints', () => {
           });
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
@@ -305,7 +305,7 @@ describe('entrypoints', () => {
           spy = jest.fn();
         });
 
-        it('cli:start-server network-info exits with code 0', (done) => {
+        it('cli:start-server network-info exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(
             exePath('cli'),
@@ -325,13 +325,13 @@ describe('entrypoints', () => {
           );
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
         });
 
-        it('run network-info exits with code 0', (done) => {
+        it('run network-info exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(exePath('run'), {
             env: {
@@ -344,7 +344,7 @@ describe('entrypoints', () => {
           });
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
@@ -463,7 +463,7 @@ describe('entrypoints', () => {
         await serverClosePromise(ogmiosServer);
       });
 
-      it('cli:start-server exits with code 0', (done) => {
+      it('cli:start-server exits with code 1', (done) => {
         expect.assertions(2);
         ogmiosServer.listen(ogmiosConnection.port, () => {
           proc = fork(
@@ -487,14 +487,14 @@ describe('entrypoints', () => {
           );
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
         });
       });
 
-      it('run exits with code 0', (done) => {
+      it('run exits with code 1', (done) => {
         expect.assertions(2);
         ogmiosServer.listen(ogmiosConnection.port, () => {
           proc = fork(exePath('run'), {
@@ -509,7 +509,7 @@ describe('entrypoints', () => {
           });
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
@@ -528,7 +528,7 @@ describe('entrypoints', () => {
         await serverClosePromise(ogmiosServer);
       });
 
-      it('cli:start-server exits with code 0', (done) => {
+      it('cli:start-server exits with code 1', (done) => {
         expect.assertions(2);
         ogmiosServer.listen(ogmiosConnection.port, () => {
           proc = fork(
@@ -550,14 +550,14 @@ describe('entrypoints', () => {
           );
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });
         });
       });
 
-      it('run exits with code 0', (done) => {
+      it('run exits with code 1', (done) => {
         expect.assertions(2);
         ogmiosServer.listen(ogmiosConnection.port, () => {
           proc = fork(exePath('run'), {
@@ -571,7 +571,7 @@ describe('entrypoints', () => {
           });
           proc.stderr!.on('data', spy);
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             expect(spy).toHaveBeenCalled();
             done();
           });

--- a/packages/cardano-services/test/entrypoints.txWorker.test.ts
+++ b/packages/cardano-services/test/entrypoints.txWorker.test.ts
@@ -110,14 +110,14 @@ describe('tx-worker entrypoints', () => {
       });
 
       describe('with bad parallel option', () => {
-        it('cli:start-worker exits with code 0', (done) => {
+        it('cli:start-worker exits with code 1', (done) => {
           expect.assertions(2);
           proc = fork(exePath('cli'), [...commonArgs, '--parallel', 'test'], { stdio: 'pipe' });
           proc.stderr!.on('data', (data) =>
             expect(data.toString()).toMatch('tx-submit requires a valid Parallel mode')
           );
           proc.on('exit', (code) => {
-            expect(code).toBe(0);
+            expect(code).toBe(1);
             done();
           });
         });
@@ -170,12 +170,12 @@ describe('tx-worker entrypoints', () => {
   });
 
   describe('without a working RabbitMQ server', () => {
-    it('cli:start-worker exits with code 0', (done) => {
+    it('cli:start-worker exits with code 1', (done) => {
       expect.assertions(2);
       proc = fork(exePath('cli'), [...commonArgs, '--rabbitmq-url', BAD_CONNECTION_URL.toString()], { stdio: 'pipe' });
       proc.stderr!.on('data', (data) => expect(data.toString()).toMatch('ECONNREFUSED'));
       proc.on('exit', (code) => {
-        expect(code).toBe(0);
+        expect(code).toBe(1);
         done();
       });
     });

--- a/packages/core/src/Provider/Provider.ts
+++ b/packages/core/src/Provider/Provider.ts
@@ -3,6 +3,10 @@ export type HealthCheckResponse = {
 };
 
 export interface Provider {
+  start?(): Promise<void>;
+  /**
+   * @throws ProviderError
+   */
   close?(): Promise<void>;
   /**
    * @throws ProviderError

--- a/yarn.lock
+++ b/yarn.lock
@@ -4545,6 +4545,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -8888,6 +8893,13 @@ node-addon-api@^3.0.0, node-addon-api@^3.0.2:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-fetch@2.6.0:
   version "2.6.0"


### PR DESCRIPTION
# Context

We need to cache the following values in the context of [DbSyncNetworkInfoProvider](https://github.com/input-output-hk/cardano-js-sdk/blob/b70ae5222a54634ba50bba0c9cc73b03832afe00/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts#L28-L31) to limit impact on the DB:

`this.#builder.queryTotalSupply(maxLovelaceSupply)` -  Constant for the epoch
`this.#builder.queryCirculatingSupply()` - Changes every block
`this.#builder.queryActiveStake()` - Constant for the epoch
`this.#builder.queryLiveStake()` -  Changes every block

The two constant values can be cached using knowledge of the current epoch, triggered at the point of epoch rollover, and then set a configurable value in minutes with a sensible default to cover the other two.

# Proposed Solution
**Capturing the epoch rollover ( cache invalidation for epoch values )**
- The implemented approach here is to just start up an interval on boot with a light query, and it run indefinitely.
- The optimized approach is to start a Chain-Sync Ogmios client with an epoch check in the `rollForward` handler, start polling the DB once we observe a rollover.

In order to know when there is epoch rollover, we query the latest one from `epoch` table and store it in the cache as current. The validation query is set to run every 10 seconds change, check if there is a new epoch with data created greater than the cached one, if so - override it and invalidate the cache.

**Validation requirements**
- Default caching duration of 120 minutes for queryCirculatingSupply  and queryLiveStake
- Duration must be an integer from 1 to 2880 (2 days). This does not impact queryTotalSupply or queryActiveStake, as the cache invalidation is defined by the epoch rollover.
- Polling interval is 10 seconds

# Important Changes Introduced
- add `DB_QUERIES_CACHE_TTL` env in `run` with custom range validation
- add `DB_POLL_INTERVAL` env in `run` 
- add `--db-queries-cache-ttl` option in `cli`with custom range validation
- add `--db-poll-interval` option in `cli`
- add [CacheService](https://github.com/input-output-hk/cardano-js-sdk/pull/276/files#diff-9e8c39a0834f189fcd5eb822e9a84eac51cbf6ab7b401e8fdfb160625a78044eR7) to cache heavy db queries (used `node-cache` package )
- add db sync polling on [NetworkInfoProvider](https://github.com/input-output-hk/cardano-js-sdk/blob/12ce8b4c18d1df087fb5d1a7295ebe569aa6d188/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts#L12) provider start (10 secs polling interval)
- create test utils [wrapWithTransaction](https://github.com/input-output-hk/cardano-js-sdk/blob/4f2694e56028ba76cf96bd4e93e9c7883d5850fd/packages/cardano-services/test/util.ts#L58) and [ingestDbData](https://github.com/input-output-hk/cardano-js-sdk/blob/4f2694e56028ba76cf96bd4e93e9c7883d5850fd/packages/cardano-services/test/util.ts#L40) helping where needs to be reproduced specific test cases but finally db snapshot and state shouldn't be mutated for other tests
- extend `Provider` and `HttpService` in order to keep services builder pure [(7ceca49):](https://github.com/input-output-hk/cardano-js-sdk/pull/276/commits/7ceca494f698905e7e7492ad09bae5fbb250bea6)
-- extend `Provider` interface with `start` optional method
-- extend `DbSyncProvider` and `HttpSrvice` with `start` method
-- invoke services `start()` within `HttpServer.startImpl()`
-- remove db `healthCheck` during services creation, keep them pure
-- align tests and enhance `loadHttpServer.test.ts`