### PR TITLE
refactor: Remove HTTPService.create static methods and perform provider health checks during service initialization

### DIFF
--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -61,6 +61,7 @@ export class HttpServer extends RunnableModule {
       this.logger.info(`Prometheus metrics configured at ${this.#config.metrics.options?.metricsPath || '/metrics'}`);
     }
     for (const service of this.#dependencies.services) {
+      await service.initialize();
       this.app.use(`/${service.slug}`, service.router);
       this.logger.debug(`Using /${service.slug}`);
     }
@@ -81,12 +82,12 @@ export class HttpServer extends RunnableModule {
   }
 
   async startImpl(): Promise<void> {
-    this.server = await listenPromise(this.app, this.#config.listen);
     for (const service of this.#dependencies.services) await service.start();
+    this.server = await listenPromise(this.app, this.#config.listen);
   }
 
   async shutdownImpl(): Promise<void> {
-    for (const service of this.#dependencies.services) await service.close();
+    for (const service of this.#dependencies.services) await service.shutdown();
 
     return serverClosePromise(this.server);
   }

--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -2,13 +2,15 @@ import { HealthCheckResponse, ProviderError, ProviderFailure } from '@cardano-sd
 import { HttpServer } from './HttpServer';
 import { Logger, dummyLogger } from 'ts-log';
 import { ProviderHandler } from '../util';
+import { RunnableModule } from '../RunnableModule';
 import express from 'express';
 
-export abstract class HttpService {
+export abstract class HttpService extends RunnableModule {
   public router: express.Router;
   public slug: string;
 
   protected constructor(slug: string, router: express.Router, logger = dummyLogger) {
+    super(slug, logger);
     this.router = router;
     this.slug = slug;
     const healthHandler = async (req: express.Request, res: express.Response) => {
@@ -27,14 +29,15 @@ export abstract class HttpService {
     this.router.post('/health', healthHandler);
   }
 
-  async start(): Promise<void> {
+  async startImpl(): Promise<void> {
     return Promise.resolve();
   }
 
-  async close(): Promise<void> {
+  async shutdownImpl(): Promise<void> {
     return Promise.resolve();
   }
 
+  protected abstract initializeImpl(): Promise<void>;
   protected abstract healthCheck(): Promise<HealthCheckResponse>;
 
   static routeHandler(logger: Logger): ProviderHandler {

--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -5,7 +5,7 @@ import { ProviderHandler } from '../util';
 import { RunnableModule } from '../RunnableModule';
 import express from 'express';
 
-export class HttpService extends RunnableModule {
+export abstract class HttpService extends RunnableModule {
   public router: express.Router;
   public slug: string;
   public provider: Provider;

--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -1,18 +1,21 @@
-import { HealthCheckResponse, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { HealthCheckResponse, Provider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { HttpServer } from './HttpServer';
 import { Logger, dummyLogger } from 'ts-log';
 import { ProviderHandler } from '../util';
 import { RunnableModule } from '../RunnableModule';
 import express from 'express';
 
-export abstract class HttpService extends RunnableModule {
+export class HttpService extends RunnableModule {
   public router: express.Router;
   public slug: string;
+  public provider: Provider;
 
-  protected constructor(slug: string, router: express.Router, logger = dummyLogger) {
+  constructor(slug: string, provider: Provider, router: express.Router, logger = dummyLogger) {
     super(slug, logger);
     this.router = router;
     this.slug = slug;
+    this.provider = provider;
+
     const healthHandler = async (req: express.Request, res: express.Response) => {
       logger.debug('/health', { ip: req.ip });
       let body: HealthCheckResponse | Error['message'];
@@ -29,16 +32,23 @@ export abstract class HttpService extends RunnableModule {
     this.router.post('/health', healthHandler);
   }
 
+  async initializeImpl(): Promise<void> {
+    if (!(await this.healthCheck()).ok) {
+      throw new ProviderError(ProviderFailure.Unhealthy);
+    }
+  }
+
   async startImpl(): Promise<void> {
-    return Promise.resolve();
+    await this.provider.start?.();
   }
 
   async shutdownImpl(): Promise<void> {
-    return Promise.resolve();
+    await this.provider.close?.();
   }
 
-  protected abstract initializeImpl(): Promise<void>;
-  protected abstract healthCheck(): Promise<HealthCheckResponse>;
+  async healthCheck(): Promise<HealthCheckResponse> {
+    return await this.provider.healthCheck();
+  }
 
   static routeHandler(logger: Logger): ProviderHandler {
     return async (args, _r, res, _n, handler) => {

--- a/packages/cardano-services/src/Rewards/RewardsHttpService.ts
+++ b/packages/cardano-services/src/Rewards/RewardsHttpService.ts
@@ -2,7 +2,7 @@ import * as OpenApiValidator from 'express-openapi-validator';
 import { DbSyncRewardsProvider } from './DbSyncRewardProvider/DbSyncRewards';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
-import { RewardsProvider } from '@cardano-sdk/core';
+import { ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
 import { ServiceNames } from '../Program';
 import { providerHandler } from '../util';
 import express from 'express';
@@ -19,9 +19,7 @@ export class RewardsHttpService extends HttpService {
     super(ServiceNames.Rewards, router, logger);
     this.#rewardsProvider = rewardsProvider;
   }
-  async healthCheck() {
-    return this.#rewardsProvider.healthCheck();
-  }
+
   static create({ logger = dummyLogger, rewardsProvider }: RewardServiceDependencies) {
     const router = express.Router();
     const apiSpec = path.join(__dirname, 'openApi.json');
@@ -45,5 +43,15 @@ export class RewardsHttpService extends HttpService {
       providerHandler(rewardsProvider.rewardsHistory.bind(rewardsProvider))(HttpService.routeHandler(logger), logger)
     );
     return new RewardsHttpService({ logger, rewardsProvider }, router);
+  }
+
+  async initializeImpl(): Promise<void> {
+    if (!(await this.healthCheck()).ok) {
+      throw new ProviderError(ProviderFailure.Unhealthy);
+    }
+  }
+
+  async healthCheck() {
+    return this.#rewardsProvider.healthCheck();
   }
 }

--- a/packages/cardano-services/src/StakePool/StakePoolHttpService.ts
+++ b/packages/cardano-services/src/StakePool/StakePoolHttpService.ts
@@ -2,7 +2,6 @@ import * as OpenApiValidator from 'express-openapi-validator';
 import { DbSyncStakePoolProvider } from './DbSyncStakePoolProvider';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
-import { ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { ServiceNames } from '../Program';
 import { providerHandler } from '../util';
 import express from 'express';
@@ -14,27 +13,21 @@ export interface StakePoolServiceDependencies {
 }
 
 export class StakePoolHttpService extends HttpService {
-  #stakePoolProvider: DbSyncStakePoolProvider;
-  private constructor(
+  constructor(
     { logger = dummyLogger, stakePoolProvider }: StakePoolServiceDependencies,
-    router: express.Router
+    router: express.Router = express.Router()
   ) {
-    super(ServiceNames.StakePool, router, logger);
-    this.#stakePoolProvider = stakePoolProvider;
-  }
+    super(ServiceNames.StakePool, stakePoolProvider, router, logger);
 
-  static create({ logger = dummyLogger, stakePoolProvider }: StakePoolServiceDependencies) {
-    const router = express.Router();
     const apiSpec = path.join(__dirname, 'openApi.json');
     router.use(
       OpenApiValidator.middleware({
         apiSpec,
-        ignoreUndocumented: true, // otherwhise /metrics endpoint should be included in spec
+        ignoreUndocumented: true,
         validateRequests: true,
         validateResponses: true
       })
     );
-    // Add initial healthCheck of the provider when implemented
     router.post(
       '/search',
       providerHandler(stakePoolProvider.queryStakePools.bind(stakePoolProvider))(
@@ -49,16 +42,5 @@ export class StakePoolHttpService extends HttpService {
         logger
       )
     );
-    return new StakePoolHttpService({ logger, stakePoolProvider }, router);
-  }
-
-  async initializeImpl(): Promise<void> {
-    if (!(await this.healthCheck()).ok) {
-      throw new ProviderError(ProviderFailure.Unhealthy);
-    }
-  }
-
-  async healthCheck() {
-    return this.#stakePoolProvider.healthCheck();
   }
 }

--- a/packages/cardano-services/src/StakePool/StakePoolHttpService.ts
+++ b/packages/cardano-services/src/StakePool/StakePoolHttpService.ts
@@ -13,12 +13,17 @@ export interface StakePoolServiceDependencies {
 }
 
 export class StakePoolHttpService extends HttpService {
-  private constructor({ logger = dummyLogger }: StakePoolServiceDependencies, router: express.Router) {
+  #stakePoolProvider: DbSyncStakePoolProvider;
+  private constructor(
+    { logger = dummyLogger, stakePoolProvider }: StakePoolServiceDependencies,
+    router: express.Router
+  ) {
     super(ServiceNames.StakePool, router, logger);
+    this.#stakePoolProvider = stakePoolProvider;
   }
 
   async healthCheck() {
-    return Promise.resolve({ ok: true });
+    return this.#stakePoolProvider.healthCheck();
   }
 
   static create({ logger = dummyLogger, stakePoolProvider }: StakePoolServiceDependencies) {

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -53,14 +53,14 @@ describe('ChainHistoryHttpService', () => {
       } as unknown as DbSyncChainHistoryProvider;
     });
 
-    it('should not throw during service create if the ChainHistoryProvider is unhealthy', async () => {
-      expect(() => ChainHistoryHttpService.create({ chainHistoryProvider })).not.toThrow(
+    it('should not throw during service create if the ChainHistoryProvider is unhealthy', () => {
+      expect(() => new ChainHistoryHttpService({ chainHistoryProvider })).not.toThrow(
         new ProviderError(ProviderFailure.Unhealthy)
       );
     });
 
     it('throws during service initialization if the ChainHistoryProvider is unhealthy', async () => {
-      service = await ChainHistoryHttpService.create({ chainHistoryProvider });
+      service = new ChainHistoryHttpService({ chainHistoryProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
@@ -69,7 +69,7 @@ describe('ChainHistoryHttpService', () => {
   describe('healthy state', () => {
     beforeAll(async () => {
       chainHistoryProvider = new DbSyncChainHistoryProvider(dbConnection);
-      service = await ChainHistoryHttpService.create({ chainHistoryProvider });
+      service = new ChainHistoryHttpService({ chainHistoryProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await httpServer.initialize();
       await httpServer.start();

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -18,6 +18,10 @@ class SomeHttpService extends HttpService {
     return Promise.resolve({ ok: true });
   }
 
+  async initializeImpl(): Promise<void> {
+    await this.healthCheck();
+  }
+
   static create(logger = dummyLogger, assertReq?: (req: express.Request) => void) {
     const router = express.Router();
     router.post('/echo', (req, res) => {

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -45,14 +45,14 @@ describe('NetworkInfoHttpService', () => {
       } as unknown as DbSyncNetworkInfoProvider;
     });
 
-    it('should not throw during service create if the NetworkInfoProvider is unhealthy', async () => {
-      expect(() => NetworkInfoHttpService.create({ networkInfoProvider })).not.toThrow(
+    it('should not throw during service create if the NetworkInfoProvider is unhealthy', () => {
+      expect(() => new NetworkInfoHttpService({ networkInfoProvider })).not.toThrow(
         new ProviderError(ProviderFailure.Unhealthy)
       );
     });
 
     it('throws during service initialization if the NetworkInfoProvider is unhealthy', async () => {
-      service = NetworkInfoHttpService.create({ networkInfoProvider });
+      service = new NetworkInfoHttpService({ networkInfoProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
@@ -68,7 +68,7 @@ describe('NetworkInfoHttpService', () => {
       config = { listen: { port } };
       apiUrlBase = `http://localhost:${port}/network-info`;
       networkInfoProvider = new DbSyncNetworkInfoProvider({ cardanoNodeConfigPath, dbPollInterval }, { cache, db });
-      service = NetworkInfoHttpService.create({ networkInfoProvider });
+      service = new NetworkInfoHttpService({ networkInfoProvider });
       httpServer = new HttpServer(config, { services: [service] });
       doNetworkInfoRequest = doServerRequest(apiUrlBase);
 

--- a/packages/cardano-services/test/Program/loadHttpServer.test.ts
+++ b/packages/cardano-services/test/Program/loadHttpServer.test.ts
@@ -105,20 +105,19 @@ describe('loadHttpServer', () => {
       await serverClosePromise(ogmiosServer);
     });
 
-    it('throws if any internal providers are unhealthy', async () => {
+    it('should not throw if any internal providers are unhealthy during HTTP server initialization', async () => {
       await expect(
-        async () =>
-          await loadHttpServer({
-            apiUrl,
-            options: {
-              dbConnectionString,
-              dbPollInterval,
-              dbQueriesCacheTtl,
-              ogmiosUrl: new URL(ogmiosConnection.address.webSocket)
-            },
-            serviceNames: [ServiceNames.StakePool, ServiceNames.TxSubmit]
-          })
-      ).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+        loadHttpServer({
+          apiUrl,
+          options: {
+            dbConnectionString,
+            dbPollInterval,
+            dbQueriesCacheTtl,
+            ogmiosUrl: new URL(ogmiosConnection.address.webSocket)
+          },
+          serviceNames: [ServiceNames.StakePool, ServiceNames.TxSubmit]
+        })
+      ).resolves.not.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
   });
 });

--- a/packages/cardano-services/test/Program/loadHttpServer.test.ts
+++ b/packages/cardano-services/test/Program/loadHttpServer.test.ts
@@ -60,7 +60,8 @@ describe('loadHttpServer', () => {
           ServiceNames.TxSubmit,
           ServiceNames.ChainHistory,
           ServiceNames.Utxo,
-          ServiceNames.NetworkInfo
+          ServiceNames.NetworkInfo,
+          ServiceNames.Rewards
         ]
       });
       expect(httpServer).toBeInstanceOf(HttpServer);
@@ -71,7 +72,13 @@ describe('loadHttpServer', () => {
         async () =>
           await loadHttpServer({
             apiUrl,
-            serviceNames: [ServiceNames.StakePool]
+            serviceNames: [
+              ServiceNames.StakePool,
+              ServiceNames.Utxo,
+              ServiceNames.ChainHistory,
+              ServiceNames.Rewards,
+              ServiceNames.NetworkInfo
+            ]
           })
       ).rejects.toThrow(MissingProgramOption);
     });

--- a/packages/cardano-services/test/Program/loadHttpServer.test.ts
+++ b/packages/cardano-services/test/Program/loadHttpServer.test.ts
@@ -45,8 +45,8 @@ describe('loadHttpServer', () => {
       await serverClosePromise(ogmiosServer);
     });
 
-    it('loads the nominated HTTP services and server if required program arguments are set', async () => {
-      httpServer = await loadHttpServer({
+    it('loads the nominated HTTP services and server if required program arguments are set', () => {
+      httpServer = loadHttpServer({
         apiUrl,
         options: {
           cardanoNodeConfigPath,
@@ -67,30 +67,28 @@ describe('loadHttpServer', () => {
       expect(httpServer).toBeInstanceOf(HttpServer);
     });
 
-    it('throws if postgres-dependent service is nominated without providing the connection string', async () => {
-      await expect(
-        async () =>
-          await loadHttpServer({
-            apiUrl,
-            serviceNames: [
-              ServiceNames.StakePool,
-              ServiceNames.Utxo,
-              ServiceNames.ChainHistory,
-              ServiceNames.Rewards,
-              ServiceNames.NetworkInfo
-            ]
-          })
-      ).rejects.toThrow(MissingProgramOption);
+    it('throws if postgres-dependent service is nominated without providing the connection string', () => {
+      expect(() =>
+        loadHttpServer({
+          apiUrl,
+          serviceNames: [
+            ServiceNames.StakePool,
+            ServiceNames.Utxo,
+            ServiceNames.ChainHistory,
+            ServiceNames.Rewards,
+            ServiceNames.NetworkInfo
+          ]
+        })
+      ).toThrow(MissingProgramOption);
     });
 
-    it('throws if genesis-config dependent service is nominated without providing the node config path', async () => {
-      await expect(
-        async () =>
-          await loadHttpServer({
-            apiUrl,
-            serviceNames: [ServiceNames.NetworkInfo]
-          })
-      ).rejects.toThrow(MissingProgramOption);
+    it('throws if genesis-config dependent service is nominated without providing the node config path', () => {
+      expect(() =>
+        loadHttpServer({
+          apiUrl,
+          serviceNames: [ServiceNames.NetworkInfo]
+        })
+      ).toThrow(MissingProgramOption);
     });
   });
 
@@ -105,8 +103,8 @@ describe('loadHttpServer', () => {
       await serverClosePromise(ogmiosServer);
     });
 
-    it('should not throw if any internal providers are unhealthy during HTTP server initialization', async () => {
-      await expect(
+    it('should not throw if any internal providers are unhealthy during HTTP server initialization', () => {
+      expect(() =>
         loadHttpServer({
           apiUrl,
           options: {
@@ -117,7 +115,7 @@ describe('loadHttpServer', () => {
           },
           serviceNames: [ServiceNames.StakePool, ServiceNames.TxSubmit]
         })
-      ).resolves.not.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+      ).not.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
   });
 });

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -42,14 +42,14 @@ describe('RewardsHttpService', () => {
       } as unknown as DbSyncRewardsProvider;
     });
 
-    it('should not throw during service create if the RewardsProvider is unhealthy', async () => {
-      expect(() => RewardsHttpService.create({ rewardsProvider })).not.toThrow(
+    it('should not throw during service create if the RewardsProvider is unhealthy', () => {
+      expect(() => new RewardsHttpService({ rewardsProvider })).not.toThrow(
         new ProviderError(ProviderFailure.Unhealthy)
       );
     });
 
     it('throws during service initialization if the RewardsProvider is unhealthy', async () => {
-      service = RewardsHttpService.create({ rewardsProvider });
+      service = new RewardsHttpService({ rewardsProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
@@ -58,7 +58,7 @@ describe('RewardsHttpService', () => {
   describe('healthy state', () => {
     beforeAll(async () => {
       rewardsProvider = new DbSyncRewardsProvider(dbConnection);
-      service = RewardsHttpService.create({ rewardsProvider });
+      service = new RewardsHttpService({ rewardsProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await httpServer.initialize();
       await httpServer.start();

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -79,14 +79,14 @@ describe('StakePoolHttpService', () => {
       } as unknown as DbSyncStakePoolProvider;
     });
 
-    it('should not throw during service create if the StakePoolProvider is unhealthy', async () => {
-      expect(() => StakePoolHttpService.create({ stakePoolProvider })).not.toThrow(
+    it('should not throw during service create if the StakePoolProvider is unhealthy', () => {
+      expect(() => new StakePoolHttpService({ stakePoolProvider })).not.toThrow(
         new ProviderError(ProviderFailure.Unhealthy)
       );
     });
 
     it('throws during service initialization if the StakePoolProvider is unhealthy', async () => {
-      service = StakePoolHttpService.create({ stakePoolProvider });
+      service = new StakePoolHttpService({ stakePoolProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
@@ -96,7 +96,7 @@ describe('StakePoolHttpService', () => {
   describe('healthy state', () => {
     beforeAll(async () => {
       stakePoolProvider = new DbSyncStakePoolProvider(dbConnection);
-      service = StakePoolHttpService.create({ stakePoolProvider });
+      service = new StakePoolHttpService({ stakePoolProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await httpServer.initialize();
       await httpServer.start();

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -39,8 +39,8 @@ describe('TxSubmitHttpService', () => {
       };
     });
 
-    it('throws during initialization if the TxSubmitProvider is unhealthy', async () => {
-      await expect(() => TxSubmitHttpService.create({ txSubmitProvider })).rejects.toThrow(
+    it('should not throw during initialization if the TxSubmitProvider is unhealthy', async () => {
+      await expect(TxSubmitHttpService.create({ txSubmitProvider })).resolves.not.toThrow(
         new ProviderError(ProviderFailure.Unhealthy)
       );
     });

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -39,8 +39,8 @@ describe('TxSubmitHttpService', () => {
       };
     });
 
-    it('should not throw during initialization if the TxSubmitProvider is unhealthy', async () => {
-      await expect(TxSubmitHttpService.create({ txSubmitProvider })).resolves.not.toThrow(
+    it('should not throw during initialization if the TxSubmitProvider is unhealthy', () => {
+      expect(() => new TxSubmitHttpService({ txSubmitProvider })).not.toThrow(
         new ProviderError(ProviderFailure.Unhealthy)
       );
     });
@@ -59,7 +59,9 @@ describe('TxSubmitHttpService', () => {
     beforeAll(async () => {
       isOk = () => true;
       txSubmitProvider = { healthCheck: jest.fn(() => Promise.resolve({ ok: isOk() })), submitTx: jest.fn() };
-      httpServer = new HttpServer(config, { services: [await TxSubmitHttpService.create({ txSubmitProvider })] });
+      httpServer = new HttpServer(config, {
+        services: [new TxSubmitHttpService({ txSubmitProvider })]
+      });
       await httpServer.initialize();
       await httpServer.start();
       expect(await serverHealth()).toEqual({ ok: true });
@@ -93,7 +95,9 @@ describe('TxSubmitHttpService', () => {
   describe('healthy and successful submission', () => {
     beforeAll(async () => {
       txSubmitProvider = { healthCheck: jest.fn(() => Promise.resolve({ ok: true })), submitTx: jest.fn() };
-      httpServer = new HttpServer(config, { services: [await TxSubmitHttpService.create({ txSubmitProvider })] });
+      httpServer = new HttpServer(config, {
+        services: [new TxSubmitHttpService({ txSubmitProvider })]
+      });
       await httpServer.initialize();
       await httpServer.start();
     });
@@ -162,7 +166,9 @@ describe('TxSubmitHttpService', () => {
           healthCheck: jest.fn(() => Promise.resolve({ ok: true })),
           submitTx: jest.fn(() => Promise.reject(stubErrors))
         };
-        httpServer = new HttpServer(config, { services: [await TxSubmitHttpService.create({ txSubmitProvider })] });
+        httpServer = new HttpServer(config, {
+          services: [new TxSubmitHttpService({ txSubmitProvider })]
+        });
         await httpServer.initialize();
         await httpServer.start();
       });

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -42,12 +42,12 @@ describe('UtxoHttpService', () => {
       } as unknown as DbSyncUtxoProvider;
     });
 
-    it('should not throw during service create if the UtxoProvider is unhealthy', async () => {
-      expect(() => UtxoHttpService.create({ utxoProvider })).not.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+    it('should not throw during service create if the UtxoProvider is unhealthy', () => {
+      expect(() => new UtxoHttpService({ utxoProvider })).not.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
 
     it('throws during service initialization if the UtxoProvider is unhealthy', async () => {
-      service = UtxoHttpService.create({ utxoProvider });
+      service = new UtxoHttpService({ utxoProvider });
       httpServer = new HttpServer(config, { services: [service] });
       await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
     });
@@ -56,7 +56,7 @@ describe('UtxoHttpService', () => {
   describe('healthy state', () => {
     beforeAll(async () => {
       utxoProvider = new DbSyncUtxoProvider(dbConnection);
-      service = UtxoHttpService.create({ utxoProvider });
+      service = new UtxoHttpService({ utxoProvider });
       httpServer = new HttpServer(config, { services: [service] });
       provider = utxoHttpProvider(apiUrlBase);
       await httpServer.initialize();


### PR DESCRIPTION
# Context
We need to keep all services pure during initialization time (static `create` method). 
In order to do that, we need to remove real health checks inside `create` service method, more of that, the static `create` method becomes redundant and we can use `public constructor` directly for the service creation phase.

Provider's health checks should be performed during the service initialization phase and all services need to be aligned with that.

# Proposed Solution
See the changes introduced.

# Important Changes Introduced
- make `HttpService` a concrete class, extending `RunnableModule`
- make all HTTP services constructable, remove the static `create` method from them
- perform provider health checks during service `initialize`
- hoist all repeatable methods from individual services to `HttpService` parent class
- rework `loadHttpServer` and `serviceMapFactory` as synchronous methods
- update relevant tests and mocks