### PR TITLE
refactor: modular wallet utils

### DIFF
--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -1,50 +1,106 @@
 import { BigIntMath } from '@cardano-sdk/util';
 import { Cardano, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
-import { ObservableWallet, OutputValidation } from '../types';
+import { Observable, firstValueFrom } from 'rxjs';
+import { OutputValidation } from '../types';
 import { ResolveInputAddress } from '../KeyManagement';
 import { computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit } from '@cardano-sdk/cip2';
-import { firstValueFrom } from 'rxjs';
 import { txInEquals } from './util';
 
-/**
- * @returns common wallet utility functions that are aware of wallet state and computes useful things
- */
-export const createWalletUtil = (wallet: ObservableWallet) => {
-  const validateOutput = async (
-    output: Cardano.TxOut,
-    protocolParameters?: Pick<ProtocolParametersRequiredByWallet, 'coinsPerUtxoWord' | 'maxValueSize'>
+export type ProtocolParametersRequiredByOutputValidator = Pick<
+  ProtocolParametersRequiredByWallet,
+  'coinsPerUtxoWord' | 'maxValueSize'
+>;
+export interface OutputValidatorContext {
+  /**
+   * Subscribed on every OutputValidator call
+   */
+  protocolParameters$: Observable<ProtocolParametersRequiredByOutputValidator>;
+}
+export interface InputResolverContext {
+  utxo: {
+    /**
+     * Subscribed on every InputResolver call
+     */
+    available$: Observable<Cardano.Utxo[]>;
+  };
+}
+export type WalletUtilContext = OutputValidatorContext & InputResolverContext;
+
+export interface OutputValidator {
+  /**
+   * @returns Validates that token bundle size is within limits and computes minimum coin quantity
+   */
+  validateValue(output: Cardano.Value): Promise<OutputValidation>;
+  /**
+   * @returns For every value, validates that token bundle size is within limits and computes minimum coin quantity
+   */
+  validateValues(outputs: Iterable<Cardano.Value>): Promise<Map<Cardano.Value, OutputValidation>>;
+  /**
+   * @returns Validates that token bundle size is within limits and computes minimum coin quantity
+   */
+  validateOutput(output: Cardano.TxOut): Promise<OutputValidation>;
+  /**
+   * @returns For every output, validates that token bundle size is within limits and computes minimum coin quantity
+   */
+  validateOutputs(outputs: Iterable<Cardano.TxOut>): Promise<Map<Cardano.TxOut, OutputValidation>>;
+}
+
+export interface InputResolver {
+  resolveInputAddress: ResolveInputAddress;
+}
+
+export const createOutputValidator = ({ protocolParameters$ }: OutputValidatorContext): OutputValidator => {
+  const validateValue = async (
+    value: Cardano.Value,
+    protocolParameters?: ProtocolParametersRequiredByOutputValidator
   ): Promise<OutputValidation> => {
-    const { coinsPerUtxoWord, maxValueSize } = protocolParameters || (await firstValueFrom(wallet.protocolParameters$));
-    const minimumCoin = BigInt(computeMinimumCoinQuantity(coinsPerUtxoWord)(output.value.assets));
+    const { coinsPerUtxoWord, maxValueSize } = protocolParameters || (await firstValueFrom(protocolParameters$));
+    const minimumCoin = BigInt(computeMinimumCoinQuantity(coinsPerUtxoWord)(value.assets));
     return {
-      coinMissing: BigIntMath.max([minimumCoin - output.value.coins, 0n])!,
+      coinMissing: BigIntMath.max([minimumCoin - value.coins, 0n])!,
       minimumCoin,
-      tokenBundleSizeExceedsLimit: tokenBundleSizeExceedsLimit(maxValueSize)(output.value.assets)
+      tokenBundleSizeExceedsLimit: tokenBundleSizeExceedsLimit(maxValueSize)(value.assets)
     };
   };
-  const resolveInputAddress: ResolveInputAddress = async (input: Cardano.NewTxIn) => {
-    const utxoAvailable = await firstValueFrom(wallet.utxo.available$);
-    return utxoAvailable?.find(([txIn]) => txInEquals(txIn, input))?.[1].address || null;
+  const validateValues = async (values: Iterable<Cardano.Value>) => {
+    const protocolParameters = await firstValueFrom(protocolParameters$);
+    const validations = new Map<Cardano.Value, OutputValidation>();
+    for (const value of values) {
+      validations.set(value, await validateValue(value, protocolParameters));
+    }
+    return validations;
   };
+  const validateOutput = (output: Cardano.TxOut, protocolParameters?: ProtocolParametersRequiredByOutputValidator) =>
+    validateValue(output.value, protocolParameters);
 
   return {
-    resolveInputAddress,
-    /**
-     * @returns Validates that token bundle size is within limits and computes minimum coin quantity
-     */
     validateOutput,
-    /**
-     * @returns For every output, validates that token bundle size is within limits and computes minimum coin quantity
-     */
-    validateOutputs: async (outputs: Iterable<Cardano.TxOut>): Promise<Map<Cardano.TxOut, OutputValidation>> => {
-      const protocolParameters = await firstValueFrom(wallet.protocolParameters$);
+    async validateOutputs(outputs: Iterable<Cardano.TxOut>): Promise<Map<Cardano.TxOut, OutputValidation>> {
+      const protocolParameters = await firstValueFrom(protocolParameters$);
       const validations = new Map<Cardano.TxOut, OutputValidation>();
       for (const output of outputs) {
         validations.set(output, await validateOutput(output, protocolParameters));
       }
       return validations;
-    }
+    },
+    validateValue,
+    validateValues
   };
 };
+
+export const createInputResolver = ({ utxo }: InputResolverContext): InputResolver => ({
+  async resolveInputAddress(input: Cardano.NewTxIn) {
+    const utxoAvailable = await firstValueFrom(utxo.available$);
+    return utxoAvailable?.find(([txIn]) => txInEquals(txIn, input))?.[1].address || null;
+  }
+});
+
+/**
+ * @returns common wallet utility functions that are aware of wallet state and computes useful things
+ */
+export const createWalletUtil = (context: WalletUtilContext) => ({
+  ...createOutputValidator(context),
+  ...createInputResolver(context)
+});
 
 export type WalletUtil = ReturnType<typeof createWalletUtil>;

--- a/packages/wallet/test/integration/CustomObservableWallet.test.ts
+++ b/packages/wallet/test/integration/CustomObservableWallet.test.ts
@@ -1,0 +1,164 @@
+/* eslint-disable sonarjs/no-extra-arguments */
+/* eslint-disable unicorn/consistent-function-scoping */
+import * as mocks from '../mocks';
+import { Cardano, coreToCsl } from '@cardano-sdk/core';
+import {
+  KeyManagement,
+  ObservableWallet,
+  OutputValidator,
+  ProtocolParametersRequiredByOutputValidator,
+  RewardAccount,
+  SingleAddressWallet,
+  StakeKeyStatus,
+  coldObservableProvider,
+  createOutputValidator
+} from '../../src';
+import { RetryBackoffConfig } from 'backoff-rxjs';
+import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
+import { of, timer } from 'rxjs';
+
+describe('CustomObservableWallet', () => {
+  describe('can create an application-specific subset of ObservableWallet interface', () => {
+    type LaceBalance = {
+      // Can use partial types
+      utxo: Pick<ObservableWallet['balance']['utxo'], 'available$'>;
+      rewardAccounts: ObservableWallet['balance']['rewardAccounts'];
+    };
+
+    /**
+     * Wallet interface as used by the application
+     */
+    interface LaceObservableWallet {
+      // Interface supports multi-addresses for the most part (note plural in addresses$ and delegation.rewardAccounts$)
+      // Might be missing some data (e.g. balance by address):
+      // we're not sure what kind of data multi-address wallet wants to present to the users,
+      // but we're open to extending the ObservableWallet interface to support more use cases.
+      addresses$: ObservableWallet['addresses$'];
+      delegation: {
+        rewardAccounts$: ObservableWallet['delegation']['rewardAccounts$'];
+      };
+      balance: LaceBalance;
+      submitTx: ObservableWallet['submitTx'];
+    }
+
+    it('can use SingleAddressWallet to satisfy application-specific interface', async () => {
+      // this compiles
+      const extensionWallet: LaceObservableWallet = new SingleAddressWallet(
+        { name: 'Extension Wallet' },
+        {
+          assetProvider: mocks.mockAssetProvider(),
+          chainHistoryProvider: mocks.mockChainHistoryProvider(),
+          keyAgent: KeyManagement.util.createAsyncKeyAgent(await mocks.testKeyAgent()),
+          networkInfoProvider: mocks.mockNetworkInfoProvider(),
+          rewardsProvider: mocks.mockRewardsProvider(),
+          stakePoolProvider: createStubStakePoolProvider(),
+          txSubmitProvider: mocks.mockTxSubmitProvider(),
+          utxoProvider: mocks.mockUtxoProvider()
+        }
+      );
+      extensionWallet;
+    });
+
+    it('does not necessarily have to use SingleAddressWallet, but can still utilize SDK utils', () => {
+      // let's say we have an API endpoint to submit transaction as bytes and not as SDK's Cardano.NewTxAlonzo
+      const submitTxBytesHexString: (tx: string) => Promise<void> = () => Promise.resolve();
+      // and another endpoint to get wallet addresses
+      const getAddresses: () => Promise<KeyManagement.GroupedAddress[]> = async () => [];
+      // and another endpoint to get wallet's utxo balance
+      const getAvailableUtxoBalance: () => Promise<Cardano.Value> = async () => ({ coins: 10_000_000n });
+      // and another endpoint to get wallet's total reward accounts deposit
+      const getAvailableRewardAccountsDeposit: () => Promise<Cardano.Lovelace> = async () => 200_000n;
+      // and another endpoint to get wallet's reward accounts info (such as stake pool delegated to)
+      const getRewardAccountsDelegation: () => Promise<RewardAccount[]> = async () => [
+        {
+          address: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
+          keyStatus: StakeKeyStatus.Unregistering,
+          rewardBalance: 5000n
+        }
+      ];
+      // some additional arguments might be needed to utilize SDK utils
+      const retryBackoffConfig: RetryBackoffConfig = { initialInterval: 1000 };
+      // for the sake of simplicity, let's say we just want to poll all backend endpoints every 10s
+      const walletUpdateTrigger$ = timer(0, 10_000);
+
+      // this compiles
+      const desktopWallet: LaceObservableWallet = {
+        // for the sake of simplicity, let's say we don't care about wallet's persistence/restoration
+        // and want to just re-fetch data upon every subscription and then update using some interval.
+        // If we did want more features, there are other SDK utils we could use
+        addresses$: coldObservableProvider({
+          provider: getAddresses,
+          retryBackoffConfig,
+          trigger$: walletUpdateTrigger$
+        }),
+        balance: {
+          rewardAccounts: {
+            // can entirely bypass SDK and it's utils, providing custom observables
+            deposit$: of(200_000n),
+            rewards$: coldObservableProvider({
+              provider: getAvailableRewardAccountsDeposit,
+              retryBackoffConfig,
+              trigger$: walletUpdateTrigger$
+            })
+          },
+          utxo: {
+            available$: coldObservableProvider({
+              provider: getAvailableUtxoBalance,
+              retryBackoffConfig,
+              trigger$: walletUpdateTrigger$
+            })
+          }
+        },
+        delegation: {
+          rewardAccounts$: coldObservableProvider({
+            provider: getRewardAccountsDelegation,
+            retryBackoffConfig,
+            trigger$: walletUpdateTrigger$
+          })
+        },
+        submitTx(tx: Cardano.NewTxAlonzo) {
+          // can use utils from SDK, in this case `coreToCsl.tx`
+          // if you want to submit hex-encoded tx, there is also cslToCore.newTx for the reverse
+          const txBytes = Buffer.from(coreToCsl.tx(tx).to_bytes()).toString('hex');
+          return submitTxBytesHexString(txBytes);
+        }
+      };
+      desktopWallet;
+    });
+
+    describe('can use SDK abstractions that are not in scope of ObservableWallet interface', () => {
+      // Let's say application depends on an OutputValidator. This util is a good example,
+      // but many other utils depend on core.Cardano or ObservableWallet types,
+      // which are not necessarily resolved by your custom wallet type.
+      // Please let us know if you'd like to use some util
+      // that is too constrained by the types - we're open to refactors
+      let outputValidator: OutputValidator;
+
+      it('can utilize SingleAddressWallet', () => {
+        const wallet: SingleAddressWallet = {} as SingleAddressWallet;
+        // this compiles
+        outputValidator = createOutputValidator(wallet);
+        outputValidator;
+      });
+
+      it('can provide an implementation that utilize SDK utils, but doesnt depend on full ObservableWallet', () => {
+        const protocolParameters$ = of<ProtocolParametersRequiredByOutputValidator>({
+          coinsPerUtxoWord: 34_482,
+          maxValueSize: 5000
+        });
+        // this compiles
+        outputValidator = createOutputValidator({ protocolParameters$ });
+      });
+
+      it('can provide custom implementation', () => {
+        outputValidator = {
+          validateOutput: async (_output) => ({
+            coinMissing: 0n,
+            minimumCoin: 1_000_000n,
+            tokenBundleSizeExceedsLimit: false
+          })
+        } as OutputValidator;
+      });
+    });
+  });
+});

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable max-len */
+import { Cardano } from '@cardano-sdk/core';
+import {
+  OutputValidator,
+  ProtocolParametersRequiredByOutputValidator,
+  createInputResolver,
+  createOutputValidator
+} from '../../src';
+import { of } from 'rxjs';
+
+describe('WalletUtil', () => {
+  describe('createOutputValidator', () => {
+    let validator: OutputValidator;
+
+    beforeAll(() => {
+      validator = createOutputValidator({
+        protocolParameters$: of<ProtocolParametersRequiredByOutputValidator>({
+          coinsPerUtxoWord: 34_482,
+          maxValueSize: 90
+        })
+      });
+    });
+
+    it('validateValue validates minimum coin quantity', async () => {
+      expect((await validator.validateValue({ coins: 2_000_000n })).coinMissing).toBe(0n);
+      expect((await validator.validateValue({ coins: 500_000n })).coinMissing).toBeGreaterThan(0n);
+    });
+
+    it('validateValue validates bundle size', async () => {
+      expect(
+        (
+          await validator.validateValue({
+            assets: new Map([
+              [Cardano.AssetId('b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237'), 1n]
+            ]),
+            coins: 2_000_000n
+          })
+        ).tokenBundleSizeExceedsLimit
+      ).toBe(false);
+      expect(
+        (
+          await validator.validateValue({
+            assets: new Map([
+              [Cardano.AssetId('b01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237'), 1n],
+              [Cardano.AssetId('c01fb3b8c3dd6b3705a5dc8bcd5a70759f70ad5d97a72005caeac3c652657675746f31333237'), 2n]
+            ]),
+            coins: 2_000_000n
+          })
+        ).tokenBundleSizeExceedsLimit
+      ).toBe(true);
+    });
+  });
+
+  describe('createInputResolver', () => {
+    it('resolveInputAddress resolves inputs from provided utxo set', async () => {
+      const utxo: Cardano.Utxo[] = [
+        [
+          {
+            address: Cardano.Address(
+              'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+            ),
+            index: 0,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+          },
+          {
+            address: Cardano.Address('addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg'),
+            value: { coins: 50_000_000n }
+          }
+        ]
+      ];
+      const resolver = createInputResolver({ utxo: { available$: of(utxo) } });
+      expect(
+        await resolver.resolveInputAddress({
+          index: 0,
+          txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+        })
+      ).toBe('addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg');
+      expect(
+        await resolver.resolveInputAddress({
+          index: 0,
+          txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d4')
+        })
+      ).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
# Context

- Implementing new providers for `SingleAddressWallet` requires resolving **all** fields defined in core package. This is not always possible.
- Using `ObservableWallet` interface as a base in a custom wallet application in not always possible for similar reasons.
- Creating a new wallet interface and basing implementation on SDK utils is also complicated, because most utils depend on either full `Cardano.*` types or full `ObservableWallet`, which (again) could not necessarily be resolved and might be difficult or impossible to do without losing type safety that is provided by TypeScript.

# Proposed Solution

- Refactor `WalletUtil` as an example of what we would eventually do with the rest of the SDK utils 0339afdc86494cea7d760383c869a0258deafc07:
  - Replace `ObservableWallet` arg with minimal `{protocolParameters$, utxo}`
  - Export `OutputValidator` and `InputResolver` utils separately
- (:exclamation:) Add a new documentation-style test as an example of how custom wallets could be implemented utilizing pieces of the SDK and not necessarily a fully-fledged SingleAddressWallet 8c231cd051e97e88fca5d081bd21a98c48945c29 
- Propose 1 more change in scope of this PR to give a decent minimal subset of ObservableWallet type required by cip30 d2a24cee3d10d0f1532b4179e872e0361e2c99fb