### PR TITLE
feat(cardano-services-client): add asset info http provider

### DIFF
--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -1,0 +1,17 @@
+import { AssetProvider } from '@cardano-sdk/core';
+import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+
+export const defaultAssetProviderPaths: HttpProviderConfigPaths<AssetProvider> = {
+  getAsset: '/get-asset'
+};
+
+/**
+ * Connect to a Cardano Services HttpServer instance with the service available
+ *
+ * @param {string} baseUrl server root url, w/o trailing /
+ */
+export const assetInfoHttpProvider = (baseUrl: string, paths = defaultAssetProviderPaths): AssetProvider =>
+  createHttpProvider<AssetProvider>({
+    baseUrl,
+    paths
+  });

--- a/packages/cardano-services-client/src/AssetInfoProvider/index.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './assetInfoHttpProvider';

--- a/packages/cardano-services-client/src/index.ts
+++ b/packages/cardano-services-client/src/index.ts
@@ -1,4 +1,5 @@
 export { TxSubmitProvider } from '@cardano-sdk/core';
+export * from './AssetInfoProvider';
 export * from './HttpProvider';
 export * from './TxSubmitProvider';
 export * from './StakePoolProvider';

--- a/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
@@ -1,0 +1,32 @@
+import { Cardano } from '@cardano-sdk/core';
+import { assetInfoHttpProvider } from '../../src';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+const url = 'http://some-hostname:3000/asset';
+
+describe('assetInfoHttpProvider', () => {
+  let axiosMock: MockAdapter;
+
+  beforeAll(() => {
+    axiosMock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  afterAll(() => {
+    axiosMock.restore();
+  });
+
+  describe('getAsset', () => {
+    test('getAsset doesnt throw', async () => {
+      axiosMock.onPost().replyOnce(200, {});
+      const provider = assetInfoHttpProvider(url);
+      await expect(
+        provider.getAsset(Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958'))
+      ).resolves.toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
# Context

We need to add an asset info http provider to `@cardano-sdk/cardano-services-client`.

# Proposed Solution

Added `assetInfoHttpProvider`.

# Important Changes Introduced
