### PR TITLE
test: cardano-services tests racing for binding the port

### DIFF
--- a/packages/cardano-services-client/test/HttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HttpProvider.test.ts
@@ -3,10 +3,9 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { HttpProviderConfig, createHttpProvider } from '../src';
 import { ProviderError, ProviderFailure } from '@cardano-sdk/core';
-import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
-
 import { Server } from 'http';
-import { getPort } from 'get-port-please';
+import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
+import { getRandomPort } from 'get-port-please';
 import express, { RequestHandler } from 'express';
 
 type ComplexArg2 = { map: Map<string, Buffer> };
@@ -45,7 +44,7 @@ describe('createHttpServer', () => {
     });
 
   beforeAll(async () => {
-    port = await getPort();
+    port = await getRandomPort();
     baseUrl = `http://localhost:${port}`;
   });
 

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -49,7 +49,7 @@
     "run:http-server:debug": "npx nodemon --legacy-watch --exec 'node -r ts-node/register --inspect=0.0.0.0:9229 src/run.ts'",
     "run:tx-worker": "ts-node --transpile-only src/startWorker.ts",
     "run:tx-worker:debug": "npx nodemon --legacy-watch --exec 'node -r ts-node/register --inspect=0.0.0.0:9229 src/startWorker.ts'",
-    "test": "jest --runInBand -c ./jest.config.js",
+    "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:debug": "DEBUG=true yarn test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -16,7 +16,7 @@ import { createDbSyncMetadataService } from '../../src/Metadata';
 import { doServerRequest } from '../util';
 import { dummyLogger } from 'ts-log';
 import { fromSerializableObject } from '@cardano-sdk/util';
