### PR TITLE
ci: add on workflow_dispatch in nightly publish workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,7 @@
-name: Publish (nightly)
+name: nightly
 
 on:
+  workflow_dispatch:
   schedule:
     # Every day 00:00 UTC
     - cron:  '0 0 * * *'


### PR DESCRIPTION
# Context

Need to be able to manually trigger nightly publish workflow