### PR TITLE
Feature/adp 1806 optimize polling strategy to utilize navigator on line

### DIFF
--- a/packages/wallet/src/services/util/connectionStatusTracker.ts
+++ b/packages/wallet/src/services/util/connectionStatusTracker.ts
@@ -1,0 +1,34 @@
+import { NEVER, Observable, distinctUntilChanged, fromEvent, map, merge, shareReplay, startWith } from 'rxjs';
+
+export enum ConnectionStatus {
+  down = 0,
+  up
+}
+
+export type ConnectionStatusTracker = Observable<ConnectionStatus>;
+
+export interface ConnectionStatusTrackerInternals {
+  isNodeEnv?: boolean;
+  online$?: Observable<unknown>;
+  offline$?: Observable<unknown>;
+  initialStatus?: boolean;
+}
+
+/**
+ * Returns an observable that emits the online status of the browser.
+ * When running in Node, it always emits 'up'
+ *
+ * @returns {ConnectionStatusTracker} ConnectionStatusTracker
+ */
+export const createSimpleConnectionStatusTracker = ({
+  isNodeEnv = typeof window === 'undefined',
+  online$ = isNodeEnv ? NEVER : fromEvent(window, 'online'),
+  offline$ = isNodeEnv ? NEVER : fromEvent(window, 'offline'),
+  initialStatus = isNodeEnv ? true : navigator.onLine
+}: ConnectionStatusTrackerInternals = {}): ConnectionStatusTracker =>
+  merge(online$.pipe(map(() => true)), offline$.pipe(map(() => false))).pipe(
+    startWith(initialStatus),
+    map((onLine) => (onLine ? ConnectionStatus.up : ConnectionStatus.down)),
+    distinctUntilChanged(),
+    shareReplay(1)
+  );

--- a/packages/wallet/src/services/util/index.ts
+++ b/packages/wallet/src/services/util/index.ts
@@ -2,3 +2,4 @@ export * from './persistentTrackerSubjects';
 export * from './equals';
 export * from './trigger';
 export * from './coldObservableProvider';
+export * from './connectionStatusTracker';

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -3,11 +3,20 @@
 import * as mocks from '../mocks';
 import { AssetId, createStubStakePoolProvider, somePartialStakePools } from '@cardano-sdk/util-dev';
 import { Cardano, ChainHistoryProvider, NetworkInfoProvider, RewardsProvider, UtxoProvider } from '@cardano-sdk/core';
-import { KeyManagement, ObservableWallet, SingleAddressWallet } from '../../src';
+import {
+  ConnectionStatus,
+  ConnectionStatusTracker,
+  KeyManagement,
+  ObservableWallet,
+  PollingConfig,
+  SingleAddressWallet
+} from '../../src';
+import { ReplaySubject, firstValueFrom } from 'rxjs';
 import { WalletStores, createInMemoryWalletStores } from '../../src/persistence';
 import { currentEpoch, networkInfo, queryTransactionsResult, queryTransactionsResult2 } from '../mocks';
-import { firstValueFrom } from 'rxjs';
+
 import { waitForWalletStateSettle } from '../util';
+import delay from 'delay';
 import flatten from 'lodash/flatten';
 
 const name = 'Test Wallet';
@@ -19,10 +28,12 @@ interface Providers {
   utxoProvider: UtxoProvider;
   chainHistoryProvider: ChainHistoryProvider;
   networkInfoProvider: NetworkInfoProvider;
+  connectionStatusTracker$?: ConnectionStatusTracker;
 }
 
