### PR TITLE
feat: cardano-services dependency port resolution using DNS SRV records

### DIFF
--- a/packages/cardano-services/.env.test
+++ b/packages/cardano-services/.env.test
@@ -1,3 +1,15 @@
 DB_CONNECTION_STRING=postgresql://postgres:doNoUseThisSecret!@127.0.0.1:5433/testnet
 CARDANO_NODE_CONFIG_PATH=./config/network/testnet/cardano-node/config.json
 CACHE_TTL=120
+
+RABBITMQ_URL=amqp://localhost
+OGMIOS_URL=ws://localhost:1338
+
+# SRV names
+POSTGRES_SRV_SERVICE_NAME=db-test-domain
+POSTGRES_DB=testnet
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=doNoUseThisSecret!
+
+OGMIOS_SRV_SERVICE_NAME=ogmios-test-domain
+RABBITMQ_SRV_SERVICE_NAME=rabbitmq-test-domain

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -100,6 +100,7 @@
     "fraction.js": "^4.2.0",
     "json-bigint": "^1.0.0",
     "lodash": "^4.17.21",
+    "p-retry": "^4.2.0",
     "pg": "^8.7.3",
     "prom-client": "^14.0.1",
     "reflect-metadata": "~0.1.13",

--- a/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
+++ b/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
@@ -2,15 +2,18 @@ import { CommonOptionDescriptions } from '../ProgramsCommon';
 
 enum HttpServerOptionDescriptions {
   ApiUrl = 'API URL',
-  DbConnection = 'DB Connection',
+  DbConnection = 'DB Connection string',
   MetricsEnabled = 'Enable Prometheus Metrics',
   OgmiosUrl = 'Ogmios URL',
   RabbitMQUrl = 'RabbitMQ URL',
   UseQueue = 'Enables RabbitMQ',
   CardanoNodeConfigPath = 'Cardano node config path',
-  CacheTtl = 'Cache TTL in minutes between 1 and 2880',
-  EpochPollInterval = 'Epoch poll interval'
+  EpochPollInterval = 'Epoch poll interval',
+  PostgresSrvArgs = 'Postgres SRV service name, db, user and password'
 }
 
 export type ProgramOptionDescriptions = CommonOptionDescriptions | HttpServerOptionDescriptions;
-export const ProgramOptionDescriptions = { ...CommonOptionDescriptions, ...HttpServerOptionDescriptions };
+export const ProgramOptionDescriptions = {
+  ...CommonOptionDescriptions,
+  ...HttpServerOptionDescriptions
+};

--- a/packages/cardano-services/src/Program/errors/InvalidArgsCombination.ts
+++ b/packages/cardano-services/src/Program/errors/InvalidArgsCombination.ts
@@ -1,0 +1,8 @@
+import { CustomError } from 'ts-custom-error';
+
+export class InvalidArgsCombination extends CustomError {
+  public constructor(firstOption: string, secondOption: string) {
+    super();
+    this.message = `${firstOption} arg is not compatible with the ${secondOption}, please choose one of them.`;
+  }
+}

