### PR TITLE
fix: division by zero error at pool rewards query

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
@@ -82,7 +82,7 @@ export class StakePoolBuilder {
     return Promise.all(
       hashesIds.map(async (hashId) => {
         const result: QueryResult<EpochRewardModel> = await this.#db.query(Queries.findPoolEpochRewards(limit), [
-          hashId
+          [hashId]
         ]);
         return result.rows.length > 0 ? mapEpochReward(result.rows[0], hashId) : undefined;
       })

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
@@ -149,7 +149,7 @@ export const mapEpochReward = (epochRewardModel: EpochRewardModel, hashId: numbe
   epochReward: {
     activeStake: BigInt(epochRewardModel.active_stake),
     epoch: epochRewardModel.epoch_no,
-    epochLength: epochRewardModel.epoch_length,
+    epochLength: Number(epochRewardModel.epoch_length),
     memberROI: epochRewardModel.member_roi,
     operatorFees: BigInt(epochRewardModel.operator_fees),
     totalRewards: BigInt(epochRewardModel.total_rewards)

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -277,7 +277,7 @@ pool_stake_per_epoch AS (
 epoch_rewards AS (
 	SELECT 
 		epochs.epoch_no,
-		epochs.epoch_length,
+		epochs.epoch_length::TEXT,
 		stake.hash_id,
 		COALESCE(rewards.total_amount, 0) AS total_rewards,
 		COALESCE(stake.active_stake, 0) AS active_stake,		

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -243,72 +243,92 @@ LEFT JOIN owners_total_utxos otu on
 where id = ANY($1)
 `;
 
-export const findPoolEpochRewards = (limit?: number) => `
+const epochRewardsSubqueries = (limit?: number) => `
 WITH epochs AS (
 	SELECT 
-		"no",
+	  "no" AS epoch_no,
 		(extract(epoch FROM (end_time - start_time)) * 1000) AS epoch_length
-	FROM epoch 
+	FROM epoch
 	ORDER BY id DESC
   ${limit !== undefined ? `LIMIT ${limit}` : ''}
 ),
-total_stake_per_epoch AS (
-  SELECT 
-      e."no" AS epoch_no,
-      sum(es.amount) AS active_stake
-    FROM epochs e
-    LEFT JOIN epoch_stake es on
-      es.epoch_no  = e."no" and 
-      es.pool_id = $1
-    GROUP BY e."no"
-  ),
-  total_rewards_per_epoch AS (
-  SELECT 
-    sum(r.amount) AS total_amount,
-    e."no" AS epoch_no
-  FROM  epochs e
-  LEFT JOIN reward r on
-    r.earned_epoch = e."no" and 
-    r.pool_id = $1
-  GROUP BY e."no"
-  )
-  SELECT 
-    rewards.epoch_no,
-    e.epoch_length,
-    COALESCE(rewards.total_amount,0) AS total_rewards,
-    CASE
-    WHEN update.fixed_cost >= rewards.total_amount
-    THEN rewards.total_amount
-    ELSE (
-      COALESCE (FLOOR((rewards.total_amount-update.fixed_cost) * update.margin) + update.fixed_cost,0)
-    )
-    END AS operator_fees,
-    COALESCE(total_stake.active_stake,0) AS active_stake,
-    CASE
-    WHEN update.fixed_cost >= rewards.total_amount
-    THEN (
-      COALESCE((rewards.total_amount - (rewards.total_amount + update.fixed_cost))
-      /total_stake.active_stake, 0)
-    )
-    ELSE (
-      COALESCE((rewards.total_amount - (((rewards.total_amount-update.fixed_cost) * update.margin) + update.fixed_cost))
-      /total_stake.active_stake, 0)
-    ) END AS member_roi
-  FROM total_rewards_per_epoch rewards
-  JOIN epochs e on 
-    e."no" = rewards.epoch_no
-  LEFT JOIN total_stake_per_epoch total_stake on 
-    rewards.epoch_no = total_stake.epoch_no
-  JOIN pool_update update
-    ON update.id = (
+pool_rewards_per_epoch AS (
+	SELECT
+		reward.pool_id AS hash_id,
+		epochs.epoch_no,
+		SUM(reward.amount) AS total_amount
+	FROM epochs
+	JOIN reward 
+		ON reward.earned_epoch = epochs.epoch_no
+		AND reward.pool_id = ANY($1)
+	GROUP BY reward.pool_id, epochs.epoch_no
+),
+pool_stake_per_epoch AS (
+	SELECT
+		epoch_stake.pool_id AS hash_id,
+		epochs.epoch_no,
+    SUM(epoch_stake.amount) AS active_stake
+	FROM epochs
+	JOIN epoch_stake 
+		ON epoch_stake.epoch_no = epochs.epoch_no
+		AND epoch_stake.pool_id = ANY($1)
+	GROUP BY epoch_stake.pool_id, epochs.epoch_no
+),
+epoch_rewards AS (
+	SELECT 
+		epochs.epoch_no,
+		epochs.epoch_length,
+		stake.hash_id,
+		COALESCE(rewards.total_amount, 0) AS total_rewards,
+		COALESCE(stake.active_stake, 0) AS active_stake,		
+		CASE 
+			WHEN pool.fixed_cost >= rewards.total_amount
+	    	THEN COALESCE(rewards.total_amount, 0)
+	    	ELSE (
+	      	COALESCE(
+	      		FLOOR((rewards.total_amount - pool.fixed_cost) * pool.margin) + pool.fixed_cost
+	      	, 0)
+	    	) 
+		END AS operator_fees,
+		CASE 
+			WHEN COALESCE(stake.active_stake, 0) = 0
+				THEN 0
+			WHEN pool.fixed_cost >= rewards.total_amount
+		    THEN (
+		      COALESCE(
+		      	(rewards.total_amount - COALESCE(rewards.total_amount, 0)) / stake.active_stake
+		      , 0)
+		    )
+		    ELSE (
+		      COALESCE(
+						(rewards.total_amount - 
+							COALESCE(
+	      				FLOOR((rewards.total_amount - pool.fixed_cost) * pool.margin) + pool.fixed_cost
+	      			, 0)) / stake.active_stake
+		      , 0)
+		    ) END AS member_roi
+  FROM pool_stake_per_epoch AS stake 
+  JOIN epochs 
+  	ON epochs.epoch_no = stake.epoch_no
+  LEFT JOIN pool_rewards_per_epoch AS rewards
+  	ON rewards.epoch_no = stake.epoch_no
+  	AND rewards.hash_id = stake.hash_id
+  JOIN pool_update AS pool
+    ON pool.id = (
       SELECT id
-      FROM pool_update pu2
-      WHERE pu2.hash_id = $1 
-        and pu2.active_epoch_no <= rewards.epoch_no
+      FROM pool_update
+      WHERE hash_id = stake.hash_id 
+        AND active_epoch_no <= epochs.epoch_no
       ORDER BY id DESC
       LIMIT 1
     )
-   order by rewards.epoch_no desc
+)`;
+
+export const findPoolEpochRewards = (limit?: number) => `
+  ${epochRewardsSubqueries(limit)}
+  SELECT * 
+  FROM epoch_rewards
+  ORDER BY epoch_no desc
 `;
 
 export const findPools = `

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
@@ -59,7 +59,7 @@ export interface EpochReward {
 
 export interface EpochRewardModel {
   epoch_no: number;
-  epoch_length: number;
+  epoch_length: string;
   operator_fees: string;
   active_stake: string;
   member_roi: number;

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -876,9 +876,9 @@ Array [
 exports[`StakePoolBuilder queryPoolRewards queryPoolRewards 1`] = `
 Array [
   Object {
-    "activeStake": 0n,
-    "epoch": 183,
-    "epochLength": 431910000,
+    "activeStake": 1004862928388n,
+    "epoch": 77,
+    "epochLength": 431980000,
     "memberROI": 0,
     "operatorFees": 0n,
     "totalRewards": 0n,

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
@@ -74,7 +74,7 @@ describe('mappers', () => {
   };
   const epochRewardModel = {
     active_stake: '10000000',
-    epoch_length: 10_000_000,
+    epoch_length: '10000000',
     epoch_no: 2,
     member_roi: 0.000_000_05,
     operator_fees: '233333333',
@@ -154,7 +154,7 @@ describe('mappers', () => {
       epochReward: {
         activeStake: BigInt(epochRewardModel.active_stake),
         epoch: epochRewardModel.epoch_no,
-        epochLength: epochRewardModel.epoch_length,
+        epochLength: Number(epochRewardModel.epoch_length),
         memberROI: epochRewardModel.member_roi,
         operatorFees: BigInt(epochRewardModel.operator_fees),
         totalRewards: BigInt(epochRewardModel.total_rewards)

--- a/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
@@ -1008,10 +1008,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -2099,10 +2099,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -3097,10 +3097,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -3596,10 +3596,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4349,10 +4349,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4424,10 +4424,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -4925,10 +4925,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5914,10 +5914,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -5989,10 +5989,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7237,10 +7237,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -7735,10 +7735,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -8910,10 +8910,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9076,10 +9076,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9741,10 +9741,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -9816,10 +9816,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11242,10 +11242,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11317,10 +11317,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -11975,10 +11975,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12050,10 +12050,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12135,10 +12135,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "497443657",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",
@@ -12210,10 +12210,10 @@ Object {
         Object {
           "activeStake": Object {
             "__type": "bigint",
-            "value": "0",
+            "value": "1004862928388",
           },
-          "epoch": 183,
-          "epochLength": 431910000,
+          "epoch": 77,
+          "epochLength": 431980000,
           "memberROI": 0,
           "operatorFees": Object {
             "__type": "bigint",


### PR DESCRIPTION
# Context

When stake-pool server is started with testnet-db-snapshot DB then called POST ”stake-pool/search”   with the request - 
```
{ "args":[] }
```
It returns 500 and divide by zero error. 

# Proposed Solution
Add `WHEN COALESCE(stake.active_stake, 0) = 0 THEN 0` check to epoch rewards query
