### PR TITLE
feat(cardano-services): adds asset http service

### DIFF
--- a/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
@@ -21,7 +21,7 @@ describe('assetInfoHttpProvider', () => {
   });
 
   describe('getAsset', () => {
-    test('getAsset doesnt throw', async () => {
+    test("getAsset doesn't throw", async () => {
       axiosMock.onPost().replyOnce(200, {});
       const provider = assetInfoHttpProvider(url);
       await expect(

--- a/packages/cardano-services/copy-assets.sh
+++ b/packages/cardano-services/copy-assets.sh
@@ -4,12 +4,13 @@
 
 cp ./package.json ./dist/cjs/original-package.json
 
-cp ./src/StakePool/openApi.json ./dist/cjs/StakePool/openApi.json
-cp ./src/TxSubmit/openApi.json ./dist/cjs/TxSubmit/openApi.json
-cp ./src/Utxo/openApi.json ./dist/cjs/Utxo/openApi.json
+cp ./src/Asset/openApi.json ./dist/cjs/Asset/openApi.json
 cp ./src/ChainHistory/openApi.json ./dist/cjs/ChainHistory/openApi.json
 cp ./src/NetworkInfo/openApi.json ./dist/cjs/NetworkInfo/openApi.json
 cp ./src/Rewards/openApi.json ./dist/cjs/Rewards/openApi.json
+cp ./src/StakePool/openApi.json ./dist/cjs/StakePool/openApi.json
+cp ./src/TxSubmit/openApi.json ./dist/cjs/TxSubmit/openApi.json
+cp ./src/Utxo/openApi.json ./dist/cjs/Utxo/openApi.json
 
 # TODO: uncomment when ESM builds are enabled for this package
 # cp ./src/StakePool/openApi.json ./dist/esm/StakePool/openApi.json

--- a/packages/cardano-services/src/Asset/AssetHttpService.ts
+++ b/packages/cardano-services/src/Asset/AssetHttpService.ts
@@ -1,0 +1,46 @@
+import * as OpenApiValidator from 'express-openapi-validator';
+import { AssetProvider } from '@cardano-sdk/core';
+import { HttpService } from '../Http';
+import { Logger } from 'ts-log';
+import { ServiceNames } from '../Program';
+import { providerHandler } from '../util';
+import express from 'express';
+import path from 'path';
+
+/**
+ * Dependencies that are need to create AssetHttpService
+ */
+export interface AssetHttpServiceDependencies {
+  /**
+   * The asset provider to fetch data
+   */
+  assetProvider: AssetProvider;
+
+  /**
+   * The logger object
+   */
+  logger: Logger;
+}
+
+/**
+ * The Asset Http Service
+ */
+export class AssetHttpService extends HttpService {
+  constructor({ assetProvider, logger }: AssetHttpServiceDependencies, router: express.Router = express.Router()) {
+    super(ServiceNames.Asset, assetProvider, router, logger);
+
+    const apiSpec = path.join(__dirname, 'openApi.json');
+    router.use(
+      OpenApiValidator.middleware({
+        apiSpec,
+        ignoreUndocumented: true,
+        validateRequests: true,
+        validateResponses: true
+      })
+    );
+    router.post(
+      '/get-asset',
+      providerHandler(assetProvider.getAsset.bind(assetProvider))(HttpService.routeHandler(logger), logger)
+    );
+  }
+}

--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -25,6 +25,14 @@ interface TokenMetadataServiceRecord {
   url?: StringValue;
 }
 
+const propertiesToChange: Record<string, string> = { description: 'desc', logo: 'icon' };
+export const toCoreTokenMetadata = (record: TokenMetadataServiceRecord) =>
+  Object.fromEntries(
+    Object.entries(record)
+      .filter(([key]) => ['decimals', 'description', 'logo', 'name', 'ticker', 'url'].includes(key))
+      .map(([key, value]) => [propertiesToChange[key] || key, value.value])
+  ) as Asset.TokenMetadata;
+
 const toProviderError = (error: unknown, details: string) => {
   if (error instanceof ProviderError) return error;
 
@@ -125,7 +133,7 @@ export class CardanoTokenRegistry implements TokenMetadataService {
 
           if (subject) {
             const assetId = Cardano.AssetId(subject);
-            const metadata = this.parseTokenMetadataServiceRecord(record);
+            const metadata = toCoreTokenMetadata(record);
 
             tokenMetadata[assetIds.indexOf(assetId)] = metadata;
             this.#cache.set(assetId.toString(), metadata);
@@ -163,19 +171,5 @@ export class CardanoTokenRegistry implements TokenMetadataService {
     }
 
     return [assetIdsToRequest, cachedTokenMetadata] as const;
-  }
-
-  private parseTokenMetadataServiceRecord(record: TokenMetadataServiceRecord) {
-    const { decimals, description, logo, name, ticker, url } = record;
-    const metadata: Asset.TokenMetadata = {};
-
-    metadata.decimals = decimals?.value;
-    metadata.desc = description?.value;
-    metadata.icon = logo?.value;
-    metadata.name = name?.value;
-    metadata.ticker = ticker?.value;
-    metadata.url = url?.value;
-
-    return metadata;
   }
 }

--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -4,7 +4,8 @@ import { Logger } from 'ts-log';
 import { TokenMetadataService } from './types';
 import axios, { AxiosInstance } from 'axios';
 
-const DEFAULT_METADATA_SERVER_URI = 'https://tokens.cardano.org';
+export const DEFAULT_TOKEN_METADATA_CACHE_TTL = 600;
+export const DEFAULT_TOKEN_METADATA_SERVER_URL = 'https://tokens.cardano.org';
 
 interface NumberValue {
   value?: number;
@@ -39,17 +40,17 @@ export interface CardanoTokenRegistryConfiguration {
   /**
    * The cache TTL in seconds. Default: 10 minutes.
    */
-  cacheTTL?: number;
+  tokenMetadataCacheTTL?: number;
 
   /**
    * The Cardano Token Registry public API base URL. Default: https://tokens.cardano.org
    */
-  metadataServerUri?: string;
+  tokenMetadataServerUrl?: string;
 }
 
 interface CardanoTokenRegistryConfigurationWithRequired extends CardanoTokenRegistryConfiguration {
-  cacheTTL: number;
-  metadataServerUri: string;
+  tokenMetadataCacheTTL: number;
+  tokenMetadataServerUrl: string;
 }
 
 /**
@@ -88,13 +89,13 @@ export class CardanoTokenRegistry implements TokenMetadataService {
 
   constructor({ cache, logger }: CardanoTokenRegistryDependencies, config: CardanoTokenRegistryConfiguration = {}) {
     const defaultConfig: CardanoTokenRegistryConfigurationWithRequired = {
-      cacheTTL: 600,
-      metadataServerUri: DEFAULT_METADATA_SERVER_URI,
+      tokenMetadataCacheTTL: DEFAULT_TOKEN_METADATA_CACHE_TTL,
+      tokenMetadataServerUrl: DEFAULT_TOKEN_METADATA_SERVER_URL,
       ...config
     };
 
-    this.#cache = cache || new InMemoryCache(defaultConfig.cacheTTL);
-    this.#axiosClient = axios.create({ baseURL: defaultConfig.metadataServerUri });
+    this.#cache = cache || new InMemoryCache(defaultConfig.tokenMetadataCacheTTL);
+    this.#axiosClient = axios.create({ baseURL: defaultConfig.tokenMetadataServerUrl });
     this.#logger = logger;
   }
 

--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -139,7 +139,7 @@ export class CardanoTokenRegistry implements TokenMetadataService {
         }
       }
     } catch (error) {
-      throw toProviderError(error, 'while fetching metadata from token registriy');
+      throw toProviderError(error, 'while fetching metadata from token registry');
     }
 
     return tokenMetadata;
@@ -156,7 +156,7 @@ export class CardanoTokenRegistry implements TokenMetadataService {
       const cachedMetadata = this.#cache.getVal<Asset.TokenMetadata>(stringAssetId);
 
       if (cachedMetadata) {
-        this.#logger.debug(`Using chached asset metatada value for "${stringAssetId}"`);
+        this.#logger.debug(`Using cached asset metatada value for "${stringAssetId}"`);
         cachedTokenMetadata[i] = cachedMetadata;
       } else assetIdsToRequest.push(assetId);
     }

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider.ts
@@ -10,7 +10,7 @@ import { Pool } from 'pg';
  */
 export type DbSyncAssetProviderDependencies = {
   /**
-   * The db-sync database Pgpool
+   * The db-sync database PgPool
    */
   db: Pool;
 
@@ -26,7 +26,7 @@ export type DbSyncAssetProviderDependencies = {
   ntfMetadataService: NftMetadataService;
 
   /**
-   * The TokenMetadataService toretrieve Asset.TokenMetadata.
+   * The TokenMetadataService to retrieve Asset.TokenMetadata.
    */
   tokenMetadataService: TokenMetadataService;
 };

--- a/packages/cardano-services/src/Asset/index.ts
+++ b/packages/cardano-services/src/Asset/index.ts
@@ -1,3 +1,5 @@
+export * from './AssetBuilder';
+export * from './AssetHttpService';
 export * from './CardanoTokenRegistry';
 export * from './DbSyncAssetProvider';
 export * from './DbSyncNftMetadataService';

--- a/packages/cardano-services/src/Asset/openApi.json
+++ b/packages/cardano-services/src/Asset/openApi.json
@@ -1,0 +1,119 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Asset",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/asset/get-asset": {
+      "post": {
+        "summary": "Get Asset Info",
+        "operationId": "getAssetInfo",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetAssetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AssetInfo": {
+        "type": "object",
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "fingerprint": {
+            "type": "string"
+          },
+          "mintOrBurnCount": {
+            "type": "number"
+          },
+          "name": {
+            "type": "string"
+          },
+          "policyId": {
+            "type": "string"
+          }
+        }
+      },
+      "ExtraData": {
+        "type": "object",
+        "properties": {
+          "history": {
+            "type": "boolean"
+          },
+          "nftMetadata": {
+            "type": "boolean"
+          },
+          "tokenMetadata": {
+            "type": "boolean"
+          }
+        }
+      },
+      "GetAssetRequest": {
+        "required": ["args"],
+        "type": "object",
+        "properties": {
+          "args": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/ExtraData"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -56,6 +56,13 @@ export abstract class HttpService extends RunnableModule {
         return HttpServer.sendJSON(res, await handler(...args));
       } catch (error) {
         logger.error(error);
+
+        if (error instanceof ProviderError) {
+          const code = error.reason === ProviderFailure.NotFound ? 404 : 500;
+
+          return HttpServer.sendJSON(res, error, code);
+        }
+
         return HttpServer.sendJSON(res, new ProviderError(ProviderFailure.Unhealthy, error), 500);
       }
     };

--- a/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
+++ b/packages/cardano-services/src/Program/ProgramOptionDescriptions.ts
@@ -2,14 +2,16 @@ import { CommonOptionDescriptions } from '../ProgramsCommon';
 
 enum HttpServerOptionDescriptions {
   ApiUrl = 'API URL',
+  CardanoNodeConfigPath = 'Cardano node config path',
   DbConnection = 'DB Connection string',
+  EpochPollInterval = 'Epoch poll interval',
   MetricsEnabled = 'Enable Prometheus Metrics',
   OgmiosUrl = 'Ogmios URL',
+  PostgresSrvArgs = 'Postgres SRV service name, db, user and password',
   RabbitMQUrl = 'RabbitMQ URL',
-  UseQueue = 'Enables RabbitMQ',
-  CardanoNodeConfigPath = 'Cardano node config path',
-  EpochPollInterval = 'Epoch poll interval',
-  PostgresSrvArgs = 'Postgres SRV service name, db, user and password'
+  TokenMetadataCacheTtl = 'Token Metadata API cache TTL in minutes',
+  TokenMetadataServerUrl = 'Token Metadata API server URL',
+  UseQueue = 'Enables RabbitMQ'
 }
 
 export type ProgramOptionDescriptions = CommonOptionDescriptions | HttpServerOptionDescriptions;

--- a/packages/cardano-services/src/Program/ServiceNames.ts
+++ b/packages/cardano-services/src/Program/ServiceNames.ts
@@ -3,6 +3,7 @@
  *
  */
 export enum ServiceNames {
+  Asset = 'asset',
   StakePool = 'stake-pool',
   NetworkInfo = 'network-info',
   TxSubmit = 'tx-submit',

--- a/packages/cardano-services/src/Program/utils.ts
+++ b/packages/cardano-services/src/Program/utils.ts
@@ -5,12 +5,12 @@ import { ClientConfig, Pool, QueryConfig } from 'pg';
 import { CommonOptionDescriptions, CommonProgramOptions } from '../ProgramsCommon';
 import { HttpServerOptions } from './loadHttpServer';
 import { InvalidArgsCombination, MissingProgramOption } from './errors';
+import { Logger } from 'ts-log';
 import { Ogmios, ogmiosTxSubmitProvider, urlToConnectionConfig } from '@cardano-sdk/ogmios';
 import { ProgramOptionDescriptions } from './ProgramOptionDescriptions';
 import { ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
 import { RabbitMqTxSubmitProvider } from '@cardano-sdk/rabbitmq';
 import { ServiceNames } from './ServiceNames';
-import Logger from 'bunyan';
 import dns, { SrvRecord } from 'dns';
 import pRetry, { FailedAttemptError } from 'p-retry';
 

--- a/packages/cardano-services/src/ProgramsCommon/CommonOptionDescriptions.ts
+++ b/packages/cardano-services/src/ProgramsCommon/CommonOptionDescriptions.ts
@@ -1,10 +1,10 @@
 export enum CommonOptionDescriptions {
+  CacheTtl = 'Cache TTL in minutes between 1 and 2880',
   LoggerMinSeverity = 'Log level',
-  OgmiosUrl = 'Ogmios URL',
-  RabbitMQUrl = 'RabbitMQ URL',
   OgmiosSrvServiceName = 'Ogmios SRV service name',
+  OgmiosUrl = 'Ogmios URL',
   RabbitMQSrvServiceName = 'RabbitMQ SRV service name',
+  RabbitMQUrl = 'RabbitMQ URL',
   ServiceDiscoveryBackoffFactor = 'Exponential backoff factor for service discovery',
-  ServiceDiscoveryTimeout = 'Timeout for service discovery attempts',
-  CacheTtl = 'Cache TTL in minutes between 1 and 2880'
+  ServiceDiscoveryTimeout = 'Timeout for service discovery attempts'
 }

--- a/packages/cardano-services/src/TxWorker/loadTxWorker.ts
+++ b/packages/cardano-services/src/TxWorker/loadTxWorker.ts
@@ -1,4 +1,5 @@
 import { CommonProgramOptions } from '../ProgramsCommon';
+import { Logger } from 'ts-log';
 import { TxSubmitWorker, TxSubmitWorkerConfig } from '@cardano-sdk/rabbitmq';
 import { createDnsResolver, getOgmiosTxSubmitProvider, getRabbitMqUrl } from '../Program';
 import { createLogger } from 'bunyan';
@@ -10,9 +11,11 @@ export interface TxWorkerArgs {
   options: TxWorkerOptions;
 }
 
-export const loadTxWorker = async (args: TxWorkerArgs) => {
+export const loadTxWorker = async (args: TxWorkerArgs, logger?: Logger) => {
   const { loggerMinSeverity, serviceDiscoveryBackoffFactor, serviceDiscoveryTimeout } = args.options;
-  const logger = createLogger({ level: loggerMinSeverity, name: 'tx-worker' });
+
+  if (!logger) logger = createLogger({ level: loggerMinSeverity, name: 'tx-worker' });
+
   const dnsResolver = createDnsResolver(
     {
       factor: serviceDiscoveryBackoffFactor,

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -11,6 +11,7 @@ import {
 import { CACHE_TTL_DEFAULT } from './InMemoryCache';
 import { Command } from 'commander';
 import { CommonOptionDescriptions, Programs, USE_QUEUE_DEFAULT, WrongOption } from './ProgramsCommon';
+import { DEFAULT_TOKEN_METADATA_CACHE_TTL, DEFAULT_TOKEN_METADATA_SERVER_URL } from './Asset';
 import { EPOCH_POLL_INTERVAL_DEFAULT } from './NetworkInfo';
 import { InvalidLoggerLevel } from './errors';
 import {
@@ -111,6 +112,18 @@ commonOptions(
     ProgramOptionDescriptions.EpochPollInterval,
     (interval) => Number.parseInt(interval, 10),
     EPOCH_POLL_INTERVAL_DEFAULT
+  )
+  .option(
+    '--token-metadata-cache-ttl <tokenMetadataCacheTTL>',
+    ProgramOptionDescriptions.TokenMetadataCacheTtl,
+    cacheTtlValidator,
+    DEFAULT_TOKEN_METADATA_CACHE_TTL
+  )
+  .option(
+    '--token-metadata-server-url <tokenMetadataServerUrl>',
+    ProgramOptionDescriptions.TokenMetadataServerUrl,
+    (url) => new URL(url).toString(),
+    DEFAULT_TOKEN_METADATA_SERVER_URL
   )
   .option('--use-queue', ProgramOptionDescriptions.UseQueue, () => true, USE_QUEUE_DEFAULT)
   .option('--postgres-srv-service-name <postgresSrvServiceName>', ProgramOptionDescriptions.PostgresSrvArgs)

--- a/packages/cardano-services/src/index.ts
+++ b/packages/cardano-services/src/index.ts
@@ -1,3 +1,4 @@
+export * from './Asset';
 export * from './Http';
 export * from './Program';
 export * from './RunnableModule';

--- a/packages/cardano-services/src/run.ts
+++ b/packages/cardano-services/src/run.ts
@@ -11,6 +11,7 @@ import {
   loadHttpServer
 } from './Program';
 import { CACHE_TTL_DEFAULT } from './InMemoryCache';
+import { DEFAULT_TOKEN_METADATA_CACHE_TTL, DEFAULT_TOKEN_METADATA_SERVER_URL } from './Asset';
 import { ENABLE_METRICS_DEFAULT, USE_QUEUE_DEFAULT } from './ProgramsCommon';
 import { EPOCH_POLL_INTERVAL_DEFAULT } from './NetworkInfo';
 import { LogLevel } from 'bunyan';
@@ -52,6 +53,10 @@ const envSpecs = {
   SERVICE_DISCOVERY_BACKOFF_FACTOR: envalid.num({ default: SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT }),
   SERVICE_DISCOVERY_TIMEOUT: envalid.num({ default: SERVICE_DISCOVERY_TIMEOUT_DEFAULT }),
   SERVICE_NAMES: envalid.str({ example: Object.values(ServiceNames).toString() }),
+  TOKEN_METADATA_CACHE_TTL: envalid.makeValidator(cacheTtlValidator)(
+    envalid.num({ default: DEFAULT_TOKEN_METADATA_CACHE_TTL })
+  ),
+  TOKEN_METADATA_SERVER_URL: envalid.url({ default: DEFAULT_TOKEN_METADATA_SERVER_URL }),
   USE_QUEUE: envalid.bool({ default: USE_QUEUE_DEFAULT })
 };
 
@@ -68,6 +73,8 @@ void (async () => {
   const cardanoNodeConfigPath = env.CARDANO_NODE_CONFIG_PATH;
   const serviceDiscoveryBackoffFactor = env.SERVICE_DISCOVERY_BACKOFF_FACTOR;
   const serviceDiscoveryTimeout = env.SERVICE_DISCOVERY_TIMEOUT;
+  const tokenMetadataCacheTTL = env.TOKEN_METADATA_CACHE_TTL;
+  const tokenMetadataServerUrl = env.TOKEN_METADATA_SERVER_URL;
   const postgresSrvServiceName = env.POSTGRES_SRV_SERVICE_NAME;
   const postgresDb = env.POSTGRES_DB;
   const postgresUser = env.POSTGRES_USER;
@@ -108,6 +115,8 @@ void (async () => {
         rabbitmqUrl,
         serviceDiscoveryBackoffFactor,
         serviceDiscoveryTimeout,
+        tokenMetadataCacheTTL,
+        tokenMetadataServerUrl,
         useQueue: env.USE_QUEUE
       },
       serviceNames

--- a/packages/cardano-services/test/Asset/AssetBuilder.test.ts
+++ b/packages/cardano-services/test/Asset/AssetBuilder.test.ts
@@ -1,4 +1,4 @@
-import { AssetBuilder } from '../../src/Asset/AssetBuilder';
+import { AssetBuilder } from '../../src/Asset';
 import { Cardano } from '@cardano-sdk/core';
 import { Pool } from 'pg';
 import { dummyLogger } from 'ts-log';

--- a/packages/cardano-services/test/Asset/AssetHttpService.test.ts
+++ b/packages/cardano-services/test/Asset/AssetHttpService.test.ts
@@ -1,0 +1,155 @@
+import {
+  AssetHttpService,
+  CardanoTokenRegistry,
+  DbSyncAssetProvider,
+  DbSyncNftMetadataService,
+  HttpServer,
+  HttpServerConfig,
+  NftMetadataService,
+  TokenMetadataService
+} from '../../src';
+import { AssetProvider } from '@cardano-sdk/core';
+import { Pool } from 'pg';
+import { createDbSyncMetadataService } from '../../src/Metadata';
+import { fromSerializableObject } from '@cardano-sdk/util';
+import { getPort } from 'get-port-please';
+import { dummyLogger as logger } from 'ts-log';
+import { mockTokenRegistry } from './CardanoTokenRegistry.test';
+import axios from 'axios';
+
+const APPLICATION_JSON = 'application/json';
+const APPLICATION_CBOR = 'application/cbor';
+const UNSUPPORTED_MEDIA_STRING = 'Request failed with status code 415';
+const BAD_REQUEST_STRING = 'Request failed with status code 400';
+
+describe('AssetHttpService', () => {
+  let apiUrlBase: string;
+  let assetProvider: AssetProvider;
+  let closeMock: () => Promise<void> = jest.fn();
+  let config: HttpServerConfig;
+  let db: Pool;
+  let httpServer: HttpServer;
+  let ntfMetadataService: NftMetadataService;
+  let service: AssetHttpService;
+  let port: number;
+  let tokenMetadataServerUrl = '';
+  let tokenMetadataService: TokenMetadataService;
+
+  beforeAll(async () => {
+    port = await getPort();
+    apiUrlBase = `http://localhost:${port}/asset`;
+    config = { listen: { port } };
+  });
+
+  describe('healthy state', () => {
+    beforeAll(async () => {
+      ({ closeMock, tokenMetadataServerUrl } = await mockTokenRegistry(() => ({})));
+      db = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });
+      ntfMetadataService = new DbSyncNftMetadataService({
+        db,
+        logger,
+        metadataService: createDbSyncMetadataService(db, logger)
+      });
+      tokenMetadataService = new CardanoTokenRegistry({ logger }, { tokenMetadataServerUrl });
+      assetProvider = new DbSyncAssetProvider({ db, logger, ntfMetadataService, tokenMetadataService });
+      service = new AssetHttpService({ assetProvider, logger });
+      httpServer = new HttpServer(config, { services: [service] });
+      await httpServer.initialize();
+      await httpServer.start();
+    });
+
+    afterAll(async () => {
+      await httpServer.shutdown();
+      tokenMetadataService.shutdown();
+      await db.end();
+      await closeMock();
+    });
+
+    describe('/health', () => {
+      it('/health response should be true', async () => {
+        const res = await axios.post(`${apiUrlBase}/health`, undefined, {
+          headers: { 'Content-Type': APPLICATION_JSON }
+        });
+        expect(res.status).toBe(200);
+        expect(res.data).toEqual({ ok: true });
+      });
+    });
+
+    describe('/get-asset', () => {
+      it('returns a 415 coded response if the wrong content type header is used', async () => {
+        try {
+          await axios.post(`${apiUrlBase}/get-asset`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+          expect(error.response.status).toBe(415);
+          expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+        }
+      });
+
+      it('returns 400 coded response if the request is bad formed', async () => {
+        try {
+          await axios.post(`${apiUrlBase}/get-asset`, { args: [['test']] });
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+          expect(error.response.status).toBe(400);
+          expect(error.message).toBe(BAD_REQUEST_STRING);
+        }
+      });
+
+      it('returns 404 coded response for not existing existing asset id', async () => {
+        try {
+          const res = await axios.post(`${apiUrlBase}/get-asset`, {
+            args: ['0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef']
+          });
+          expect(res.data[0]).toEqual({});
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+          expect(error.response.status).toBe(404);
+        }
+      });
+
+      it('returns asset info for existing asset id', async () => {
+        const res = await axios.post(`${apiUrlBase}/get-asset`, {
+          args: ['50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65']
+        });
+        expect(fromSerializableObject(res.data)).toEqual({
+          assetId: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65',
+          fingerprint: 'asset1f0azzptnr8dghzjh7egqvdjmt33e3lz5uy59th',
+          mintOrBurnCount: 1,
+          name: '6d616361726f6e2d63616b65',
+          policyId: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb',
+          quantity: 1n
+        });
+      });
+
+      it('returns asset info with extra data when requested', async () => {
+        const res = await axios.post(`${apiUrlBase}/get-asset`, {
+          args: [
+            '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65',
+            { history: true, nftMetadata: true, tokenMetadata: true }
+          ]
+        });
+        const { history, nftMetadata, tokenMetadata } = fromSerializableObject(res.data);
+        expect(history).toEqual([
+          {
+            quantity: 1n,
+            transactionId: 'f66791a0354c43d8c5a93671eb96d94633e3419f3ccbb0a00c00a152d3b6ca06'
+          }
+        ]);
+        expect(nftMetadata).toEqual({
+          description: ['This is my first NFT of the macaron cake'],
+          files: undefined,
+          image: ['ipfs://QmcDAmZubQig7tGUgEwbWcgdvz4Aoa2EiRZyFoX3fXTVmr'],
+          mediaType: undefined,
+          name: 'macaron cake token',
+          otherProperties: new Map([['id', 1n]]),
+          version: '1.0'
+        });
+        expect(tokenMetadata).toEqual({
+          desc: 'This is my first NFT of the macaron cake',
+          name: 'macaron cake token'
+        });
+      });
+    });
+  });
+});

--- a/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
+++ b/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
@@ -31,7 +31,7 @@ const mockTokenRegistry = async (handler: () => { body: unknown; code?: number }
       server.close((error) => (error ? rejecter(error) : resolver()));
       return closePromise;
     },
-    metadataServerUri: `http://localhost:${port}`
+    tokenMetadataServerUrl: `http://localhost:${port}`
   };
 };
 
@@ -108,7 +108,7 @@ describe('CardanoTokenRegistry', () => {
 
   describe('error cases are correctly logged', () => {
     let closeMock: () => Promise<void> = jest.fn();
-    let metadataServerUri: string;
+    let tokenMetadataServerUrl: string;
 
     beforeEach(() => (closeMock = jest.fn()));
 
@@ -116,8 +116,8 @@ describe('CardanoTokenRegistry', () => {
 
     it('null record', async () => {
       const logger = testLogger();
-      ({ closeMock, metadataServerUri } = await mockTokenRegistry(() => ({ body: { subjects: [null] } })));
-      const tokenRegistry = new CardanoTokenRegistry({ logger }, { metadataServerUri });
+      ({ closeMock, tokenMetadataServerUrl } = await mockTokenRegistry(() => ({ body: { subjects: [null] } })));
+      const tokenRegistry = new CardanoTokenRegistry({ logger }, { tokenMetadataServerUrl });
 
       await expect(tokenRegistry.getTokenMetadata([validAssetId])).rejects.toThrow(ProviderError);
     });
@@ -125,8 +125,8 @@ describe('CardanoTokenRegistry', () => {
     it('record without the subject property', async () => {
       const logger = testLogger();
       const record = { test: 'test' };
-      ({ closeMock, metadataServerUri } = await mockTokenRegistry(() => ({ body: { subjects: [record] } })));
-      const tokenRegistry = new CardanoTokenRegistry({ logger }, { metadataServerUri });
+      ({ closeMock, tokenMetadataServerUrl } = await mockTokenRegistry(() => ({ body: { subjects: [record] } })));
+      const tokenRegistry = new CardanoTokenRegistry({ logger }, { tokenMetadataServerUrl });
 
       await expect(tokenRegistry.getTokenMetadata([validAssetId])).rejects.toThrow(ProviderError);
     });
@@ -147,8 +147,8 @@ describe('CardanoTokenRegistry', () => {
         };
       };
       const logger = testLogger();
-      ({ closeMock, metadataServerUri } = await mockTokenRegistry(record));
-      const tokenRegistry = new CardanoTokenRegistry({ logger }, { metadataServerUri });
+      ({ closeMock, tokenMetadataServerUrl } = await mockTokenRegistry(record));
+      const tokenRegistry = new CardanoTokenRegistry({ logger }, { tokenMetadataServerUrl });
 
       const result = await tokenRegistry.getTokenMetadata([invalidAssetId, validAssetId]);
 

--- a/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
+++ b/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
@@ -36,7 +36,7 @@ const mockTokenRegistry = async (handler: () => { body: unknown; code?: number }
 };
 
 describe('CardanoTokenRegistry', () => {
-  const nonvalidAssetId = Cardano.AssetId('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+  const invalidAssetId = Cardano.AssetId('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
   const validAssetId = Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958');
 
   describe('return value', () => {
@@ -44,8 +44,8 @@ describe('CardanoTokenRegistry', () => {
 
     afterAll(() => tokenRegistry.shutdown());
 
-    it('returns null for nonexisting AssetId', async () => {
-      expect(await tokenRegistry.getTokenMetadata([nonvalidAssetId])).toEqual([null]);
+    it('returns null for non-existent AssetId', async () => {
+      expect(await tokenRegistry.getTokenMetadata([invalidAssetId])).toEqual([null]);
     });
 
     it('returns metadata when subject exists', async () => {
@@ -69,8 +69,8 @@ describe('CardanoTokenRegistry', () => {
     });
 
     it('correctly returns null or metadata for request with good and bad assetIds', async () => {
-      const firstResult = await tokenRegistry.getTokenMetadata([nonvalidAssetId, validAssetId]);
-      const secondResult = await tokenRegistry.getTokenMetadata([validAssetId, nonvalidAssetId]);
+      const firstResult = await tokenRegistry.getTokenMetadata([invalidAssetId, validAssetId]);
+      const secondResult = await tokenRegistry.getTokenMetadata([validAssetId, invalidAssetId]);
 
       expect(firstResult[0]).toBeNull();
       expect(firstResult[1]).not.toBeNull();
@@ -150,9 +150,9 @@ describe('CardanoTokenRegistry', () => {
       ({ closeMock, metadataServerUri } = await mockTokenRegistry(record));
       const tokenRegistry = new CardanoTokenRegistry({ logger }, { metadataServerUri });
 
-      const result = await tokenRegistry.getTokenMetadata([nonvalidAssetId, validAssetId]);
+      const result = await tokenRegistry.getTokenMetadata([invalidAssetId, validAssetId]);
 
-      await expect(tokenRegistry.getTokenMetadata([nonvalidAssetId, validAssetId])).rejects.toThrow(ProviderError);
+      await expect(tokenRegistry.getTokenMetadata([invalidAssetId, validAssetId])).rejects.toThrow(ProviderError);
 
       expect(result[0]).toBeNull();
       expect(result[1]).toEqual({ name: 'test' });

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -10,7 +10,7 @@ import { Pool } from 'pg';
 import { createDbSyncMetadataService } from '../../src/Metadata';
 import { dummyLogger as logger } from 'ts-log';
 
-export const nonvalidAssetId = Cardano.AssetId('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+export const notValidAssetId = Cardano.AssetId('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
 export const validAssetId = Cardano.AssetId(
   '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65'
 );
@@ -38,7 +38,7 @@ describe('DbSyncAssetProvider', () => {
   });
 
   it('rejects for not found assetId', async () => {
-    await expect(provider.getAsset(nonvalidAssetId)).rejects.toThrow(ProviderError);
+    await expect(provider.getAsset(notValidAssetId)).rejects.toThrow(ProviderError);
   });
 
   it('returns an AssetInfo without extra data', async () => {

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -1,4 +1,4 @@
-import { Cardano, ProviderError } from '@cardano-sdk/core';
+import { Asset, Cardano, ProviderError } from '@cardano-sdk/core';
 import {
   CardanoTokenRegistry,
   DbSyncAssetProvider,
@@ -9,6 +9,7 @@ import {
 import { Pool } from 'pg';
 import { createDbSyncMetadataService } from '../../src/Metadata';
 import { dummyLogger as logger } from 'ts-log';
+import { mockTokenRegistry } from './CardanoTokenRegistry.test';
 
 export const notValidAssetId = Cardano.AssetId('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
 export const validAssetId = Cardano.AssetId(
@@ -16,25 +17,29 @@ export const validAssetId = Cardano.AssetId(
 );
 
 describe('DbSyncAssetProvider', () => {
+  let closeMock: () => Promise<void> = jest.fn();
   let db: Pool;
   let ntfMetadataService: NftMetadataService;
   let provider: DbSyncAssetProvider;
+  let tokenMetadataServerUrl = '';
   let tokenMetadataService: TokenMetadataService;
 
-  beforeAll(() => {
+  beforeAll(async () => {
+    ({ closeMock, tokenMetadataServerUrl } = await mockTokenRegistry(() => ({})));
     db = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });
     ntfMetadataService = new DbSyncNftMetadataService({
       db,
       logger,
       metadataService: createDbSyncMetadataService(db, logger)
     });
-    tokenMetadataService = new CardanoTokenRegistry({ logger });
+    tokenMetadataService = new CardanoTokenRegistry({ logger }, { tokenMetadataServerUrl });
     provider = new DbSyncAssetProvider({ db, logger, ntfMetadataService, tokenMetadataService });
   });
 
   afterAll(async () => {
     tokenMetadataService.shutdown();
     await db.end();
+    await closeMock();
   });
 
   it('rejects for not found assetId', async () => {
@@ -58,7 +63,18 @@ describe('DbSyncAssetProvider', () => {
     expect(asset.history).toEqual([
       { quantity: BigInt(1), transactionId: 'f66791a0354c43d8c5a93671eb96d94633e3419f3ccbb0a00c00a152d3b6ca06' }
     ]);
-    expect(asset.nftMetadata).not.toBeUndefined();
-    expect(asset.tokenMetadata).not.toBeUndefined();
+    expect(asset.nftMetadata).toStrictEqual({
+      description: ['This is my first NFT of the macaron cake'],
+      files: undefined,
+      image: [Asset.Uri('ipfs://QmcDAmZubQig7tGUgEwbWcgdvz4Aoa2EiRZyFoX3fXTVmr')],
+      mediaType: undefined,
+      name: 'macaron cake token',
+      otherProperties: new Map([['id', 1n]]),
+      version: '1.0'
+    });
+    expect(asset.tokenMetadata).toStrictEqual({
+      desc: 'This is my first NFT of the macaron cake',
+      name: 'macaron cake token'
+    });
   });
 });

--- a/packages/cardano-services/test/Program/utils.test.ts
+++ b/packages/cardano-services/test/Program/utils.test.ts
@@ -22,6 +22,7 @@ import { TxSubmitWorker } from '@cardano-sdk/rabbitmq';
 import { createHealthyMockOgmiosServer, ogmiosServerReady } from '../util';
 import { createLogger } from 'bunyan';
 import { createMockOgmiosServer } from '../../../ogmios/test/mocks/mockOgmiosServer';
+import { dummyLogger } from 'ts-log';
 import { getPort, getRandomPort } from 'get-port-please';
 import { listenPromise, serverClosePromise } from '../../src/util';
 import { txsPromise } from '../../../rabbitmq/test/utils';
@@ -495,17 +496,19 @@ describe('Service dependency abstractions', () => {
       await listenPromise(mockServer, connection);
       await ogmiosServerReady(connection);
 
-      txSubmitWorker = await loadTxWorker({
-        options: {
-          cacheTtl: 10_000,
-          loggerMinSeverity: 'error',
-          ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
-          parallel: true,
-          rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
-          serviceDiscoveryBackoffFactor: 1.1,
-          serviceDiscoveryTimeout: 1000
-        }
-      });
+      txSubmitWorker = await loadTxWorker(
+        {
+          options: {
+            cacheTtl: 10_000,
+            ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
+            parallel: true,
+            rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
+            serviceDiscoveryBackoffFactor: 1.1,
+            serviceDiscoveryTimeout: 1000
+          }
+        },
+        dummyLogger
+      );
       await txSubmitWorker.start();
     });
 


### PR DESCRIPTION
# Context

We need to add an http service to serve asset related functions.

# Proposed Solution

Added `AssetHttpService` and `TokenMetadataProvider` to expose `CardanoTokenRegistry.getTokenMetadata`.

# Important Changes Introduced
