### PR TITLE
feat: service discovery error handling for TxSubmitWorker

### DIFF
--- a/packages/cardano-services/src/Program/utils.ts
+++ b/packages/cardano-services/src/Program/utils.ts
@@ -253,17 +253,3 @@ export const getRabbitMqTxSubmitProvider = async (
     CommonOptionDescriptions.RabbitMQSrvServiceName
   ]);
 };
-
-export const getRabbitMqUrl = async (dnsResolver: DnsResolver, args: CommonProgramOptions) => {
-  if (args.rabbitmqSrvServiceName) {
-    const record = await dnsResolver(args.rabbitmqSrvServiceName);
-    return srvRecordToRabbitmqURL(record);
-  }
-  if (args.rabbitmqUrl) {
-    return args.rabbitmqUrl;
-  }
-  throw new MissingProgramOption(ServiceNames.TxSubmit, [
-    CommonOptionDescriptions.RabbitMQUrl,
-    CommonOptionDescriptions.RabbitMQSrvServiceName
-  ]);
-};

--- a/packages/cardano-services/src/TxWorker/utils.ts
+++ b/packages/cardano-services/src/TxWorker/utils.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable no-use-before-define */
+import { CONNECTION_ERROR_EVENT, TxSubmitWorker } from '@cardano-sdk/rabbitmq';
+import { CommonOptionDescriptions } from '../ProgramsCommon';
+import { DnsResolver, MissingProgramOption, ServiceNames, srvRecordToRabbitmqURL } from '../Program';
+import { Logger } from 'ts-log';
+import { TxSubmitProvider } from '@cardano-sdk/core';
+import { TxWorkerOptions } from './loadTxWorker';
+
+type WorkerFactory = () => Promise<TxSubmitWorker>;
+
+/**
+ * Create a worker factory with service discovery
+ *
+ * @param {DnsResolver} dnsResolver used for dns resoluton
+ * @param {TxSubmitProvider} txSubmitProvider tx submit provider 'ogmiosTxSubmitProvider'
+ * @param {Logger} logger common logger
+ * @param {TxWorkerOptions} options needed for tx worker initialization
+ * @returns {WorkerFactory} WorkerFactory with service discovery, returning a 'TxSubmitWorker' instance
+ */
+export const createWorkerFactoryWithDiscovery =
+  (
+    dnsResolver: DnsResolver,
+    txSubmitProvider: TxSubmitProvider,
+    logger: Logger,
+    options: TxWorkerOptions
+  ): WorkerFactory =>
+  async () => {
+    const record = await dnsResolver(options.rabbitmqSrvServiceName!);
+    return new TxSubmitWorker(
+      { ...options, rabbitmqUrl: srvRecordToRabbitmqURL(record) },
+      { logger, txSubmitProvider }
+    );
+  };
+
+/**
+ * Create and start a new worker instance with registered listener for connection error events
+ *
+ * @param {WorkerFactory} workerFactory creates a worker instance with service discovery
+ */
+export const createAndStartNewWorker = async (workerFactory: WorkerFactory) => {
+  const newWorker = await workerFactory();
+  attachOnConnectionErrorHandler(newWorker, workerFactory);
+  await newWorker.start();
+};
+
+/**
+ * With service discovery, register a listener for 'connection-error' event type
+ * emitted in the case of a connection-related runtime error
+ *
+ * @param {TxSubmitWorker} worker TxSubmitWorker instance
+ * @param {WorkerFactory} factory creates a worker instance with service discovery
+ */
+export const attachOnConnectionErrorHandler = (worker: TxSubmitWorker, factory: WorkerFactory) => {
+  worker.on(CONNECTION_ERROR_EVENT, () => createAndStartNewWorker(factory));
+};
+
+export type RunningTxSubmitWorker = Pick<TxSubmitWorker, 'stop' | 'getStatus'>;
+
+/**
+ * An abstraction which starts and manages restarts of the worker instance with service discovery
+ *
+ * @param {WorkerFactory} workerFactory creates a worker instance with service discovery
+ * @returns {RunningTxSubmitWorker} RunningTxSubmitWorker instance
+ */
+export const startTxSubmitWorkerWithDiscovery = async (
+  workerFactory: WorkerFactory
+): Promise<RunningTxSubmitWorker> => {
+  let worker: TxSubmitWorker;
+  await createAndStartNewWorker(async () => (worker = await workerFactory()));
+
+  return {
+    getStatus: () => worker.getStatus(),
+    stop: () => worker.stop()
+  };
+};
+
+export const getRunningTxSubmitWorker = async (
+  dnsResolver: DnsResolver,
+  txSubmitProvider: TxSubmitProvider,
+  logger: Logger,
+  options?: TxWorkerOptions
+): Promise<RunningTxSubmitWorker> => {
+  if (options?.rabbitmqSrvServiceName)
+    return startTxSubmitWorkerWithDiscovery(
+      createWorkerFactoryWithDiscovery(dnsResolver, txSubmitProvider, logger, options)
+    );
+  if (options?.rabbitmqUrl) {
+    const worker = new TxSubmitWorker({ ...options, rabbitmqUrl: options.rabbitmqUrl }, { logger, txSubmitProvider });
+    await worker.start();
+    return worker;
+  }
+  throw new MissingProgramOption(ServiceNames.TxSubmit, [
+    CommonOptionDescriptions.RabbitMQUrl,
+    CommonOptionDescriptions.RabbitMQSrvServiceName
+  ]);
+};

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -20,7 +20,7 @@ import {
   POLLING_CYCLE_DEFAULT,
   TxWorkerOptionDescriptions,
   TxWorkerOptions,
-  loadTxWorker
+  loadAndStartTxWorker
 } from './TxWorker';
 import { SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT, SERVICE_DISCOVERY_TIMEOUT_DEFAULT } from './Program/utils';
 import { URL } from 'url';