-import { getPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import axios from 'axios';
 
 const UNSUPPORTED_MEDIA_STRING = 'Request failed with status code 415';
@@ -34,7 +34,7 @@ describe('ChainHistoryHttpService', () => {
   let doChainHistoryRequest: ReturnType<typeof doServerRequest>;
 
   beforeAll(async () => {
-    port = await getPort();
+    port = await getRandomPort();
     apiUrlBase = `http://localhost:${port}/chain-history`;
     config = { listen: { port } };
     dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -16,7 +16,7 @@ import { HttpServer, HttpServerConfig } from '../../src';
 import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../src/InMemoryCache';
 import { Pool } from 'pg';
 import { doServerRequest, ingestDbData, sleep, wrapWithTransaction } from '../util';
-import { getPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import { networkInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import axios from 'axios';
 
@@ -49,9 +49,12 @@ describe('NetworkInfoHttpService', () => {
     }
   ];
 
+  beforeAll(async () => {
+    port = await getRandomPort();
+  });
+
   describe('unhealthy NetworkInfoProvider', () => {
     beforeEach(async () => {
-      port = await getPort();
       apiUrlBase = `http://localhost:${port}/network-info`;
       config = { listen: { port } };
       cardanoNode = {
@@ -94,7 +97,6 @@ describe('NetworkInfoHttpService', () => {
     });
 
     beforeAll(async () => {
-      port = await getPort();
       apiUrlBase = `http://localhost:${port}/network-info`;
       cardanoNode = {
         eraSummaries: jest.fn(() => Promise.resolve(mockEraSummaries)),

--- a/packages/cardano-services/test/Program/utils.test.ts
+++ b/packages/cardano-services/test/Program/utils.test.ts
@@ -22,7 +22,7 @@ import { TxSubmitWorker } from '@cardano-sdk/rabbitmq';
 import { createHealthyMockOgmiosServer, ogmiosServerReady } from '../util';
 import { createLogger } from 'bunyan';
 import { createMockOgmiosServer } from '../../../ogmios/test/mocks/mockOgmiosServer';
-import { getPort, getRandomPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import { listenPromise, serverClosePromise } from '../../src/util';
 import { txsPromise } from '../../../rabbitmq/test/utils';
 import { types } from 'util';
@@ -44,6 +44,7 @@ jest.mock('dns', () => ({
 }));
 
 describe('Service dependency abstractions', () => {
+  let port: number;
   const APPLICATION_JSON = 'application/json';
   const cache = new InMemoryCache(UNLIMITED_CACHE_TTL);
   const cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
@@ -62,11 +63,12 @@ describe('Service dependency abstractions', () => {
     shutdown: jest.fn(() => Promise.resolve()),
     systemStart: jest.fn(() => Promise.resolve(new Date(1_563_999_616_000)))
   };
-
+  beforeAll(async () => {
+    port = await getRandomPort();
+  });
   describe('Postgres-dependant service with service discovery', () => {
     let httpServer: HttpServer;
     let db: Pool | undefined;
-    let port: number;
     let apiUrlBase: string;
     let config: HttpServerConfig;
     let service: NetworkInfoHttpService;
@@ -87,7 +89,6 @@ describe('Service dependency abstractions', () => {
 
     describe('Established connection', () => {
       beforeAll(async () => {
-        port = await getPort();
         config = { listen: { port } };
         apiUrlBase = `http://localhost:${port}/network-info`;
         networkInfoProvider = new DbSyncNetworkInfoProvider(
@@ -125,7 +126,6 @@ describe('Service dependency abstractions', () => {
   describe('Postgres-dependant service with provided db connection string', () => {
     let httpServer: HttpServer;
     let db: Pool | undefined;
-    let port: number;
     let apiUrlBase: string;
     let config: HttpServerConfig;
     let service: NetworkInfoHttpService;
@@ -141,7 +141,6 @@ describe('Service dependency abstractions', () => {
 
     describe('Established connection', () => {
       beforeAll(async () => {
-        port = await getPort();
         config = { listen: { port } };
         apiUrlBase = `http://localhost:${port}/network-info`;
         networkInfoProvider = new DbSyncNetworkInfoProvider(
@@ -233,7 +232,6 @@ describe('Service dependency abstractions', () => {
     let ogmiosConnection: Connection;
     let txSubmitProvider: TxSubmitProvider;
     let httpServer: HttpServer;
-    let port: number;
     let config: HttpServerConfig;
 
     beforeAll(async () => {
@@ -245,7 +243,6 @@ describe('Service dependency abstractions', () => {
 
     describe('Established connection', () => {
       beforeAll(async () => {
-        port = await getPort();
         apiUrlBase = `http://localhost:${port}/tx-submit`;
         config = { listen: { port } };
         txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
@@ -286,7 +283,6 @@ describe('Service dependency abstractions', () => {
     let ogmiosConnection: Connection;
     let txSubmitProvider: TxSubmitProvider;
     let httpServer: HttpServer;
-    let port: number;
     let config: HttpServerConfig;
 
     beforeAll(async () => {
@@ -298,7 +294,6 @@ describe('Service dependency abstractions', () => {
 
     describe('Established connection', () => {
       beforeAll(async () => {
-        port = await getPort();
         apiUrlBase = `http://localhost:${port}/tx-submit`;
         config = { listen: { port } };
         txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
@@ -397,12 +392,10 @@ describe('Service dependency abstractions', () => {
     let apiUrlBase: string;
     let txSubmitProvider: TxSubmitProvider;
     let httpServer: HttpServer;
-    let port: number;
     let config: HttpServerConfig;
 
     describe('Established connection', () => {
       beforeAll(async () => {
-        port = await getPort();
         apiUrlBase = `http://localhost:${port}/tx-submit`;
         config = { listen: { port } };
         txSubmitProvider = await getRabbitMqTxSubmitProvider(dnsResolver, logger, {
@@ -440,12 +433,10 @@ describe('Service dependency abstractions', () => {
     let apiUrlBase: string;
     let txSubmitProvider: TxSubmitProvider;
     let httpServer: HttpServer;
-    let port: number;
     let config: HttpServerConfig;
 
     describe('Established connection', () => {
       beforeAll(async () => {
-        port = await getPort();
         apiUrlBase = `http://localhost:${port}/tx-submit`;
         config = { listen: { port } };
         txSubmitProvider = await getRabbitMqTxSubmitProvider(dnsResolver, logger, {

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -3,7 +3,7 @@
 import { Cardano, ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
 import { DbSyncRewardsProvider, HttpServer, HttpServerConfig, RewardsHttpService } from '../../src';
 import { Pool } from 'pg';
-import { getPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import { rewardsHttpProvider } from '@cardano-sdk/cardano-services-client';
 import axios from 'axios';
 
@@ -22,7 +22,7 @@ describe('RewardsHttpService', () => {
   let config: HttpServerConfig;
 
   beforeAll(async () => {
-    port = await getPort();
+    port = await getRandomPort();
     apiUrlBase = `http://localhost:${port}/rewards`;
     config = { listen: { port } };
     dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -14,8 +14,8 @@ import {
 import { DbSyncStakePoolProvider, HttpServer, HttpServerConfig, StakePoolHttpService } from '../../src';
 import { Pool } from 'pg';
 import { doServerRequest } from '../util';
-import { getPort } from 'get-port-please';
-import { stakePoolHttpProvider } from '../../../cardano-services-client';
+import { getRandomPort } from 'get-port-please';
+import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 import axios from 'axios';
 
 const UNSUPPORTED_MEDIA_STRING = 'Request failed with status code 415';
@@ -60,7 +60,7 @@ describe('StakePoolHttpService', () => {
   let doStakePoolRequest: ReturnType<typeof doServerRequest>;
 
   beforeAll(async () => {
-    port = await getPort();
+    port = await getRandomPort();
     apiUrlBase = `http://localhost:${port}/stake-pool`;
     config = { listen: { port } };
     dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -3,8 +3,7 @@
 import { APPLICATION_JSON, CONTENT_TYPE, HttpServer, HttpServerConfig, TxSubmitHttpService } from '../../src';
 import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
 import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
-
-import { getPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import { txSubmitHttpProvider } from '@cardano-sdk/cardano-services-client';
 import axios from 'axios';
 import cbor from 'cbor';
@@ -22,7 +21,7 @@ describe('TxSubmitHttpService', () => {
   let config: HttpServerConfig;
 
   beforeAll(async () => {
-    port = await getPort();
+    port = await getRandomPort();
     apiUrlBase = `http://localhost:${port}/tx-submit`;
     config = { listen: { port } };
   });

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -2,7 +2,7 @@
 import { Cardano, ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
 import { DbSyncUtxoProvider, HttpServer, HttpServerConfig, UtxoHttpService } from '../../src';
 import { Pool } from 'pg';
-import { getPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import { utxoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import axios from 'axios';
 
@@ -24,7 +24,7 @@ describe('UtxoHttpService', () => {
   let provider: UtxoProvider;
 
   beforeAll(async () => {
-    port = await getPort();
+    port = await getRandomPort();
     apiUrlBase = `http://localhost:${port}/utxo`;
     config = { listen: { port } };
     dbConnection = new Pool({ connectionString: process.env.DB_CONNECTION_STRING });

--- a/packages/cardano-services/test/util/http.test.ts
+++ b/packages/cardano-services/test/util/http.test.ts
@@ -1,11 +1,14 @@
-import { getPort } from 'get-port-please';
+import { getRandomPort } from 'get-port-please';
 import { listenPromise, serverClosePromise } from '../../src/util/http';
 import express from 'express';
 import http from 'http';
 
 describe('http utils', () => {
+  let port: number;
+  beforeAll(async () => {
+    port = await getRandomPort();
+  });
   describe('listenPromise', () => {
-    let port: number;
     let server: http.Server;
 
     afterEach(() => {
@@ -14,14 +17,12 @@ describe('http utils', () => {
 
     it('promisifies express app.listen', async () => {
       const app = express();
-      port = await getPort();
       expect((server = await listenPromise(app, { port }))).toBeInstanceOf(http.Server);
       await expect(listenPromise(app, { port })).rejects.toThrow();
     });
 
     it('promisifies server.listen', async () => {
       server = http.createServer();
-      port = await getPort();
       server = await listenPromise(server, { port });
       expect(server).toBeInstanceOf(http.Server);
       await expect(listenPromise(server, { port })).rejects.toThrow();
@@ -29,12 +30,10 @@ describe('http utils', () => {
   });
 
   describe('serverClosePromise', () => {
-    let port: number;
     let server: http.Server;
 
     it('promisifies server.close', async () => {
       server = http.createServer();
-      port = await getPort();
       const spy = jest.fn();
       await listenPromise(server, { port });
       server.on('close', spy);


### PR DESCRIPTION
# Context

yarn test sometimes fail with an error from httpServer.start() when it cannot bind to port.
yarn test --runInBand seems to be working well, so the tests are probably racing to bind the same port.

# Proposed Solution

Refactor tests and replace `getPort()` per `getRandomPort()` and remove `--runInBand` flag from `test` script
