### PR TITLE
refactor: generic NetworkInfoProvider.ledgerTip

### DIFF
--- a/packages/core/src/Provider/NetworkInfoProvider/types.ts
+++ b/packages/core/src/Provider/NetworkInfoProvider/types.ts
@@ -26,8 +26,8 @@ export type StakeSummary = {
   live: Cardano.Lovelace;
 };
 
-export interface NetworkInfoProvider {
-  ledgerTip(): Promise<Cardano.Tip>;
+export interface NetworkInfoProvider<Tip = Cardano.Tip> {
+  ledgerTip(): Promise<Tip>;
   currentWalletProtocolParameters(): Promise<ProtocolParametersRequiredByWallet>;
   genesisParameters(): Promise<Cardano.CompactGenesis>;
   lovelaceSupply(): Promise<SupplySummary>;

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -1,4 +1,4 @@
-import { Assets } from '../../types';
+import { Assets, WC } from '../../types';
 import {
   Cardano,
   EpochRewards,
@@ -14,7 +14,7 @@ import { InMemoryDocumentStore } from './InMemoryDocumentStore';
 import { InMemoryKeyValueStore } from './InMemoryKeyValueStore';
 import { WalletStores } from '../types';
 
-export class InMemoryTipStore extends InMemoryDocumentStore<Cardano.Tip> {}
+export class InMemoryTipStore<Tip extends WC.Tip> extends InMemoryDocumentStore<Tip> {}
 export class InMemoryProtocolParametersStore extends InMemoryDocumentStore<ProtocolParametersRequiredByWallet> {}
 export class InMemoryGenesisParametersStore extends InMemoryDocumentStore<Cardano.CompactGenesis> {}
 export class InMemoryStakeSummaryStore extends InMemoryDocumentStore<StakeSummary> {}
@@ -33,7 +33,7 @@ export class InMemoryRewardsHistoryStore extends InMemoryKeyValueStore<Cardano.R
 export class InMemoryStakePoolsStore extends InMemoryKeyValueStore<Cardano.PoolId, Cardano.StakePool> {}
 export class InMemoryRewardsBalancesStore extends InMemoryKeyValueStore<Cardano.RewardAccount, Cardano.Lovelace> {}
 
-export const createInMemoryWalletStores = (): WalletStores => ({
+export const createInMemoryWalletStores = <Tip extends WC.Tip>(): WalletStores<Tip> => ({
   addresses: new InMemoryAddressesStore(),
   assets: new InMemoryAssetsStore(),
   destroy() {

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -1,4 +1,4 @@
-import { Assets } from '../types';
+import { Assets, WC } from '../types';
 import {
   Cardano,
   EpochRewards,
@@ -75,8 +75,8 @@ export interface KeyValueStore<K, V> extends Omit<CollectionStore<KeyValueCollec
   setValue(key: K, value: V): Observable<void>;
 }
 
-export interface WalletStores extends Destroyable {
-  tip: DocumentStore<Cardano.Tip>;
+export interface WalletStores<Tip extends WC.Tip = WC.Tip> extends Destroyable {
+  tip: DocumentStore<Tip>;
   utxo: CollectionStore<Cardano.Utxo>;
   unspendableUtxo: CollectionStore<Cardano.Utxo>;
   transactions: OrderedCollectionStore<Cardano.TxAlonzo>;

--- a/packages/wallet/src/services/EpochTracker.ts
+++ b/packages/wallet/src/services/EpochTracker.ts
@@ -1,10 +1,11 @@
-import { Cardano, EpochInfo, TimeSettings, createSlotEpochInfoCalc } from '@cardano-sdk/core';
+import { EpochInfo, TimeSettings, createSlotEpochInfoCalc } from '@cardano-sdk/core';
 import { Observable, distinctUntilChanged, map, switchMap } from 'rxjs';
 import { TrackerSubject } from '@cardano-sdk/util-rxjs';
+import { WC } from '../types';
 import { epochInfoEquals } from './util';
 
 export const currentEpochTracker = (
-  tip$: Observable<Cardano.Tip>,
+  tip$: Observable<WC.Tip>,
   timeSettings$: Observable<TimeSettings[]>
 ): TrackerSubject<EpochInfo> =>
   new TrackerSubject(

--- a/packages/wallet/src/services/ProviderTracker/TrackedNetworkInfoProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedNetworkInfoProvider.ts
@@ -1,6 +1,8 @@
+/* eslint-disable brace-style */
 import { BehaviorSubject } from 'rxjs';
 import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTracker';
 import { NetworkInfoProvider } from '@cardano-sdk/core';
+import { WC } from '../../types';
 
 export class NetworkInfoProviderStats {
   readonly stake$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
@@ -32,16 +34,21 @@ export class NetworkInfoProviderStats {
 /**
  * Wraps a NetworkInfoProvider, tracking # of calls of each function
  */
-export class TrackedNetworkInfoProvider extends ProviderTracker implements NetworkInfoProvider {
+// Review: sometimes it's beneficial to use default arguments.
+// It reduces # of changes required (e.g. no changes needed in ProviderStatusTracker)
+export class TrackedNetworkInfoProvider<Tip extends WC.Tip = WC.Tip>
+  extends ProviderTracker
+  implements NetworkInfoProvider<Tip>
+{
   readonly stats = new NetworkInfoProviderStats();
   readonly stake: NetworkInfoProvider['stake'];
   readonly lovelaceSupply: NetworkInfoProvider['lovelaceSupply'];
   readonly timeSettings: NetworkInfoProvider['timeSettings'];
-  readonly ledgerTip: NetworkInfoProvider['ledgerTip'];
+  readonly ledgerTip: NetworkInfoProvider<Tip>['ledgerTip'];
   readonly currentWalletProtocolParameters: NetworkInfoProvider['currentWalletProtocolParameters'];
   readonly genesisParameters: NetworkInfoProvider['genesisParameters'];
 
-  constructor(networkInfoProvider: NetworkInfoProvider) {
+  constructor(networkInfoProvider: NetworkInfoProvider<Tip>) {
     super();
     networkInfoProvider = networkInfoProvider;
 

--- a/packages/wallet/src/services/TransactionsTracker.ts
+++ b/packages/wallet/src/services/TransactionsTracker.ts
@@ -27,6 +27,7 @@ import { FailedTx, TransactionFailure, TransactionsTracker } from './types';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { Shutdown } from '@cardano-sdk/util';
 import { TrackerSubject } from '@cardano-sdk/util-rxjs';
+import { WC } from '../types';
 import { coldObservableProvider, distinctBlock, transactionsEquals } from './util';
 import intersectionBy from 'lodash/intersectionBy';
 import sortBy from 'lodash/sortBy';
@@ -35,7 +36,7 @@ import unionBy from 'lodash/unionBy';
 export interface TransactionsTrackerProps {
   chainHistoryProvider: ChainHistoryProvider;
   addresses$: Observable<Cardano.Address[]>;
-  tip$: Observable<Cardano.Tip>;
+  tip$: Observable<WC.Tip>;
   retryBackoffConfig: RetryBackoffConfig;
   transactionsHistoryStore: OrderedCollectionStore<Cardano.TxAlonzo>;
   inFlightTransactionsStore: DocumentStore<Cardano.NewTxAlonzo[]>;

--- a/packages/wallet/src/services/util/equals.ts
+++ b/packages/wallet/src/services/util/equals.ts
@@ -1,5 +1,6 @@
 import { Cardano, EpochInfo, TimeSettings } from '@cardano-sdk/core';
 import { GroupedAddress } from '../../KeyManagement';
+import { WC } from '../../types';
 import isEqual from 'lodash/isEqual';
 
 export const strictEquals = <T>(a: T, b: T) => a === b;
@@ -11,7 +12,7 @@ export const arrayEquals = <T>(arrayA: T[], arrayB: T[], itemEquals: (a: T, b: T
 
 export const shallowArrayEquals = <T>(a: T[], b: T[]) => arrayEquals(a, b, strictEquals);
 
-export const tipEquals = (a: Cardano.Tip, b: Cardano.Tip) => a.hash === b.hash;
+export const tipEquals = (a: WC.Tip, b: WC.Tip) => a.slot === b.slot;
 
 export const txEquals = (a: Cardano.TxAlonzo, b: Cardano.TxAlonzo) => a.id === b.id;
 

--- a/packages/wallet/src/services/util/trigger.ts
+++ b/packages/wallet/src/services/util/trigger.ts
@@ -1,8 +1,9 @@
-import { Cardano, TimeSettings } from '@cardano-sdk/core';
 import { Observable, distinctUntilChanged, map } from 'rxjs';
+import { TimeSettings } from '@cardano-sdk/core';
+import { WC } from '../../types';
 import { timeSettingsEquals } from './equals';
 
-export const distinctBlock = (tip$: Observable<Cardano.Tip>) =>
+export const distinctBlock = (tip$: Observable<WC.Tip>) =>
   tip$.pipe(
     map(({ blockNo }) => blockNo),
     distinctUntilChanged()

--- a/packages/wallet/src/types/ObservableWallet.ts
+++ b/packages/wallet/src/types/ObservableWallet.ts
@@ -9,12 +9,12 @@ import {
 } from '@cardano-sdk/core';
 import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/cip30';
-import { Cip30SignDataRequest } from './KeyManagement/cip8';
-import { GroupedAddress } from './KeyManagement';
+import { Cip30SignDataRequest } from '../KeyManagement/cip8';
+import { GroupedAddress } from '../KeyManagement';
 import { Observable } from 'rxjs';
 import { SelectionSkeleton } from '@cardano-sdk/cip2';
 import { Shutdown } from '@cardano-sdk/util';
-import { TxInternals } from './Transaction';
+import { TxInternals } from '../Transaction';
 
 export type InitializeTxProps = {
   outputs?: Set<Cardano.TxOut>;

--- a/packages/wallet/src/types/ObservableWallet.ts
+++ b/packages/wallet/src/types/ObservableWallet.ts
@@ -1,3 +1,4 @@
+import * as WC from './WalletCore';
 import {
   Asset,
   Cardano,
@@ -7,7 +8,7 @@ import {
   SupplySummary,
   TimeSettings
 } from '@cardano-sdk/core';
-import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
+import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from '../services';
 import { Cip30DataSignature } from '@cardano-sdk/cip30';
 import { Cip30SignDataRequest } from '../KeyManagement/cip8';
 import { GroupedAddress } from '../KeyManagement';
@@ -70,12 +71,12 @@ export interface SyncStatus extends Shutdown {
   isSettled$: Observable<boolean>;
 }
 
-export interface ObservableWallet {
+export interface ObservableWallet<Tip = WC.Tip> {
   readonly balance: BalanceTracker;
   readonly delegation: DelegationTracker;
   readonly utxo: TransactionalObservables<Cardano.Utxo[]>;
   readonly transactions: TransactionsTracker;
-  readonly tip$: Observable<Cardano.Tip>;
+  readonly tip$: Observable<Tip>;
   readonly genesisParameters$: Observable<Cardano.CompactGenesis>;
   readonly lovelaceSupply$: Observable<SupplySummary>;
   readonly stake$: Observable<StakeSummary>;

--- a/packages/wallet/src/types/WalletCore.ts
+++ b/packages/wallet/src/types/WalletCore.ts
@@ -1,0 +1,3 @@
+import { Cardano } from '@cardano-sdk/core';
+
+export type Tip = Pick<Cardano.Tip, 'slot' | 'blockNo'>;

--- a/packages/wallet/src/types/index.ts
+++ b/packages/wallet/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './ObservableWallet';

--- a/packages/wallet/src/types/index.ts
+++ b/packages/wallet/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './ObservableWallet';
+export * as WC from './WalletCore';

--- a/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
+++ b/packages/wallet/test/e2e/SingleAddressWallet/metadata.test.ts
@@ -1,5 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
-import { SingleAddressWallet } from '../../../src';
+import { CompleteObservableWallet, SingleAddressWallet } from '../../../src';
 import {
   assetProvider,
   chainHistoryProvider,
@@ -14,7 +14,7 @@ import { filter, firstValueFrom, map } from 'rxjs';
 import { isNotNil } from '@cardano-sdk/util';
 
 describe('SingleAddressWallet/metadata', () => {
-  let wallet: SingleAddressWallet;
+  let wallet: CompleteObservableWallet;
   let ownAddress: Cardano.Address;
 
   beforeAll(async () => {

--- a/packages/wallet/test/integration/partialWallet.test.ts
+++ b/packages/wallet/test/integration/partialWallet.test.ts
@@ -1,0 +1,64 @@
+import * as mocks from '../mocks';
+import { Cardano, NetworkInfoProvider } from '@cardano-sdk/core';
+import { KeyManagement, ObservableWallet, SingleAddressWallet, WC } from '../../src';
+import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
+import { firstValueFrom } from 'rxjs';
+
+// SingleAddressWallet generic parameters compatible with WC.* (WalletCore) types
+// because they are either used internally or considered essential
+interface CustomTip extends WC.Tip {
+  // You can pick any extra fields (that are not available in WC.* types) that you need from SDK `core` package types.
+  // Typically you would pick something from Cardano.Tip,
+  // but the only property that is not available in WC.Tip is 'hash'
+  // and we also want to demonstrate the absence of Cardano.* fields
+  date: Cardano.Block['date'];
+}
+
+const stubCustomNetworkInfoProvider: NetworkInfoProvider<CustomTip> = {
+  ...mocks.mockNetworkInfoProvider(),
+  async ledgerTip() {
+    return {
+      blockNo: 123,
+      date: new Date(),
+      slot: 12_345
+    };
+  }
+};
+
+// A specific wallet implementation would use this type internally
+type CustomObservableWallet = ObservableWallet<CustomTip>;
+
+describe('integration/partialWallet', () => {
+  it(`can create SingleAddressWallet with a custom provider
+  that omits some field from Cardano.* type and includes an extra field not present in WC.* type`, async () => {
+    const wallet = new SingleAddressWallet(
+      {
+        name: 'Custom'
+      },
+      {
+        assetProvider: mocks.mockAssetProvider(),
+        chainHistoryProvider: mocks.mockChainHistoryProvider(),
+        keyAgent: KeyManagement.util.createAsyncKeyAgent(await mocks.testKeyAgent()),
+        networkInfoProvider: stubCustomNetworkInfoProvider,
+        rewardsProvider: mocks.mockRewardsProvider(),
+        stakePoolProvider: createStubStakePoolProvider(),
+        txSubmitProvider: mocks.mockTxSubmitProvider(),
+        utxoProvider: mocks.mockUtxoProvider()
+      }
+    );
+    // this compiles
+    const asObservableWallet: CustomObservableWallet = wallet;
+    asObservableWallet;
+
+    const tip = await firstValueFrom(wallet.tip$);
+
+    // this compiles
+    tip.slot;
+    tip.date;
+
+    // this doesnt compile
+    // tip.hash;
+
+    wallet.shutdown();
+  });
+});

--- a/packages/wallet/test/services/ProviderTracker/TrackedNetworkInfoProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedNetworkInfoProvider.test.ts
@@ -1,10 +1,16 @@
 import { BehaviorSubject } from 'rxjs';
-import { CLEAN_FN_STATS, NetworkInfoProviderStats, ProviderFnStats, TrackedNetworkInfoProvider } from '../../../src';
+import {
+  CLEAN_FN_STATS,
+  NetworkInfoProviderStats,
+  ProviderFnStats,
+  TrackedNetworkInfoProvider,
+  WC
+} from '../../../src';
 import { NetworkInfoProvider } from '@cardano-sdk/core';
 import { mockNetworkInfoProvider } from '../../mocks';
 
 describe('TrackedNetworkInfoProvider', () => {
-  let networkInfoProvider: NetworkInfoProvider;
+  let networkInfoProvider: NetworkInfoProvider<WC.Tip>;
   let trackedNetworkInfoProvider: TrackedNetworkInfoProvider;
   beforeEach(() => {
     networkInfoProvider = mockNetworkInfoProvider();
@@ -14,7 +20,7 @@ describe('TrackedNetworkInfoProvider', () => {
   describe('wraps underlying provider functions, tracks # of calls/responses and resets on stats.reset()', () => {
     const testFunctionStats =
       <T>(
-        call: (networkInfoProvider: NetworkInfoProvider) => Promise<T>,
+        call: (networkInfoProvider: NetworkInfoProvider<WC.Tip>) => Promise<T>,
         selectStats: (stats: NetworkInfoProviderStats) => BehaviorSubject<ProviderFnStats>
         // eslint-disable-next-line unicorn/consistent-function-scoping
       ) =>

--- a/packages/wallet/test/services/util/equals.test.ts
+++ b/packages/wallet/test/services/util/equals.test.ts
@@ -75,9 +75,9 @@ describe('equals', () => {
     expect(groupedAddressesEquals(addresses1, addresses2)).toBe(false);
   });
 
-  test('tipEquals compares hash', () => {
-    const tip1 = { hash: 'hash1' } as unknown as Cardano.Tip;
-    const tip2 = { hash: 'hash2' } as unknown as Cardano.Tip;
+  test('tipEquals compares slot', () => {
+    const tip1 = { slot: 123 } as unknown as Cardano.Tip;
+    const tip2 = { slot: 1234 } as unknown as Cardano.Tip;
     expect(tipEquals(tip1, { ...tip1 })).toBe(true);
     expect(tipEquals(tip1, tip2)).toBe(false);
   });


### PR DESCRIPTION
# Context

Implementing new providers for SingleAddressWallet requires resolving **all** fields defined in `core` package. This is not always possible.

# Proposed Solution

This PR demonstrates a generic parameter-based approach for more flexible types. It only implements the approach for `NetworkInfoProvider.ledgerTip` as a means to evaluate the approach. A full refactor would introduce a lot more changes, adding many more generic parameters to `ObservableWalllet` and `SingleAddressWallet`. See [this test](https://github.com/input-output-hk/cardano-js-sdk/blob/2e254cf7b1e4e8742e7849740f6d913215d41b64/packages/wallet/test/integration/partialWallet.test.ts) for usage example.

Relevant commits: 0632420abca4e9cd680bed26df37124dbd2a72b9 2e254cf7b1e4e8742e7849740f6d913215d41b64

# Other Changes Introduced

- chore(wallet): convert types.ts into directory module with index 485728f8e6d60c2b1a8b863ddeeb771f0d1ac83e