-const createWallet = async (stores: WalletStores, providers: Providers) => {
-  const { rewardsProvider, utxoProvider, chainHistoryProvider, networkInfoProvider } = providers;
+const createWallet = async (stores: WalletStores, providers: Providers, pollingConfig?: PollingConfig) => {
+  const { rewardsProvider, utxoProvider, chainHistoryProvider, networkInfoProvider, connectionStatusTracker$ } =
+    providers;
   const txSubmitProvider = mocks.mockTxSubmitProvider();
   const assetProvider = mocks.mockAssetProvider();
   const stakePoolProvider = createStubStakePoolProvider();
@@ -37,10 +48,11 @@ const createWallet = async (stores: WalletStores, providers: Providers) => {
   const keyAgent = await mocks.testAsyncKeyAgent([groupedAddress]);
   keyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);
   return new SingleAddressWallet(
-    { name },
+    { name, polling: pollingConfig },
     {
       assetProvider,
       chainHistoryProvider,
+      connectionStatusTracker$,
       keyAgent,
       networkInfoProvider,
       rewardsProvider,
@@ -175,6 +187,82 @@ describe('SingleAddressWallet load', () => {
     // eslint-disable-next-line unicorn/no-useless-undefined
     await assertWalletProperties(wallet, undefined, []);
     await waitForWalletStateSettle(wallet);
+    wallet.shutdown();
+  });
+
+  it('tip value ignored while connection is down', async () => {
+    const ONCE_SETTLED_FETCH_AFTER = 5;
+    const AUTO_TRIGGER_AFTER = 30;
+
+    const stores = createInMemoryWalletStores();
+    const rewardsProvider = mocks.mockRewardsProvider();
+    const networkInfoProvider = mocks.mockNetworkInfoProvider();
+    // Call to ledgerTip() has to return a different value every time,
+    // or else wallet won't fetch any other data from the rest of the providers
+    networkInfoProvider.ledgerTip.mockImplementationOnce(
+      (() => {
+        let numCall = 0;
+        return async (): Promise<Cardano.Tip> => {
+          const blockNo = ++numCall;
+          return {
+            blockNo,
+            hash: Cardano.BlockId(blockNo.toString(16).padStart(64, '0')),
+            slot: blockNo * 100
+          };
+        };
+      })()
+    );
+
+    const chainHistoryProvider = mocks.mockChainHistoryProvider();
+    const utxoProvider = mocks.mockUtxoProvider();
+    utxoProvider.utxoByAddresses = jest
+      .fn()
+      .mockImplementationOnce(() => mocks.utxo)
+      .mockImplementation(
+        () =>
+          new Promise(() => {
+            // Make sure wallet never settles
+          })
+      );
+    const connectionStatusTracker$ = new ReplaySubject<ConnectionStatus>(1);
+    const wallet = await createWallet(
+      stores,
+      {
+        chainHistoryProvider,
+        connectionStatusTracker$,
+        networkInfoProvider,
+        rewardsProvider,
+        utxoProvider
+      },
+      { interval: ONCE_SETTLED_FETCH_AFTER, maxInterval: AUTO_TRIGGER_AFTER }
+    );
+
+    // Initial fetch when wallet is instantiated
+    expect(networkInfoProvider.ledgerTip).toHaveBeenCalledTimes(0);
+
+    // tip$ fetch triggered by ConnectionStatus going up
+    connectionStatusTracker$.next(ConnectionStatus.up);
+    expect(networkInfoProvider.ledgerTip).toHaveBeenCalledTimes(1);
+
+    // settling from ledgerTip call that was triggered by connectionStatusTracker$.next(ConnectionStatus.up);
+    await waitForWalletStateSettle(wallet);
+    // max interval should start here
+    await delay(ONCE_SETTLED_FETCH_AFTER + 1);
+    expect(networkInfoProvider.ledgerTip).toHaveBeenCalledTimes(2);
+
+    // since we changed ledgerTip implementation to never resolve, wallet shouldn't get settled again
+
+    // Auto interval tip$ trigger
+    // Don't need to add ONCE_SETTLED_FETCH_AFTER + 1
+    // because it's already awaited in a delay above
+    await delay(AUTO_TRIGGER_AFTER);
+    expect(networkInfoProvider.ledgerTip).toHaveBeenCalledTimes(3);
+
+    // Auto interval tip$ trigger no longer works once offline
+    connectionStatusTracker$.next(ConnectionStatus.down);
+    await delay(AUTO_TRIGGER_AFTER + ONCE_SETTLED_FETCH_AFTER + 1);
+    expect(networkInfoProvider.ledgerTip).toHaveBeenCalledTimes(3);
+
     wallet.shutdown();
   });
 });

--- a/packages/wallet/test/services/util/coldObservableProvider.test.ts
+++ b/packages/wallet/test/services/util/coldObservableProvider.test.ts
@@ -1,6 +1,6 @@
+import { BehaviorSubject, EmptyError, Subject, firstValueFrom } from 'rxjs';
 import { RetryBackoffConfig, retryBackoff } from 'backoff-rxjs';
 import { coldObservableProvider } from '../../../src';
-import { firstValueFrom } from 'rxjs';
 
 // There might be a more elegant way to mock with original implementation (spy)
 jest.mock('backoff-rxjs', () => ({
@@ -17,5 +17,24 @@ describe('coldObservableProvider', () => {
     expect(underlyingProvider).toBeCalledTimes(2);
     expect(retryBackoff).toBeCalledTimes(2);
     expect(retryBackoff).toBeCalledWith(backoffConfig);
+  });
+
+  it('provider is unsubscribed on cancel emit', async () => {
+    const fakeProviderSubject = new Subject();
+    const underlyingProvider = () => firstValueFrom(fakeProviderSubject);
+    const backoffConfig: RetryBackoffConfig = { initialInterval: 1 };
+    const cancel$ = new BehaviorSubject<boolean>(true);
+    const provider$ = coldObservableProvider({
+      cancel$,
+      provider: underlyingProvider,
+      retryBackoffConfig: backoffConfig
+    });
+
+    try {
+      await firstValueFrom(provider$);
+    } catch (error) {
+      expect(error).toBeInstanceOf(EmptyError);
+    }
+    expect.assertions(1);
   });
 });

--- a/packages/wallet/test/services/util/connectionStatusTracker.test.ts
+++ b/packages/wallet/test/services/util/connectionStatusTracker.test.ts
@@ -1,0 +1,60 @@
+import { ConnectionStatus, ConnectionStatusTrackerInternals, createSimpleConnectionStatusTracker } from '../../../src';
+import { Subject, filter, firstValueFrom } from 'rxjs';
+import { createTestScheduler } from '@cardano-sdk/util-dev';
+
+describe('createSimpleConnectionStatusTracker', () => {
+  it('creates ConnectionStatusTracker that always emits `up` when in Node', async () => {
+    createTestScheduler().run(({ expectObservable }) => {
+      const nodeConnection$ = createSimpleConnectionStatusTracker({ isNodeEnv: true });
+      expectObservable(nodeConnection$).toBe('p', { p: ConnectionStatus.up });
+    });
+  });
+
+  describe('Browser', () => {
+    let mockInternals: ConnectionStatusTrackerInternals;
+    const connEvents = new Subject<boolean>();
+
+    beforeEach(() => {
+      mockInternals = {
+        initialStatus: true,
+        isNodeEnv: false,
+        offline$: connEvents.pipe(filter((online) => !online)),
+        online$: connEvents.pipe(filter((online) => online))
+      };
+    });
+
+    it('emits initialStatus as starting value', async () => {
+      const connectionStatus = firstValueFrom(createSimpleConnectionStatusTracker(mockInternals));
+      expect(await connectionStatus).toBe(ConnectionStatus.up);
+    });
+
+    it('emits `down` when offline$ emits', () => {
+      createTestScheduler().run(({ cold, expectObservable }) => {
+        mockInternals.offline$ = cold('-a|');
+        mockInternals.online$ = cold('--|');
+        const connectionStatus$ = createSimpleConnectionStatusTracker(mockInternals);
+        expectObservable(connectionStatus$).toBe('xd|', { d: ConnectionStatus.down, x: ConnectionStatus.up });
+      });
+    });
+
+    it('emits only distinct values', () => {
+      createTestScheduler().run(({ cold, expectObservable }) => {
+        mockInternals.offline$ = cold('-aa|');
+        mockInternals.online$ = cold('---|');
+        const connectionStatus$ = createSimpleConnectionStatusTracker(mockInternals);
+        expectObservable(connectionStatus$).toBe('xd-|', { d: ConnectionStatus.down, x: ConnectionStatus.up });
+      });
+    });
+
+    it('subsequent subscribers get the last known value', () => {
+      createTestScheduler().run(({ cold, expectObservable }) => {
+        mockInternals.offline$ = cold('---|');
+        mockInternals.online$ = cold('---|');
+
+        const connectionStatus$ = createSimpleConnectionStatusTracker(mockInternals);
+        expectObservable(connectionStatus$).toBe('u--|', { u: ConnectionStatus.up });
+        expectObservable(connectionStatus$).toBe('u--|', { u: ConnectionStatus.up });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Context

ADP-1806 Utilize Navigator.onLine and window.online/offline events to optimize polling strategy

# Proposed Solution
- `ConnectionStatusTracker` observable type is used to notify connection state changes.
- `createSimpleConnectionStatusTracker` is used by default in SingleAddressWallet:
  - When running in browser, window online/offline events are used to determine if the connection is up or down.
  - When running in Node, the connection will always be reported as up, because there is no simple mechanism to determine if the active interface is connected or not.
- Users can provide their own `ConnectionStatusTracker` observable to `SingleAddressWallet`
- Providers exponential backoff is canceled while connection is down
- `TipTracker` will emit only while connection is up


# Important Changes Introduced
