### PR TITLE
feat: Enhance InMemoryCache 'get' method

### DIFF
--- a/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
+++ b/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
@@ -27,9 +27,13 @@ export class InMemoryCache {
       return cachedValue;
     }
 
-    const result = await dbSyncQuery();
-    this.#cache.set(key, result, ttl);
-    return result;
+    const resultPromise = dbSyncQuery();
+    this.#cache.set(
+      key,
+      resultPromise.catch(() => this.#cache.del(key)),
+      ttl
+    );
+    return resultPromise;
   }
 
   /**

--- a/packages/cardano-services/test/InMemoryCache/InMemoryCache.test.ts
+++ b/packages/cardano-services/test/InMemoryCache/InMemoryCache.test.ts
@@ -2,79 +2,101 @@
 import { CACHE_TTL_DEFAULT, InMemoryCache } from '../../src/InMemoryCache';
 import NodeCache from 'node-cache';
 
-jest.mock('node-cache');
-
 describe('InMemoryCache', () => {
-  let nodeCache: NodeCache;
-  let cache: InMemoryCache;
-
   const CURRENT_EPOCH_KEY = 'NetworkInfo_current_epoch';
   const TOTAL_STAKE_KEY = 'NetworkInfo_total_stake';
-  const totalStakeCachedValue = 4_500_000_000;
+  const totalStakeCachedValue = 4_500_000_001;
   const currentEpoch = 250;
   const cachedValues: any = {
     [CURRENT_EPOCH_KEY]: currentEpoch,
     [TOTAL_STAKE_KEY]: totalStakeCachedValue
   };
+  const cacheMiss = undefined;
 
-  beforeAll(() => {
-    (NodeCache as jest.MockedClass<any>).mockImplementation(() => ({
+  describe('with mocked node-cache', () => {
+    const nodeCacheMocked: jest.MockedClass<any> = {
       close: jest.fn(),
+      del: jest.fn(() => true),
       flushAll: jest.fn(),
       get: jest.fn((key) => cachedValues[key]),
       getVal: jest.fn((key) => cachedValues[key]),
       keys: jest.fn(() => [CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]),
       set: jest.fn(() => true)
-    }));
-    nodeCache = new NodeCache();
-    cache = new InMemoryCache(CACHE_TTL_DEFAULT, nodeCache);
+    };
+    const cache = new InMemoryCache(CACHE_TTL_DEFAULT, nodeCacheMocked);
+
+    afterEach(async () => {
+      jest.clearAllMocks();
+    });
+
+    it('get with cache hit', async () => {
+      const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve());
+      expect(response).toEqual(totalStakeCachedValue);
+      expect(nodeCacheMocked.get).toBeCalled();
+      expect(nodeCacheMocked.set).not.toBeCalled();
+    });
+
+    it('get with cache miss', async () => {
+      const dbQueryTotalStakeResponse = '445566778899';
+      (nodeCacheMocked as jest.MockedClass<any>).get.mockImplementationOnce(() => cacheMiss);
+
+      const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve(dbQueryTotalStakeResponse));
+      expect(response).toEqual(dbQueryTotalStakeResponse);
+      expect(nodeCacheMocked.get).toBeCalled();
+      expect(nodeCacheMocked.set).toBeCalled();
+    });
+
+    it('get with cache miss but db query fails the cache is properly cleared', async () => {
+      (nodeCacheMocked as jest.MockedClass<any>).get.mockImplementationOnce(() => cacheMiss);
+      await expect(cache.get(TOTAL_STAKE_KEY, () => Promise.reject('db'))).rejects.toEqual('db');
+
+      expect(nodeCacheMocked.get).toBeCalled();
+      expect(nodeCacheMocked.set).toBeCalled();
+      expect(nodeCacheMocked.del).toHaveBeenCalledWith(TOTAL_STAKE_KEY);
+    });
+
+    it('set', async () => {
+      expect(cache.set(CURRENT_EPOCH_KEY, currentEpoch, 120)).toEqual(true);
+      expect(nodeCacheMocked.set).toBeCalled();
+    });
+
+    it('getVal', async () => {
+      expect(cache.getVal(TOTAL_STAKE_KEY)).toEqual(totalStakeCachedValue);
+      expect(nodeCacheMocked.get).toBeCalled();
+    });
+
+    it('keys', async () => {
+      const keys = cache.keys();
+      expect(keys).toEqual([CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]);
+      expect(nodeCacheMocked.keys).toBeCalled();
+    });
+
+    it('shutdown', async () => {
+      cache.shutdown();
+      expect(nodeCacheMocked.close).toBeCalled();
+    });
+
+    it('clear', async () => {
+      cache.clear();
+      expect(nodeCacheMocked.flushAll).toBeCalled();
+    });
   });
 
-  afterEach(async () => {
-    jest.clearAllMocks();
-  });
+  describe('with real node-cache', () => {
+    it('get called multiple times does not query twice and returns the same result', async () => {
+      const realCache = new InMemoryCache(CACHE_TTL_DEFAULT, new NodeCache());
 
-  it('get with cache hit', async () => {
-    const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve());
-    expect(response).toEqual(totalStakeCachedValue);
-    expect(nodeCache.get).toBeCalled();
-    expect(nodeCache.set).not.toBeCalled();
-  });
+      let resolveQuery: Function;
+      const queryResult = new Promise((resolve) => (resolveQuery = resolve));
+      const dbSyncQuery = jest.fn(() => queryResult);
 
-  it('get with cache miss', async () => {
-    const cacheMiss = undefined;
-    const dbQueryTotalStakeResponse = '445566778899';
-    (nodeCache as jest.MockedClass<any>).get.mockImplementationOnce(() => cacheMiss);
+      const result1 = realCache.get(TOTAL_STAKE_KEY, dbSyncQuery);
+      const result2 = realCache.get(TOTAL_STAKE_KEY, dbSyncQuery);
 
-    const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve(dbQueryTotalStakeResponse));
-    expect(response).toEqual(dbQueryTotalStakeResponse);
-    expect(nodeCache.get).toBeCalled();
-    expect(nodeCache.set).toBeCalled();
-  });
+      resolveQuery!('db');
+      expect(await Promise.all([result1, result2])).toEqual(['db', 'db']);
 
-  it('set', async () => {
-    expect(cache.set(CURRENT_EPOCH_KEY, currentEpoch, 120)).toEqual(true);
-    expect(nodeCache.set).toBeCalled();
-  });
-
-  it('getVal', async () => {
-    expect(cache.getVal(TOTAL_STAKE_KEY)).toEqual(totalStakeCachedValue);
-    expect(nodeCache.get).toBeCalled();
-  });
-
-  it('keys', async () => {
-    const keys = cache.keys();
-    expect(keys).toEqual([CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]);
-    expect(nodeCache.keys).toBeCalled();
-  });
-
-  it('shutdown', async () => {
-    cache.shutdown();
-    expect(nodeCache.close).toBeCalled();
-  });
-
-  it('clear', async () => {
-    cache.clear();
-    expect(nodeCache.flushAll).toBeCalled();
+      expect(dbSyncQuery).toBeCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
# Context

In case when the cache is cleared and multiple simultaneous requests come in, we would run the DB query multiple times.
Raised by @mkazlauskas 

# Proposed Solution

Caching the promise instead of resolving the value, so the next invocation will instantly return the same promise.
In case of DB query fails -> `result.catch()` resets the cache so don't have to wait for the TTL

# Important Changes Introduced
