### PR TITLE
refactor(cardano-services): order epoch and block queries by number instead of id

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -57,7 +57,7 @@ export const findTip = `
 		hash,
 		slot_no
 	FROM block
-	ORDER BY block.id DESC
+	ORDER BY block.block_no DESC NULLS LAST
 	LIMIT 1`;
 
 export const findProtocolParameters = `
@@ -98,7 +98,7 @@ export const findBlocksByHashes = `
 	LEFT JOIN block AS prev_blk ON block.previous_id = prev_blk.id
 	LEFT JOIN pool_hash AS pool ON pool.id = leader.pool_hash_id
 	WHERE block.hash = ANY($1)
-	ORDER BY block.id ASC`;
+	ORDER BY block.block_no ASC NULLS LAST`;
 
 export const findBlocksOutputByHashes = `
 	SELECT
@@ -109,7 +109,7 @@ export const findBlocksOutputByHashes = `
 	JOIN block ON block.id = tx.block_id
 	WHERE block.hash = ANY($1)
 	GROUP BY block.hash, block.id
-	ORDER BY block.id ASC`;
+	ORDER BY block.block_no ASC NULLS LAST`;
 
 export const findMultiAssetByTxOut = `
 	SELECT 

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -28,7 +28,7 @@ export const findTotalSupply = `
         FROM ada_pots
             WHERE ada_pots.epoch_no = (
             SELECT no FROM epoch
-            ORDER BY id DESC 
+            ORDER BY no DESC 
             LIMIT 1
         )
     )

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -6,7 +6,7 @@ export const findLastEpoch = `
  SELECT 
   "no"
  FROM epoch
- ORDER BY id DESC 
+ ORDER BY no DESC 
  LIMIT 1
 `;
 
@@ -31,7 +31,7 @@ with current_epoch AS (
   FROM epoch e
   JOIN epoch_param ep on 
     ep.epoch_no = e."no"
-  order by e.id desc limit 1
+  order by e.no desc limit 1
 ),
 blocks_created AS (
   SELECT 
@@ -249,7 +249,7 @@ WITH epochs AS (
 	  "no" AS epoch_no,
 		(extract(epoch FROM (end_time - start_time)) * 1000) AS epoch_length
 	FROM epoch
-	ORDER BY id DESC
+	ORDER BY no DESC
   ${limit !== undefined ? `LIMIT ${limit}` : ''}
 ),
 pool_rewards_per_epoch AS (

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -12,7 +12,7 @@ Object {
  SELECT 
   \\"no\\"
  FROM epoch
- ORDER BY id DESC 
+ ORDER BY no DESC 
  LIMIT 1
 ),
      pools_delegated AS (
@@ -151,7 +151,7 @@ Object {
  SELECT 
   \\"no\\"
  FROM epoch
- ORDER BY id DESC 
+ ORDER BY no DESC 
  LIMIT 1
 ), pools_by_identifier AS (
     


### PR DESCRIPTION
# Context

Currently, we are retrieving the last epoch using `ORDER BY id DESC LIMIT 1`, with `id` being the table id.

We should use `no` of the epoch record instead of `id` . Given that the epoch table index is created by `no` (`idx_epoc_no`)

# Proposed Solution

Modify block and epoch queries so they are ordered by number instead of `id`