### PR TITLE
test(cardano-services): update test case for rewardsHttpProvider

### DIFF
--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -174,12 +174,15 @@ describe('RewardsHttpService', () => {
           expect(response).toMatchSnapshot();
         });
         it('returns address rewards history with epochs ', async () => {
+          const accountWithRewardsAtEpoch76 = Cardano.RewardAccount(
+            'stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr'
+          );
           const response = await provider.rewardsHistory({
             epochs: {
-              lowerBound: 10,
-              upperBound: 11
+              lowerBound: 75,
+              upperBound: 76
             },
-            rewardAccounts: [rewardAcc]
+            rewardAccounts: [accountWithRewardsAtEpoch76]
           });
           expect(response).toMatchSnapshot();
         });

--- a/packages/cardano-services/test/Reward/__snapshots__/RewardsHttpService.test.ts.snap
+++ b/packages/cardano-services/test/Reward/__snapshots__/RewardsHttpService.test.ts.snap
@@ -4,7 +4,16 @@ exports[`RewardsHttpService healthy state with rewardsHttpProvider rewardAccount
 
 exports[`RewardsHttpService healthy state with rewardsHttpProvider rewardAccountBalance returns address balance 1`] = `5000000000n`;
 
-exports[`RewardsHttpService healthy state with rewardsHttpProvider rewardsHistory returns address rewards history with epochs  1`] = `Map {}`;
+exports[`RewardsHttpService healthy state with rewardsHttpProvider rewardsHistory returns address rewards history with epochs  1`] = `
+Map {
+  "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr" => Array [
+    Object {
+      "epoch": "76",
+      "rewards": 500000000n,
+    },
+  ],
+}
+`;
 
 exports[`RewardsHttpService healthy state with rewardsHttpProvider rewardsHistory returns no rewards address history for empty reward accounts 1`] = `Map {}`;
 


### PR DESCRIPTION
# Context

Test case “RewardsHttpService healthy state with rewardsHttpProvider rewardsHistory returns address rewards history with epochs 1” has an empty expected result.

# Proposed Solution

Change epochs filters and address of the request in order to expect a non empty response.
 
# Important Changes Introduced

N/A