--- a/packages/cardano-services/src/Program/errors/MissingProgramOption.ts
+++ b/packages/cardano-services/src/Program/errors/MissingProgramOption.ts
@@ -3,8 +3,10 @@ import { ProgramOptionDescriptions } from '../ProgramOptionDescriptions';
 import { ServiceNames } from '../ServiceNames';
 
 export class MissingProgramOption extends CustomError {
-  public constructor(service: ServiceNames, option: ProgramOptionDescriptions) {
+  public constructor(service: ServiceNames, option: ProgramOptionDescriptions | ProgramOptionDescriptions[]) {
     super();
-    this.message = `${service} requires the ${option} program option`;
+    this.message = `${service} requires the ${
+      typeof option === 'string' ? option : option.join(' or ')
+    } program option.`;
   }
 }

--- a/packages/cardano-services/src/Program/errors/index.ts
+++ b/packages/cardano-services/src/Program/errors/index.ts
@@ -1,2 +1,3 @@
 export * from './MissingProgramOption';
 export * from './UnknownServiceName';
+export * from './InvalidArgsCombination';

--- a/packages/cardano-services/src/Program/index.ts
+++ b/packages/cardano-services/src/Program/index.ts
@@ -3,3 +3,4 @@ export * from './errors';
 export * from './loadHttpServer';
 export * from './ProgramOptionDescriptions';
 export * from './ServiceNames';
+export * from './utils';

--- a/packages/cardano-services/src/Program/utils.ts
+++ b/packages/cardano-services/src/Program/utils.ts
@@ -1,0 +1,269 @@
+/* eslint-disable max-len */
+/* eslint-disable promise/no-nesting */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ClientConfig, Pool, QueryConfig } from 'pg';
+import { CommonOptionDescriptions, CommonProgramOptions } from '../ProgramsCommon';
+import { HttpServerOptions } from './loadHttpServer';
+import { InvalidArgsCombination, MissingProgramOption } from './errors';
+import { Ogmios, ogmiosTxSubmitProvider, urlToConnectionConfig } from '@cardano-sdk/ogmios';
+import { ProgramOptionDescriptions } from './ProgramOptionDescriptions';
+import { ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { RabbitMqTxSubmitProvider } from '@cardano-sdk/rabbitmq';
+import { ServiceNames } from './ServiceNames';
+import Logger from 'bunyan';
+import dns, { SrvRecord } from 'dns';
+import pRetry, { FailedAttemptError } from 'p-retry';
+
+export const SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT = 1.1;
+export const SERVICE_DISCOVERY_TIMEOUT_DEFAULT = 60 * 1000;
+export const DNS_SRV_CACHE_KEY = 'DNS_SRV_Record';
+
+export type RetryBackoffConfig = {
+  factor?: number;
+  maxRetryTime?: number;
+};
+
+export const onFailedAttemptFor =
+  (serviceName: string, logger: Logger) =>
+  async ({ attemptNumber, message, retriesLeft }: FailedAttemptError) => {
+    const nextAction = retriesLeft > 0 ? 'retrying...' : 'exiting';
+    logger.trace(message);
+    logger.debug(
+      `Establishing connection to ${serviceName}: Attempt ${attemptNumber} of ${
+        attemptNumber + retriesLeft
+      }, ${nextAction}`
+    );
+    if (retriesLeft === 0) {
+      logger.error(message);
+      // Invokes onDeath() callback within cardano-services entrypoints, following by server.shutdown() and process.exit(1)
+      process.kill(process.pid, 'SIGTERM');
+    }
+  };
+
+// Select the first random record from the DNS server resolved list
+export const resolveSrvRecord = async (serviceName: string): Promise<SrvRecord> => {
+  const [srvRecord] = await dns.promises.resolveSrv(serviceName);
+  return srvRecord;
+};
+
+export const createDnsResolver = (config: RetryBackoffConfig, logger: Logger) => async (serviceName: string) =>
+  await pRetry(async () => await resolveSrvRecord(serviceName), {
+    factor: config.factor,
+    maxRetryTime: config.maxRetryTime,
+    onFailedAttempt: onFailedAttemptFor(serviceName, logger)
+  });
+
+export type DnsResolver = ReturnType<typeof createDnsResolver>;
+
+/**
+ * Creates a extended Pool client :
+ * - use passed srv service name in order to resolve the port
+ * - make dealing with failovers (re-resolving the port) opaque
+ * - use exponential backoff retry internally with default timeout and factor
+ * - intercept 'query' operation and handle connection errors runtime
+ * - all other operations are bind to pool object withoud modifications
+ *
+ * @returns pg.Pool instance
+ */
+export const getPoolWithServiceDiscovery = async (
+  dnsResolver: DnsResolver,
+  logger: Logger,
+  { host, database, password, user }: ClientConfig
+): Promise<Pool> => {
+  const { name, port } = await dnsResolver(host!);
+  let pool = new Pool({ database, host: name, password, port, user });
+
+  return new Proxy<Pool>({} as Pool, {
+    get(_, prop) {
+      if (prop === 'then') return;
+      if (prop === 'query') {
+        return (args: string | QueryConfig, values?: any) =>
+          pool.query(args, values).catch(async (error) => {
+            if (error.code && ['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET'].includes(error.code)) {
+              const record = await dnsResolver(host!);
+              logger.info(`DNS resolution for Postgres service, resolved with record: ${JSON.stringify(record)}`);
+              pool = new Pool({ database, host: record.name, password, port: record.port, user });
+              return await pool.query(args, values);
+            }
+            throw error;
+          });
+      }
+      // Bind if it is a function, no intercept operations
+      if (typeof pool[prop as keyof Pool] === 'function') {
+        const method = pool[prop as keyof Pool] as any;
+        return method.bind(pool);
+      }
+    }
+  });
+};
+
+export const getPool = async (
+  dnsResolver: DnsResolver,
+  logger: Logger,
+  options?: HttpServerOptions
+): Promise<Pool | undefined> => {
+  if (options?.dbConnectionString && options.postgresSrvServiceName)
+    throw new InvalidArgsCombination(ProgramOptionDescriptions.DbConnection, ProgramOptionDescriptions.PostgresSrvArgs);
+  if (options?.dbConnectionString) return new Pool({ connectionString: options.dbConnectionString });
+  if (options?.postgresSrvServiceName && options?.postgresUser && options.postgresDb && options.postgresPassword) {
+    return getPoolWithServiceDiscovery(dnsResolver, logger, {
+      database: options.postgresDb,
+      host: options.postgresSrvServiceName,
+      password: options.postgresPassword,
+      user: options.postgresUser
+    });
+  }
+  // If db connection string is not passed nor postgres srv service name
+  return undefined;
+};
+
+export const isOgmiosConnectionError = (error: any) => {
+  if (
+    (error?.innerError?.code && ['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET'].includes(error.innerError.code)) ||
+    error instanceof Ogmios.WebSocketClosed
+  ) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Creates a extended TxSubmitProvider instance :
+ * - use passed srv service name in order to resolve the port
+ * - make dealing with failovers (re-resolving the port) opaque
+ * - use exponential backoff retry internally with default timeout and factor
+ * - intercept 'submitTx' operation and handle connection errors runtime
+ * - all other operations are bind to pool object withoud modifications
+ *
+ * @returns TxSubmitProvider instance
+ */
+export const ogmiosTxSubmitProviderWithDiscovery = async (
+  dnsResolver: DnsResolver,
+  logger: Logger,
+  serviceName: string
+): Promise<TxSubmitProvider> => {
+  const { name, port } = await dnsResolver(serviceName!);
+  let ogmiosProvider = ogmiosTxSubmitProvider({ host: name, port });
+
+  return new Proxy<TxSubmitProvider>({} as TxSubmitProvider, {
+    get(_, prop) {
+      if (prop === 'then') return;
+      if (prop === 'submitTx') {
+        return (args: Uint8Array) =>
+          ogmiosProvider.submitTx(args).catch(async (error) => {
+            if (isOgmiosConnectionError(error)) {
+              const record = await dnsResolver(serviceName!);
+              logger.info(`DNS resolution for Ogmios service, resolved with record: ${JSON.stringify(record)}`);
+              await ogmiosProvider
+                .close?.()
+                .catch((error_) => logger.warn(`Ogmios provider failed to close after DNS resolution: ${error_}`));
+              ogmiosProvider = ogmiosTxSubmitProvider({ host: record.name, port: record.port });
+              return await ogmiosProvider.submitTx(args);
+            }
+            throw error;
+          });
+      }
+      // Bind if it is a function, no intercept operations
+      if (typeof ogmiosProvider[prop as keyof TxSubmitProvider] === 'function') {
+        const method = ogmiosProvider[prop as keyof TxSubmitProvider] as any;
+        return method.bind(ogmiosProvider);
+      }
+    }
+  });
+};
+
+export const getOgmiosTxSubmitProvider = async (
+  dnsResolver: DnsResolver,
+  logger: Logger,
+  options?: CommonProgramOptions
+): Promise<TxSubmitProvider> => {
+  if (options?.ogmiosSrvServiceName)
+    return ogmiosTxSubmitProviderWithDiscovery(dnsResolver, logger, options.ogmiosSrvServiceName);
+  if (options?.ogmiosUrl) return ogmiosTxSubmitProvider(urlToConnectionConfig(options?.ogmiosUrl));
+  throw new MissingProgramOption(ServiceNames.TxSubmit, [
+    CommonOptionDescriptions.OgmiosUrl,
+    CommonOptionDescriptions.OgmiosSrvServiceName
+  ]);
+};
+
+export const srvRecordToRabbitmqURL = ({ name, port }: SrvRecord) => new URL(`amqp://${name}:${port}`);
+
+/**
+ * Creates a extended RabbitMqTxSubmitProvider instance :
+ * - use passed srv service name in order to resolve the port
+ * - make dealing with failovers (re-resolving the port) opaque
+ * - use exponential backoff retry internally with default timeout and factor
+ * - intercept 'submitTx' operation and handle connection errors runtime
+ * - all other operations are bind to pool object withoud modifications
+ *
+ * @returns RabbitMqTxSubmitProvider instance
+ */
+export const rabbitMqTxSubmitProviderWithDiscovery = async (
+  dnsResolver: DnsResolver,
+  logger: Logger,
+  serviceName: string
+): Promise<RabbitMqTxSubmitProvider> => {
+  const record = await dnsResolver(serviceName!);
+  let rabbitmqProvider = new RabbitMqTxSubmitProvider({
+    rabbitmqUrl: srvRecordToRabbitmqURL(record)
+  });
+
+  return new Proxy<RabbitMqTxSubmitProvider>({} as RabbitMqTxSubmitProvider, {
+    get(_, prop) {
+      if (prop === 'then') return;
+      if (prop === 'submitTx') {
+        return (args: Uint8Array) =>
+          rabbitmqProvider.submitTx(args).catch(async (error) => {
+            if (
+              error.innerError?.reason === ProviderFailure.ConnectionFailure ||
+              isOgmiosConnectionError(error.innerError)
+            ) {
+              const resolvedRecord = await dnsResolver(serviceName!);
+              logger.info(`DNS resolution for RabbitMQ service, resolved with record: ${JSON.stringify(record)}`);
+              await rabbitmqProvider
+                .close?.()
+                .catch((error_) => logger.warn(`RabbitMQ provider failed to close after DNS resolution: ${error_}`));
+              rabbitmqProvider = new RabbitMqTxSubmitProvider({
+                rabbitmqUrl: srvRecordToRabbitmqURL(resolvedRecord)
+              });
+              return await rabbitmqProvider.submitTx(args);
+            }
+            throw error;
+          });
+      }
+      // Bind if it is a function, no intercept operations
+      if (typeof rabbitmqProvider[prop as keyof RabbitMqTxSubmitProvider] === 'function') {
+        const method = rabbitmqProvider[prop as keyof RabbitMqTxSubmitProvider] as any;
+        return method.bind(rabbitmqProvider);
+      }
+    }
+  });
+};
+
+export const getRabbitMqTxSubmitProvider = async (
+  dnsResolver: DnsResolver,
+  logger: Logger,
+  options?: CommonProgramOptions
+): Promise<RabbitMqTxSubmitProvider> => {
+  if (options?.rabbitmqSrvServiceName)
+    return rabbitMqTxSubmitProviderWithDiscovery(dnsResolver, logger, options.rabbitmqSrvServiceName);
+  if (options?.rabbitmqUrl) return new RabbitMqTxSubmitProvider({ rabbitmqUrl: options.rabbitmqUrl });
+  throw new MissingProgramOption(ServiceNames.TxSubmit, [
+    CommonOptionDescriptions.RabbitMQUrl,
+    CommonOptionDescriptions.RabbitMQSrvServiceName
+  ]);
+};
+
+export const getRabbitMqUrl = async (dnsResolver: DnsResolver, args: CommonProgramOptions) => {
+  if (args.rabbitmqSrvServiceName) {
+    const record = await dnsResolver(args.rabbitmqSrvServiceName);
+    return srvRecordToRabbitmqURL(record);
+  }
+  if (args.rabbitmqUrl) {
+    return args.rabbitmqUrl;
+  }
+  throw new MissingProgramOption(ServiceNames.TxSubmit, [
+    CommonOptionDescriptions.RabbitMQUrl,
+    CommonOptionDescriptions.RabbitMQSrvServiceName
+  ]);
+};

--- a/packages/cardano-services/src/ProgramsCommon/CommonOptionDescriptions.ts
+++ b/packages/cardano-services/src/ProgramsCommon/CommonOptionDescriptions.ts
@@ -1,5 +1,10 @@
 export enum CommonOptionDescriptions {
   LoggerMinSeverity = 'Log level',
   OgmiosUrl = 'Ogmios URL',
-  RabbitMQUrl = 'RabbitMQ URL'
+  RabbitMQUrl = 'RabbitMQ URL',
+  OgmiosSrvServiceName = 'Ogmios SRV service name',
+  RabbitMQSrvServiceName = 'RabbitMQ SRV service name',
+  ServiceDiscoveryBackoffFactor = 'Exponential backoff factor for service discovery',
+  ServiceDiscoveryTimeout = 'Timeout for service discovery attempts',
+  CacheTtl = 'Cache TTL in minutes between 1 and 2880'
 }

--- a/packages/cardano-services/src/ProgramsCommon/options.ts
+++ b/packages/cardano-services/src/ProgramsCommon/options.ts
@@ -9,4 +9,9 @@ export interface CommonProgramOptions {
   loggerMinSeverity?: LogLevel;
   ogmiosUrl?: URL;
   rabbitmqUrl?: URL;
+  ogmiosSrvServiceName?: string;
+  rabbitmqSrvServiceName?: string;
+  serviceDiscoveryBackoffFactor?: number;
+  serviceDiscoveryTimeout?: number;
+  cacheTtl: number;
 }

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -21,6 +21,7 @@ import {
   TxWorkerOptions,
   loadTxWorker
 } from './TxWorker';
+import { SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT, SERVICE_DISCOVERY_TIMEOUT_DEFAULT } from './Program/utils';
 import { URL } from 'url';
 import { cacheTtlValidator } from './util/validators';
 import { loggerMethodNames } from './util';
@@ -71,6 +72,21 @@ const commonOptions = (command: Command) =>
       CommonOptionDescriptions.RabbitMQUrl,
       (url) => new URL(url),
       new URL(RABBITMQ_URL_DEFAULT)
+    )
+    .option('--ogmios-srv-service-name <ogmiosSrvServiceName>', ProgramOptionDescriptions.OgmiosSrvServiceName)
+    .option('--rabbitmq-srv-service-name <rabbitmqSrvServiceName>', ProgramOptionDescriptions.RabbitMQSrvServiceName)
+    .option('--cache-ttl <cacheTtl>', ProgramOptionDescriptions.CacheTtl, cacheTtlValidator, CACHE_TTL_DEFAULT)
+    .option(
+      '--service-discovery-backoff-factor <serviceDiscoveryBackoffFactor>',
+      ProgramOptionDescriptions.ServiceDiscoveryBackoffFactor,
+      (factor) => Number.parseFloat(factor),
+      SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT
+    )
+    .option(
+      '--service-discovery-timeout <serviceDiscoveryTimeout>',
+      ProgramOptionDescriptions.ServiceDiscoveryTimeout,
+      (interval) => Number.parseInt(interval, 10),
+      SERVICE_DISCOVERY_TIMEOUT_DEFAULT
     );
 
 const program = new Command('cardano-services');
@@ -97,15 +113,25 @@ commonOptions(
     EPOCH_POLL_INTERVAL_DEFAULT
   )
   .option('--use-queue', ProgramOptionDescriptions.UseQueue, () => true, USE_QUEUE_DEFAULT)
+  .option('--postgres-srv-service-name <postgresSrvServiceName>', ProgramOptionDescriptions.PostgresSrvArgs)
+  .option('--postgres-db <postgresDb>', ProgramOptionDescriptions.PostgresSrvArgs)
+  .option('--postgres-user <postgresUser>', ProgramOptionDescriptions.PostgresSrvArgs)
+  .option('--postgres-password <postgresPassword>', ProgramOptionDescriptions.PostgresSrvArgs)
   .action(async (serviceNames: ServiceNames[], options: { apiUrl: URL } & HttpServerOptions) => {
     const { apiUrl, ...rest } = options;
-    const server = loadHttpServer({ apiUrl: apiUrl || API_URL_DEFAULT, options: rest, serviceNames });
-    await server.initialize();
-    await server.start();
-    onDeath(async () => {
-      await server.shutdown();
+    try {
+      const server = await loadHttpServer({ apiUrl: apiUrl || API_URL_DEFAULT, options: rest, serviceNames });
+      await server.initialize();
+      await server.start();
+      onDeath(async () => {
+        await server.shutdown();
+        process.exit(1);
+      });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
       process.exit(1);
-    });
+    }
   });
 
 commonOptions(program.command('start-worker').description('Start RabbitMQ worker'))

--- a/packages/cardano-services/src/startWorker.ts
+++ b/packages/cardano-services/src/startWorker.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import * as envalid from 'envalid';
+import { CACHE_TTL_DEFAULT } from './InMemoryCache';
 import { LogLevel } from 'bunyan';
 import {
   OGMIOS_URL_DEFAULT,
@@ -9,18 +10,25 @@ import {
   RABBITMQ_URL_DEFAULT,
   loadTxWorker
 } from './TxWorker';
+import { SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT, SERVICE_DISCOVERY_TIMEOUT_DEFAULT } from './Program';
 import { URL } from 'url';
+import { cacheTtlValidator } from './util/validators';
 import { config } from 'dotenv';
 import { loggerMethodNames } from './util';
 import onDeath from 'death';
 
 const envSpecs = {
+  CACHE_TTL: envalid.makeValidator(cacheTtlValidator)(envalid.num({ default: CACHE_TTL_DEFAULT })),
   LOGGER_MIN_SEVERITY: envalid.str({ choices: loggerMethodNames as string[], default: 'info' }),
+  OGMIOS_SRV_SERVICE_NAME: envalid.str({ default: undefined }),
   OGMIOS_URL: envalid.url({ default: OGMIOS_URL_DEFAULT }),
   PARALLEL: envalid.bool({ default: PARALLEL_MODE_DEFAULT }),
   PARALLEL_TXS: envalid.num({ default: PARALLEL_TXS_DEFAULT }),
   POLLING_CYCLE: envalid.num({ default: POLLING_CYCLE_DEFAULT }),
-  RABBITMQ_URL: envalid.url({ default: RABBITMQ_URL_DEFAULT })
+  RABBITMQ_SRV_SERVICE_NAME: envalid.str({ default: undefined }),
+  RABBITMQ_URL: envalid.url({ default: RABBITMQ_URL_DEFAULT }),
+  SERVICE_DISCOVERY_BACKOFF_FACTOR: envalid.num({ default: SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT }),
+  SERVICE_DISCOVERY_TIMEOUT: envalid.num({ default: SERVICE_DISCOVERY_TIMEOUT_DEFAULT })
 };
 
 void (async () => {
@@ -30,12 +38,17 @@ void (async () => {
   try {
     const worker = await loadTxWorker({
       options: {
+        cacheTtl: env.CACHE_TTL,
         loggerMinSeverity: env.LOGGER_MIN_SEVERITY as LogLevel,
+        ogmiosSrvServiceName: env.OGMIOS_SRV_SERVICE_NAME,
         ogmiosUrl: new URL(env.OGMIOS_URL),
         parallel: env.PARALLEL,
         parallelTxs: env.PARALLEL_TXS,
         pollingCycle: env.POLLING_CYCLE,
-        rabbitmqUrl: new URL(env.RABBITMQ_URL)
+        rabbitmqSrvServiceName: env.RABBITMQ_SRV_SERVICE_NAME,
+        rabbitmqUrl: new URL(env.RABBITMQ_URL),
+        serviceDiscoveryBackoffFactor: env.SERVICE_DISCOVERY_BACKOFF_FACTOR,
+        serviceDiscoveryTimeout: env.SERVICE_DISCOVERY_TIMEOUT
       }
     });
     await worker.start();

--- a/packages/cardano-services/test/Program/utils.test.ts
+++ b/packages/cardano-services/test/Program/utils.test.ts
@@ -1,0 +1,560 @@
+/* eslint-disable sonarjs/no-identical-functions */
+/* eslint-disable sonarjs/no-duplicate-string */
+/* eslint-disable max-len */
+import { Cardano, EraSummary, TxSubmitProvider } from '@cardano-sdk/core';
+import { Connection } from '@cardano-ogmios/client';
+import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../src/NetworkInfo';
+import {
+  HttpServer,
+  HttpServerConfig,
+  TxSubmitHttpService,
+  createDnsResolver,
+  getOgmiosTxSubmitProvider,
+  getPool,
+  getRabbitMqTxSubmitProvider,
+  loadTxWorker
+} from '../../src';
+import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../src/InMemoryCache';
+import { Ogmios } from '@cardano-sdk/ogmios';
+import { Pool } from 'pg';
+import { SrvRecord } from 'dns';
+import { TxSubmitWorker } from '@cardano-sdk/rabbitmq';
+import { createHealthyMockOgmiosServer, ogmiosServerReady } from '../util';
+import { createLogger } from 'bunyan';
+import { createMockOgmiosServer } from '@cardano-sdk/ogmios/test/mocks/mockOgmiosServer';
+import { getPort, getRandomPort } from 'get-port-please';
+import { listenPromise, serverClosePromise } from '../../src/util';
+import { txsPromise } from '@cardano-sdk/rabbitmq/test/utils';
+import { types } from 'util';
+import axios from 'axios';
+import http from 'http';
+
+jest.mock('dns', () => ({
+  promises: {
+    resolveSrv: async (serviceName: string): Promise<SrvRecord[]> => {
+      if (serviceName === process.env.POSTGRES_SRV_SERVICE_NAME)
+        return [{ name: 'localhost', port: 5433, priority: 6, weight: 5 }];
+      if (serviceName === process.env.OGMIOS_SRV_SERVICE_NAME)
+        return [{ name: 'localhost', port: 1337, priority: 6, weight: 5 }];
+      if (serviceName === process.env.RABBITMQ_SRV_SERVICE_NAME)
+        return [{ name: 'localhost', port: 5672, priority: 6, weight: 5 }];
+      return [];
+    }
+  }
+}));
+
+describe('Service dependency abstractions', () => {
+  const APPLICATION_JSON = 'application/json';
+  const cache = new InMemoryCache(UNLIMITED_CACHE_TTL);
+  const cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
+  const logger = createLogger({ level: 'error', name: 'test' });
+  const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
+  const mockEraSummaries: EraSummary[] = [
+    { parameters: { epochLength: 21_600, slotLength: 20_000 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
+    {
+      parameters: { epochLength: 432_000, slotLength: 1000 },
+      start: { slot: 1_598_400, time: new Date(1_595_964_016_000) }
+    }
+  ];
+  const cardanoNode = {
+    eraSummaries: jest.fn(() => Promise.resolve(mockEraSummaries)),
+    initialize: jest.fn(() => Promise.resolve()),
+    shutdown: jest.fn(() => Promise.resolve()),
+    systemStart: jest.fn(() => Promise.resolve(new Date(1_563_999_616_000)))
+  };
+
+  describe('Postgres-dependant service with service discovery', () => {
+    let httpServer: HttpServer;
+    let db: Pool | undefined;
+    let port: number;
+    let apiUrlBase: string;
+    let config: HttpServerConfig;
+    let service: NetworkInfoHttpService;
+    let networkInfoProvider: DbSyncNetworkInfoProvider;
+
+    beforeAll(async () => {
+      db = await getPool(dnsResolver, logger, {
+        cacheTtl: 10_000,
+        epochPollInterval: 1000,
+        postgresDb: process.env.POSTGRES_DB!,
+        postgresPassword: process.env.POSTGRES_PASSWORD!,
+        postgresSrvServiceName: process.env.POSTGRES_SRV_SERVICE_NAME!,
+        postgresUser: process.env.POSTGRES_USER!,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+    });
+
+    describe('Established connection', () => {
+      beforeAll(async () => {
+        port = await getPort();
+        config = { listen: { port } };
+        apiUrlBase = `http://localhost:${port}/network-info`;
+        networkInfoProvider = new DbSyncNetworkInfoProvider(
+          { cardanoNodeConfigPath, epochPollInterval: 2000 },
+          { cache, cardanoNode, db: db! }
+        );
+        service = new NetworkInfoHttpService({ networkInfoProvider });
+        httpServer = new HttpServer(config, { services: [service] });
+
+        await httpServer.initialize();
+        await httpServer.start();
+      });
+
+      afterAll(async () => {
+        await db!.end();
+        await httpServer.shutdown();
+        await cache.shutdown();
+        jest.clearAllTimers();
+      });
+
+      it('db should be a instance of Proxy ', () => {
+        expect(types.isProxy(db!)).toEqual(true);
+      });
+
+      it('forwards the db health response', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+  });
+
+  describe('Postgres-dependant service with provided db connection string', () => {
+    let httpServer: HttpServer;
+    let db: Pool | undefined;
+    let port: number;
+    let apiUrlBase: string;
+    let config: HttpServerConfig;
+    let service: NetworkInfoHttpService;
+    let networkInfoProvider: DbSyncNetworkInfoProvider;
+
+    beforeAll(async () => {
+      db = await getPool(dnsResolver, logger, {
+        cacheTtl: 10_000,
+        dbConnectionString: process.env.DB_CONNECTION_STRING,
+        epochPollInterval: 1000
+      });
+    });
+
+    describe('Established connection', () => {
+      beforeAll(async () => {
+        port = await getPort();
+        config = { listen: { port } };
+        apiUrlBase = `http://localhost:${port}/network-info`;
+        networkInfoProvider = new DbSyncNetworkInfoProvider(
+          { cardanoNodeConfigPath, epochPollInterval: 2000 },
+          { cache, cardanoNode, db: db! }
+        );
+        service = new NetworkInfoHttpService({ networkInfoProvider });
+        httpServer = new HttpServer(config, { services: [service] });
+
+        await httpServer.initialize();
+        await httpServer.start();
+      });
+
+      afterAll(async () => {
+        await db!.end();
+        await httpServer.shutdown();
+        await cache.shutdown();
+        jest.clearAllTimers();
+      });
+
+      it('db should not be instance a of Proxy ', () => {
+        expect(types.isProxy(db!)).toEqual(false);
+      });
+
+      it('forwards the db health response', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+  });
+
+  describe('Db provider with service discovery and Postgres server failover', () => {
+    let provider: Pool | undefined;
+    const pgPortDefault = 5433;
+
+    it('should resolve successfully if a connection error is thrown and re-connects to a new resolved record', async () => {
+      const HEALTH_CHECK_QUERY = 'SELECT 1';
+      const srvRecord = { name: 'localhost', port: pgPortDefault, priority: 1, weight: 1 };
+      const failingPostgresMockPort = await getRandomPort();
+      let resolverAlreadyCalled = false;
+
+      // Initially resolves with a failing postgres port, then swap to the default one
+      const dnsResolverMock = jest.fn().mockImplementation(async () => {
+        if (!resolverAlreadyCalled) {
+          resolverAlreadyCalled = true;
+          return { ...srvRecord, port: failingPostgresMockPort };
+        }
+        return srvRecord;
+      });
+
+      provider = await getPool(dnsResolverMock, logger, {
+        cacheTtl: 10_000,
+        epochPollInterval: 1000,
+        postgresDb: process.env.POSTGRES_DB!,
+        postgresPassword: process.env.POSTGRES_PASSWORD!,
+        postgresSrvServiceName: process.env.POSTGRES_SRV_SERVICE_NAME!,
+        postgresUser: process.env.POSTGRES_USER!,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      const result = await provider!.query(HEALTH_CHECK_QUERY);
+      await expect(result.rowCount).toBeTruthy();
+      expect(dnsResolverMock).toBeCalledTimes(2);
+    });
+
+    it('should execute a provider operation without to intercept it', async () => {
+      provider = await getPool(dnsResolver, logger, {
+        cacheTtl: 10_000,
+        epochPollInterval: 1000,
+        postgresDb: process.env.POSTGRES_DB!,
+        postgresPassword: process.env.POSTGRES_PASSWORD!,
+        postgresSrvServiceName: process.env.POSTGRES_SRV_SERVICE_NAME!,
+        postgresUser: process.env.POSTGRES_USER!,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      await expect(provider!.end()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Ogmios-dependant service with service discovery', () => {
+    let apiUrlBase: string;
+    let ogmiosServer: http.Server;
+    let ogmiosConnection: Connection;
+    let txSubmitProvider: TxSubmitProvider;
+    let httpServer: HttpServer;
+    let port: number;
+    let config: HttpServerConfig;
+
+    beforeAll(async () => {
+      ogmiosServer = createHealthyMockOgmiosServer();
+      ogmiosConnection = Ogmios.createConnectionObject();
+      await listenPromise(ogmiosServer, { port: ogmiosConnection.port });
+      await ogmiosServerReady(ogmiosConnection);
+    });
+
+    describe('Established connection', () => {
+      beforeAll(async () => {
+        port = await getPort();
+        apiUrlBase = `http://localhost:${port}/tx-submit`;
+        config = { listen: { port } };
+        txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
+          cacheTtl: 10_000,
+          ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
+          serviceDiscoveryBackoffFactor: 1.1,
+          serviceDiscoveryTimeout: 1000
+        });
+        httpServer = new HttpServer(config, {
+          services: [new TxSubmitHttpService({ txSubmitProvider })]
+        });
+        await httpServer.initialize();
+        await httpServer.start();
+      });
+
+      afterAll(async () => {
+        await httpServer.shutdown();
+        await serverClosePromise(ogmiosServer);
+      });
+
+      it('txSubmitProvider should be instance of a Proxy ', () => {
+        expect(types.isProxy(txSubmitProvider)).toEqual(true);
+      });
+
+      it('forwards the txSubmitProvider health response', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+  });
+
+  describe('Ogmios-dependant service with provided connection url', () => {
+    let apiUrlBase: string;
+    let ogmiosServer: http.Server;
+    let ogmiosConnection: Connection;
+    let txSubmitProvider: TxSubmitProvider;
+    let httpServer: HttpServer;
+    let port: number;
+    let config: HttpServerConfig;
+
+    beforeAll(async () => {
+      ogmiosServer = createHealthyMockOgmiosServer();
+      ogmiosConnection = Ogmios.createConnectionObject();
+      await listenPromise(ogmiosServer, { port: ogmiosConnection.port });
+      await ogmiosServerReady(ogmiosConnection);
+    });
+
+    describe('Established connection', () => {
+      beforeAll(async () => {
+        port = await getPort();
+        apiUrlBase = `http://localhost:${port}/tx-submit`;
+        config = { listen: { port } };
+        txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
+          cacheTtl: 10_000,
+          ogmiosUrl: new URL(ogmiosConnection.address.webSocket)
+        });
+        httpServer = new HttpServer(config, {
+          services: [new TxSubmitHttpService({ txSubmitProvider })]
+        });
+        await httpServer.initialize();
+        await httpServer.start();
+      });
+
+      afterAll(async () => {
+        await httpServer.shutdown();
+        await serverClosePromise(ogmiosServer);
+      });
+
+      it('txSubmitProvider should not be a instance of Proxy ', () => {
+        expect(types.isProxy(txSubmitProvider)).toEqual(false);
+      });
+
+      it('forwards the txSubmitProvider health response', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+  });
+
+  describe('TxSubmitProvider with service discovery and Ogmios server failover', () => {
+    let mockServer: http.Server;
+    let connection: Connection;
+    let provider: TxSubmitProvider;
+    const ogmiosPortDefault = 1337;
+
+    beforeEach(async () => {
+      connection = Ogmios.createConnectionObject({ port: ogmiosPortDefault });
+      // Setup working a default Ogmios with submitTx operation throwing a non-connection error
+      mockServer = createMockOgmiosServer({
+        healthCheck: { response: { networkSynchronization: 0.999, success: true } },
+        submitTx: { response: { failWith: { type: 'eraMismatch' }, success: false } }
+      });
+      await listenPromise(mockServer, connection);
+      await ogmiosServerReady(connection);
+    });
+
+    afterEach(async () => {
+      if (mockServer !== undefined) {
+        await serverClosePromise(mockServer);
+      }
+    });
+
+    it('should initially fail with a connection error, then re-resolve the port and propagate the correct non-connection error to the caller', async () => {
+      const srvRecord = { name: 'localhost', port: ogmiosPortDefault, priority: 1, weight: 1 };
+      const failingOgmiosMockPort = await getRandomPort();
+      let resolverAlreadyCalled = false;
+
+      // Initially resolves with a failing ogmios port, then swap to the default one
+      const dnsResolverMock = jest.fn().mockImplementation(async () => {
+        if (!resolverAlreadyCalled) {
+          resolverAlreadyCalled = true;
+          return { ...srvRecord, port: failingOgmiosMockPort };
+        }
+        return srvRecord;
+      });
+
+      provider = await getOgmiosTxSubmitProvider(dnsResolverMock, logger, {
+        cacheTtl: 10_000,
+        ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      await expect(provider.submitTx(new Uint8Array([]))).rejects.toBeInstanceOf(
+        Cardano.TxSubmissionErrors.EraMismatchError
+      );
+      expect(dnsResolverMock).toBeCalledTimes(2);
+    });
+
+    it('should execute a provider operation without to intercept it', async () => {
+      provider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
+        cacheTtl: 10_000,
+        ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
+    });
+  });
+
+  describe('RabbitMQ-dependant service with service discovery', () => {
+    let apiUrlBase: string;
+    let txSubmitProvider: TxSubmitProvider;
+    let httpServer: HttpServer;
+    let port: number;
+    let config: HttpServerConfig;
+
+    describe('Established connection', () => {
+      beforeAll(async () => {
+        port = await getPort();
+        apiUrlBase = `http://localhost:${port}/tx-submit`;
+        config = { listen: { port } };
+        txSubmitProvider = await getRabbitMqTxSubmitProvider(dnsResolver, logger, {
+          cacheTtl: 10_000,
+          rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
+          serviceDiscoveryBackoffFactor: 1.1,
+          serviceDiscoveryTimeout: 1000
+        });
+        httpServer = new HttpServer(config, {
+          services: [new TxSubmitHttpService({ txSubmitProvider })]
+        });
+        await httpServer.initialize();
+        await httpServer.start();
+      });
+
+      afterAll(async () => {
+        await httpServer.shutdown();
+      });
+
+      it('txSubmitProvider should be instance of a Proxy ', () => {
+        expect(types.isProxy(txSubmitProvider)).toEqual(true);
+      });
+
+      it('forwards the txSubmitProvider health response', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+  });
+
+  describe('RabbitMQ-dependant service with provided connection url', () => {
+    let apiUrlBase: string;
+    let txSubmitProvider: TxSubmitProvider;
+    let httpServer: HttpServer;
+    let port: number;
+    let config: HttpServerConfig;
+
+    describe('Established connection', () => {
+      beforeAll(async () => {
+        port = await getPort();
+        apiUrlBase = `http://localhost:${port}/tx-submit`;
+        config = { listen: { port } };
+        txSubmitProvider = await getRabbitMqTxSubmitProvider(dnsResolver, logger, {
+          cacheTtl: 10_000,
+          rabbitmqUrl: new URL(process.env.RABBITMQ_URL!)
+        });
+        httpServer = new HttpServer(config, {
+          services: [new TxSubmitHttpService({ txSubmitProvider })]
+        });
+        await httpServer.initialize();
+        await httpServer.start();
+      });
+
+      afterAll(async () => {
+        await httpServer.shutdown();
+      });
+
+      it('txSubmitProvider should not be a instance of Proxy ', () => {
+        expect(types.isProxy(txSubmitProvider)).toEqual(false);
+      });
+
+      it('forwards the txSubmitProvider health response', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+  });
+
+  describe('TxSubmitProvider with service discovery and RabbitMQ server failover', () => {
+    let mockServer: http.Server;
+    let connection: Connection;
+    let provider: TxSubmitProvider;
+    let txSubmitWorker: TxSubmitWorker;
+    const ogmiosPortDefault = 1337;
+    const rabbitmqPortDedault = 5672;
+
+    beforeEach(async () => {
+      connection = Ogmios.createConnectionObject({ port: ogmiosPortDefault });
+      // Setup working a default Ogmios with submitTx operation throwing a non-connection error
+      mockServer = createMockOgmiosServer({
+        healthCheck: { response: { networkSynchronization: 0.999, success: true } },
+        submitTx: { response: { failWith: { type: 'eraMismatch' }, success: false } }
+      });
+      await listenPromise(mockServer, connection);
+      await ogmiosServerReady(connection);
+
+      txSubmitWorker = await loadTxWorker({
+        options: {
+          cacheTtl: 10_000,
+          loggerMinSeverity: 'error',
+          ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
+          parallel: true,
+          rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
+          serviceDiscoveryBackoffFactor: 1.1,
+          serviceDiscoveryTimeout: 1000
+        }
+      });
+      await txSubmitWorker.start();
+    });
+
+    afterEach(async () => {
+      if (mockServer !== undefined) {
+        await serverClosePromise(mockServer);
+      }
+      if (txSubmitWorker !== undefined) {
+        await txSubmitWorker.stop();
+      }
+    });
+
+    it('should initially fail with a connection error, then re-resolve the port and propagate the correct non-connection error to the caller', async () => {
+      const srvRecord = { name: 'localhost', port: rabbitmqPortDedault, priority: 1, weight: 1 };
+      const failingRabbitMqMockPort = await getRandomPort();
+      let resolverAlreadyCalled = false;
+
+      // Initially resolves with a failing rabbitmq port, then swap to the default one
+      const dnsResolverMock = jest.fn().mockImplementation(async () => {
+        if (!resolverAlreadyCalled) {
+          resolverAlreadyCalled = true;
+          return { ...srvRecord, port: failingRabbitMqMockPort };
+        }
+        return srvRecord;
+      });
+
+      provider = await getRabbitMqTxSubmitProvider(dnsResolverMock, logger, {
+        cacheTtl: 10_000,
+        rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME!,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      const txs = await txsPromise;
+      await expect(provider.submitTx(txs[0].txBodyUint8Array)).rejects.toBeInstanceOf(
+        Cardano.TxSubmissionErrors.EraMismatchError
+      );
+      expect(dnsResolverMock).toBeCalledTimes(2);
+    });
+
+    it('should execute a provider operation without to intercept it', async () => {
+      provider = await getRabbitMqTxSubmitProvider(dnsResolver, logger, {
+        cacheTtl: 10_000,
+        rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
+    });
+  });
+});

--- a/packages/cardano-services/test/entrypoints.txWorker.test.ts
+++ b/packages/cardano-services/test/entrypoints.txWorker.test.ts
@@ -12,13 +12,17 @@ const exePath = (name: 'cli' | 'startWorker') => path.join(__dirname, '..', 'dis
 
 describe('tx-worker entrypoints', () => {
   let commonArgs: string[];
+  let commonArgsWithServiceDiscovery: string[];
   let commonEnv: Record<string, string>;
+  let commonEnvWithServiceDiscovery: Record<string, string>;
   let hook: () => void;
   let hookLogs: string[];
   let hookPromise: Promise<void>;
   let loggerHookCounter: number;
   let ogmiosServer: http.Server;
   let proc: ChildProcess;
+  let rabbitmqSrvServiceName: string;
+  let ogmiosSrvServiceName: string;
 
   const resetHook = () => (hook = jest.fn());
 
@@ -43,10 +47,29 @@ describe('tx-worker entrypoints', () => {
     const port = await getRandomPort();
     const ogmiosConnection = Ogmios.createConnectionObject({ port });
     ogmiosServer = createHealthyMockOgmiosServer(() => hook());
+    rabbitmqSrvServiceName = process.env.RABBITMQ_SRV_SERVICE_NAME!;
+    ogmiosSrvServiceName = process.env.OGMIOS_SRV_SERVICE_NAME!;
     await listenPromise(ogmiosServer, { port });
     await ogmiosServerReady(ogmiosConnection);
     commonArgs = ['start-worker', '--logger-min-severity', 'error', '--ogmios-url', ogmiosConnection.address.webSocket];
+    commonArgsWithServiceDiscovery = [
+      'start-worker',
+      '--logger-min-severity',
+      'error',
+      '--rabbitmq-srv-service-name',
+      rabbitmqSrvServiceName,
+      '--ogmios-srv-service-name',
+      ogmiosSrvServiceName,
+      '--service-discovery-timeout',
+      '1000'
+    ];
     commonEnv = { LOGGER_MIN_SEVERITY: 'error', OGMIOS_URL: ogmiosConnection.address.webSocket };
+    commonEnvWithServiceDiscovery = {
+      LOGGER_MIN_SEVERITY: 'error',
+      OGMIOS_SRV_SERVICE_NAME: ogmiosSrvServiceName,
+      RABBITMQ_SRV_SERVICE_NAME: rabbitmqSrvServiceName,
+      SERVICE_DISCOVERY_TIMEOUT: '1000'
+    };
   });
 
   afterAll(async () => await serverClosePromise(ogmiosServer));
@@ -178,6 +201,38 @@ describe('tx-worker entrypoints', () => {
         env: { ...commonEnv, RABBITMQ_URL: BAD_CONNECTION_URL.toString() },
         stdio: 'pipe'
       });
+      proc.on('exit', (code) => {
+        expect(code).toBe(1);
+        done();
+      });
+    });
+  });
+
+  describe('with service discovery', () => {
+    it('cli:start-worker throws DNS SRV error and exits with code 1', (done) => {
+      expect.assertions(2);
+      proc = fork(exePath('cli'), commonArgsWithServiceDiscovery, { stdio: 'pipe' });
+
+      proc.stderr!.on('data', (data) => {
+        expect(data.toString().includes('querySrv ENOTFOUND')).toEqual(true);
+      });
+
+      proc.on('exit', (code) => {
+        expect(code).toBe(1);
+        done();
+      });
+    });
+
+    it('startWorker throws DNS SRV error and exits with code 1', (done) => {
+      expect.assertions(2);
+      proc = fork(exePath('startWorker'), {
+        env: commonEnvWithServiceDiscovery,
+        stdio: 'pipe'
+      });
+      proc.stderr!.on('data', (data) => {
+        expect(data.toString().includes('querySrv ENOTFOUND')).toEqual(true);
+      });
+
       proc.on('exit', (code) => {
         expect(code).toBe(1);
         done();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2855,6 +2855,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -10061,6 +10066,14 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-retry@^4.2.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
@@ -11038,6 +11051,11 @@ retry-axios@^2.4.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.6.0.tgz#d4dc5c8a8e73982e26a705e46a33df99a28723e0"
   integrity sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# Context
Add new `cardano-services` CLI and HttpServer arguments to support resolving the ports using DNS SRV records for:

**CLI:**
`--ogmios-srv-service-name` (alternative to `--ogmios-url`)

`--rabitmq-srv-service-name` (alternative to `--rabbitmq-url`)

`--postgres-srv-service-name` + `--postgres-db` + `--postgres-user` + `--postgres-password` (alternative to `--db-connection-string`)

**HTTP Server:**
`RABBITMQ_SRV_SERVICE_NAME` (alternative to `--RABBITMQ_URL`)

`OGMIOS_SRV_SERVICE_NAME` (alternative to`OGMIOS_URL`)

`POSTGRES_SRV_SERVICE_NAME` + `POSTGRES_DB` + `POSTGRES_USER` + `POSTGRES_PASSWORD` (alternative to `DB_CONNECTION_STRING`)

Use those new variables to resolve port of those services with [dns.resolveSrv](https://nodejs.org/docs/latest-v14.x/api/dns.html#dns_dns_resolvesrv_hostname_callback)

# Acceptance Criteria 
- If a connection error is thrown either during startup or during a request, the service should attempt to resolve another address using exponential back-off with no initial delay.

- The backoff factor should be configurable, with a sensible default.

- If a connection cannot be re-established after a configurable period of time in seconds, defaulting to **60**, the process should terminate. Exit process upon connection failure

- If the connection error is thrown at request time, the request must be held open until the timeout is reached.

- Try using a default back-off factor of **1.1**

# Proposed Solution
- Wrap client libraries of each service (_ogmios_, _rabbitmq_, _postgres_) to make dealing with failovers (re-resolving the port) opaque

# Important Changes Introduced
- implement DNS resolve SRV records with exponential backoff retry logic
- create an abstraction over client libraries of each service (_postgres, rabbitmq, ogmios_) based on the provided program arguments
- For `Ogmios` and `RabbitMQ` client libraries, **service discovery** takes preference over the **url**  arg which will leave us with the ability to fall back on fixed defaults. When it comes to `Postgres` -> we throw an `InvalidArgsCombination` error if both are provided and `MissingProgramOption` error if neither one of them is provided.
- implement `createDnsResolver` factory method, in which `DnsResolver` instance is passed forward in order to re-resolve the port if connection failover occurs during runtime
- implement `resolveSrvRecord` which select the first random record from the DNS server resolved list
- use `Proxy` native module to intercept the provider's operations if the SRV service name is provided, it handles failovers produced by the `cardano-services` service dependencies
- extend `cli.ts` with:
-- `--service-discovery-backoff-factor`
-- `--service-discovery-backoff-timeout`
-- `--rabbitmq-srv-service-name`
-- `--ogmios-srv-service-name`
-- `--postgres-srv-service-name`
-- `--postgres-db`
-- `--postgres-user`
-- `--postgres-password`
- extend `run.ts` with:
-- `SERVICE_DISCOVERY_BACKOFF_FACTOR`
-- `SERVICE_DISCOVERY_BACKOFF_TIMEOUT`
-- `RABBITMQ_SRV_SERVICE_NAME`
-- `OGMIOS_SRV_SERVICE_NAME`
-- `POSTGRES_SRV_SERVICE_NAME`
-- `POSTGRES_DB`
-- `POSTGRES_USER`
-- `POSTGRES_PASSWORD`
