### PR TITLE
Ci/git checks

### DIFF
--- a/.github/workflows/git-checks.yaml
+++ b/.github/workflows/git-checks.yaml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2.3.3
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
# Context
Last PR was merged without squashing a `fixup!` commit, as there's no control in place.

# Proposed Solution
Introduce a new GH workflow to block the merge until they're squashed
I've included a fixup! commit that will be dropped (not squashed!) to check the workflow is functional.

![image](https://user-images.githubusercontent.com/303881/176622665-91c5c8bb-bedc-4c78-913d-7f64b9ca1b96.png)
