### PR TITLE
fix: malformed string and add missing service to Docker defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ENV \
   POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password \
   POSTGRES_PORT=5432 \
   POSTGRES_USER_FILE=/run/secrets/postgres_user \
-  SERVICE_NAMES="chain-history,network-info,rewards,stake-pool,tx-submit,utxo"
+  SERVICE_NAMES=asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo
 WORKDIR /app/packages/cardano-services
 COPY packages/cardano-services/config/network/${NETWORK} /config/
 EXPOSE 3000

--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - DB_QUERIES_CACHE_TTL=${DB_QUERIES_CACHE_TTL:-120}
       - ENABLE_METRICS=${ENABLE_METRICS:-false}
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
-      - SERVICE_NAMES=${SERVICE_NAMES:-"chain-history,network-info,rewards,stake-pool,tx-submit,utxo"}
+      - SERVICE_NAMES=${SERVICE_NAMES:-asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo}
       - USE_QUEUE=${USE_QUEUE:-false}
     ports:
       - ${API_PORT:-4000}:3000

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       - DB_QUERIES_CACHE_TTL=${DB_QUERIES_CACHE_TTL:-120}
       - ENABLE_METRICS=${ENABLE_METRICS:-false}
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
-      - SERVICE_NAMES=${SERVICE_NAMES:-chain-history,network-info,rewards,stake-pool,tx-submit,utxo}
+      - SERVICE_NAMES=${SERVICE_NAMES:-asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo}
       - USE_QUEUE=${USE_QUEUE:-false}
     ports:
       - ${API_PORT:-4000}:3000


### PR DESCRIPTION
# Context
The Docker files are currently not covered by e2e tests in CI, so there were some bugs with configuration structure that slipped though, and the latest HTTP service, `asset`, was not appended to the default.

# Proposed Solution
- Fix the malformed string
- Add `asset` to the list
