### PR TITLE
Make all providers extend Provider, and fix HTTP service dependency types

### DIFF
--- a/packages/blockfrost/src/blockfrostAssetProvider.ts
+++ b/packages/blockfrost/src/blockfrostAssetProvider.ts
@@ -3,7 +3,7 @@ import { Asset, AssetProvider, Cardano, ProviderUtil } from '@cardano-sdk/core';
 import { replaceNullsWithUndefineds } from '@cardano-sdk/util';
 
 import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
-import { blockfrostMetadataToTxMetadata, fetchSequentially, toProviderError } from './util';
+import { blockfrostMetadataToTxMetadata, fetchSequentially, healthCheck, toProviderError } from './util';
 import omit from 'lodash/omit';
 
 const mapMetadata = (
@@ -106,7 +106,8 @@ export const blockfrostAssetProvider = (blockfrost: BlockFrostAPI): AssetProvide
   };
 
   const providerFunctions: AssetProvider = {
-    getAsset
+    getAsset,
+    healthCheck: healthCheck.bind(undefined, blockfrost)
   };
 
   return ProviderUtil.withProviderErrors(providerFunctions, toProviderError);

--- a/packages/blockfrost/src/blockfrostChainHistoryProvider.ts
+++ b/packages/blockfrost/src/blockfrostChainHistoryProvider.ts
@@ -7,7 +7,7 @@ import {
   ProviderError,
   ProviderFailure
 } from '@cardano-sdk/core';
-import { blockfrostMetadataToTxMetadata, fetchByAddressSequentially, formatBlockfrostError } from './util';
+import { blockfrostMetadataToTxMetadata, fetchByAddressSequentially, formatBlockfrostError, healthCheck } from './util';
 import { dummyLogger } from 'ts-log';
 import omit from 'lodash/omit';
 import orderBy from 'lodash/orderBy';
