### PR TITLE
feat: transaction chaining

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -16,7 +16,7 @@ import {
 } from '@cardano-sdk/core';
 import { Assets, InitializeTxProps, InitializeTxResult, ObservableWallet, SignDataProps, SyncStatus } from './types';
 import {
-  Balance,
+  BalanceTracker,
   DelegationTracker,
   FailedTx,
   PersistentDocumentTrackerSubject,
@@ -112,7 +112,7 @@ export class SingleAddressWallet implements ObservableWallet {
   readonly assetProvider: TrackedAssetProvider;
   readonly chainHistoryProvider: TrackedChainHistoryProvider;
   readonly utxo: TransactionalTracker<Cardano.Utxo[]>;
-  readonly balance: TransactionalTracker<Balance>;
+  readonly balance: BalanceTracker;
   readonly transactions: TransactionsTracker & Shutdown;
   readonly delegation: DelegationTracker & Shutdown;
   readonly tip$: BehaviorObservable<Cardano.Tip>;
@@ -331,7 +331,6 @@ export class SingleAddressWallet implements ObservableWallet {
     this.#tip$.sync();
   }
   shutdown() {
-    this.balance.shutdown();
     this.utxo.shutdown();
     this.transactions.shutdown();
     this.networkInfo$.complete();

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -71,7 +71,7 @@ export const createWalletApi = (
     logger.debug('getting balance');
     try {
       const wallet = await walletReady;
-      const value = await firstValueFrom(wallet.balance.available$);
+      const value = await firstValueFrom(wallet.balance.utxo.available$);
       return Buffer.from(coreToCsl.value(value).to_bytes()).toString('hex');
     } catch (error) {
       logger.error(error);

--- a/packages/wallet/src/services/AssetsTracker.ts
+++ b/packages/wallet/src/services/AssetsTracker.ts
@@ -1,5 +1,5 @@
 import { Asset, Cardano } from '@cardano-sdk/core';
-import { Balance, TransactionalTracker } from './types';
+import { BalanceTracker } from './types';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { TrackedAssetProvider } from './ProviderTracker';
 import { coldObservableProvider } from './util';
@@ -15,7 +15,7 @@ export const createAssetService =
 export type AssetService = ReturnType<typeof createAssetService>;
 
 export interface AssetsTrackerProps {
-  balanceTracker: TransactionalTracker<Balance>;
+  balanceTracker: BalanceTracker;
   assetProvider: TrackedAssetProvider;
   retryBackoffConfig: RetryBackoffConfig;
 }
@@ -28,7 +28,7 @@ export const createAssetsTracker = (
   { assetProvider, balanceTracker, retryBackoffConfig }: AssetsTrackerProps,
   { assetService = createAssetService(assetProvider, retryBackoffConfig) }: AssetsTrackerInternals = {}
 ) =>
-  balanceTracker.total$.pipe(
+  balanceTracker.utxo.total$.pipe(
     map(({ assets }) => [...(assets?.keys() || [])]),
     tap((assetIds) => assetIds.length === 0 && assetProvider.setStatInitialized(assetProvider.stats.getAsset$)),
     mergeMap((assetIds) => from(assetIds)),

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -9,18 +9,21 @@ export enum TransactionFailure {
   Timeout = 'TIMEOUT'
 }
 
-export interface Balance extends Cardano.Value {
-  rewards: Cardano.Lovelace;
-  deposit: Cardano.Lovelace;
-}
-
 export interface TransactionalObservables<T> {
   total$: Observable<T>;
   /**
-   * total - unspendable - deposit
+   * total - unspendable
    */
   available$: Observable<T>;
   unspendable$: Observable<T>;
+}
+
+export interface BalanceTracker {
+  rewardAccounts: {
+    rewards$: Observable<Cardano.Lovelace>;
+    deposit$: Observable<Cardano.Lovelace>;
+  };
+  utxo: TransactionalObservables<Cardano.Value>;
 }
 
 export interface TransactionalTracker<T> extends TransactionalObservables<T> {
@@ -83,15 +86,11 @@ export enum StakeKeyStatus {
   Unregistered = 'UNREGISTERED'
 }
 
-export interface RewardBalance {
-  total: Cardano.Lovelace;
-  available: Cardano.Lovelace;
-}
 export interface RewardAccount {
   address: Cardano.RewardAccount;
   keyStatus: StakeKeyStatus;
   delegatee?: Delegatee;
-  rewardBalance: RewardBalance;
+  rewardBalance: Cardano.Lovelace;
   // Maybe add rewardsHistory for each reward account too
 }
 

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -16,6 +16,9 @@ export interface Balance extends Cardano.Value {
 
 export interface TransactionalObservables<T> {
   total$: Observable<T>;
+  /**
+   * total - unspendable - deposit
+   */
   available$: Observable<T>;
   unspendable$: Observable<T>;
 }

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,5 +1,5 @@
 import { Asset, Cardano, EpochInfo, NetworkInfo, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
-import { Balance, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
+import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/cip30';
 import { Cip30SignDataRequest } from './KeyManagement/cip8';
 import { GroupedAddress } from './KeyManagement';
@@ -63,7 +63,7 @@ export interface SyncStatus extends Shutdown {
 }
 
 export interface ObservableWallet {
-  readonly balance: TransactionalObservables<Balance>;
+  readonly balance: BalanceTracker;
   readonly delegation: DelegationTracker;
   readonly utxo: TransactionalObservables<Cardano.Utxo[]>;
   readonly transactions: TransactionsTracker;

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -81,12 +81,11 @@ const assertWalletProperties = async (
   expect(utxoAvailable).toEqual(mocks.utxo);
   expect(utxoTotal).toEqual(mocks.utxo);
   // balance
-  const balanceAvailable = await firstValueFrom(wallet.balance.available$);
-  const balanceTotal = await firstValueFrom(wallet.balance.total$);
+  const balanceAvailable = await firstValueFrom(wallet.balance.utxo.available$);
   expect(balanceAvailable?.coins).toEqual(
     Cardano.util.coalesceValueQuantities(mocks.utxo.map((utxo) => utxo[1].value)).coins
   );
-  expect(balanceTotal?.rewards).toBe(mocks.rewardAccountBalance);
+  expect(await firstValueFrom(wallet.balance.rewardAccounts.rewards$)).toBe(mocks.rewardAccountBalance);
   // transactions
   const transactionsHistory = await firstValueFrom(wallet.transactions.history$);
   expect(transactionsHistory?.length).toBeGreaterThan(0);
@@ -109,7 +108,7 @@ const assertWalletProperties = async (
   expect(rewardAccounts).toHaveLength(1);
   expect(rewardAccounts[0].address).toBe(rewardAccount);
   expect(rewardAccounts[0].delegatee?.nextNextEpoch?.id).toEqual(expectedDelegateeId);
-  expect(rewardAccounts[0].rewardBalance.total).toBe(mocks.rewardAccountBalance);
+  expect(rewardAccounts[0].rewardBalance).toBe(mocks.rewardAccountBalance);
   // addresses$
   const addresses = await firstValueFrom(wallet.addresses$);
   expect(addresses[0].address).toEqual(address);
@@ -125,10 +124,10 @@ const assertWalletProperties = async (
 const assertWalletProperties2 = async (wallet: ObservableWallet) => {
   expect(await firstValueFrom(wallet.utxo.available$)).toEqual(mocks.utxo2);
   expect(await firstValueFrom(wallet.utxo.total$)).toEqual(mocks.utxo2);
-  expect((await firstValueFrom(wallet.balance.available$))?.coins).toEqual(
+  expect((await firstValueFrom(wallet.balance.utxo.available$))?.coins).toEqual(
     Cardano.util.coalesceValueQuantities(mocks.utxo2.map((utxo) => utxo[1].value)).coins
   );
-  expect((await firstValueFrom(wallet.balance.total$))?.rewards).toBe(mocks.rewardAccountBalance2);
+  expect(await firstValueFrom(wallet.balance.rewardAccounts.rewards$)).toBe(mocks.rewardAccountBalance2);
   expect((await firstValueFrom(wallet.transactions.history$))?.length).toEqual(queryTransactionsResult2.length);
   const walletTip = await firstValueFrom(wallet.tip$);
   expect(walletTip).toEqual(mocks.ledgerTip2);
@@ -146,7 +145,7 @@ const assertWalletProperties2 = async (wallet: ObservableWallet) => {
   expect(rewardsHistory.all).toEqual(expectedRewards);
   const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
   expect(rewardAccounts).toHaveLength(1);
-  expect(rewardAccounts[0].rewardBalance.total).toBe(mocks.rewardAccountBalance2);
+  expect(rewardAccounts[0].rewardBalance).toBe(mocks.rewardAccountBalance2);
 };
 
 describe('SingleAddressWallet load', () => {

--- a/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/delegation.test.ts
@@ -21,13 +21,14 @@ import { combineLatest, filter, firstValueFrom } from 'rxjs';
 
 const getWalletStateSnapshot = async (wallet: ObservableWallet) => {
   const [rewardAccount] = await firstValueFrom(wallet.delegation.rewardAccounts$);
-  const balanceAvailable = await firstValueFrom(wallet.balance.available$);
-  const balanceTotal = await firstValueFrom(wallet.balance.total$);
+  const balanceAvailable = await firstValueFrom(wallet.balance.utxo.available$);
+  const balanceTotal = await firstValueFrom(wallet.balance.utxo.total$);
+  const deposit = await firstValueFrom(wallet.balance.rewardAccounts.deposit$);
   const epoch = await firstValueFrom(wallet.currentEpoch$);
   const utxoTotal = await firstValueFrom(wallet.utxo.total$);
   const utxoAvailable = await firstValueFrom(wallet.utxo.available$);
   return {
-    balance: { available: balanceAvailable, total: balanceTotal },
+    balance: { available: balanceAvailable, deposit, total: balanceTotal },
     epoch: epoch.epochNo,
     isStakeKeyRegistered: rewardAccount.keyStatus === StakeKeyStatus.Registered,
     rewardAccount,
@@ -106,8 +107,8 @@ describe('SingleAddressWallet/delegation', () => {
   });
 
   const chooseWallets = async (): Promise<[ObservableWallet, ObservableWallet]> => {
-    const wallet1Balance = await firstValueFrom(wallet1.balance.available$);
-    const wallet2Balance = await firstValueFrom(wallet2.balance.available$);
+    const wallet1Balance = await firstValueFrom(wallet1.balance.utxo.available$);
+    const wallet2Balance = await firstValueFrom(wallet2.balance.utxo.available$);
     return wallet1Balance.coins > wallet2Balance.coins ? [wallet1, wallet2] : [wallet2, wallet1];
   };
 
@@ -133,7 +134,7 @@ describe('SingleAddressWallet/delegation', () => {
 
     const { poolId, certificates } = createDelegationCertificates(initialState);
     const initialDeposit = initialState.isStakeKeyRegistered ? stakeKeyDeposit : 0n;
-    expect(initialState.balance.available.deposit).toBe(initialDeposit);
+    expect(initialState.balance.deposit).toBe(initialDeposit);
 
     // Make a 1st tx with key registration (if not already registered) and stake delegation
     // Also send some coin to another wallet
@@ -153,18 +154,20 @@ describe('SingleAddressWallet/delegation', () => {
     const tx1PendingState = await getWalletStateSnapshot(sourceWallet);
 
     // Updates total and available balance right after tx is submitted
-    const expectedCoinsAfterTx1 = initialState.balance.total.coins - tx1OutputCoins - tx1Internals.body.fee;
+    const coinsSpentOnDeposit = initialState.isStakeKeyRegistered ? 0n : stakeKeyDeposit;
+    const expectedCoinsAfterTx1 =
+      initialState.balance.total.coins - tx1OutputCoins - tx1Internals.body.fee - coinsSpentOnDeposit;
     expect(tx1PendingState.balance.total.coins).toEqual(expectedCoinsAfterTx1);
     expect(tx1PendingState.balance.available.coins).toEqual(expectedCoinsAfterTx1);
+    expect(tx1PendingState.balance.deposit).toEqual(stakeKeyDeposit);
 
     await waitForTx(sourceWallet, tx1Internals);
     const tx1ConfirmedState = await getWalletStateSnapshot(sourceWallet);
 
     // Updates total and available balance after tx is confirmed
-    expect(tx1ConfirmedState.balance.total.coins).toBe(
-      expectedCoinsAfterTx1 - (initialState.isStakeKeyRegistered ? 0n : stakeKeyDeposit)
-    );
+    expect(tx1ConfirmedState.balance.total.coins).toBe(expectedCoinsAfterTx1);
     expect(tx1ConfirmedState.balance.total).toEqual(tx1ConfirmedState.balance.available);
+    expect(tx1PendingState.balance.deposit).toEqual(stakeKeyDeposit);
 
     expect(tx1ConfirmedState.rewardAccount.delegatee?.nextNextEpoch!.id).toEqual(poolId);
     // nothing changes for 2 epochs
@@ -195,6 +198,6 @@ describe('SingleAddressWallet/delegation', () => {
     const expectedCoinsAfterTx2 = expectedCoinsAfterTx1 + stakeKeyDeposit - tx2Internals.body.fee;
     expect(tx2ConfirmedState.balance.total.coins).toBe(expectedCoinsAfterTx2);
     expect(tx2ConfirmedState.balance.total).toEqual(tx2ConfirmedState.balance.available);
-    expect(tx2ConfirmedState.balance.total.deposit).toBe(0n);
+    expect(tx2ConfirmedState.balance.deposit).toBe(0n);
   });
 });

--- a/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/nft.test.ts
@@ -56,7 +56,7 @@ describe('SingleAddressWallet.assets/nft', () => {
 
   it('supports multiple CIP-25 NFT metadata in one tx', async () => {
     const nfts = await firstValueFrom(
-      combineLatest([wallet.assets$, wallet.balance.total$]).pipe(
+      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
         filter(([assets, balance]) => assets.size === balance.assets?.size),
         map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
       )
@@ -85,7 +85,7 @@ describe('SingleAddressWallet.assets/nft', () => {
 
   it('parses CIP-25 NFT metadata with files', async () => {
     const nfts = await firstValueFrom(
-      combineLatest([wallet.assets$, wallet.balance.total$]).pipe(
+      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
         filter(([assets, balance]) => assets.size === balance.assets?.size),
         map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
       )

--- a/packages/wallet/test/integration/txChainingBalance.test.ts
+++ b/packages/wallet/test/integration/txChainingBalance.test.ts
@@ -1,0 +1,40 @@
+import { Cardano } from '@cardano-sdk/core';
+import { SingleAddressWallet } from '../../src';
+import { createWallet } from './util';
+import { firstValueFrom } from 'rxjs';
+
+describe('integration/txChainingBalance', () => {
+  let wallet: SingleAddressWallet;
+
+  beforeAll(async () => {
+    // Using mock TxSubmitProvider which doesn't do anything and instantly resolves
+    wallet = await createWallet();
+  });
+
+  it('available balance includes change outputs from pending transaction', async () => {
+    const utxo = await firstValueFrom(wallet.utxo.available$);
+    const balanceBefore = await firstValueFrom(wallet.balance.utxo.available$);
+    const outputCoins = utxo[0][1].value.coins + 1n; // will always select at least 2 utxo with mock utxo set
+    const output: Cardano.TxOut = {
+      address: Cardano.Address(
+        'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+      ),
+      value: {
+        coins: outputCoins
+      }
+    };
+    const tx = await wallet.initializeTx({ outputs: new Set([output]) });
+    // Precondition
+    const coinsSpent = outputCoins + tx.body.fee;
+    const totalOutputCoins = Cardano.util.coalesceValueQuantities(tx.body.outputs.map((txOut) => txOut.value)).coins;
+    expect(totalOutputCoins).toBeGreaterThan(coinsSpent);
+    // Wallet will consider the transaction 'in flight' upon submission,
+    // UtxoProvider will not see the new utxo from change outputs.
+    // It's up to UtxoTracker to track those.
+    await wallet.submitTx(await wallet.finalizeTx(tx));
+    const balanceAfter = await firstValueFrom(wallet.balance.utxo.available$);
+    expect(balanceAfter.coins).toEqual(balanceBefore.coins - coinsSpent);
+  });
+
+  afterAll(() => wallet.shutdown());
+});

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -11,13 +11,12 @@ describe('integration/withdrawal', () => {
   });
 
   it('has balance', async () => {
-    expect(typeof (await firstValueFrom(wallet.balance.total$))?.coins).toBe('bigint');
-    expect(typeof (await firstValueFrom(wallet.balance.available$))?.rewards).toBe('bigint');
+    expect(typeof (await firstValueFrom(wallet.balance.utxo.total$))?.coins).toBe('bigint');
+    expect(typeof (await firstValueFrom(wallet.balance.rewardAccounts.rewards$))).toBe('bigint');
   });
 
   it('can submit transaction', async () => {
-    const balanceAvailable = await firstValueFrom(wallet.balance.available$);
-    const availableRewards = balanceAvailable!.rewards;
+    const availableRewards = await firstValueFrom(wallet.balance.rewardAccounts.rewards$);
 
     const rewardAccount = (await firstValueFrom(wallet.addresses$))[0].rewardAccount;
     const txInternals = await wallet.initializeTx({

--- a/packages/wallet/test/services/AssetsTracker.test.ts
+++ b/packages/wallet/test/services/AssetsTracker.test.ts
@@ -1,23 +1,25 @@
-import { Asset } from '@cardano-sdk/core';
+import { Asset, Cardano } from '@cardano-sdk/core';
 import { AssetId, createTestScheduler } from '@cardano-sdk/util-dev';
-import { AssetsTrackerProps, Balance, TransactionalTracker, createAssetsTracker } from '../../src/services';
+import { AssetsTrackerProps, BalanceTracker, TransactionalTracker, createAssetsTracker } from '../../src/services';
 import { of } from 'rxjs';
 
 describe('createAssetsTracker', () => {
   it('fetches asset info for every asset in total balance', () => {
     createTestScheduler().run(({ cold, expectObservable, flush }) => {
       const balanceTracker = {
-        total$: cold('a-b-c', {
-          a: {} as Balance,
-          b: { assets: new Map([[AssetId.TSLA, 1n]]) } as Balance,
-          c: {
-            assets: new Map([
-              [AssetId.TSLA, 1n],
-              [AssetId.PXL, 2n]
-            ])
-          } as Balance
-        })
-      } as unknown as TransactionalTracker<Balance>;
+        utxo: {
+          total$: cold('a-b-c', {
+            a: {} as Cardano.Value,
+            b: { assets: new Map([[AssetId.TSLA, 1n]]) } as Cardano.Value,
+            c: {
+              assets: new Map([
+                [AssetId.TSLA, 1n],
+                [AssetId.PXL, 2n]
+              ])
+            } as Cardano.Value
+          })
+        }
+      } as unknown as TransactionalTracker<BalanceTracker>;
       const nftMetadata = { name: 'nft' } as Asset.NftMetadata;
       const asset1 = { assetId: AssetId.TSLA } as Asset.AssetInfo;
       const asset2 = { assetId: AssetId.PXL, nftMetadata } as Asset.AssetInfo;

--- a/packages/web-extension/e2e/extension/ui.ts
+++ b/packages/web-extension/e2e/extension/ui.ts
@@ -66,7 +66,7 @@ document
 // Use observable wallet from UI:
 const wallet = consumeObservableWallet({ walletName }, { logger, runtime });
 wallet.addresses$.subscribe(([{ address }]) => (document.querySelector('#address')!.textContent = address.toString()));
-wallet.balance.available$.subscribe(
+wallet.balance.utxo.available$.subscribe(
   ({ coins }) => (document.querySelector('#balance')!.textContent = coins.toString())
 );
 

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -7,9 +7,15 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
   addresses$: RemoteApiPropertyType.HotObservable,
   assets$: RemoteApiPropertyType.HotObservable,
   balance: {
-    available$: RemoteApiPropertyType.HotObservable,
-    total$: RemoteApiPropertyType.HotObservable,
-    unspendable$: RemoteApiPropertyType.HotObservable
+    rewardAccounts: {
+      deposit$: RemoteApiPropertyType.HotObservable,
+      rewards$: RemoteApiPropertyType.HotObservable
+    },
+    utxo: {
+      available$: RemoteApiPropertyType.HotObservable,
+      total$: RemoteApiPropertyType.HotObservable,
+      unspendable$: RemoteApiPropertyType.HotObservable
+    }
   },
   currentEpoch$: RemoteApiPropertyType.HotObservable,
   delegation: {


### PR DESCRIPTION
# Context

It’d be useful to be able to submit a transaction that has an input that is an output of a transaction that didn’t get onto chain yet.

# Proposed Solution

- Include pending transaction change outputs in available utxo set [95c2671](https://github.com/input-output-hk/cardano-js-sdk/pull/283/commits/95c2671055627a7c6cb334adc1a05b6b43bcb738)
- Improve `ObservableWallet.balance` interface: with transaction chaining, deposit and rewards should be reflected to balance immediately and it no longer makes sense to have `balance.{total$,available$}.{deposit,rewards}`. Therefore there is now just a single field for deposit and rewards. [b8371f9](https://github.com/input-output-hk/cardano-js-sdk/pull/283/commits/b8371f97e151c2e9cb18e0ac431e9703fe490d26)