### PR TITLE
fix(util): add Set serialization support

### DIFF
--- a/packages/util/src/serializableObject.ts
+++ b/packages/util/src/serializableObject.ts
@@ -53,6 +53,12 @@ export const toSerializableObject = (obj: unknown, options: ToSerializableObject
         value: obj.getTime()
       };
     }
+    if (obj instanceof Set) {
+      return {
+        [transformationTypeKey]: 'Set',
+        value: [...obj].map((item) => toSerializableObject(item, options))
+      };
+    }
     if (obj instanceof Map) {
       return {
         [transformationTypeKey]: 'Map',
@@ -101,6 +107,8 @@ const fromSerializableObjectUnknown = (obj: unknown, options: FromSerializableOb
         return Buffer.from(docAsAny.value, 'hex');
       case 'Date':
         return new Date(docAsAny.value);
+      case 'Set':
+        return new Set(docAsAny.value);
       case 'Map':
         return new Map(
           docAsAny.value.map((keyValues: unknown[]) =>

--- a/packages/util/test/serializableObject.test.ts
+++ b/packages/util/test/serializableObject.test.ts
@@ -36,6 +36,7 @@ describe('serializableObject', () => {
       date: new Date(),
       error: new Error('error obj'),
       map: new Map([['key', 'value']]),
+      set: new Set(['item1', 'item2']),
       undefined
     };
     expect(serializeAndDeserialize(obj)).toEqual(obj);


### PR DESCRIPTION
# Context

initializeTx takes in Set objects. Using a remote wallet does not serialize/deserialize sets correctly. 

# Proposed Solution

Add Set support (similar to [Map](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/util/src/serializableObject.ts#L56))