@@ -25,15 +25,6 @@ export const blockfrostChainHistoryProvider = (
   blockfrost: BlockFrostAPI,
   logger = dummyLogger
 ): ChainHistoryProvider => {
-  const healthCheck: ChainHistoryProvider['healthCheck'] = async () => {
-    try {
-      const result = await blockfrost.health();
-      return { ok: result.is_healthy };
-    } catch (error) {
-      throw new ProviderError(ProviderFailure.Unknown, error);
-    }
-  };
-
   const fetchRedeemers = async ({
     redeemer_count,
     hash
@@ -301,7 +292,7 @@ export const blockfrostChainHistoryProvider = (
 
   return {
     blocksByHashes,
-    healthCheck,
+    healthCheck: healthCheck.bind(undefined, blockfrost),
     transactionsByAddresses,
     transactionsByHashes
   };

--- a/packages/blockfrost/src/blockfrostNetworkInfoProvider.ts
+++ b/packages/blockfrost/src/blockfrostNetworkInfoProvider.ts
@@ -1,7 +1,7 @@
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
 import { BlockfrostToCore } from './BlockfrostToCore';
 import { NetworkInfoProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
-import { networkMagicToIdMap, timeSettings } from './util';
+import { healthCheck, networkMagicToIdMap, timeSettings } from './util';
 
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
@@ -61,5 +61,13 @@ export const blockfrostNetworkInfoProvider = (blockfrost: BlockFrostAPI): Networ
     };
   };
 
-  return { currentWalletProtocolParameters, genesisParameters, ledgerTip, lovelaceSupply, stake, timeSettings };
+  return {
+    currentWalletProtocolParameters,
+    genesisParameters,
+    healthCheck: healthCheck.bind(undefined, blockfrost),
+    ledgerTip,
+    lovelaceSupply,
+    stake,
+    timeSettings
+  };
 };

--- a/packages/blockfrost/src/blockfrostRewardsProvider.ts
+++ b/packages/blockfrost/src/blockfrostRewardsProvider.ts
@@ -1,6 +1,6 @@
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
-import { Cardano, EpochRange, EpochRewards, ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
-import { formatBlockfrostError } from './util';
+import { Cardano, EpochRange, EpochRewards, RewardsProvider } from '@cardano-sdk/core';
+import { formatBlockfrostError, healthCheck } from './util';
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
  *
@@ -9,15 +9,6 @@ import { formatBlockfrostError } from './util';
  * @throws {Cardano.TxSubmissionErrors.UnknownTxSubmissionError}
  */
 export const blockfrostRewardsProvider = (blockfrost: BlockFrostAPI): RewardsProvider => {
-  const healthCheck: RewardsProvider['healthCheck'] = async () => {
-    try {
-      const result = await blockfrost.health();
-      return { ok: result.is_healthy };
-    } catch (error) {
-      throw new ProviderError(ProviderFailure.Unknown, error);
-    }
-  };
-
   const rewardAccountBalance: RewardsProvider['rewardAccountBalance'] = async (
     rewardAccount: Cardano.RewardAccount
   ) => {
@@ -60,7 +51,7 @@ export const blockfrostRewardsProvider = (blockfrost: BlockFrostAPI): RewardsPro
   };
 
   return {
-    healthCheck,
+    healthCheck: healthCheck.bind(undefined, blockfrost),
     rewardAccountBalance,
     rewardsHistory
   };

--- a/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
+++ b/packages/blockfrost/src/blockfrostTxSubmitProvider.ts
@@ -1,5 +1,6 @@
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
-import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { Cardano, TxSubmitProvider } from '@cardano-sdk/core';
+import { healthCheck } from './util';
 
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
@@ -9,15 +10,6 @@ import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@card
  * @throws {Cardano.TxSubmissionErrors.UnknownTxSubmissionError}
  */
 export const blockfrostTxSubmitProvider = (blockfrost: BlockFrostAPI): TxSubmitProvider => {
-  const healthCheck: TxSubmitProvider['healthCheck'] = async () => {
-    try {
-      const result = await blockfrost.health();
-      return { ok: result.is_healthy };
-    } catch (error) {
-      throw new ProviderError(ProviderFailure.Unknown, error);
-    }
-  };
-
   const submitTx: TxSubmitProvider['submitTx'] = async (signedTransaction) => {
     try {
       await blockfrost.txSubmit(signedTransaction);
@@ -27,7 +19,7 @@ export const blockfrostTxSubmitProvider = (blockfrost: BlockFrostAPI): TxSubmitP
   };
 
   return {
-    healthCheck,
+    healthCheck: healthCheck.bind(undefined, blockfrost),
     submitTx
   };
 };

--- a/packages/blockfrost/src/blockfrostUtxoProvider.ts
+++ b/packages/blockfrost/src/blockfrostUtxoProvider.ts
@@ -1,25 +1,15 @@
 import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
 import { BlockfrostToCore, BlockfrostUtxo } from './BlockfrostToCore';
-import { Cardano, ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
-import { fetchByAddressSequentially } from './util';
+import { Cardano, UtxoProvider } from '@cardano-sdk/core';
+import { fetchByAddressSequentially, healthCheck } from './util';
 
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
  *
  * @param {BlockFrostAPI} blockfrost BlockFrostAPI instance
  * @returns {UtxoProvider} UtxoProvider
- * @throws {ProviderError}
  */
 export const blockfrostUtxoProvider = (blockfrost: BlockFrostAPI): UtxoProvider => {
-  const healthCheck: UtxoProvider['healthCheck'] = async () => {
-    try {
-      const result = await blockfrost.health();
-      return { ok: result.is_healthy };
-    } catch (error) {
-      throw new ProviderError(ProviderFailure.Unknown, error);
-    }
-  };
-
   const utxoByAddresses: UtxoProvider['utxoByAddresses'] = async (addresses) => {
     const utxoResults = await Promise.all(
       addresses.map(async (address) =>
@@ -35,7 +25,7 @@ export const blockfrostUtxoProvider = (blockfrost: BlockFrostAPI): UtxoProvider 
   };
 
   return {
-    healthCheck,
+    healthCheck: healthCheck.bind(undefined, blockfrost),
     utxoByAddresses
   };
 };

--- a/packages/blockfrost/src/util.ts
+++ b/packages/blockfrost/src/util.ts
@@ -1,9 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { Error as BlockfrostError } from '@blockfrost/blockfrost-js';
+import { BlockFrostAPI, Error as BlockfrostError } from '@blockfrost/blockfrost-js';
 import {
   Cardano,
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  HealthCheckResponse,
   InvalidStringError,
   NetworkInfoProvider,
+  Provider,
   ProviderError,
   ProviderFailure,
   ProviderUtil,
@@ -133,3 +136,19 @@ export const networkMagicToIdMap: { [key in number]: Cardano.NetworkId } = {
 };
 
 export const timeSettings: NetworkInfoProvider['timeSettings'] = async () => testnetTimeSettings;
+
+/**
+ * Check health of the [Blockfrost service](https://docs.blockfrost.io/)
+ *
+ * @param {BlockFrostAPI} blockfrost BlockFrostAPI instance
+ * @returns {HealthCheckResponse} HealthCheckResponse
+ * @throws {ProviderError}
+ */
+export const healthCheck = async (blockfrost: BlockFrostAPI): ReturnType<Provider['healthCheck']> => {
+  try {
+    const result = await blockfrost.health();
+    return { ok: result.is_healthy };
+  } catch (error) {
+    throw new ProviderError(ProviderFailure.Unknown, error);
+  }
+};

--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -2,7 +2,8 @@ import { AssetProvider } from '@cardano-sdk/core';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 
 export const defaultAssetProviderPaths: HttpProviderConfigPaths<AssetProvider> = {
-  getAsset: '/get-asset'
+  getAsset: '/get-asset',
+  healthCheck: '/health'
 };
 
 /**

--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -4,6 +4,7 @@ import { NetworkInfoProvider } from '@cardano-sdk/core';
 export const defaultNetworkInfoProviderPaths: HttpProviderConfigPaths<NetworkInfoProvider> = {
   currentWalletProtocolParameters: '/current-wallet-protocol-parameters',
   genesisParameters: '/genesis-parameters',
+  healthCheck: '/health',
   ledgerTip: '/ledger-tip',
   lovelaceSupply: '/lovelace-supply',
   stake: '/stake',

--- a/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
+++ b/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
@@ -2,6 +2,7 @@ import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { StakePoolProvider } from '@cardano-sdk/core';
 
 export const defaultStakePoolProviderPaths: HttpProviderConfigPaths<StakePoolProvider> = {
+  healthCheck: '/health',
   queryStakePools: '/search',
   stakePoolStats: '/stats'
 };

--- a/packages/cardano-services/src/ChainHistory/ChainHistoryHttpService.ts
+++ b/packages/cardano-services/src/ChainHistory/ChainHistoryHttpService.ts
@@ -1,5 +1,5 @@
 import * as OpenApiValidator from 'express-openapi-validator';
-import { DbSyncChainHistoryProvider } from './DbSyncChainHistory/DbSyncChainHistoryProvider';
+import { ChainHistoryProvider } from '@cardano-sdk/core';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
 import { ServiceNames } from '../Program';
@@ -9,7 +9,7 @@ import path from 'path';
 
 export interface ChainHistoryHttpServiceDependencies {
   logger?: Logger;
-  chainHistoryProvider: DbSyncChainHistoryProvider;
+  chainHistoryProvider: ChainHistoryProvider;
 }
 
 export class ChainHistoryHttpService extends HttpService {

--- a/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
+++ b/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
@@ -1,7 +1,7 @@
 import * as OpenApiValidator from 'express-openapi-validator';
-import { DbSyncNetworkInfoProvider } from './DbSyncNetworkInfoProvider';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
+import { NetworkInfoProvider } from '@cardano-sdk/core';
 import { ServiceNames } from '../Program';
 import { providerHandler } from '../util';
 import express from 'express';
@@ -9,7 +9,7 @@ import path from 'path';
 
 export interface NetworkInfoServiceDependencies {
   logger?: Logger;
-  networkInfoProvider: DbSyncNetworkInfoProvider;
+  networkInfoProvider: NetworkInfoProvider;
 }
 
 export class NetworkInfoHttpService extends HttpService {

--- a/packages/cardano-services/src/Rewards/RewardsHttpService.ts
+++ b/packages/cardano-services/src/Rewards/RewardsHttpService.ts
@@ -1,7 +1,7 @@
 import * as OpenApiValidator from 'express-openapi-validator';
-import { DbSyncRewardsProvider } from './DbSyncRewardProvider/DbSyncRewards';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
+import { RewardsProvider } from '@cardano-sdk/core';
 import { ServiceNames } from '../Program';
 import { providerHandler } from '../util';
 import express from 'express';
@@ -9,7 +9,7 @@ import path from 'path';
 
 export interface RewardServiceDependencies {
   logger?: Logger;
-  rewardsProvider: DbSyncRewardsProvider;
+  rewardsProvider: RewardsProvider;
 }
 
 export class RewardsHttpService extends HttpService {

--- a/packages/cardano-services/src/StakePool/StakePoolHttpService.ts
+++ b/packages/cardano-services/src/StakePool/StakePoolHttpService.ts
@@ -1,15 +1,15 @@
 import * as OpenApiValidator from 'express-openapi-validator';
-import { DbSyncStakePoolProvider } from './DbSyncStakePoolProvider';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
 import { ServiceNames } from '../Program';
+import { StakePoolProvider } from '@cardano-sdk/core';
 import { providerHandler } from '../util';
 import express from 'express';
 import path from 'path';
 
 export interface StakePoolServiceDependencies {
   logger?: Logger;
-  stakePoolProvider: DbSyncStakePoolProvider;
+  stakePoolProvider: StakePoolProvider;
 }
 
 export class StakePoolHttpService extends HttpService {

--- a/packages/cardano-services/src/Utxo/UtxoHttpService.ts
+++ b/packages/cardano-services/src/Utxo/UtxoHttpService.ts
@@ -1,15 +1,15 @@
 import * as OpenApiValidator from 'express-openapi-validator';
-import { DbSyncUtxoProvider } from './DbSyncUtxoProvider';
 import { HttpService } from '../Http';
 import { Logger, dummyLogger } from 'ts-log';
 import { ServiceNames } from '../Program';
+import { UtxoProvider } from '@cardano-sdk/core';
 import { providerHandler } from '../util';
 import express from 'express';
 import path from 'path';
 
 export interface UtxoServiceDependencies {
   logger?: Logger;
-  utxoProvider: DbSyncUtxoProvider;
+  utxoProvider: UtxoProvider;
 }
 
 export class UtxoHttpService extends HttpService {

--- a/packages/core/src/Provider/AssetProvider/types.ts
+++ b/packages/core/src/Provider/AssetProvider/types.ts
@@ -1,4 +1,4 @@
-import { Asset, Cardano } from '../..';
+import { Asset, Cardano, Provider } from '../..';
 
 interface AssetExtraData {
   nftMetadata?: boolean;
@@ -6,7 +6,7 @@ interface AssetExtraData {
   history?: boolean;
 }
 
-export interface AssetProvider {
+export interface AssetProvider extends Provider {
   /**
    * @param id asset ID (concatenated hex values of policyId + assetName)
    * @throws ProviderError

--- a/packages/core/src/Provider/NetworkInfoProvider/types.ts
+++ b/packages/core/src/Provider/NetworkInfoProvider/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, TimeSettings } from '../..';
+import { Cardano, Provider, TimeSettings } from '../..';
 
 export type ProtocolParametersRequiredByWallet = Required<
   Pick<
@@ -26,7 +26,7 @@ export type StakeSummary = {
   live: Cardano.Lovelace;
 };
 
-export interface NetworkInfoProvider {
+export interface NetworkInfoProvider extends Provider {
   ledgerTip(): Promise<Cardano.Tip>;
   currentWalletProtocolParameters(): Promise<ProtocolParametersRequiredByWallet>;
   genesisParameters(): Promise<Cardano.CompactGenesis>;

--- a/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
+++ b/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
@@ -1,4 +1,4 @@
-import { Cardano } from '../../..';
+import { Cardano, Provider } from '../../..';
 import { SortFields } from '../util';
 
 type FilterCondition = 'and' | 'or';
@@ -65,7 +65,7 @@ export interface StakePoolStats {
   };
 }
 
-export interface StakePoolProvider {
+export interface StakePoolProvider extends Provider {
   /**
    * @param {StakePoolQueryOptions} options query options
    * @returns Stake pools

--- a/packages/e2e/src/FaucetProvider/providers/cardanoWalletFaucetProvider.ts
+++ b/packages/e2e/src/FaucetProvider/providers/cardanoWalletFaucetProvider.ts
@@ -9,7 +9,7 @@ import { FaucetProvider, FaucetRequestResult, FaucetRequestTransactionStatus } f
 import { HealthCheckResponse } from '@cardano-sdk/core';
 import { Stopwatch } from 'ts-stopwatch';
 
-// Constnats
+// Constants
 const FAUCET_PASSPHRASE = 'passphrase';
 const FAUCET_WALLET_NAME = 'faucet';
 const HTTP_ERROR_CODE_IN_CONFLICT = 409;

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -92,6 +92,9 @@ class NullAssetProvider implements AssetProvider {
       } as Asset.AssetInfo)
     );
   }
+  healthCheck() {
+    return Promise.resolve({ ok: true });
+  }
 }
 
 assetProviderFactory.register(

--- a/packages/util-dev/src/createStubStakePoolProvider.ts
+++ b/packages/util-dev/src/createStubStakePoolProvider.ts
@@ -42,6 +42,10 @@ export const createStubStakePoolProvider = (
   stakePools: Cardano.StakePool[] = somePartialStakePools,
   delayMs?: number
 ): StakePoolProvider => ({
+  healthCheck: async () => {
+    if (delayMs) await delay(delayMs);
+    return { ok: true };
+  },
   queryStakePools: async (options) => {
     if (delayMs) await delay(delayMs);
     const identifierFilters = options?.filters?.identifier;

--- a/packages/wallet/src/services/ProviderTracker/TrackedNetworkInfoProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedNetworkInfoProvider.ts
@@ -3,6 +3,7 @@ import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTrac
 import { NetworkInfoProvider } from '@cardano-sdk/core';
 
 export class NetworkInfoProviderStats {
+  readonly healthCheck$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly stake$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly lovelaceSupply$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly timeSettings$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
@@ -11,6 +12,7 @@ export class NetworkInfoProviderStats {
   readonly ledgerTip$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
 
   shutdown() {
+    this.healthCheck$.complete();
     this.stake$.complete();
     this.lovelaceSupply$.complete();
     this.timeSettings$.complete();
@@ -20,6 +22,7 @@ export class NetworkInfoProviderStats {
   }
 
   reset() {
+    this.healthCheck$.next(CLEAN_FN_STATS);
     this.stake$.next(CLEAN_FN_STATS);
     this.lovelaceSupply$.next(CLEAN_FN_STATS);
     this.timeSettings$.next(CLEAN_FN_STATS);
@@ -34,6 +37,7 @@ export class NetworkInfoProviderStats {
  */
 export class TrackedNetworkInfoProvider extends ProviderTracker implements NetworkInfoProvider {
   readonly stats = new NetworkInfoProviderStats();
+  readonly healthCheck: NetworkInfoProvider['healthCheck'];
   readonly stake: NetworkInfoProvider['stake'];
   readonly lovelaceSupply: NetworkInfoProvider['lovelaceSupply'];
   readonly timeSettings: NetworkInfoProvider['timeSettings'];
@@ -45,6 +49,7 @@ export class TrackedNetworkInfoProvider extends ProviderTracker implements Netwo
     super();
     networkInfoProvider = networkInfoProvider;
 
+    this.healthCheck = () => this.trackedCall(() => networkInfoProvider.healthCheck(), this.stats.healthCheck$);
     this.stake = () => this.trackedCall(networkInfoProvider.stake, this.stats.stake$);
     this.lovelaceSupply = () => this.trackedCall(networkInfoProvider.lovelaceSupply, this.stats.lovelaceSupply$);
     this.timeSettings = () => this.trackedCall(networkInfoProvider.timeSettings, this.stats.timeSettings$);

--- a/packages/wallet/src/services/ProviderTracker/TrackedStakePoolProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedStakePoolProvider.ts
@@ -3,15 +3,18 @@ import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTrac
 import { StakePoolProvider } from '@cardano-sdk/core';
 
 export class StakePoolProviderStats {
+  readonly healthCheck$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly queryStakePools$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly stakePoolStats$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
 
   shutdown() {
+    this.healthCheck$.complete();
     this.queryStakePools$.complete();
     this.stakePoolStats$.complete();
   }
 
   reset() {
+    this.healthCheck$.next(CLEAN_FN_STATS);
     this.queryStakePools$.next(CLEAN_FN_STATS);
     this.stakePoolStats$.next(CLEAN_FN_STATS);
   }
@@ -22,12 +25,15 @@ export class StakePoolProviderStats {
  */
 export class TrackedStakePoolProvider extends ProviderTracker implements StakePoolProvider {
   readonly stats = new StakePoolProviderStats();
+  readonly healthCheck: StakePoolProvider['healthCheck'];
   readonly queryStakePools: StakePoolProvider['queryStakePools'];
   readonly stakePoolStats: StakePoolProvider['stakePoolStats'];
 
   constructor(queryStakePoolsProvider: StakePoolProvider) {
     super();
     queryStakePoolsProvider = queryStakePoolsProvider;
+
+    this.healthCheck = () => this.trackedCall(() => queryStakePoolsProvider.healthCheck(), this.stats.healthCheck$);
 
     this.queryStakePools = (fragments) =>
       this.trackedCall(() => queryStakePoolsProvider.queryStakePools(fragments), this.stats.queryStakePools$);

--- a/packages/wallet/test/mocks/mockAssetProvider.ts
+++ b/packages/wallet/test/mocks/mockAssetProvider.ts
@@ -15,7 +15,8 @@ export const asset = {
 } as Asset.AssetInfo;
 
 export const mockAssetProvider = () => ({
-  getAsset: jest.fn().mockResolvedValue(asset)
+  getAsset: jest.fn().mockResolvedValue(asset),
+  healthCheck: jest.fn().mockResolvedValue({ ok: true })
 });
 
 export type MockAssetProvider = ReturnType<typeof mockAssetProvider>;

--- a/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
+++ b/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
@@ -23,9 +23,9 @@ export const networkInfo = {
 export const mockNetworkInfoProvider = () => ({
   currentWalletProtocolParameters: jest.fn().mockResolvedValue(protocolParameters),
   genesisParameters: jest.fn().mockResolvedValue(genesisParameters),
+  healthCheck: jest.fn().mockResolvedValue({ ok: true }),
   ledgerTip: jest.fn().mockResolvedValue(ledgerTip),
   lovelaceSupply: jest.fn().mockResolvedValue(networkInfo.lovelaceSupply),
-  networkInfo: jest.fn().mockResolvedValue(networkInfo),
   stake: jest.fn().mockResolvedValue(networkInfo.stake),
   timeSettings: jest.fn().mockResolvedValue(networkInfo.network.timeSettings)
 });

--- a/packages/wallet/test/mocks/mockNetworkInfoProvider2.ts
+++ b/packages/wallet/test/mocks/mockNetworkInfoProvider2.ts
@@ -30,9 +30,9 @@ export const mockNetworkInfoProvider2 = (delayMs: number) => {
   return {
     currentWalletProtocolParameters: delayedJestFn(protocolParameters2),
     genesisParameters: delayedJestFn(genesisParameters2),
+    healthCheck: delayedJestFn({ ok: true }),
     ledgerTip: delayedJestFn(ledgerTip2),
     lovelaceSupply: jest.fn().mockResolvedValue(networkInfo.lovelaceSupply),
-    networkInfo: jest.fn().mockResolvedValue(networkInfo),
     stake: jest.fn().mockResolvedValue(networkInfo.stake),
     timeSettings: jest.fn().mockResolvedValue(networkInfo.network.timeSettings)
   };

--- a/packages/wallet/test/services/ProviderTracker/TrackedAssetProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedAssetProvider.test.ts
@@ -53,5 +53,14 @@ describe('TrackedAssetProvider', () => {
         () => expect(assetProvider.getAsset).toBeCalledWith(assetId, extraData)
       )
     );
+
+    test(
+      'healthCheck',
+      testFunctionStats(
+        (provider) => provider.healthCheck(),
+        (stats) => stats.healthCheck$,
+        () => expect(assetProvider.healthCheck).toBeCalled()
+      )
+    );
   });
 });

--- a/packages/wallet/test/services/ProviderTracker/TrackedChainHistoryProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedChainHistoryProvider.test.ts
@@ -66,6 +66,15 @@ describe('TrackedChainHistoryProvider', () => {
     );
 
     test(
+      'healthCheck',
+      testFunctionStats(
+        (provider) => provider.healthCheck(),
+        (stats) => stats.healthCheck$,
+        (mock) => mock.healthCheck
+      )
+    );
+
+    test(
       'transactionsByAddresses',
       testFunctionStats(
         (provider) => provider.transactionsByAddresses({ addresses: [] }),

--- a/packages/wallet/test/services/ProviderTracker/TrackedNetworkInfoProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedNetworkInfoProvider.test.ts
@@ -46,6 +46,14 @@ describe('TrackedNetworkInfoProvider', () => {
     );
 
     test(
+      'healthCheck',
+      testFunctionStats(
+        (provider) => provider.healthCheck(),
+        (stats) => stats.healthCheck$
+      )
+    );
+
+    test(
       'lovelaceSupply',
       testFunctionStats(
         (provider) => provider.lovelaceSupply(),

--- a/packages/wallet/test/services/ProviderTracker/TrackedRewardsProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedRewardsProvider.test.ts
@@ -53,6 +53,15 @@ describe('TrackedRewardsProvider', () => {
       };
 
     test(
+      'healthCheck',
+      testFunctionStats(
+        (rp) => rp.healthCheck(),
+        (stats) => stats.healthCheck$,
+        (mockRP) => mockRP.healthCheck
+      )
+    );
+
+    test(
       'rewards',
       testFunctionStats(
         (rp) => rp.rewardAccountBalance(rewardAccount),

--- a/packages/wallet/test/services/ProviderTracker/TrackedStakePoolProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedStakePoolProvider.test.ts
@@ -38,6 +38,14 @@ describe('TrackedStakePoolProvider', () => {
       };
 
     test(
+      'healthCheck',
+      testFunctionStats(
+        (provider) => provider.healthCheck(),
+        (stats) => stats.healthCheck$
+      )
+    );
+
+    test(
       'queryStakePools',
       testFunctionStats(
         (provider) => provider.queryStakePools({}),

--- a/packages/wallet/test/services/ProviderTracker/TrackedUtxoProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedUtxoProvider.test.ts
@@ -38,6 +38,14 @@ describe('TrackedStakePoolProvider', () => {
       };
 
     test(
+      'healthCheck',
+      testFunctionStats(
+        (provider) => provider.healthCheck(),
+        (stats) => stats.healthCheck$
+      )
+    );
+
+    test(
       'utxoByAddresses',
       testFunctionStats(
         (provider) =>


### PR DESCRIPTION
# Context
Original implementations of some HTTP services were made depending on the concrete `DbSync*Provider` classes, rather than the interface. During review of #321, I noticed not all providers were extending `Provider`, leading to [this](https://github.com/input-output-hk/cardano-js-sdk/pull/321/files#diff-fd5402b8f766e8c72f9cceb402bae11b7c71cd91b904a2ad38954a4cfd869e9cR17)

# Proposed Solution
- Update all provider interfaces to extend `Provider`
- Replace concrete dependencies with equivalent interfaces

# Important Changes Introduced