@@ -169,8 +169,7 @@ commonOptions(program.command('start-worker').description('Start RabbitMQ worker
   .action(async (options: TxWorkerOptions) => {
     // eslint-disable-next-line no-console
     console.log(`RabbitMQ transactions worker: ${options.parallel ? 'parallel' : 'serial'} mode`);
-    const txWorker = await loadTxWorker({ options });
-    await txWorker.start();
+    const txWorker = await loadAndStartTxWorker({ options });
     onDeath(async () => {
       await txWorker.stop();
       process.exit(1);

--- a/packages/cardano-services/src/startWorker.ts
+++ b/packages/cardano-services/src/startWorker.ts
@@ -8,7 +8,7 @@ import {
   PARALLEL_TXS_DEFAULT,
   POLLING_CYCLE_DEFAULT,
   RABBITMQ_URL_DEFAULT,
-  loadTxWorker
+  loadAndStartTxWorker
 } from './TxWorker';
 import { SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT, SERVICE_DISCOVERY_TIMEOUT_DEFAULT } from './Program';
 import { URL } from 'url';
@@ -36,7 +36,7 @@ void (async () => {
   const env = envalid.cleanEnv(process.env, envSpecs);
 
   try {
-    const worker = await loadTxWorker({
+    const worker = await loadAndStartTxWorker({
       options: {
         cacheTtl: env.CACHE_TTL,
         loggerMinSeverity: env.LOGGER_MIN_SEVERITY as LogLevel,
@@ -51,7 +51,6 @@ void (async () => {
         serviceDiscoveryTimeout: env.SERVICE_DISCOVERY_TIMEOUT
       }
     });
-    await worker.start();
     onDeath(async () => {
       await worker.stop();
       // eslint-disable-next-line unicorn/no-process-exit

--- a/packages/cardano-services/test/Program/utils.test.ts
+++ b/packages/cardano-services/test/Program/utils.test.ts
@@ -496,17 +496,20 @@ describe('Service dependency abstractions', () => {
       await listenPromise(mockServer, connection);
       await ogmiosServerReady(connection);
 
-      txSubmitWorker = await loadAndStartTxWorker({
-        options: {
-          cacheTtl: 10_000,
-          loggerMinSeverity: 'error',
-          ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
-          parallel: true,
-          rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
-          serviceDiscoveryBackoffFactor: 1.1,
-          serviceDiscoveryTimeout: 1000
-        }
-      });
+      txSubmitWorker = await loadAndStartTxWorker(
+        {
+          options: {
+            cacheTtl: 10_000,
+            loggerMinSeverity: 'error',
+            ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
+            parallel: true,
+            rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
+            serviceDiscoveryBackoffFactor: 1.1,
+            serviceDiscoveryTimeout: 1000
+          }
+        },
+        dummyLogger
+      );
     });
 
     afterEach(async () => {

--- a/packages/cardano-services/test/TxWorker/utils.test.ts
+++ b/packages/cardano-services/test/TxWorker/utils.test.ts
@@ -1,0 +1,177 @@
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { Connection } from '@cardano-ogmios/client';
+import { Ogmios } from '@cardano-sdk/ogmios';
+import { RABBITMQ_URL_DEFAULT, createDnsResolver, getOgmiosTxSubmitProvider } from '../../src';
+import {
+  RunningTxSubmitWorker,
+  getRunningTxSubmitWorker,
+  startTxSubmitWorkerWithDiscovery
+} from '../../src/TxWorker/utils';
+import { SrvRecord } from 'dns';
+import { TxSubmitProvider } from '@cardano-sdk/core';
+import { createLogger } from 'bunyan';
+import { createMockOgmiosServer } from '../../../ogmios/test/mocks/mockOgmiosServer';
+import { listenPromise, serverClosePromise } from '../../src/util';
+import { ogmiosServerReady } from '../util';
+import http from 'http';
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+jest.mock('dns', () => ({
+  promises: {
+    resolveSrv: async (serviceName: string): Promise<SrvRecord[]> => {
+      if (serviceName === process.env.OGMIOS_SRV_SERVICE_NAME)
+        return [{ name: 'localhost', port: 1337, priority: 6, weight: 5 }];
+      if (serviceName === process.env.RABBITMQ_SRV_SERVICE_NAME)
+        return [{ name: 'localhost', port: 5672, priority: 6, weight: 5 }];
+      return [];
+    }
+  }
+}));
+
+describe('TxSubmitWorker abstraction', () => {
+  describe('getRunningTxSubmitWorker', () => {
+    let mockServer: http.Server;
+    let connection: Connection;
+    let txSubmitWorker: RunningTxSubmitWorker;
+    let txSubmitProvider: TxSubmitProvider;
+    const ogmiosPortDefault = 1337;
+    const rabbitmqPortDefault = 5672;
+    const logger = createLogger({ level: 'error', name: 'test' });
+    const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
+    const srvRecord = { name: 'localhost', port: rabbitmqPortDefault, priority: 1, weight: 1 };
+
+    beforeEach(async () => {
+      connection = Ogmios.createConnectionObject({ port: ogmiosPortDefault });
+      mockServer = createMockOgmiosServer({
+        healthCheck: { response: { networkSynchronization: 0.999, success: true } }
+      });
+      await listenPromise(mockServer, connection);
+      await ogmiosServerReady(connection);
+    });
+
+    afterEach(async () => {
+      if (mockServer !== undefined) {
+        await serverClosePromise(mockServer);
+      }
+
+      await txSubmitWorker.stop();
+    });
+
+    it('should instantiate a running worker without service discovery', async () => {
+      const dnsResolverMock = jest.fn();
+
+      txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
+        cacheTtl: 10_000,
+        ogmiosUrl: new URL(connection.address.webSocket)
+      });
+
+      txSubmitWorker = await getRunningTxSubmitWorker(dnsResolverMock, txSubmitProvider, logger, {
+        cacheTtl: 10_000,
+        rabbitmqUrl: new URL(RABBITMQ_URL_DEFAULT)
+      });
+
+      await expect(dnsResolverMock).toBeCalledTimes(0);
+      expect(txSubmitWorker.getStatus()).toEqual('connected');
+    });
+
+    it('should instantiate a running worker with service discovery', async () => {
+      const dnsResolverMock = jest.fn().mockResolvedValueOnce(srvRecord);
+      txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
+        cacheTtl: 10_000,
+        ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      txSubmitWorker = await getRunningTxSubmitWorker(dnsResolverMock, txSubmitProvider, logger, {
+        cacheTtl: 10_000,
+        rabbitmqSrvServiceName: process.env.RABBITMQ_SRV_SERVICE_NAME,
+        serviceDiscoveryBackoffFactor: 1.1,
+        serviceDiscoveryTimeout: 1000
+      });
+
+      await expect(dnsResolverMock).toBeCalledTimes(1);
+      expect(txSubmitWorker.getStatus()).toEqual('connected');
+    });
+  });
+
+  describe('startTxSubmitWorkerWithDiscovery', () => {
+    it('returns a started worker, which can then be stopped', async () => {
+      const start = jest.fn().mockResolvedValueOnce(void 0);
+      const stop = jest.fn().mockResolvedValueOnce(void 0);
+      const workerFactory = jest.fn().mockImplementation(async () => ({
+        on(_: string, __: any) {},
+        start,
+        stop
+      }));
+
+      const runnableWorker = await startTxSubmitWorkerWithDiscovery(workerFactory);
+      await runnableWorker.stop();
+
+      expect(start).toBeCalledTimes(1);
+      expect(stop).toBeCalledTimes(1);
+      expect(workerFactory).toBeCalledTimes(1);
+    });
+
+    it('should create and start a new instance of TxSubmitWorker when a broker connection error event is received', async () => {
+      let simulateConnectionError: any = jest.fn();
+      const firstStart = jest.fn().mockResolvedValueOnce(void 0);
+      const secondStart = jest.fn().mockResolvedValueOnce(void 0);
+      const workerFactory = jest
+        .fn()
+        .mockImplementationOnce(async () => ({
+          on(_: string, listener: any) {
+            simulateConnectionError = listener;
+          },
+          start: firstStart
+        }))
+        .mockImplementationOnce(async () => ({
+          on(__: string, ___: any) {},
+          start: secondStart
+        }));
+
+      await startTxSubmitWorkerWithDiscovery(workerFactory);
+
+      expect(firstStart).toBeCalledTimes(1);
+      expect(workerFactory).toBeCalledTimes(1);
+
+      simulateConnectionError();
+      await flushPromises();
+
+      expect(secondStart).toBeCalledTimes(1);
+      expect(workerFactory).toBeCalledTimes(2);
+    });
+  });
+
+  it('should stop the correct worker instance when a broker connection error event is received', async () => {
+    let simulateConnectionError: any = jest.fn();
+    const stopSecondWorker = jest.fn().mockResolvedValueOnce(void 0);
+    const workerFactory = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        on(_: string, listener: any) {
+          simulateConnectionError = listener;
+        },
+        start: jest.fn().mockResolvedValueOnce(void 0)
+      }))
+      .mockImplementationOnce(async () => ({
+        on(__: string, ___: any) {},
+        start: jest.fn().mockResolvedValueOnce(void 0),
+        stop: stopSecondWorker
+      }));
+
+    const runningTxSubmitWorker = await startTxSubmitWorkerWithDiscovery(workerFactory);
+
+    simulateConnectionError();
+    await flushPromises();
+
+    expect(stopSecondWorker).toBeCalledTimes(0);
+
+    await runningTxSubmitWorker.stop();
+    expect(stopSecondWorker).toBeCalledTimes(1);
+    expect(workerFactory).toBeCalledTimes(2);
+  });
+});

--- a/packages/rabbitmq/src/utils.ts
+++ b/packages/rabbitmq/src/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cardano } from '@cardano-sdk/core';
 import { OutsideOfValidityInterval } from '@cardano-ogmios/schema';
 import { toSerializableObject } from '@cardano-sdk/util';
@@ -60,3 +61,7 @@ export const waitForPending = async (channel: unknown) => {
     // If something is wrong in the workaround as well... let's simply go on and close the channel
   }
 };
+
+export const CONNECTION_ERROR_EVENT = 'connection-error';
+
+export const isConnectionError = (error: any) => ['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET'].includes(error.code);

--- a/packages/rabbitmq/src/utils.ts
+++ b/packages/rabbitmq/src/utils.ts
@@ -63,5 +63,3 @@ export const waitForPending = async (channel: unknown) => {
 };
 
 export const CONNECTION_ERROR_EVENT = 'connection-error';
-
-export const isConnectionError = (error: any) => ['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET'].includes(error.code);


### PR DESCRIPTION
# Context
Since dependency port resolution using DNS SRV records for the HTTP server is in place, we need also to wrap [TxSubmitWorker](https://github.com/input-output-hk/cardano-js-sdk/blob/8fd7c5267f8250848f954350f58bfef3735aea12/packages/cardano-services/src/TxWorker/loadTxWorker.ts#L26) within abstraction which to perform DNS resolution with retry logic if a connection error occurs between the `worker` and `rabbitmq` broker.

# Proposed Solution
- `TxSubmitWorker` class extends `EventEmitter` to be able to raise events, in our case connection-related.
- Implement `getRunningTxSubmitWorker` abstraction which determines how to instantiate TxSubmitWorker based on the provided args ( with or without service discovery )
- Implement `startTxSubmitWorkerWithDiscovery` which manages worker instances and handles connection-related errors through a listener, returns a `RunningTxSubmitWorker`, with an argument `workerFactory:WorkerFactory`
- Implement `createWorkerFactoryWithDiscovery` - creates a factory that produces `TxSubmitWorker` with service discovery

This approach gives us flexibility and control over the testing and worker factory mock.
