### PR TITLE
fix: messaging prop cache

### DIFF
--- a/packages/web-extension/e2e/extension/util.ts
+++ b/packages/web-extension/e2e/extension/util.ts
@@ -22,7 +22,7 @@ export interface BackgroundServices {
 }
 
 export const adaPriceProperties: RemoteApiProperties<BackgroundServices> = {
-  adaUsd$: RemoteApiPropertyType.Observable,
+  adaUsd$: RemoteApiPropertyType.HotObservable,
   clearAllowList: RemoteApiPropertyType.MethodReturningPromise
 };
 

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -61,7 +61,7 @@
     "@wdio/static-server-service": "^7.19.5",
     "babel-loader": "^8.2.5",
     "blake2b-no-wasm": "2.1.4",
-    "chromedriver": "^100.0.0",
+    "chromedriver": "^102.0.0",
     "copy-webpack-plugin": "^10.2.4",
     "dotenv": "^16.0.0",
     "expect-webdriverio": "^3.2.1",

--- a/packages/web-extension/src/keyAgent/util.ts
+++ b/packages/web-extension/src/keyAgent/util.ts
@@ -5,7 +5,7 @@ export const keyAgentChannel = (walletName: string) => `${walletName}$-keyAgent`
 
 export const keyAgentProperties: RemoteApiProperties<KeyManagement.AsyncKeyAgent> = {
   deriveAddress: RemoteApiPropertyType.MethodReturningPromise,
-  knownAddresses$: RemoteApiPropertyType.Observable,
+  knownAddresses$: RemoteApiPropertyType.HotObservable,
   signBlob: RemoteApiPropertyType.MethodReturningPromise,
   signTransaction: RemoteApiPropertyType.MethodReturningPromise
 };

