### PR TITLE
Chore/tip tracker and cold obs wallet args

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -198,7 +198,10 @@ export class SingleAddressWallet implements ObservableWallet {
       equals: tipEquals,
       maxPollInterval: maxInterval,
       pollInterval,
-      provider$: coldObservableProvider(this.networkInfoProvider.ledgerTip, retryBackoffConfig),
+      provider$: coldObservableProvider({
+        provider: this.networkInfoProvider.ledgerTip,
+        retryBackoffConfig
+      }),
       store: stores.tip,
       trigger$: this.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled))
     });
@@ -208,33 +211,53 @@ export class SingleAddressWallet implements ObservableWallet {
       // so we should replace the trigger from tipBlockHeight$ to epoch$.
       // This is a little complicated since there is a circular dependency.
       // Some logic is needed to initiate a fetch if epoch is not available in store already.
-      coldObservableProvider(this.networkInfoProvider.timeSettings, retryBackoffConfig, tipBlockHeight$, deepEquals),
+      coldObservableProvider({
+        equals: deepEquals,
+        provider: this.networkInfoProvider.timeSettings,
+        retryBackoffConfig,
+        trigger$: tipBlockHeight$
+      }),
       stores.timeSettings
     );
     this.currentEpoch$ = currentEpochTracker(this.tip$, this.timeSettings$);
     const epoch$ = this.currentEpoch$.pipe(map((epoch) => epoch.epochNo));
 
     this.stake$ = new PersistentDocumentTrackerSubject(
-      coldObservableProvider(this.networkInfoProvider.stake, retryBackoffConfig, epoch$, isEqual),
+      coldObservableProvider({
+        equals: isEqual,
+        provider: this.networkInfoProvider.stake,
+        retryBackoffConfig,
+        trigger$: epoch$
+      }),
       stores.stake
     );
 
     this.lovelaceSupply$ = new PersistentDocumentTrackerSubject(
-      coldObservableProvider(this.networkInfoProvider.lovelaceSupply, retryBackoffConfig, epoch$, isEqual),
+      coldObservableProvider({
+        equals: isEqual,
+        provider: this.networkInfoProvider.lovelaceSupply,
+        retryBackoffConfig,
+        trigger$: epoch$
+      }),
       stores.lovelaceSupply
     );
 
     this.protocolParameters$ = new PersistentDocumentTrackerSubject(
-      coldObservableProvider(
-        this.networkInfoProvider.currentWalletProtocolParameters,
+      coldObservableProvider({
+        equals: isEqual,
+        provider: this.networkInfoProvider.currentWalletProtocolParameters,
         retryBackoffConfig,
-        epoch$,
-        isEqual
-      ),
+        trigger$: epoch$
+      }),
       stores.protocolParameters
     );
     this.genesisParameters$ = new PersistentDocumentTrackerSubject(
-      coldObservableProvider(this.networkInfoProvider.genesisParameters, retryBackoffConfig, epoch$, isEqual),
+      coldObservableProvider({
+        equals: isEqual,
+        provider: this.networkInfoProvider.genesisParameters,
+        retryBackoffConfig,
+        trigger$: epoch$
+      }),
       stores.genesisParameters
     );
 

--- a/packages/wallet/src/services/AssetsTracker.ts
+++ b/packages/wallet/src/services/AssetsTracker.ts
@@ -7,11 +7,11 @@ import { distinct, from, map, mergeMap, of, scan, tap } from 'rxjs';
 
 export const createAssetService =
   (assetProvider: TrackedAssetProvider, retryBackoffConfig: RetryBackoffConfig) => (assetId: Cardano.AssetId) =>
