### PR TITLE
test(wallet): potentially fix cip36 test race condition

### DIFF
--- a/packages/wallet/test/cip36.test.ts
+++ b/packages/wallet/test/cip36.test.ts
@@ -20,7 +20,7 @@ describe('cip36', () => {
       const getNonce = (metadata: Cardano.TxMetadata) =>
         (metadata.get(61_284n) as Cardano.MetadatumMap).get(4n) as bigint;
       const nonce1 = getNonce(cip36.metadataBuilder.buildVotingRegistration(props));
-      await delay(1);
+      await delay(2);
       const nonce2 = getNonce(cip36.metadataBuilder.buildVotingRegistration(props));
       expect(nonce2).toBeGreaterThan(nonce1);
     });


### PR DESCRIPTION
# Context
We've been seeing the odd test failure that this change may fix. The working theory from @mkazlauskas is that `getNonce` is
being called within the same ms, which produces an identical value, rather than the documented expectation.

# Proposed Solution
Change the delay to `2`. We can debug further if this doesn't resolve it, however, it's a low-impact change worth running with.
