### PR TITLE
feat: add missing transaction fields

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -332,7 +332,11 @@ export class SingleAddressWallet implements ObservableWallet {
       auxiliaryData: props.auxiliaryData,
       certificates: props.certificates,
       changeAddress,
+      collaterals: props.collaterals,
       inputSelection,
+      mint: props.mint,
+      requiredExtraSignatures: props.requiredExtraSignatures,
+      scriptIntegrityHash: props.scriptIntegrityHash,
       validityInterval,
       withdrawals: props.withdrawals
     });
@@ -416,7 +420,11 @@ export class SingleAddressWallet implements ObservableWallet {
                 auxiliaryData: props.auxiliaryData,
                 certificates: props.certificates,
                 changeAddress,
+                collaterals: props.collaterals,
                 inputSelection,
+                mint: props.mint,
+                requiredExtraSignatures: props.requiredExtraSignatures,
+                scriptIntegrityHash: props.scriptIntegrityHash,
                 validityInterval,
                 withdrawals: props.withdrawals
               });

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -24,6 +24,10 @@ export type InitializeTxProps = {
   options?: {
     validityInterval?: Cardano.ValidityInterval;
   };
+  collaterals?: Set<Cardano.NewTxIn>;
+  mint?: Cardano.TokenMap;
+  scriptIntegrityHash?: Cardano.Hash32ByteBase16;
+  requiredExtraSignatures?: Cardano.Ed25519KeyHash[];
 };
 
 export interface FinalizeTxProps {

--- a/packages/wallet/test/Transaction/createTransactionInternals.test.ts
+++ b/packages/wallet/test/Transaction/createTransactionInternals.test.ts
@@ -1,3 +1,4 @@
+import { AssetId } from '@cardano-sdk/util-dev';
 import { Cardano, NetworkInfoProvider } from '@cardano-sdk/core';
 import { CreateTxInternalsProps, createTransactionInternals } from '../../src/Transaction';
 import { SelectionConstraints } from '../../../cip2/test/util';
@@ -52,9 +53,24 @@ describe('Transaction.createTransactionInternals', () => {
     expect(txInternals.body.outputs).toHaveLength(2);
   });
 
-  it('coverts csl types from selection result to core', async () => {
-    const txInternals = await createSimpleTransactionInternals();
+  it('converts csl types from selection result to core', async () => {
+    const props = {
+      collaterals: new Set([utxo[2][0]]),
+      mint: new Map([
+        [AssetId.PXL, 5n],
+        [AssetId.TSLA, 20n]
+      ]),
+      requiredExtraSignatures: [Cardano.Ed25519KeyHash('6199186adb51974690d7247d2646097d2c62763b767b528816fb7ed5')],
+      scriptIntegrityHash: Cardano.util.Hash32ByteBase16(
+        '3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d'
+      )
+    };
+    const txInternals = await createSimpleTransactionInternals(() => props);
     expect(txInternals.body.outputs).toHaveLength(2);
+    expect(txInternals.body.collaterals).toEqual<Cardano.NewTxIn[]>([utxo[2][0]]);
+    expect(txInternals.body.mint).toEqual<Cardano.TokenMap>(props.mint);
+    expect(txInternals.body.requiredExtraSignatures).toEqual<Cardano.Ed25519KeyHash[]>(props.requiredExtraSignatures);
+    expect(txInternals.body.scriptIntegrityHash).toEqual<Cardano.util.Hash32ByteBase16>(props.scriptIntegrityHash);
     expect(typeof txInternals.body.fee).toBe('bigint');
     expect(typeof txInternals.body.inputs[0].txId).toBe('string');
     expect(typeof txInternals.hash).toBe('string');


### PR DESCRIPTION
# Context

Some transaction body fields have not yet been defined in our[ core type](https://github.com/input-output-hk/cardano-js-sdk/blob/6431f57ee5d0624784e9ae6c6b6a73b35a514ee0/packages/core/src/Cardano/types/Transaction.ts#L37-L48), so the task here is to complete the mapping to all available properties of the current era (Babbage is out of scope, as it requires the unreleased v11 of the CSL)

Add support for those fields we're missing in [createTransactionInternals](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/wallet/src/Transaction/createTransactionInternals.ts), [cslToCore](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/core/src/CSL/cslToCore/cslToCore.ts), [coreToCsl](https://github.com/input-output-hk/cardano-js-sdk/tree/master/packages/core/src/CSL/coreToCsl), [finalizeTx](https://github.com/input-output-hk/cardano-js-sdk/blob/6431f57ee5d0624784e9ae6c6b6a73b35a514ee0/packages/wallet/src/SingleAddressWallet.ts#L329-L361):

- collaterals
- mint
- requiredExtraSignatures
- scriptIntegrityHash
- witness

# Proposed Solution
- Add missing fields to `CreateTxInternalsProps` and `InitializeTxProps`
- Add missing fields to `createTransactionInternals`, `initializeTx` and `finalizeTx`
- Modify tests to include the new fields