-    coldObservableProvider(
-      () => assetProvider.getAsset(assetId, { history: false, nftMetadata: true, tokenMetadata: true }),
+    coldObservableProvider({
+      provider: () => assetProvider.getAsset(assetId, { history: false, nftMetadata: true, tokenMetadata: true }),
       retryBackoffConfig,
-      of(true) // fetch only once
-    );
+      trigger$: of(true) // fetch only once
+    });
 export type AssetService = ReturnType<typeof createAssetService>;
 
 export interface AssetsTrackerProps {

--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -28,9 +28,10 @@ import { transactionsWithCertificates } from './transactionCertificates';
 export const createBlockEpochProvider =
   (chainHistoryProvider: ChainHistoryProvider, retryBackoffConfig: RetryBackoffConfig) =>
   (blockHashes: Cardano.BlockId[]) =>
-    coldObservableProvider(() => chainHistoryProvider.blocksByHashes(blockHashes), retryBackoffConfig).pipe(
-      map((blocks) => blocks.map(({ epoch }) => epoch))
-    );
+    coldObservableProvider({
+      provider: () => chainHistoryProvider.blocksByHashes(blockHashes),
+      retryBackoffConfig
+    }).pipe(map((blocks) => blocks.map(({ epoch }) => epoch)));
 
 export type BlockEpochProvider = ReturnType<typeof createBlockEpochProvider>;
 

--- a/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
@@ -21,14 +21,14 @@ export const createRewardsHistoryProvider =
     lowerBound: Cardano.Epoch | null
   ): Observable<Map<Cardano.RewardAccount, EpochRewards[]>> => {
     if (lowerBound) {
-      return coldObservableProvider(
-        () =>
+      return coldObservableProvider({
+        provider: () =>
           rewardsProvider.rewardsHistory({
             epochs: { lowerBound },
             rewardAccounts
           }),
         retryBackoffConfig
-      );
+      });
     }
     rewardsProvider.setStatInitialized(rewardsProvider.stats.rewardsHistory$);
     return of(new Map());

--- a/packages/wallet/src/services/TipTracker.ts
+++ b/packages/wallet/src/services/TipTracker.ts
@@ -1,0 +1,72 @@
+import { Cardano } from '@cardano-sdk/core';
+import { DocumentStore } from '../persistence';
+import { Milliseconds } from './types';
+import {
+  Observable,
+  Subject,
+  concat,
+  delay,
+  distinctUntilChanged,
+  exhaustMap,
+  filter,
+  finalize,
+  merge,
+  of,
+  startWith,
+  switchMap,
+  takeUntil,
+  timeout
+} from 'rxjs';
+import { PersistentDocumentTrackerSubject, tipEquals } from './util';
+import { SyncStatus } from '../types';
+export interface TipTrackerProps {
+  provider$: Observable<Cardano.Tip>;
+  syncStatus: SyncStatus;
+  store: DocumentStore<Cardano.Tip>;
+  /**
+   * Once
+   */
+  minPollInterval: Milliseconds;
+  maxPollInterval: Milliseconds;
+}
+
+export interface TipTrackerInternals {
+  externalTrigger$?: Subject<void>;
+}
+
+const triggerOrInterval$ = (trigger$: Observable<unknown>, interval: number): Observable<unknown> =>
+  trigger$.pipe(timeout({ each: interval, with: () => concat(of(true), triggerOrInterval$(trigger$, interval)) }));
+
+export class TipTracker extends PersistentDocumentTrackerSubject<Cardano.Tip> {
+  #externalTrigger$ = new Subject<void>();
+
+  constructor(
+    { provider$, minPollInterval, maxPollInterval, store, syncStatus }: TipTrackerProps,
+    { externalTrigger$ = new Subject() }: TipTrackerInternals = {}
+  ) {
+    super(
+      merge(
+        // schedule a fetch:
+        // - after some delay once fully synced and online
+        // - if it's not settled for maxPollInterval
+        triggerOrInterval$(syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)), maxPollInterval).pipe(
+          // trigger fetch after some delay once fully synced and online
+          delay(minPollInterval),
+          // trigger fetch on start
+          startWith(null),
+          // Throttle syncing by interval, cancel ongoing request on external trigger
+          exhaustMap(() => merge(provider$).pipe(takeUntil(externalTrigger$))),
+          distinctUntilChanged(tipEquals)
+        ),
+        // Always immediately restart request on external trigger
+        externalTrigger$.pipe(switchMap(() => provider$))
+      ).pipe(finalize(() => this.#externalTrigger$.complete())),
+      store
+    );
+    this.#externalTrigger$ = externalTrigger$;
+  }
+
+  sync() {
+    this.#externalTrigger$.next();
+  }
+}

--- a/packages/wallet/src/services/UtxoTracker.ts
+++ b/packages/wallet/src/services/UtxoTracker.ts
@@ -27,12 +27,12 @@ export const createUtxoProvider = (
 ) =>
   addresses$.pipe(
     switchMap((addresses) =>
-      coldObservableProvider(
-        () => utxoProvider.utxoByAddresses(addresses),
+      coldObservableProvider({
+        equals: utxoEquals,
+        provider: () => utxoProvider.utxoByAddresses(addresses),
         retryBackoffConfig,
-        tipBlockHeight$,
-        utxoEquals
-      )
+        trigger$: tipBlockHeight$
+      })
     )
   );
 

--- a/packages/wallet/src/services/index.ts
+++ b/packages/wallet/src/services/index.ts
@@ -8,3 +8,4 @@ export * from './types';
 export * from './ProviderTracker';
 export * from './WalletUtil';
 export * from './EpochTracker';
+export * from './TipTracker';

--- a/packages/wallet/src/services/util/coldObservableProvider.ts
+++ b/packages/wallet/src/services/util/coldObservableProvider.ts
@@ -2,13 +2,21 @@ import { Observable, distinctUntilChanged, from, of, switchMap } from 'rxjs';
 import { RetryBackoffConfig, retryBackoff } from 'backoff-rxjs';
 import { strictEquals } from './equals';
 
-export const coldObservableProvider = <T>(
-  provider: () => Promise<T>,
-  retryBackoffConfig: RetryBackoffConfig,
-  trigger$: Observable<unknown> = of(true),
-  equals: (t1: T, t2: T) => boolean = strictEquals,
+export interface ColdObservableProviderProps<T> {
+  provider: () => Promise<T>;
+  retryBackoffConfig: RetryBackoffConfig;
+  trigger$?: Observable<unknown>;
+  equals?: (t1: T, t2: T) => boolean;
+  combinator?: typeof switchMap;
+}
+
+export const coldObservableProvider = <T>({
+  provider,
+  retryBackoffConfig,
+  trigger$ = of(true),
+  equals = strictEquals,
   combinator = switchMap
-) =>
+}: ColdObservableProviderProps<T>) =>
   new Observable<T>((subscriber) => {
     const sub = trigger$
       .pipe(

--- a/packages/wallet/test/services/ProviderTracker/TipTracker.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TipTracker.test.ts
@@ -1,0 +1,102 @@
+import { Cardano } from '@cardano-sdk/core';
+import { InMemoryDocumentStore } from '../../../src/persistence';
+import { Milliseconds, SyncStatus } from '../../../src';
+import { Observable, firstValueFrom } from 'rxjs';
+import { TipTracker } from '../../../src/services';
+import { createTestScheduler } from '@cardano-sdk/util-dev';
+
+const stubObservableProvider = <T>(...calls: Observable<T>[]) => {
+  let numCall = 0;
+  return new Observable<T>((subscriber) => {
+    const sub = calls[numCall++].subscribe(subscriber);
+    return () => sub.unsubscribe();
+  });
+};
+
+const mockTips = {
+  a: { hash: 'ha' },
+  b: { hash: 'hb' },
+  c: { hash: 'hc' },
+  d: { hash: 'hd' },
+  x: { hash: 'hx' },
+  y: { hash: 'hy' }
+} as unknown as Record<string, Cardano.Tip>;
+
+describe('TipTracker', () => {
+  const pollInterval: Milliseconds = 1; // delays emission after trigger
+  let store: InMemoryDocumentStore<Cardano.Tip>;
+
+  beforeEach(() => {
+    store = new InMemoryDocumentStore();
+  });
+
+  it('calls the provider immediately, only emitting distinct values, with throttling', () => {
+    createTestScheduler().run(({ cold, expectObservable }) => {
+      const syncStatus: Partial<SyncStatus> = { isSettled$: cold('---a---bc--d|') };
+      const provider$ = stubObservableProvider<Cardano.Tip>(
+        cold('-x|', mockTips),
+        cold('--a|', mockTips),
+        cold('--b|', mockTips),
+        cold('d|', mockTips)
+      );
+      const tracker$ = new TipTracker({
+        maxPollInterval: Number.MAX_VALUE,
+        minPollInterval: pollInterval,
+        provider$,
+        store,
+        syncStatus: syncStatus as SyncStatus
+      });
+      expectObservable(tracker$.asObservable()).toBe('-x----a---b-d', mockTips);
+    });
+  });
+
+  // mostly covers PersistentDocumentTrackerSubject
+  it('emits value from store first (if present) and stores value on each source emission', async () => {
+    await firstValueFrom(store.set(mockTips.x));
+    store.set = jest.fn().mockImplementation(store.set.bind(store));
+    createTestScheduler().run(({ cold, expectObservable }) => {
+      const syncStatus: Partial<SyncStatus> = { isSettled$: cold('---a---b|') };
+      const provider$ = stubObservableProvider<Cardano.Tip>(
+        cold('-y|', mockTips),
+        cold('--a|', mockTips),
+        cold('-ab|', mockTips)
+      );
+      const tracker$ = new TipTracker({
+        maxPollInterval: Number.MAX_VALUE,
+        minPollInterval: pollInterval,
+        provider$,
+        store,
+        syncStatus: syncStatus as SyncStatus
+      });
+      expectObservable(tracker$.asObservable()).toBe('xy----a---b', mockTips);
+    });
+    expect(store.set).toBeCalledTimes(3);
+    expect(await firstValueFrom(store.get())).toBe(mockTips.b);
+  });
+
+  it('times out trigger$ with maxPollInterval, then listens for trigger$ again', () => {
+    createTestScheduler().run(({ cold, hot, expectObservable }) => {
+      const syncStatus: Partial<SyncStatus> = { isSettled$: hot('10ms a|') };
+      const provider$ = stubObservableProvider<Cardano.Tip>(
+        cold('-a|', mockTips),
+        cold('-b|', mockTips),
+        cold('-c|', mockTips)
+      );
+      const tracker$ = new TipTracker({
+        maxPollInterval: 6,
+        minPollInterval: pollInterval,
+        provider$,
+        store,
+        syncStatus: syncStatus as SyncStatus
+      });
+      // b is emitted at t=8 (before trigger$ emits anything)
+      // c is emitted at t=12 (after trigger$ emits upon resubscribing to it)
+      expectObservable(tracker$, '^ 15ms !').toBe('-a------b---c', mockTips);
+    });
+  });
+
+  // The code is fairly simple, but quite a few additional tests are needed to test all paths
+  it.todo('external trigger cancels an ongoing interval request and makes a new one');
+  it.todo('external trigger cancels an ongoing external trigger request and makes a new one');
+  it.todo('sync() calls external trigger');
+});

--- a/packages/wallet/test/services/util/coldObservableProvider.test.ts
+++ b/packages/wallet/test/services/util/coldObservableProvider.test.ts
@@ -11,7 +11,7 @@ describe('coldObservableProvider', () => {
   it('returns an observable that calls underlying provider on each subscription and uses retryBackoff', async () => {
     const underlyingProvider = jest.fn().mockResolvedValue(true);
     const backoffConfig: RetryBackoffConfig = { initialInterval: 1 };
-    const provider$ = coldObservableProvider(underlyingProvider, backoffConfig);
+    const provider$ = coldObservableProvider({ provider: underlyingProvider, retryBackoffConfig: backoffConfig });
     expect(await firstValueFrom(provider$)).toBe(true);
     expect(await firstValueFrom(provider$)).toBe(true);
     expect(underlyingProvider).toBeCalledTimes(2);

--- a/packages/wallet/test/services/util/persistentTrackerSubjects.test.ts
+++ b/packages/wallet/test/services/util/persistentTrackerSubjects.test.ts
@@ -1,19 +1,7 @@
-import { InMemoryCollectionStore, InMemoryDocumentStore } from '../../../src/persistence';
-import { Milliseconds } from '../../../src';
-import { Observable, firstValueFrom } from 'rxjs';
-import {
-  PersistentCollectionTrackerSubject,
-  SyncableIntervalPersistentDocumentTrackerSubject
-} from '../../../src/services/util';
+import { InMemoryCollectionStore } from '../../../src/persistence';
+import { PersistentCollectionTrackerSubject } from '../../../src/services/util';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
-
-const stubObservableProvider = <T>(...calls: Observable<T>[]) => {
-  let numCall = 0;
-  return new Observable<T>((subscriber) => {
-    const sub = calls[numCall++].subscribe(subscriber);
-    return () => sub.unsubscribe();
-  });
-};
+import { firstValueFrom } from 'rxjs';
 
 describe('PersistentCollectionTrackerSubject', () => {
   let store: InMemoryCollectionStore<string>;
@@ -47,70 +35,4 @@ describe('PersistentCollectionTrackerSubject', () => {
     expect(store.setAll).toBeCalledTimes(2);
     expect(await firstValueFrom(store.getAll())).toBe(c);
   });
-});
-
-describe('SyncableIntervalPersistentDocumentTrackerSubject', () => {
-  const pollInterval: Milliseconds = 1; // delays emission after trigger
-  let store: InMemoryDocumentStore<string>;
-
-  beforeEach(() => {
-    store = new InMemoryDocumentStore();
-  });
-
-  it('calls the provider immediately and on trigger$, only emitting distinct values, with throttling', () => {
-    createTestScheduler().run(({ cold, expectObservable }) => {
-      const trigger$ = cold('---a---bc--d|');
-      const provider$ = stubObservableProvider(cold('-x|'), cold('--a|'), cold('--b|'), cold('d|'));
-      const tracker$ = new SyncableIntervalPersistentDocumentTrackerSubject({
-        maxPollInterval: Number.MAX_VALUE,
-        pollInterval,
-        provider$,
-        store,
-        trigger$
-      });
-      expectObservable(tracker$.asObservable()).toBe('-x----a---b-d');
-    });
-  });
-
-  // mostly covers PersistentDocumentTrackerSubject
-  it('emits value from store first (if present) and stores value on each source emission', async () => {
-    await firstValueFrom(store.set('x'));
-    store.set = jest.fn().mockImplementation(store.set.bind(store));
-    createTestScheduler().run(({ cold, expectObservable }) => {
-      const trigger$ = cold('---a---b|');
-      const provider$ = stubObservableProvider(cold('-y|'), cold('--a|'), cold('-ab|'));
-      const tracker$ = new SyncableIntervalPersistentDocumentTrackerSubject({
-        maxPollInterval: Number.MAX_VALUE,
-        pollInterval,
-        provider$,
-        store,
-        trigger$
-      });
-      expectObservable(tracker$.asObservable()).toBe('xy----a---b');
-    });
-    expect(store.set).toBeCalledTimes(3);
-    expect(await firstValueFrom(store.get())).toBe('b');
-  });
-
-  it('times out trigger$ with maxPollInterval, then listens for trigger$ again', () => {
-    createTestScheduler().run(({ cold, hot, expectObservable }) => {
-      const trigger$ = hot('10ms a|');
-      const provider$ = stubObservableProvider(cold('-a|'), cold('-b|'), cold('-c|'));
-      const tracker$ = new SyncableIntervalPersistentDocumentTrackerSubject({
-        maxPollInterval: 6,
-        pollInterval,
-        provider$,
-        store,
-        trigger$
-      });
-      // b is emitted at t=8 (before trigger$ emits anything)
-      // c is emitted at t=12 (after trigger$ emits upon resubscribing to it)
-      expectObservable(tracker$, '^ 15ms !').toBe('-a------b---c');
-    });
-  });
-
-  // The code is fairly simple, but quite a few additional tests are needed to test all paths
-  it.todo('external trigger cancels an ongoing interval request and makes a new one');
-  it.todo('external trigger cancels an ongoing external trigger request and makes a new one');
-  it.todo('sync() calls external trigger');
 });


### PR DESCRIPTION
# Context

These changes are needed in preparation for adding connection status events.

# Proposed Solution
1. Use named parameters for coldObservableProvider to avoid having too many positional args, especially since connection status will also be a parameter.
1. Lengthy named SyncableIntervalPersistentDocumentTrackerSubject is renamed to TipTracker because it is only used for this purpose. There are also some refactoring here:
  - the type is no longer generic, it is a Cardano.Tip
  - equals is internal to the TipTracker (no longer configurable). 

# Important Changes Introduced
