### PR TITLE
fix: input addr resolver dependency

### DIFF
--- a/packages/e2e/src/Util/mnemonic.ts
+++ b/packages/e2e/src/Util/mnemonic.ts
@@ -11,11 +11,14 @@ import { KeyManagement } from '@cardano-sdk/wallet';
   const mnemonicArray = KeyManagement.util.generateMnemonicWords();
   for (const word of mnemonicArray) mnemonic += `${word} `;
 
-  const keyAgentFromMnemonic = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords({
-    getPassword: async () => Buffer.from(''),
-    mnemonicWords: mnemonicArray,
-    networkId: Cardano.NetworkId.testnet
-  });
+  const keyAgentFromMnemonic = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords(
+    {
+      getPassword: async () => Buffer.from(''),
+      mnemonicWords: mnemonicArray,
+      networkId: Cardano.NetworkId.testnet
+    },
+    { inputResolver: { resolveInputAddress: async () => null } }
+  );
 
   const derivedAddress = await keyAgentFromMnemonic.deriveAddress({
     index: 0,

--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 import { Awaited } from '@cardano-sdk/util';
 import { Cardano } from '@cardano-sdk/core';
-import { ObservableWallet, SingleAddressWallet, StakeKeyStatus, Transaction } from '@cardano-sdk/wallet';
+import { ObservableWallet, SingleAddressWallet, StakeKeyStatus, Transaction, setupWallet } from '@cardano-sdk/wallet';
 import { TX_TIMEOUT, firstValueFromTimed, waitForWalletStateSettle } from '../util';
 import {
   assetProviderFactory,
@@ -75,26 +75,35 @@ const waitForTx = async (wallet: ObservableWallet, { hash }: Transaction.TxInter
   await waitForWalletStateSettle(wallet);
 };
 
-const getWallet = async (idx: number) =>
-  new SingleAddressWallet(
-    { name: `Test Wallet ${idx}` },
-    {
-      assetProvider: await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS),
-      chainHistoryProvider: await chainHistoryProviderFactory.create(
-        env.CHAIN_HISTORY_PROVIDER,
-        env.CHAIN_HISTORY_PROVIDER_PARAMS
-      ),
-      keyAgent: await keyAgentById(idx, env.KEY_MANAGEMENT_PROVIDER, env.KEY_MANAGEMENT_PARAMS),
-      networkInfoProvider: await networkInfoProviderFactory.create(
-        env.NETWORK_INFO_PROVIDER,
-        env.NETWORK_INFO_PROVIDER_PARAMS
-      ),
-      rewardsProvider: await rewardsProviderFactory.create(env.REWARDS_PROVIDER, env.REWARDS_PROVIDER_PARAMS),
-      stakePoolProvider: await stakePoolProviderFactory.create(env.STAKE_POOL_PROVIDER, env.STAKE_POOL_PROVIDER_PARAMS),
-      txSubmitProvider: await txSubmitProviderFactory.create(env.TX_SUBMIT_PROVIDER, env.TX_SUBMIT_PROVIDER_PARAMS),
-      utxoProvider: await utxoProviderFactory.create(env.UTXO_PROVIDER, env.UTXO_PROVIDER_PARAMS)
-    }
-  );
+const getWallet = async (idx: number) => {
+  const { wallet } = await setupWallet({
+    createKeyAgent: await keyAgentById(idx, env.KEY_MANAGEMENT_PROVIDER, env.KEY_MANAGEMENT_PARAMS),
+    createWallet: async (keyAgent) =>
+      new SingleAddressWallet(
+        { name: `Test Wallet ${idx}` },
+        {
+          assetProvider: await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS),
+          chainHistoryProvider: await chainHistoryProviderFactory.create(
+            env.CHAIN_HISTORY_PROVIDER,
+            env.CHAIN_HISTORY_PROVIDER_PARAMS
+          ),
+          keyAgent,
+          networkInfoProvider: await networkInfoProviderFactory.create(
+            env.NETWORK_INFO_PROVIDER,
+            env.NETWORK_INFO_PROVIDER_PARAMS
+          ),
+          rewardsProvider: await rewardsProviderFactory.create(env.REWARDS_PROVIDER, env.REWARDS_PROVIDER_PARAMS),
+          stakePoolProvider: await stakePoolProviderFactory.create(
+            env.STAKE_POOL_PROVIDER,
+            env.STAKE_POOL_PROVIDER_PARAMS
+          ),
+          txSubmitProvider: await txSubmitProviderFactory.create(env.TX_SUBMIT_PROVIDER, env.TX_SUBMIT_PROVIDER_PARAMS),
+          utxoProvider: await utxoProviderFactory.create(env.UTXO_PROVIDER, env.UTXO_PROVIDER_PARAMS)
+        }
+      )
+  });
+  return wallet;
+};
 
 describe('SingleAddressWallet/delegation', () => {
   let wallet1: ObservableWallet;

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
@@ -1,5 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
-import { ObservableWallet, SingleAddressWallet } from '@cardano-sdk/wallet';
+import { ObservableWallet, SingleAddressWallet, setupWallet } from '@cardano-sdk/wallet';
 import {
   assetProviderFactory,
   chainHistoryProviderFactory,
@@ -14,26 +14,35 @@ import { env } from '../environment';
 import { filter, firstValueFrom } from 'rxjs';
 import { waitForWalletStateSettle } from '../util';
 
-const getWallet = async () =>
-  new SingleAddressWallet(
-    { name: 'Test Wallet' },
-    {
-      assetProvider: await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS),
-      chainHistoryProvider: await chainHistoryProviderFactory.create(
-        env.CHAIN_HISTORY_PROVIDER,
-        env.CHAIN_HISTORY_PROVIDER_PARAMS
-      ),
-      keyAgent: await keyAgentById(0, env.KEY_MANAGEMENT_PROVIDER, env.KEY_MANAGEMENT_PARAMS),
-      networkInfoProvider: await networkInfoProviderFactory.create(
-        env.NETWORK_INFO_PROVIDER,
-        env.NETWORK_INFO_PROVIDER_PARAMS
-      ),
-      rewardsProvider: await rewardsProviderFactory.create(env.REWARDS_PROVIDER, env.REWARDS_PROVIDER_PARAMS),
-      stakePoolProvider: await stakePoolProviderFactory.create(env.STAKE_POOL_PROVIDER, env.STAKE_POOL_PROVIDER_PARAMS),
-      txSubmitProvider: await txSubmitProviderFactory.create(env.TX_SUBMIT_PROVIDER, env.TX_SUBMIT_PROVIDER_PARAMS),
-      utxoProvider: await utxoProviderFactory.create(env.UTXO_PROVIDER, env.UTXO_PROVIDER_PARAMS)
-    }
-  );
+const getWallet = async () => {
+  const { wallet } = await setupWallet({
+    createKeyAgent: await keyAgentById(0, env.KEY_MANAGEMENT_PROVIDER, env.KEY_MANAGEMENT_PARAMS),
+    createWallet: async (keyAgent) =>
+      new SingleAddressWallet(
+        { name: 'Test Wallet' },
+        {
+          assetProvider: await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS),
+          chainHistoryProvider: await chainHistoryProviderFactory.create(
+            env.CHAIN_HISTORY_PROVIDER,
+            env.CHAIN_HISTORY_PROVIDER_PARAMS
+          ),
+          keyAgent,
+          networkInfoProvider: await networkInfoProviderFactory.create(
+            env.NETWORK_INFO_PROVIDER,
+            env.NETWORK_INFO_PROVIDER_PARAMS
+          ),
+          rewardsProvider: await rewardsProviderFactory.create(env.REWARDS_PROVIDER, env.REWARDS_PROVIDER_PARAMS),
+          stakePoolProvider: await stakePoolProviderFactory.create(
+            env.STAKE_POOL_PROVIDER,
+            env.STAKE_POOL_PROVIDER_PARAMS
+          ),
+          txSubmitProvider: await txSubmitProviderFactory.create(env.TX_SUBMIT_PROVIDER, env.TX_SUBMIT_PROVIDER_PARAMS),
+          utxoProvider: await utxoProviderFactory.create(env.UTXO_PROVIDER, env.UTXO_PROVIDER_PARAMS)
+        }
+      )
+  });
+  return wallet;
+};
 
 describe('SingleAddressWallet', () => {
   let wallet: ObservableWallet;

--- a/packages/e2e/test/web-extension/extension/ui.html
+++ b/packages/e2e/test/web-extension/extension/ui.html
@@ -21,6 +21,8 @@
   <button id="clearAllowList">Clear allow list</button>
   <div>Address: <span id="address">-</span></div>
   <div>Balance: <span id="balance">-</span></div>
+  <button id="buildAndSignTx">Build & Sign TX</button>
+  <div>Signature: <span id="signature">-</span></div>
   <script src="ui.js"></script>
 </body>
 

--- a/packages/e2e/test/web-extension/extension/ui.html
+++ b/packages/e2e/test/web-extension/extension/ui.html
@@ -17,7 +17,7 @@
   </div>
   <h2>ADA price</h2>
   <div id="adaPrice">Loading...</div>
-  <button id="createLedgerKeyAgent">Create LedgerKeyAgent</button>
+  <button id="createKeyAgent">Create KeyAgent</button>
   <button id="clearAllowList">Clear allow list</button>
   <div>Address: <span id="address">-</span></div>
   <div>Balance: <span id="balance">-</span></div>

--- a/packages/e2e/test/web-extension/extension/ui.ts
+++ b/packages/e2e/test/web-extension/extension/ui.ts
@@ -71,8 +71,8 @@ wallet.balance.utxo.available$.subscribe(
   ({ coins }) => (document.querySelector('#balance')!.textContent = coins.toString())
 );
 
-document.querySelector('#createLedgerKeyAgent')!.addEventListener('click', async () => {
-  // setupWallet call is required to provider context (InputResolver) to the key agent
+document.querySelector('#createKeyAgent')!.addEventListener('click', async () => {
+  // setupWallet call is required to provide context (InputResolver) to the key agent
   const { keyAgent } = await setupWallet({
     createKeyAgent: async (dependencies) =>
       KeyManagement.util.createAsyncKeyAgent(
@@ -80,7 +80,7 @@ document.querySelector('#createLedgerKeyAgent')!.addEventListener('click', async
           {
             accountIndex: 0,
             getPassword: async () => Buffer.from(''),
-            mnemonicWords: process.env.MNEMONIC_WORDS.split(' '),
+            mnemonicWords: process.env.MNEMONIC_WORDS!.split(' '),
             networkId: 0
           },
           dependencies

--- a/packages/e2e/test/web-extension/extension/ui.ts
+++ b/packages/e2e/test/web-extension/extension/ui.ts
@@ -8,7 +8,8 @@ import {
   userPromptServiceChannel,
   walletName
 } from './util';
-import { KeyManagement } from '@cardano-sdk/wallet';
+import { Cardano } from '@cardano-sdk/core';
+import { KeyManagement, setupWallet } from '@cardano-sdk/wallet';
 import {
   RemoteApiPropertyType,
   consumeObservableWallet,
@@ -16,6 +17,7 @@ import {
   exposeApi,
   exposeKeyAgent
 } from '@cardano-sdk/web-extension';
+import { firstValueFrom } from 'rxjs';
 import { runtime } from 'webextension-polyfill';
 
 const api: UserPromptService = {
@@ -70,19 +72,42 @@ wallet.balance.utxo.available$.subscribe(
 );
 
 document.querySelector('#createLedgerKeyAgent')!.addEventListener('click', async () => {
+  // setupWallet call is required to provider context (InputResolver) to the key agent
+  const { keyAgent } = await setupWallet({
+    createKeyAgent: async (dependencies) =>
+      KeyManagement.util.createAsyncKeyAgent(
+        await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords(
+          {
+            accountIndex: 0,
+            getPassword: async () => Buffer.from(''),
+            mnemonicWords: process.env.MNEMONIC_WORDS.split(' '),
+            networkId: 0
+          },
+          dependencies
+        )
+      ),
+    createWallet: async () => wallet
+  });
   // restoreKeyAgent or create a new one and expose it
   exposeKeyAgent(
     {
-      keyAgent: KeyManagement.util.createAsyncKeyAgent(
-        await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords({
-          accountIndex: 0,
-          getPassword: async () => Buffer.from(''),
-          mnemonicWords: process.env.MNEMONIC_WORDS.split(' '),
-          networkId: 0
-        })
-      ),
+      keyAgent,
       walletName
     },
     { logger, runtime }
   );
+});
+
+document.querySelector('#buildAndSignTx')!.addEventListener('click', async () => {
+  const [{ address: ownAddress }] = await firstValueFrom(wallet.addresses$);
+  const tx = await wallet.initializeTx({
+    outputs: new Set<Cardano.TxOut>([
+      {
+        address: ownAddress,
+        value: { coins: 2_000_000n }
+      }
+    ])
+  });
+  const signedTx = await wallet.finalizeTx(tx);
+  document.querySelector('#signature')!.textContent = signedTx.witness.signatures.values().next().value;
 });

--- a/packages/e2e/test/web-extension/specs/wallet.spec.ts
+++ b/packages/e2e/test/web-extension/specs/wallet.spec.ts
@@ -4,7 +4,7 @@ describe('wallet', () => {
   const pNetworkId = '#root > div > p:nth-child(8)';
   const liFirstUtxo = '#root > div > p:nth-child(9) > li';
   const btnGrantAccess = '#requestAccessGrant';
-  const btnCreateLedgerKeyAgent = '#createLedgerKeyAgent';
+  const btnCreateKeyAgent = '#createKeyAgent';
   const spanAddress = '#address';
   const spanBalance = '#balance';
   const divAdaPrice = '#adaPrice';
@@ -32,7 +32,7 @@ describe('wallet', () => {
     describe('ui grants access and creates key agent', () => {
       before(async () => {
         await $(btnGrantAccess).click();
-        await $(btnCreateLedgerKeyAgent).click();
+        await $(btnCreateKeyAgent).click();
       });
       it('ui has access to remote ObservableWallet', async () => {
         await browser.waitUntil(async () => {

--- a/packages/e2e/test/web-extension/specs/wallet.spec.ts
+++ b/packages/e2e/test/web-extension/specs/wallet.spec.ts
@@ -8,6 +8,8 @@ describe('wallet', () => {
   const spanAddress = '#address';
   const spanBalance = '#balance';
   const divAdaPrice = '#adaPrice';
+  const btnSignAndBuildTx = '#buildAndSignTx';
+  const divSignature = '#signature';
 
   before(async () => {
     await browser.url('/');
@@ -42,6 +44,13 @@ describe('wallet', () => {
           }
         });
         await expect($(spanAddress)).toHaveTextContaining('addr');
+      });
+      it('can build and sign a transaction', async () => {
+        await $(btnSignAndBuildTx).click();
+        await browser.waitUntil(async () => {
+          const signature = await $(divSignature).getText();
+          return signature.length > 1;
+        });
       });
       it('dapp has access to cip30 WalletApi', async () => {
         await browser.switchWindow('React App');

--- a/packages/e2e/test/web-extension/tsconfig.json
+++ b/packages/e2e/test/web-extension/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
     "baseUrl": "./extension",
@@ -28,5 +28,3 @@
     }
   ]
 }
-
-

--- a/packages/wallet/src/KeyManagement/KeyAgentBase.ts
+++ b/packages/wallet/src/KeyManagement/KeyAgentBase.ts
@@ -3,17 +3,20 @@ import {
   AccountKeyDerivationPath,
   GroupedAddress,
   KeyAgent,
+  KeyAgentDependencies,
   KeyRole,
   SerializableKeyAgentData,
   SignBlobResult,
   SignTransactionOptions
 } from './types';
 import { CSL, Cardano, util } from '@cardano-sdk/core';
+import { InputResolver } from '../services';
 import { STAKE_KEY_DERIVATION_PATH } from './util';
 import { TxInternals } from '../Transaction';
 
 export abstract class KeyAgentBase implements KeyAgent {
   readonly #serializableData: SerializableKeyAgentData;
+  protected readonly inputResolver: InputResolver;
 
   get knownAddresses(): GroupedAddress[] {
     return this.#serializableData.knownAddresses;
@@ -37,11 +40,12 @@ export abstract class KeyAgentBase implements KeyAgent {
   abstract exportRootPrivateKey(): Promise<Cardano.Bip32PrivateKey>;
   abstract signTransaction(
     txInternals: TxInternals,
-    signTransactionOptions: SignTransactionOptions
+    signTransactionOptions?: SignTransactionOptions
   ): Promise<Cardano.Signatures>;
 
-  constructor(serializableData: SerializableKeyAgentData) {
+  constructor(serializableData: SerializableKeyAgentData, { inputResolver }: KeyAgentDependencies) {
     this.#serializableData = serializableData;
+    this.inputResolver = inputResolver;
   }
 
   /**

--- a/packages/wallet/src/KeyManagement/restoreKeyAgent.ts
+++ b/packages/wallet/src/KeyManagement/restoreKeyAgent.ts
@@ -3,6 +3,7 @@
 import {
   GetPassword,
   KeyAgent,
+  KeyAgentDependencies,
   KeyAgentType,
   SerializableInMemoryKeyAgentData,
   SerializableKeyAgentData,
@@ -22,10 +23,24 @@ export interface RestoreInMemoryKeyAgentProps {
   getPassword?: GetPassword;
 }
 
-export function restoreKeyAgent(data: SerializableInMemoryKeyAgentData, getPassword: GetPassword): Promise<KeyAgent>;
-export function restoreKeyAgent(data: SerializableKeyAgentData, getPassword?: GetPassword): Promise<KeyAgent>;
-export function restoreKeyAgent(data: SerializableLedgerKeyAgentData): Promise<KeyAgent>;
-export function restoreKeyAgent(data: SerializableTrezorKeyAgentData): Promise<KeyAgent>;
+export function restoreKeyAgent(
+  data: SerializableInMemoryKeyAgentData,
+  dependencies: KeyAgentDependencies,
+  getPassword: GetPassword
+): Promise<KeyAgent>;
+export function restoreKeyAgent(
+  data: SerializableKeyAgentData,
+  dependencies: KeyAgentDependencies,
+  getPassword?: GetPassword
+): Promise<KeyAgent>;
+export function restoreKeyAgent(
+  data: SerializableLedgerKeyAgentData,
+  dependencies: KeyAgentDependencies
+): Promise<KeyAgent>;
+export function restoreKeyAgent(
+  data: SerializableTrezorKeyAgentData,
+  dependencies: KeyAgentDependencies
+): Promise<KeyAgent>;
 /**
  * Restore key agent from serializable data
  *
@@ -33,6 +48,7 @@ export function restoreKeyAgent(data: SerializableTrezorKeyAgentData): Promise<K
  */
 export async function restoreKeyAgent<T extends SerializableKeyAgentData>(
   data: T,
+  dependencies: KeyAgentDependencies,
   getPassword?: GetPassword
 ): Promise<KeyAgent> {
   switch (data.__typename) {
@@ -45,13 +61,13 @@ export async function restoreKeyAgent<T extends SerializableKeyAgentData>(
       if (!getPassword) {
         throw new InvalidSerializableDataError('Expected "getPassword" in RestoreKeyAgentProps for InMemoryKeyAgent"');
       }
-      return new InMemoryKeyAgent({ ...data, getPassword });
+      return new InMemoryKeyAgent({ ...data, getPassword }, dependencies);
     }
     case KeyAgentType.Ledger: {
-      return new LedgerKeyAgent(data);
+      return new LedgerKeyAgent(data, dependencies);
     }
     case KeyAgentType.Trezor: {
-      return new TrezorKeyAgent(data);
+      return new TrezorKeyAgent(data, dependencies);
     }
     default:
       throw new InvalidSerializableDataError(

--- a/packages/wallet/src/KeyManagement/types.ts
+++ b/packages/wallet/src/KeyManagement/types.ts
@@ -1,4 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
+import { InputResolver } from '../services';
 import { Observable } from 'rxjs';
 import { Shutdown } from '@cardano-sdk/util';
 import { TxInternals } from '../Transaction';
@@ -48,6 +49,10 @@ export enum CommunicationType {
 }
 
 export type BIP32Path = Array<number>;
+
+export interface KeyAgentDependencies {
+  inputResolver: InputResolver;
+}
 
 export interface AccountAddressDerivationPath {
   type: AddressType;
@@ -114,14 +119,7 @@ export type LedgerTransportType = TransportWebHID | TransportNodeHid;
  */
 export type GetPassword = (noCache?: true) => Promise<Uint8Array>;
 
-/**
- * @param txIn transaction input to resolve address from
- * @returns input owner address
- */
-export type ResolveInputAddress = (txIn: Cardano.NewTxIn) => Promise<Cardano.Address | null>;
-
 export interface SignTransactionOptions {
-  inputAddressResolver: ResolveInputAddress;
   additionalKeyPaths?: AccountKeyDerivationPath[];
 }
 
@@ -138,7 +136,7 @@ export interface KeyAgent {
   /**
    * @throws AuthenticationError
    */
-  signTransaction(txInternals: TxInternals, options: SignTransactionOptions): Promise<Cardano.Signatures>;
+  signTransaction(txInternals: TxInternals, options?: SignTransactionOptions): Promise<Cardano.Signatures>;
   /**
    * @throws AuthenticationError
    */

--- a/packages/wallet/src/KeyManagement/util/ownSignatureKeyPaths.ts
+++ b/packages/wallet/src/KeyManagement/util/ownSignatureKeyPaths.ts
@@ -1,5 +1,6 @@
-import { AccountKeyDerivationPath, GroupedAddress, KeyRole, ResolveInputAddress } from '../types';
+import { AccountKeyDerivationPath, GroupedAddress, KeyRole } from '../types';
 import { Cardano } from '@cardano-sdk/core';
+import { InputResolver } from '../../services';
 import { isNotNil } from '@cardano-sdk/util';
 import uniq from 'lodash/uniq';
 
@@ -11,13 +12,13 @@ import uniq from 'lodash/uniq';
 export const ownSignatureKeyPaths = async (
   txBody: Cardano.NewTxBodyAlonzo,
   knownAddresses: GroupedAddress[],
-  resolveInputAddress: ResolveInputAddress
+  inputResolver: InputResolver
 ): Promise<AccountKeyDerivationPath[]> => {
   const paymentKeyPaths = uniq(
     (
       await Promise.all(
         txBody.inputs.map(async (input) => {
-          const ownAddress = await resolveInputAddress(input);
+          const ownAddress = await inputResolver.resolveInputAddress(input);
           if (!ownAddress) return null;
           return knownAddresses.find(({ address }) => address === ownAddress);
         })

--- a/packages/wallet/src/KeyManagement/util/stubSignTransaction.ts
+++ b/packages/wallet/src/KeyManagement/util/stubSignTransaction.ts
@@ -1,5 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
-import { GroupedAddress, ResolveInputAddress } from '../types';
+import { GroupedAddress } from '../types';
+import { InputResolver } from '../../services';
 import { ownSignatureKeyPaths } from './ownSignatureKeyPaths';
 
 const randomHexChar = () => Math.floor(Math.random() * 16).toString(16);
@@ -8,10 +9,10 @@ const randomPublicKey = () => Cardano.Ed25519PublicKey(Array.from({ length: 64 }
 export const stubSignTransaction = async (
   txBody: Cardano.NewTxBodyAlonzo,
   knownAddresses: GroupedAddress[],
-  inputAddressResolver: ResolveInputAddress
+  inputResolver: InputResolver
 ): Promise<Cardano.Signatures> =>
   new Map(
-    (await ownSignatureKeyPaths(txBody, knownAddresses, inputAddressResolver)).map(() => [
+    (await ownSignatureKeyPaths(txBody, knownAddresses, inputResolver)).map(() => [
       randomPublicKey(),
       Cardano.Ed25519Signature(
         // eslint-disable-next-line max-len

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -349,10 +349,8 @@ export class SingleAddressWallet implements ObservableWallet {
   ): Promise<Cardano.NewTxAlonzo> {
     const addresses = await firstValueFrom(this.addresses$);
     const signatures = stubSign
-      ? await keyManagementUtil.stubSignTransaction(tx.body, addresses, this.util.resolveInputAddress)
-      : await this.keyAgent.signTransaction(tx, {
-          inputAddressResolver: this.util.resolveInputAddress
-        });
+      ? await keyManagementUtil.stubSignTransaction(tx.body, addresses, this.util)
+      : await this.keyAgent.signTransaction(tx);
     return {
       auxiliaryData,
       body: tx.body,

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -5,3 +5,4 @@ export * from './types';
 export * from './services';
 export * as storage from './persistence';
 export * as cip30 from './cip30';
+export * from './setupWallet';

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -104,3 +104,39 @@ export const createWalletUtil = (context: WalletUtilContext) => ({
 });
 
 export type WalletUtil = ReturnType<typeof createWalletUtil>;
+
+type SetWalletUtilContext = (context: WalletUtilContext) => void;
+
+/**
+ * Creates a WalletUtil that has an additional function to `initialize` by setting the context.
+ * Calls to WalletUtil functions will only resolve after initializing.
+ *
+ * @returns common wallet utility functions that are aware of wallet state and computes useful things
+ */
+export const createLazyWalletUtil = (): WalletUtil & { initialize: SetWalletUtilContext } => {
+  let initialize: SetWalletUtilContext;
+  const resolverReady = new Promise((resolve: SetWalletUtilContext) => (initialize = resolve)).then(createWalletUtil);
+  return {
+    initialize: initialize!,
+    async resolveInputAddress(input) {
+      const resolver = await resolverReady;
+      return resolver.resolveInputAddress(input);
+    },
+    async validateOutput(output) {
+      const resolver = await resolverReady;
+      return resolver.validateOutput(output);
+    },
+    async validateOutputs(outputs) {
+      const resolver = await resolverReady;
+      return resolver.validateOutputs(outputs);
+    },
+    async validateValue(value) {
+      const resolver = await resolverReady;
+      return resolver.validateValue(value);
+    },
+    async validateValues(values) {
+      const resolver = await resolverReady;
+      return resolver.validateValues(values);
+    }
+  };
+};

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -2,9 +2,14 @@ import { BigIntMath } from '@cardano-sdk/util';
 import { Cardano, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
 import { Observable, firstValueFrom } from 'rxjs';
 import { OutputValidation } from '../types';
-import { ResolveInputAddress } from '../KeyManagement';
 import { computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit } from '@cardano-sdk/cip2';
 import { txInEquals } from './util';
+
+/**
+ * @param txIn transaction input to resolve address from
+ * @returns input owner address
+ */
+export type ResolveInputAddress = (txIn: Cardano.NewTxIn) => Promise<Cardano.Address | null>;
 
 export type ProtocolParametersRequiredByOutputValidator = Pick<
   ProtocolParametersRequiredByWallet,

--- a/packages/wallet/src/setupWallet.ts
+++ b/packages/wallet/src/setupWallet.ts
@@ -1,0 +1,26 @@
+import { AsyncKeyAgent, KeyAgentDependencies } from './KeyManagement';
+import { ObservableWallet } from './types';
+import { WalletUtil, WalletUtilContext, createLazyWalletUtil } from './services';
+
+export interface SetupWalletProps<TWallet, TKeyAgent> {
+  createKeyAgent: (dependencies: KeyAgentDependencies) => Promise<TKeyAgent>;
+  createWallet: (keyAgent: TKeyAgent) => Promise<TWallet>;
+}
+
+/**
+ * Creates a wallet and a key agent that has the context of that wallet.
+ *
+ * Use this if you want to create a KeyAgent that uses wallet as InputResolver.
+ *
+ * Encapsulates the logic to resolve circular dependency of Wallet->KeyAgent->InputResolver(WalletUtil)->Wallet.
+ */
+export const setupWallet = async <TWallet extends WalletUtilContext = ObservableWallet, TKeyAgent = AsyncKeyAgent>({
+  createKeyAgent,
+  createWallet
+}: SetupWalletProps<TWallet, TKeyAgent>) => {
+  const walletUtil = createLazyWalletUtil();
+  const keyAgent = await createKeyAgent({ inputResolver: walletUtil });
+  const wallet = await createWallet(keyAgent);
+  walletUtil.initialize(wallet);
+  return { keyAgent, wallet, walletUtil: walletUtil as WalletUtil };
+};

--- a/packages/wallet/test/KeyManagement/KeyAgentBase.test.ts
+++ b/packages/wallet/test/KeyManagement/KeyAgentBase.test.ts
@@ -1,13 +1,13 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { CSL, Cardano } from '@cardano-sdk/core';
-import { KeyManagement } from '../../src';
+import { KeyManagement, createLazyWalletUtil } from '../../src';
 
 const NETWORK_ID = Cardano.NetworkId.testnet;
 const ACCOUNT_INDEX = 1;
 
 class MockKeyAgent extends KeyManagement.KeyAgentBase {
   constructor(data: KeyManagement.SerializableInMemoryKeyAgentData) {
-    super(data);
+    super(data, { inputResolver: createLazyWalletUtil() });
   }
 
   serializableDataImpl = jest.fn();

--- a/packages/wallet/test/KeyManagement/cip8/cip30signData.test.ts
+++ b/packages/wallet/test/KeyManagement/cip8/cip30signData.test.ts
@@ -15,7 +15,7 @@ describe('cip30signData', () => {
   beforeAll(async () => {
     const keyAgentReady = testKeyAgent();
     keyAgent = await keyAgentReady;
-    asyncKeyAgent = await testAsyncKeyAgent(undefined, keyAgentReady);
+    asyncKeyAgent = await testAsyncKeyAgent(undefined, undefined, keyAgentReady);
     address = await asyncKeyAgent.deriveAddress(addressDerivationPath);
   });
 

--- a/packages/wallet/test/KeyManagement/util/createAsyncKeyAgent.test.ts
+++ b/packages/wallet/test/KeyManagement/util/createAsyncKeyAgent.test.ts
@@ -1,20 +1,25 @@
 import { Cardano } from '@cardano-sdk/core';
-import { KeyManagement } from '../../../src';
+import { InputResolver, KeyManagement } from '../../../src';
 import { firstValueFrom } from 'rxjs';
 
 describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
   let keyAgent: KeyManagement.KeyAgent;
   let asyncKeyAgent: KeyManagement.AsyncKeyAgent;
+  let inputResolver: jest.Mocked<InputResolver>;
   const addressDerivationPath = { index: 0, type: 0 };
 
   beforeEach(async () => {
     const mnemonicWords = KeyManagement.util.generateMnemonicWords();
     const getPassword = jest.fn().mockResolvedValue(Buffer.from('password'));
-    keyAgent = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords({
-      getPassword,
-      mnemonicWords,
-      networkId: Cardano.NetworkId.testnet
-    });
+    inputResolver = { resolveInputAddress: jest.fn() };
+    keyAgent = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords(
+      {
+        getPassword,
+        mnemonicWords,
+        networkId: Cardano.NetworkId.testnet
+      },
+      { inputResolver }
+    );
     asyncKeyAgent = KeyManagement.util.createAsyncKeyAgent(keyAgent);
   });
   it('deriveAddress/signBlob/signTransaction are unchanged', async () => {
@@ -26,13 +31,13 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
     await expect(asyncKeyAgent.signBlob(keyDerivationPath, blob)).resolves.toEqual(
       await keyAgent.signBlob(keyDerivationPath, blob)
     );
-    const options: KeyManagement.SignTransactionOptions = { inputAddressResolver: () => Promise.resolve(null) };
+    inputResolver.resolveInputAddress.mockResolvedValue(null);
     const txInternals = {
       body: { fee: 20_000n, inputs: [], outputs: [], validityInterval: {} } as Cardano.TxBodyAlonzo,
       hash: Cardano.TransactionId('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec')
     };
-    await expect(asyncKeyAgent.signTransaction(txInternals, options)).resolves.toEqual(
-      await keyAgent.signTransaction(txInternals, options)
+    await expect(asyncKeyAgent.signTransaction(txInternals)).resolves.toEqual(
+      await keyAgent.signTransaction(txInternals)
     );
   });
   it('knownAddresses$ is emits initial addresses and after new address derivation', async () => {

--- a/packages/wallet/test/KeyManagement/util/ownSignaturePaths.test.ts
+++ b/packages/wallet/test/KeyManagement/util/ownSignaturePaths.test.ts
@@ -23,12 +23,12 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     const knownAddresses = [address1, address2].map((address, index) =>
       createGroupedAddress(address, AddressType.External, index)
     );
-    const resolveInput = jest
+    const resolveInputAddress = jest
       .fn()
       .mockReturnValueOnce(address1)
       .mockReturnValueOnce(address2)
       .mockReturnValueOnce(address1);
-    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, resolveInput)).toEqual([
+    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInputAddress })).toEqual([
       {
         index: 0,
         role: KeyRole.External

--- a/packages/wallet/test/KeyManagement/util/stubSignTransaction.test.ts
+++ b/packages/wallet/test/KeyManagement/util/stubSignTransaction.test.ts
@@ -1,5 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
-import { GroupedAddress, ResolveInputAddress } from '../../../src/KeyManagement';
+import { GroupedAddress } from '../../../src/KeyManagement';
+import { InputResolver } from '../../../src';
 import { stubSignTransaction } from '../../../src/KeyManagement/util';
 
 jest.mock('../../../src/KeyManagement/util/ownSignatureKeyPaths');
@@ -7,12 +8,12 @@ const { ownSignatureKeyPaths } = jest.requireMock('../../../src/KeyManagement/ut
 
 describe('KeyManagement.util.stubSignTransaction', () => {
   it('returns as many signatures as number of keys returned by ownSignaturePaths', async () => {
-    const inputAddressResolver = {} as ResolveInputAddress; // not called
+    const inputResolver = {} as InputResolver; // not called
     const txBody = {} as Cardano.TxBodyAlonzo;
     const knownAddresses = [{} as GroupedAddress];
     ownSignatureKeyPaths.mockReturnValueOnce([{}]).mockReturnValueOnce([{}, {}]);
-    expect((await stubSignTransaction(txBody, knownAddresses, inputAddressResolver)).size).toBe(1);
-    expect((await stubSignTransaction(txBody, knownAddresses, inputAddressResolver)).size).toBe(2);
-    expect(ownSignatureKeyPaths).toBeCalledWith(txBody, knownAddresses, inputAddressResolver);
+    expect((await stubSignTransaction(txBody, knownAddresses, inputResolver)).size).toBe(1);
+    expect((await stubSignTransaction(txBody, knownAddresses, inputResolver)).size).toBe(2);
+    expect(ownSignatureKeyPaths).toBeCalledWith(txBody, knownAddresses, inputResolver);
   });
 });

--- a/packages/wallet/test/hardware/LedgerKeyAgent.integration.test.ts
+++ b/packages/wallet/test/hardware/LedgerKeyAgent.integration.test.ts
@@ -1,6 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
 import { CommunicationType, KeyAgent, LedgerKeyAgent, restoreKeyAgent, util } from '../../src/KeyManagement';
-import { ObservableWallet, SingleAddressWallet } from '../../src';
+import { ObservableWallet, SingleAddressWallet, setupWallet } from '../../src';
 import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { firstValueFrom } from 'rxjs';
 import {
@@ -12,7 +12,7 @@ import {
   mockUtxoProvider
 } from '../mocks';
 
-const createWallet = (keyAgent: KeyAgent) => {
+const createWallet = async (keyAgent: KeyAgent) => {
   const txSubmitProvider = mockTxSubmitProvider();
   const stakePoolProvider = createStubStakePoolProvider();
   const networkInfoProvider = mockNetworkInfoProvider();
@@ -40,14 +40,22 @@ const getAddress = async (wallet: ObservableWallet) => (await firstValueFrom(wal
 
 describe('LedgerKeyAgent+SingleAddressWallet', () => {
   test('creating and restoring LedgerKeyAgent wallet', async () => {
-    const freshKeyAgent = await LedgerKeyAgent.createWithDevice({
-      communicationType: CommunicationType.Node,
-      networkId: Cardano.NetworkId.testnet,
-      protocolMagic: 1_097_911_063
+    const { wallet: freshWallet, keyAgent: freshKeyAgent } = await setupWallet({
+      createKeyAgent: (dependencies) =>
+        LedgerKeyAgent.createWithDevice(
+          {
+            communicationType: CommunicationType.Node,
+            networkId: Cardano.NetworkId.testnet,
+            protocolMagic: 1_097_911_063
+          },
+          dependencies
+        ),
+      createWallet
     });
-    const freshWallet = createWallet(freshKeyAgent);
-    const restoredKeyAgent = await restoreKeyAgent(freshKeyAgent.serializableData);
-    const restoredWallet = createWallet(restoredKeyAgent);
+    const { wallet: restoredWallet } = await setupWallet({
+      createKeyAgent: (dependencies) => restoreKeyAgent(freshKeyAgent.serializableData, dependencies),
+      createWallet
+    });
     expect(await getAddress(freshWallet)).toEqual(await getAddress(restoredWallet));
     // TODO: finalizeTx with both wallets, assert that signature equals
     freshWallet.shutdown();

--- a/packages/wallet/test/integration/CustomObservableWallet.test.ts
+++ b/packages/wallet/test/integration/CustomObservableWallet.test.ts
@@ -48,7 +48,7 @@ describe('CustomObservableWallet', () => {
         {
           assetProvider: mocks.mockAssetProvider(),
           chainHistoryProvider: mocks.mockChainHistoryProvider(),
-          keyAgent: KeyManagement.util.createAsyncKeyAgent(await mocks.testKeyAgent()),
+          keyAgent: await mocks.testAsyncKeyAgent(),
           networkInfoProvider: mocks.mockNetworkInfoProvider(),
           rewardsProvider: mocks.mockRewardsProvider(),
           stakePoolProvider: createStubStakePoolProvider(),

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -26,7 +26,7 @@ describe('cip30', () => {
 
   beforeAll(async () => {
     // CREATE A WALLET
-    wallet = await createWallet();
+    ({ wallet } = await createWallet());
     confirmationCallback = jest.fn().mockResolvedValue(true);
     api = cip30.createWalletApi(Promise.resolve(wallet), confirmationCallback);
     await waitForWalletStateSettle(wallet);

--- a/packages/wallet/test/integration/transactionTime.test.ts
+++ b/packages/wallet/test/integration/transactionTime.test.ts
@@ -7,7 +7,7 @@ describe('integration/transactionTime', () => {
   let wallet: SingleAddressWallet;
 
   beforeAll(async () => {
-    wallet = await createWallet();
+    ({ wallet } = await createWallet());
   });
 
   it('provides utils necessary for computing transaction time', async () => {

--- a/packages/wallet/test/integration/txChainingBalance.test.ts
+++ b/packages/wallet/test/integration/txChainingBalance.test.ts
@@ -8,7 +8,7 @@ describe('integration/txChainingBalance', () => {
 
   beforeAll(async () => {
     // Using mock TxSubmitProvider which doesn't do anything and instantly resolves
-    wallet = await createWallet();
+    ({ wallet } = await createWallet());
   });
 
   it('available balance includes change outputs from pending transaction', async () => {

--- a/packages/wallet/test/integration/util.ts
+++ b/packages/wallet/test/integration/util.ts
@@ -1,4 +1,4 @@
-import { SingleAddressWallet } from '../../src';
+import { SingleAddressWallet, setupWallet } from '../../src';
 import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import {
   mockAssetProvider,
@@ -10,26 +10,29 @@ import {
   testAsyncKeyAgent
 } from '../mocks';
 
-export const createWallet = async () => {
-  const keyAgent = await testAsyncKeyAgent();
-  const txSubmitProvider = mockTxSubmitProvider();
-  const stakePoolProvider = createStubStakePoolProvider();
-  const networkInfoProvider = mockNetworkInfoProvider();
-  const assetProvider = mockAssetProvider();
-  const utxoProvider = mockUtxoProvider();
-  const chainHistoryProvider = mockChainHistoryProvider();
-  const rewardsProvider = mockRewardsProvider();
-  return new SingleAddressWallet(
-    { name: 'Test Wallet' },
-    {
-      assetProvider,
-      chainHistoryProvider,
-      keyAgent,
-      networkInfoProvider,
-      rewardsProvider,
-      stakePoolProvider,
-      txSubmitProvider,
-      utxoProvider
+export const createWallet = async () =>
+  setupWallet({
+    createKeyAgent: (dependencies) => testAsyncKeyAgent(undefined, dependencies),
+    createWallet: async (keyAgent) => {
+      const txSubmitProvider = mockTxSubmitProvider();
+      const stakePoolProvider = createStubStakePoolProvider();
+      const networkInfoProvider = mockNetworkInfoProvider();
+      const assetProvider = mockAssetProvider();
+      const utxoProvider = mockUtxoProvider();
+      const chainHistoryProvider = mockChainHistoryProvider();
+      const rewardsProvider = mockRewardsProvider();
+      return new SingleAddressWallet(
+        { name: 'Test Wallet' },
+        {
+          assetProvider,
+          chainHistoryProvider,
+          keyAgent,
+          networkInfoProvider,
+          rewardsProvider,
+          stakePoolProvider,
+          txSubmitProvider,
+          utxoProvider
+        }
+      );
     }
-  );
-};
+  });

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -7,7 +7,7 @@ describe('integration/withdrawal', () => {
   let wallet: SingleAddressWallet;
 
   beforeAll(async () => {
-    wallet = await createWallet();
+    ({ wallet } = await createWallet());
   });
 
   it('has balance', async () => {

--- a/packages/wallet/test/mocks/index.ts
+++ b/packages/wallet/test/mocks/index.ts
@@ -7,3 +7,4 @@ export * from './mockAssetProvider';
 export * from './mockUtxoProvider';
 export * from './mockChainHistoryProvider';
 export * from './mockRewardsProvider';
+export * from './mockKeyAgentDependencies';

--- a/packages/wallet/test/mocks/mockKeyAgentDependencies.ts
+++ b/packages/wallet/test/mocks/mockKeyAgentDependencies.ts
@@ -1,0 +1,7 @@
+import { KeyAgentDependencies } from '../../src/KeyManagement';
+
+export const mockKeyAgentDependencies = (): jest.Mocked<KeyAgentDependencies> => ({
+  inputResolver: {
+    resolveInputAddress: jest.fn().mockResolvedValue(null)
+  }
+});

--- a/packages/wallet/test/mocks/testKeyAgent.ts
+++ b/packages/wallet/test/mocks/testKeyAgent.ts
@@ -1,22 +1,32 @@
 import { Cardano } from '@cardano-sdk/core';
-import { GroupedAddress } from '../../src/KeyManagement';
+import { GroupedAddress, KeyAgentDependencies } from '../../src/KeyManagement';
 import { KeyManagement } from '../../src';
+import { mockKeyAgentDependencies } from './mockKeyAgentDependencies';
 
 export const getPassword = jest.fn(async () => Buffer.from('password'));
 
 export const networkId = Cardano.NetworkId.testnet;
 
-export const testKeyAgent = async (addresses?: GroupedAddress[]) => {
-  const keyAgent = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords({
-    getPassword,
-    mnemonicWords: KeyManagement.util.generateMnemonicWords(),
-    networkId
-  });
+export const testKeyAgent = async (
+  addresses?: GroupedAddress[],
+  dependencies: KeyAgentDependencies | undefined = mockKeyAgentDependencies()
+) => {
+  const keyAgent = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords(
+    {
+      getPassword,
+      mnemonicWords: KeyManagement.util.generateMnemonicWords(),
+      networkId
+    },
+    dependencies
+  );
   if (addresses) {
     keyAgent.knownAddresses.push(...addresses);
   }
   return keyAgent;
 };
 
-export const testAsyncKeyAgent = async (addresses?: GroupedAddress[], keyAgentReady = testKeyAgent(addresses)) =>
-  KeyManagement.util.createAsyncKeyAgent(await keyAgentReady);
+export const testAsyncKeyAgent = async (
+  addresses?: GroupedAddress[],
+  dependencies: KeyAgentDependencies | undefined = mockKeyAgentDependencies(),
+  keyAgentReady = testKeyAgent(addresses, dependencies)
+) => KeyManagement.util.createAsyncKeyAgent(await keyAgentReady);

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -3,7 +3,9 @@ import { Cardano } from '@cardano-sdk/core';
 import {
   OutputValidator,
   ProtocolParametersRequiredByOutputValidator,
+  WalletUtilContext,
   createInputResolver,
+  createLazyWalletUtil,
   createOutputValidator
 } from '../../src';
 import { of } from 'rxjs';
@@ -81,6 +83,21 @@ describe('WalletUtil', () => {
           txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d4')
         })
       ).toBeNull();
+    });
+  });
+
+  describe('createLazyWalletUtil', () => {
+    it('awaits for "initialize" to be called before resolving call to any util', async () => {
+      const util = createLazyWalletUtil();
+      const resultPromise = util.validateValue({ coins: 2_000_000n });
+      util.initialize({
+        protocolParameters$: of<ProtocolParametersRequiredByOutputValidator>({
+          coinsPerUtxoByte: 4310,
+          maxValueSize: 90
+        })
+      } as WalletUtilContext);
+      const result = await resultPromise;
+      expect(result.coinMissing).toBe(0n);
     });
   });
 });

--- a/packages/wallet/test/setupWallet.test.ts
+++ b/packages/wallet/test/setupWallet.test.ts
@@ -1,0 +1,27 @@
+import { setupWallet } from '../src';
+
+jest.mock('../src/services/WalletUtil');
+const { createLazyWalletUtil } = jest.requireMock('../src/services/WalletUtil');
+
+describe('setupWallet', () => {
+  it('initializes WalletUtil with the wallet that is then used as InputResolver for KeyAgent', async () => {
+    const initialize = jest.fn();
+    const walletUtil = { initialize };
+    createLazyWalletUtil.mockReturnValueOnce(walletUtil);
+    // actual values doesn't matter for this test, adding any property to be able to assert toEqual
+    const keyAgent = { keyAgent: true };
+    const wallet = { wallet: true };
+
+    const createKeyAgent = jest.fn().mockResolvedValueOnce(keyAgent);
+    const createWallet = jest.fn().mockResolvedValueOnce(wallet);
+    expect(
+      await setupWallet({
+        createKeyAgent,
+        createWallet
+      })
+    ).toEqual({ keyAgent, wallet, walletUtil });
+    expect(initialize).toBeCalledWith(wallet);
+    expect(createKeyAgent).toBeCalledWith({ inputResolver: walletUtil });
+    expect(createWallet).toBeCalledWith(keyAgent);
+  });
+});


### PR DESCRIPTION
# Context

KeyAgent.signTransaction takes in an [inputAddressResolver](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/wallet/src/KeyManagement/types.ts#L124) which is passed as an argument in a remote function call, which isn't supported in our web-extension messaging implementation.

# Proposed Solution

Refactor KeyAgent interface: inject `InputResolver` in the constructor of all concrete implementations and remove it as a prop in `KeyAgent.signTransaction` 702dd1a510eff160e702536f2d2778291239ac3d.

As a result, creating and restoring any KeyAgent now requires `{inputResolver}` as 2nd argument. This introduced a circular dependency (Wallet->KeyAgent->InputResolver(WalletUtil)->Wallet) when using `ObservableWallet` as source for the WalletUtil (which is an InputResolver). To overcome this, created a lazy version of WalletUtil 2eca4fc369b4e2baae6e6437c5c749d09853fdd8. To encapsulate the new not-so-obvious initialization logic, exported a new `setupWallet` util.

# Important Changes Introduced

- Add web-extension e2e test to build and sign a transaction that reproduces the problem described in Context
- Unrelated to context of this PR:
  - [test(e2e): fix base tsconfig path for web-extension](https://github.com/input-output-hk/cardano-js-sdk/commit/7be6bf31b80ccecd24f16a19cd7a893f99fdc31a)
  - [test(e2e): rename web-extension create keyagent button](https://github.com/input-output-hk/cardano-js-sdk/pull/332/commits/c4ce8c2e3f9c58e7064a5007260d1059617f1f70)[test(e2e): rename web-extension create keyagent button](https://github.com/input-output-hk/cardano-js-sdk/pull/332/commits/c4ce8c2e3f9c58e7064a5007260d1059617f1f70) 

## Notes

- ~~`setupWallet` has no tests~~ aced5bbb779a4978e48a8b68c99a62de8c16503b
- Tests I **didn't run** after making changes in this PR:
  - `wallet`: `test:hw -t 'Trezor'`
  - `e2e`: `test:blockfrost`, `test:faucet`, `test:cardano-services