--- a/packages/web-extension/src/messaging/remoteApi.ts
+++ b/packages/web-extension/src/messaging/remoteApi.ts
@@ -106,7 +106,7 @@ export const consumeMessengerRemoteApi = <T extends object>(
           }
         } else if (propMetadata === RemoteApiPropertyType.MethodReturningPromise) {
           return (receiver[prop] = consumeMethod({ getErrorPrototype, propName }, { logger, messenger }));
-        } else if (propMetadata === RemoteApiPropertyType.Observable) {
+        } else if (propMetadata === RemoteApiPropertyType.HotObservable) {
           const observableMessenger = messenger.deriveChannel(propName);
           const messageData$ = observableMessenger.message$.pipe(map(({ data }) => fromSerializableObject(data)));
           const unsubscribe$ = messageData$.pipe(
@@ -188,7 +188,7 @@ export const bindObservableChannels = <API extends object>(
   { messenger }: MessengerApiDependencies
 ) => {
   const subscriptions = Object.entries(properties)
-    .filter(([, propType]) => propType === RemoteApiPropertyType.Observable)
+    .filter(([, propType]) => propType === RemoteApiPropertyType.HotObservable)
     .map(([observableProperty]) => {
       if (!isObservable(api[observableProperty as keyof API])) {
         throw new NotImplementedError(`Trying to expose non-implemented observable ${observableProperty}`);

--- a/packages/web-extension/src/messaging/types.ts
+++ b/packages/web-extension/src/messaging/types.ts
@@ -79,8 +79,13 @@ export interface PortMessage<Data = unknown> {
 
 export enum RemoteApiPropertyType {
   MethodReturningPromise,
-  // eslint-disable-next-line @typescript-eslint/no-shadow
-  Observable
+  /**
+   * Exposing this observable:
+   * - subscribes immediately
+   * - shares a single underlying subscription for all connections
+   * - replays 1 last emitted value upon connection
+   */
+  HotObservable
 }
 
 export interface MethodRequestOptions {

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -4,45 +4,45 @@ import { RemoteApiProperties, RemoteApiPropertyType } from '../messaging';
 export const observableWalletChannel = (walletName: string) => `${walletName}$`;
 
 export const observableWalletProperties: RemoteApiProperties<ObservableWallet> = {
-  addresses$: RemoteApiPropertyType.Observable,
-  assets$: RemoteApiPropertyType.Observable,
+  addresses$: RemoteApiPropertyType.HotObservable,
+  assets$: RemoteApiPropertyType.HotObservable,
   balance: {
-    available$: RemoteApiPropertyType.Observable,
-    total$: RemoteApiPropertyType.Observable,
-    unspendable$: RemoteApiPropertyType.Observable
+    available$: RemoteApiPropertyType.HotObservable,
+    total$: RemoteApiPropertyType.HotObservable,
+    unspendable$: RemoteApiPropertyType.HotObservable
   },
-  currentEpoch$: RemoteApiPropertyType.Observable,
+  currentEpoch$: RemoteApiPropertyType.HotObservable,
   delegation: {
-    rewardAccounts$: RemoteApiPropertyType.Observable,
-    rewardsHistory$: RemoteApiPropertyType.Observable
+    rewardAccounts$: RemoteApiPropertyType.HotObservable,
+    rewardsHistory$: RemoteApiPropertyType.HotObservable
   },
   finalizeTx: RemoteApiPropertyType.MethodReturningPromise,
-  genesisParameters$: RemoteApiPropertyType.Observable,
+  genesisParameters$: RemoteApiPropertyType.HotObservable,
   getName: RemoteApiPropertyType.MethodReturningPromise,
   initializeTx: RemoteApiPropertyType.MethodReturningPromise,
-  networkInfo$: RemoteApiPropertyType.Observable,
-  protocolParameters$: RemoteApiPropertyType.Observable,
+  networkInfo$: RemoteApiPropertyType.HotObservable,
+  protocolParameters$: RemoteApiPropertyType.HotObservable,
   signData: RemoteApiPropertyType.MethodReturningPromise,
   submitTx: RemoteApiPropertyType.MethodReturningPromise,
   syncStatus: {
-    isAnyRequestPending$: RemoteApiPropertyType.Observable,
-    isSettled$: RemoteApiPropertyType.Observable,
-    isUpToDate$: RemoteApiPropertyType.Observable
+    isAnyRequestPending$: RemoteApiPropertyType.HotObservable,
+    isSettled$: RemoteApiPropertyType.HotObservable,
+    isUpToDate$: RemoteApiPropertyType.HotObservable
   },
-  tip$: RemoteApiPropertyType.Observable,
+  tip$: RemoteApiPropertyType.HotObservable,
   transactions: {
-    history$: RemoteApiPropertyType.Observable,
+    history$: RemoteApiPropertyType.HotObservable,
     outgoing: {
-      confirmed$: RemoteApiPropertyType.Observable,
-      failed$: RemoteApiPropertyType.Observable,
-      inFlight$: RemoteApiPropertyType.Observable,
-      pending$: RemoteApiPropertyType.Observable,
-      submitting$: RemoteApiPropertyType.Observable
+      confirmed$: RemoteApiPropertyType.HotObservable,
+      failed$: RemoteApiPropertyType.HotObservable,
+      inFlight$: RemoteApiPropertyType.HotObservable,
+      pending$: RemoteApiPropertyType.HotObservable,
+      submitting$: RemoteApiPropertyType.HotObservable
     }
   },
   utxo: {
-    available$: RemoteApiPropertyType.Observable,
-    total$: RemoteApiPropertyType.Observable,
-    unspendable$: RemoteApiPropertyType.Observable
+    available$: RemoteApiPropertyType.HotObservable,
+    total$: RemoteApiPropertyType.HotObservable,
+    unspendable$: RemoteApiPropertyType.HotObservable
   }
 };

--- a/packages/web-extension/test/messaging/remoteApi.test.ts
+++ b/packages/web-extension/test/messaging/remoteApi.test.ts
@@ -110,9 +110,9 @@ const setUp = (someNumbers$: Observable<bigint> = of(0n), nestedSomeNumbers$ = o
           }
         }
       },
-      nestedSomeNumbers$: RemoteApiPropertyType.Observable
+      nestedSomeNumbers$: RemoteApiPropertyType.HotObservable
     },
-    someNumbers$: RemoteApiPropertyType.Observable
+    someNumbers$: RemoteApiPropertyType.HotObservable
   };
   const hostMessenger = createMessenger(baseChannel, true);
   const hostSubscription = exposeMessengerApi(
@@ -130,10 +130,10 @@ const setUp = (someNumbers$: Observable<bigint> = of(0n), nestedSomeNumbers$ = o
       properties: {
         ...properties,
         nestedNonExposed: {
-          nestedNonExposed$: RemoteApiPropertyType.Observable
+          nestedNonExposed$: RemoteApiPropertyType.HotObservable
         },
         nonExposedMethod: RemoteApiPropertyType.MethodReturningPromise,
-        nonExposedObservable$: RemoteApiPropertyType.Observable
+        nonExposedObservable$: RemoteApiPropertyType.HotObservable
       }
     },
     { logger, messenger: createMessenger(baseChannel, false) }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3663,13 +3663,6 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
-  dependencies:
-    follow-redirects "^1.14.4"
-
 axios@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
@@ -4417,13 +4410,13 @@ chrome-trace-event@^1.0.2:
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
-chromedriver@^100.0.0:
-  version "100.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-100.0.0.tgz#1b4bf5c89cea12c79f53bc94d8f5bb5aa79ed7be"
-  integrity sha512-oLfB0IgFEGY9qYpFQO/BNSXbPw7bgfJUN5VX8Okps9W2qNT4IqKh5hDwKWtpUIQNI6K3ToWe2/J5NdpurTY02g==
+chromedriver@^102.0.0:
+  version "102.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-102.0.0.tgz#02844c39ee33d1e88ac8c48fbe28cb8423e970a4"
+  integrity sha512-xer/0g1Oarkjc2e+4nyoLgZT4kJHYhcj3PcxD1nEoGJQYEllTjprN1uDpSb4BkgMGo0ydfIS1VDkszrr/J9OOg==
   dependencies:
     "@testim/chrome-version" "^1.1.2"
-    axios "^0.24.0"
+    axios "^0.27.2"
     del "^6.0.0"
     extract-zip "^2.0.1"
     https-proxy-agent "^5.0.0"
@@ -6196,7 +6189,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.7:
+follow-redirects@^1.14.0, follow-redirects@^1.14.7:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==


### PR DESCRIPTION
# Context

Extension messaging remote api object shouldn't recreate objects on every property access

```typescript
const obj = consumeRemoteApi(...)
obj.prop === obj.prop // false, should be true
```

# Proposed Solution

Cache remote api properties 44764aa6ef578d43b5726ba56a7d5c2f80958359

# Important Changes Introduced

- chore(web-extension): bump chromedriver dependency version 9d042391c237836108f22c98044a447f1982a399
- refactor(web-extension)!: rename RemoteApiProperty.Observable->HotObservable 4bc99224d3cdcadc90729eecd8cb9ea2d6227438
