### PR TITLE
Fix/adp 2081 allow patching axios with custom adapter

### DIFF
--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -1,4 +1,5 @@
 import { AssetProvider } from '@cardano-sdk/core';
+import { AxiosAdapter } from 'axios';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 
 export const defaultAssetProviderPaths: HttpProviderConfigPaths<AssetProvider> = {
@@ -10,9 +11,16 @@ export const defaultAssetProviderPaths: HttpProviderConfigPaths<AssetProvider> =
  * Connect to a Cardano Services HttpServer instance with the service available
  *
  * @param {string} baseUrl server root url, w/o trailing /
+ * @param paths A mapping between provider method names and url paths. Paths have to use /leadingSlash
+ * @param adapter This adapter that allows to you to modify the way Axios make requests.
  */
-export const assetInfoHttpProvider = (baseUrl: string, paths = defaultAssetProviderPaths): AssetProvider =>
+export const assetInfoHttpProvider = (
+  baseUrl: string,
+  paths = defaultAssetProviderPaths,
+  adapter?: AxiosAdapter
+): AssetProvider =>
   createHttpProvider<AssetProvider>({
+    adapter,
     baseUrl,
     paths
   });

--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -1,8 +1,10 @@
 import { AssetProvider } from '@cardano-sdk/core';
-import { AxiosAdapter } from 'axios';
-import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 
-export const defaultAssetProviderPaths: HttpProviderConfigPaths<AssetProvider> = {
+/**
+ * The AssetProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<AssetProvider> = {
   getAsset: '/get-asset',
   healthCheck: '/health'
 };
@@ -10,17 +12,10 @@ export const defaultAssetProviderPaths: HttpProviderConfigPaths<AssetProvider> =
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
- * @param {string} baseUrl server root url, w/o trailing /
- * @param paths A mapping between provider method names and url paths. Paths have to use /leadingSlash
- * @param adapter This adapter that allows to you to modify the way Axios make requests.
+ * @param config The configuration object fot the AssetProvider Provider.
  */
-export const assetInfoHttpProvider = (
-  baseUrl: string,
-  paths = defaultAssetProviderPaths,
-  adapter?: AxiosAdapter
-): AssetProvider =>
+export const assetInfoHttpProvider = (config: CreateHttpProviderConfig<AssetProvider>): AssetProvider =>
   createHttpProvider<AssetProvider>({
-    adapter,
-    baseUrl,
+    ...config,
     paths
   });

--- a/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
+++ b/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
@@ -1,8 +1,10 @@
-import { AxiosAdapter } from 'axios';
 import { ChainHistoryProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
-import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 
-export const defaultChainHistoryProviderPaths: HttpProviderConfigPaths<ChainHistoryProvider> = {
+/**
+ * The ChainHistoryProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<ChainHistoryProvider> = {
   blocksByHashes: '/blocks/by-hashes',
   healthCheck: '/health',
   transactionsByAddresses: '/txs/by-addresses',
@@ -12,19 +14,14 @@ export const defaultChainHistoryProviderPaths: HttpProviderConfigPaths<ChainHist
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
- * @param {string} baseUrl server root url, w/o trailing /
- * @param paths A mapping between provider method names and url paths. Paths have to use /leadingSlash
- * @param adapter This adapter that allows to you to modify the way Axios make requests.
+ * @param config The configuration object fot the NetworkInfoProvider Provider.
  * @returns {ChainHistoryProvider} ChainHistoryProvider
  */
 export const chainHistoryHttpProvider = (
-  baseUrl: string,
-  paths = defaultChainHistoryProviderPaths,
-  adapter?: AxiosAdapter
+  config: CreateHttpProviderConfig<ChainHistoryProvider>
 ): ChainHistoryProvider =>
   createHttpProvider<ChainHistoryProvider>({
-    adapter,
-    baseUrl,
+    ...config,
     mapError: (error, method) => {
       if (method === 'healthCheck' && !error) {
         return { ok: false };

--- a/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
+++ b/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
@@ -1,3 +1,4 @@
+import { AxiosAdapter } from 'axios';
 import { ChainHistoryProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 
@@ -12,13 +13,17 @@ export const defaultChainHistoryProviderPaths: HttpProviderConfigPaths<ChainHist
  * Connect to a Cardano Services HttpServer instance with the service available
  *
  * @param {string} baseUrl server root url, w/o trailing /
+ * @param paths A mapping between provider method names and url paths. Paths have to use /leadingSlash
+ * @param adapter This adapter that allows to you to modify the way Axios make requests.
  * @returns {ChainHistoryProvider} ChainHistoryProvider
  */
 export const chainHistoryHttpProvider = (
   baseUrl: string,
-  paths = defaultChainHistoryProviderPaths
+  paths = defaultChainHistoryProviderPaths,
+  adapter?: AxiosAdapter
 ): ChainHistoryProvider =>
   createHttpProvider<ChainHistoryProvider>({
+    adapter,
     baseUrl,
     mapError: (error, method) => {
       if (method === 'healthCheck' && !error) {

--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -1,3 +1,4 @@
+import { AxiosAdapter } from 'axios';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { NetworkInfoProvider } from '@cardano-sdk/core';
 
@@ -15,12 +16,16 @@ export const defaultNetworkInfoProviderPaths: HttpProviderConfigPaths<NetworkInf
  * Connect to a Cardano Services HttpServer instance with the service available
  *
  * @param {string} baseUrl server root url, w/o trailing /
+ * @param paths A mapping between provider method names and url paths. Paths have to use /leadingSlash
+ * @param adapter This adapter that allows to you to modify the way Axios make requests.
  */
 export const networkInfoHttpProvider = (
   baseUrl: string,
-  paths = defaultNetworkInfoProviderPaths
+  paths = defaultNetworkInfoProviderPaths,
+  adapter?: AxiosAdapter
 ): NetworkInfoProvider =>
   createHttpProvider<NetworkInfoProvider>({
+    adapter,
     baseUrl,
     paths
   });

--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -1,8 +1,10 @@
-import { AxiosAdapter } from 'axios';
-import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { NetworkInfoProvider } from '@cardano-sdk/core';
 
-export const defaultNetworkInfoProviderPaths: HttpProviderConfigPaths<NetworkInfoProvider> = {
+/**
+ * The NetworkInfoProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<NetworkInfoProvider> = {
   currentWalletProtocolParameters: '/current-wallet-protocol-parameters',
   genesisParameters: '/genesis-parameters',
   healthCheck: '/health',
@@ -15,17 +17,10 @@ export const defaultNetworkInfoProviderPaths: HttpProviderConfigPaths<NetworkInf
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
- * @param {string} baseUrl server root url, w/o trailing /
- * @param paths A mapping between provider method names and url paths. Paths have to use /leadingSlash
- * @param adapter This adapter that allows to you to modify the way Axios make requests.
+ * @param config The configuration object fot the NetworkInfoProvider Provider.
  */
-export const networkInfoHttpProvider = (
-  baseUrl: string,
-  paths = defaultNetworkInfoProviderPaths,
-  adapter?: AxiosAdapter
-): NetworkInfoProvider =>
+export const networkInfoHttpProvider = (config: CreateHttpProviderConfig<NetworkInfoProvider>): NetworkInfoProvider =>
   createHttpProvider<NetworkInfoProvider>({
-    adapter,
-    baseUrl,
+    ...config,
     paths
   });

--- a/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
+++ b/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
@@ -1,9 +1,11 @@
-import { AxiosAdapter } from 'axios';
-import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
 import { mapHealthCheckError } from '../mapHealthCheckError';
 
-export const defaultRewardProviderPaths: HttpProviderConfigPaths<RewardsProvider> = {
+/**
+ * The RewardsProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<RewardsProvider> = {
   healthCheck: '/health',
   rewardAccountBalance: '/account-balance',
   rewardsHistory: '/history'
@@ -12,18 +14,11 @@ export const defaultRewardProviderPaths: HttpProviderConfigPaths<RewardsProvider
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
- * @param {string} baseUrl server root url, w/o trailing /
- * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
- * @param adapter This adapter that allows to you to modify the way Axios make requests.
+ * @param config The configuration object fot the RewardsProvider Provider.
  */
-export const rewardsHttpProvider = (
-  baseUrl: string,
-  paths = defaultRewardProviderPaths,
-  adapter?: AxiosAdapter
-): RewardsProvider =>
+export const rewardsHttpProvider = (config: CreateHttpProviderConfig<RewardsProvider>): RewardsProvider =>
   createHttpProvider<RewardsProvider>({
-    adapter,
-    baseUrl,
+    ...config,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mapError: (error: any, method) => {
       if (method === 'healthCheck') {

--- a/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
+++ b/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
@@ -1,3 +1,4 @@
+import { AxiosAdapter } from 'axios';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
 import { mapHealthCheckError } from '../mapHealthCheckError';
@@ -12,9 +13,16 @@ export const defaultRewardProviderPaths: HttpProviderConfigPaths<RewardsProvider
  * Connect to a Cardano Services HttpServer instance with the service available
  *
  * @param {string} baseUrl server root url, w/o trailing /
+ * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
+ * @param adapter This adapter that allows to you to modify the way Axios make requests.
  */
-export const rewardsHttpProvider = (baseUrl: string, paths = defaultRewardProviderPaths): RewardsProvider =>
+export const rewardsHttpProvider = (
+  baseUrl: string,
+  paths = defaultRewardProviderPaths,
+  adapter?: AxiosAdapter
+): RewardsProvider =>
   createHttpProvider<RewardsProvider>({
+    adapter,
     baseUrl,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mapError: (error: any, method) => {

--- a/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
+++ b/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
@@ -1,8 +1,10 @@
-import { AxiosAdapter } from 'axios';
-import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { StakePoolProvider } from '@cardano-sdk/core';
 
-export const defaultStakePoolProviderPaths: HttpProviderConfigPaths<StakePoolProvider> = {
+/**
+ * The StakePoolProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<StakePoolProvider> = {
   healthCheck: '/health',
   queryStakePools: '/search',
   stakePoolStats: '/stats'
@@ -11,17 +13,10 @@ export const defaultStakePoolProviderPaths: HttpProviderConfigPaths<StakePoolPro
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
- * @param {string} baseUrl server root url, w/o trailing /
- * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
- * @param adapter This adapter that allows to you to modify the way Axios make requests.
+ * @param config The configuration object fot the StakePool Provider.
  */
-export const stakePoolHttpProvider = (
-  baseUrl: string,
-  paths = defaultStakePoolProviderPaths,
-  adapter?: AxiosAdapter
-): StakePoolProvider =>
+export const stakePoolHttpProvider = (config: CreateHttpProviderConfig<StakePoolProvider>): StakePoolProvider =>
   createHttpProvider<StakePoolProvider>({
-    adapter,
-    baseUrl,
+    ...config,
     paths
   });

--- a/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
+++ b/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
@@ -1,3 +1,4 @@
+import { AxiosAdapter } from 'axios';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { StakePoolProvider } from '@cardano-sdk/core';
 
@@ -11,9 +12,16 @@ export const defaultStakePoolProviderPaths: HttpProviderConfigPaths<StakePoolPro
  * Connect to a Cardano Services HttpServer instance with the service available
  *
  * @param {string} baseUrl server root url, w/o trailing /
+ * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
+ * @param adapter This adapter that allows to you to modify the way Axios make requests.
  */
-export const stakePoolHttpProvider = (baseUrl: string, paths = defaultStakePoolProviderPaths): StakePoolProvider =>
+export const stakePoolHttpProvider = (
+  baseUrl: string,
+  paths = defaultStakePoolProviderPaths,
+  adapter?: AxiosAdapter
+): StakePoolProvider =>
   createHttpProvider<StakePoolProvider>({
+    adapter,
     baseUrl,
     paths
   });

--- a/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AxiosAdapter } from 'axios';
 import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
-import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { mapHealthCheckError } from '../mapHealthCheckError';
 
-export const defaultTxSubmitProviderPaths: HttpProviderConfigPaths<TxSubmitProvider> = {
+/**
+ * The TxSubmitProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<TxSubmitProvider> = {
   healthCheck: '/health',
   submitTx: '/submit'
 };
@@ -26,21 +28,14 @@ const toTxSubmissionError = (error: any): Cardano.TxSubmissionError | null => {
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
- * @param {string} baseUrl server root url, w/o trailing /
- * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
- * @param adapter This adapter that allows to you to modify the way Axios make requests.
+ * @param config The configuration object fot the TxSubmit Provider.
  * @returns {TxSubmitProvider} TxSubmitProvider
  * @throws {ProviderError} if reason === ProviderFailure.BadRequest then
  * innerError is set to either one of Cardano.TxSubmissionErrors or Cardano.UnknownTxSubmissionError
  */
-export const txSubmitHttpProvider = (
-  baseUrl: string,
-  paths = defaultTxSubmitProviderPaths,
-  adapter?: AxiosAdapter
-): TxSubmitProvider =>
+export const txSubmitHttpProvider = (config: CreateHttpProviderConfig<TxSubmitProvider>): TxSubmitProvider =>
   createHttpProvider<TxSubmitProvider>({
-    adapter,
-    baseUrl,
+    ...config,
     mapError: (error: any, method) => {
       switch (method) {
         case 'healthCheck': {

--- a/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { AxiosAdapter } from 'axios';
 import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { mapHealthCheckError } from '../mapHealthCheckError';
@@ -26,12 +27,19 @@ const toTxSubmissionError = (error: any): Cardano.TxSubmissionError | null => {
  * Connect to a Cardano Services HttpServer instance with the service available
  *
  * @param {string} baseUrl server root url, w/o trailing /
+ * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
+ * @param adapter This adapter that allows to you to modify the way Axios make requests.
  * @returns {TxSubmitProvider} TxSubmitProvider
  * @throws {ProviderError} if reason === ProviderFailure.BadRequest then
  * innerError is set to either one of Cardano.TxSubmissionErrors or Cardano.UnknownTxSubmissionError
  */
-export const txSubmitHttpProvider = (baseUrl: string, paths = defaultTxSubmitProviderPaths): TxSubmitProvider =>
+export const txSubmitHttpProvider = (
+  baseUrl: string,
+  paths = defaultTxSubmitProviderPaths,
+  adapter?: AxiosAdapter
+): TxSubmitProvider =>
   createHttpProvider<TxSubmitProvider>({
+    adapter,
     baseUrl,
     mapError: (error: any, method) => {
       switch (method) {

--- a/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
+++ b/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
@@ -1,9 +1,11 @@
-import { AxiosAdapter } from 'axios';
-import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
 import { mapHealthCheckError } from '../mapHealthCheckError';
 
-export const defaultUtxoProviderPaths: HttpProviderConfigPaths<UtxoProvider> = {
+/**
+ * The UtxoProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<UtxoProvider> = {
   healthCheck: '/health',
   utxoByAddresses: '/utxo-by-addresses'
 };
@@ -11,18 +13,11 @@ export const defaultUtxoProviderPaths: HttpProviderConfigPaths<UtxoProvider> = {
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
- * @param {string} baseUrl server root url, w/o trailing /
- * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
- * @param adapter This adapter that allows to you to modify the way Axios make requests.
+ * @param config The configuration object fot the Utxo Provider.
  */
-export const utxoHttpProvider = (
-  baseUrl: string,
-  paths = defaultUtxoProviderPaths,
-  adapter?: AxiosAdapter
-): UtxoProvider =>
+export const utxoHttpProvider = (config: CreateHttpProviderConfig<UtxoProvider>): UtxoProvider =>
   createHttpProvider<UtxoProvider>({
-    adapter,
-    baseUrl,
+    ...config,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mapError: (error: any, method) => {
       if (method === 'healthCheck') {

--- a/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
+++ b/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
@@ -1,3 +1,4 @@
+import { AxiosAdapter } from 'axios';
 import { HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 import { ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
 import { mapHealthCheckError } from '../mapHealthCheckError';
@@ -11,9 +12,16 @@ export const defaultUtxoProviderPaths: HttpProviderConfigPaths<UtxoProvider> = {
  * Connect to a Cardano Services HttpServer instance with the service available
  *
  * @param {string} baseUrl server root url, w/o trailing /
+ * @param paths  A mapping between provider method names and url paths. Paths have to use /leadingSlash
+ * @param adapter This adapter that allows to you to modify the way Axios make requests.
  */
-export const utxoHttpProvider = (baseUrl: string, paths = defaultUtxoProviderPaths): UtxoProvider =>
+export const utxoHttpProvider = (
+  baseUrl: string,
+  paths = defaultUtxoProviderPaths,
+  adapter?: AxiosAdapter
+): UtxoProvider =>
   createHttpProvider<UtxoProvider>({
+    adapter,
     baseUrl,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mapError: (error: any, method) => {

--- a/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
@@ -1,9 +1,14 @@
 import { Cardano } from '@cardano-sdk/core';
+import { INFO, createLogger } from 'bunyan';
 import { assetInfoHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
+
 import axios from 'axios';
 
-const url = 'http://some-hostname:3000/asset';
+const config = {
+  baseUrl: 'http://some-hostname:3000/asset',
+  logger: createLogger({ level: INFO, name: 'unit tests' })
+};
 
 describe('assetInfoHttpProvider', () => {
   let axiosMock: MockAdapter;
@@ -23,7 +28,7 @@ describe('assetInfoHttpProvider', () => {
   describe('getAsset', () => {
     test("getAsset doesn't throw", async () => {
       axiosMock.onPost().replyOnce(200, {});
-      const provider = assetInfoHttpProvider(url);
+      const provider = assetInfoHttpProvider(config);
       await expect(
         provider.getAsset(Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958'))
       ).resolves.toEqual({});

--- a/packages/cardano-services-client/test/ChainHistoryProvider/chainHistoryProvider.test.ts
+++ b/packages/cardano-services-client/test/ChainHistoryProvider/chainHistoryProvider.test.ts
@@ -1,16 +1,20 @@
 /* eslint-disable sonarjs/no-duplicate-string */
+import { INFO, createLogger } from 'bunyan';
 import { ProviderFailure } from '@cardano-sdk/core';
 import { axiosError } from '../util';
 import { chainHistoryHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const url = 'http://some-hostname:3000/history';
+const config = {
+  baseUrl: 'http://some-hostname:3000/history',
+  logger: createLogger({ level: INFO, name: 'unit tests' })
+};
 
 describe('chainHistoryProvider', () => {
   describe('healthCheck', () => {
     it('is not ok if cannot connect', async () => {
-      const provider = chainHistoryHttpProvider(url);
+      const provider = chainHistoryHttpProvider(config);
       await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
     });
   });
@@ -30,13 +34,13 @@ describe('chainHistoryProvider', () => {
     describe('healthCheck', () => {
       it('is ok if 200 response body is { ok: true }', async () => {
         axiosMock.onPost().replyOnce(200, { ok: true });
-        const provider = chainHistoryHttpProvider(url);
+        const provider = chainHistoryHttpProvider(config);
         await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
       });
 
       it('is not ok if 200 response body is { ok: false }', async () => {
         axiosMock.onPost().replyOnce(200, { ok: false });
-        const provider = chainHistoryHttpProvider(url);
+        const provider = chainHistoryHttpProvider(config);
         await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
       });
     });
@@ -44,7 +48,7 @@ describe('chainHistoryProvider', () => {
     describe('blocks', () => {
       it('resolves if successful', async () => {
         axiosMock.onPost().replyOnce(200, []);
-        const provider = chainHistoryHttpProvider(url);
+        const provider = chainHistoryHttpProvider(config);
         await expect(provider.blocksByHashes([])).resolves.not.toThrow();
       });
 
@@ -53,7 +57,7 @@ describe('chainHistoryProvider', () => {
           axiosMock.onPost().replyOnce(() => {
             throw axiosError();
           });
-          const provider = chainHistoryHttpProvider(url);
+          const provider = chainHistoryHttpProvider(config);
           await expect(provider.blocksByHashes([])).rejects.toThrow(ProviderFailure.Unknown);
         });
       });
@@ -62,7 +66,7 @@ describe('chainHistoryProvider', () => {
     describe('transactionsByHashes', () => {
       it('resolves if successful', async () => {
         axiosMock.onPost().replyOnce(200, []);
-        const provider = chainHistoryHttpProvider(url);
+        const provider = chainHistoryHttpProvider(config);
         await expect(provider.transactionsByHashes([])).resolves.not.toThrow();
       });
 
@@ -71,7 +75,7 @@ describe('chainHistoryProvider', () => {
           axiosMock.onPost().replyOnce(() => {
             throw axiosError();
           });
-          const provider = chainHistoryHttpProvider(url);
+          const provider = chainHistoryHttpProvider(config);
           await expect(provider.transactionsByHashes([])).rejects.toThrow(ProviderFailure.Unknown);
         });
       });
@@ -80,7 +84,7 @@ describe('chainHistoryProvider', () => {
     describe('transactionsByAddresses', () => {
       it('resolves if successful', async () => {
         axiosMock.onPost().replyOnce(200, []);
-        const provider = chainHistoryHttpProvider(url);
+        const provider = chainHistoryHttpProvider(config);
         await expect(provider.transactionsByAddresses({ addresses: [] })).resolves.not.toThrow();
       });
 
@@ -89,7 +93,7 @@ describe('chainHistoryProvider', () => {
           axiosMock.onPost().replyOnce(() => {
             throw axiosError();
           });
-          const provider = chainHistoryHttpProvider(url);
+          const provider = chainHistoryHttpProvider(config);
           await expect(provider.transactionsByAddresses({ addresses: [] })).rejects.toThrow(ProviderFailure.Unknown);
         });
       });

--- a/packages/cardano-services-client/test/HttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HttpProvider.test.ts
@@ -5,6 +5,8 @@ import { HttpProviderConfig, createHttpProvider } from '../src';
 import { ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
 
+import { INFO, createLogger } from 'bunyan';
+import { Logger } from 'ts-log';
 import { Server } from 'http';
 import { getPort } from 'get-port-please';
 import express, { RequestHandler } from 'express';
@@ -34,12 +36,14 @@ const stubProviderPaths = {
 describe('createHttpServer', () => {
   let port: number;
   let baseUrl: string;
+  const logger: Logger = createLogger({ level: INFO, name: 'unit tests' });
 
   const createTxSubmitProviderClient = (
     config: Pick<HttpProviderConfig<TestProvider>, 'axiosOptions' | 'mapError'> = {}
   ) =>
     createHttpProvider<TestProvider>({
       baseUrl,
+      logger,
       paths: stubProviderPaths,
       ...config
     });

--- a/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
@@ -1,9 +1,13 @@
 /* eslint-disable max-len */
+import { INFO, createLogger } from 'bunyan';
 import { networkInfoHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const url = 'http://hostname:3000/network';
+const config = {
+  baseUrl: 'http://some-hostname:3000/network',
+  logger: createLogger({ level: INFO, name: 'unit tests' })
+};
 
 describe('networkInfoHttpProvider', () => {
   let axiosMock: MockAdapter;
@@ -21,37 +25,37 @@ describe('networkInfoHttpProvider', () => {
 
   test('stake does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
-    const provider = networkInfoHttpProvider(url);
+    const provider = networkInfoHttpProvider(config);
     await expect(provider.stake()).resolves.toEqual({});
   });
 
   test('lovelace  does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
-    const provider = networkInfoHttpProvider(url);
+    const provider = networkInfoHttpProvider(config);
     await expect(provider.lovelaceSupply()).resolves.toEqual({});
   });
 
   test('timeSettings does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
-    const provider = networkInfoHttpProvider(url);
+    const provider = networkInfoHttpProvider(config);
     await expect(provider.timeSettings()).resolves.toEqual({});
   });
 
   test('ledgerTip does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
-    const provider = networkInfoHttpProvider(url);
+    const provider = networkInfoHttpProvider(config);
     await expect(provider.ledgerTip()).resolves.toEqual({});
   });
 
   test('genesisParameters does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
-    const provider = networkInfoHttpProvider(url);
+    const provider = networkInfoHttpProvider(config);
     await expect(provider.genesisParameters()).resolves.toEqual({});
   });
 
   test('currentWalletProtocolParameters does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
-    const provider = networkInfoHttpProvider(url);
+    const provider = networkInfoHttpProvider(config);
     await expect(provider.currentWalletProtocolParameters()).resolves.toEqual({});
   });
 });

--- a/packages/cardano-services-client/test/RewardProvider/rewardsHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/RewardProvider/rewardsHttpProvider.test.ts
@@ -1,9 +1,14 @@
 import { Cardano, EpochRewards } from '@cardano-sdk/core';
+import { INFO, createLogger } from 'bunyan';
 import { rewardsHttpProvider } from '../../src';
 import { toSerializableObject } from '@cardano-sdk/util';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-const url = 'http://some-hostname:3000/rewards';
+
+const config = {
+  baseUrl: 'http://some-hostname:3000/rewards',
+  logger: createLogger({ level: INFO, name: 'unit tests' })
+};
 
 describe('rewardsHttpProvider', () => {
   const rewardAccount = Cardano.RewardAccount('stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6');
@@ -22,27 +27,27 @@ describe('rewardsHttpProvider', () => {
   describe('healthCheck', () => {
     it('is ok if 200 response body is { ok: true }', async () => {
       axiosMock.onPost().replyOnce(200, { ok: true });
-      const provider = rewardsHttpProvider(url);
+      const provider = rewardsHttpProvider(config);
       await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
     });
 
     it('is not ok if 200 response body is { ok: false }', async () => {
       axiosMock.onPost().replyOnce(200, { ok: false });
-      const provider = rewardsHttpProvider(url);
+      const provider = rewardsHttpProvider(config);
       await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
     });
   });
   test('rewardAccountBalance doesnt throw', async () => {
     const expectedResponse = toSerializableObject(BigInt('0'));
     axiosMock.onPost().replyOnce(200, expectedResponse);
-    const provider = rewardsHttpProvider(url);
+    const provider = rewardsHttpProvider(config);
     const response = toSerializableObject(await provider.rewardAccountBalance(rewardAccount));
     expect(response).toEqual(expectedResponse);
   });
   test('rewardsHistory doesnt throw', async () => {
     const expectedResponse = toSerializableObject(new Map<Cardano.RewardAccount, EpochRewards[]>());
     axiosMock.onPost().replyOnce(200, expectedResponse);
-    const provider = rewardsHttpProvider(url);
+    const provider = rewardsHttpProvider(config);
     const response = toSerializableObject(
       await provider.rewardsHistory({ epochs: { lowerBound: 10, upperBound: 20 }, rewardAccounts: [rewardAccount] })
     );

--- a/packages/cardano-services-client/test/StakePoolProvider/stakePoolHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/StakePoolProvider/stakePoolHttpProvider.test.ts
@@ -1,8 +1,12 @@
+import { INFO, createLogger } from 'bunyan';
 import { stakePoolHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const url = 'http://some-hostname:3000/stake-pool';
+const config = {
+  baseUrl: 'http://some-hostname:3000/stake-pool',
+  logger: createLogger({ level: INFO, name: 'unit tests' })
+};
 
 describe('stakePoolHttpProvider', () => {
   let axiosMock: MockAdapter;
@@ -19,13 +23,13 @@ describe('stakePoolHttpProvider', () => {
   });
   test('queryStakePools doesnt throw', async () => {
     axiosMock.onPost().replyOnce(200, []);
-    const provider = stakePoolHttpProvider(url);
+    const provider = stakePoolHttpProvider(config);
     await expect(provider.queryStakePools()).resolves.toEqual([]);
   });
 
   test('stakePoolStats doesnt throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
-    const provider = stakePoolHttpProvider(url);
+    const provider = stakePoolHttpProvider(config);
     await expect(provider.stakePoolStats()).resolves.toEqual({});
   });
 });

--- a/packages/cardano-services-client/test/Utxo/utxoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/Utxo/utxoHttpProvider.test.ts
@@ -1,10 +1,14 @@
 /* eslint-disable max-len */
 import { Cardano } from '@cardano-sdk/core';
+import { INFO, createLogger } from 'bunyan';
 import { utxoHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const url = 'http://some-hostname:3000/utxo';
+const config = {
+  baseUrl: 'http://some-hostname:3000/utxo',
+  logger: createLogger({ level: INFO, name: 'unit tests' })
+};
 
 describe('utxoHttpProvider', () => {
   let axiosMock: MockAdapter;
@@ -21,19 +25,19 @@ describe('utxoHttpProvider', () => {
   });
   describe('healtCheck', () => {
     it('is not ok if cannot connect', async () => {
-      const provider = utxoHttpProvider(url);
+      const provider = utxoHttpProvider(config);
       await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
     });
     describe('mocked', () => {
       it('is ok if 200 response body is { ok: true }', async () => {
         axiosMock.onPost().replyOnce(200, { ok: true });
-        const provider = utxoHttpProvider(url);
+        const provider = utxoHttpProvider(config);
         await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
       });
 
       it('is not ok if 200 response body is { ok: false }', async () => {
         axiosMock.onPost().replyOnce(200, { ok: false });
-        const provider = utxoHttpProvider(url);
+        const provider = utxoHttpProvider(config);
         await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
       });
     });
@@ -41,7 +45,7 @@ describe('utxoHttpProvider', () => {
   describe('utxoByAddresses', () => {
     test('utxoByAddresses doesnt throw', async () => {
       axiosMock.onPost().replyOnce(200, []);
-      const provider = utxoHttpProvider(url);
+      const provider = utxoHttpProvider(config);
       await expect(
         provider.utxoByAddresses([
           Cardano.Address(


### PR DESCRIPTION
# Context

The Cardano services HTTP clients cannot be used in the browser environment because they depend on Axios.

# Proposed Solution

Allow the HTTP clients to receive an Axios adapter so we can replace the default adapter with one that uses fetch instead.

# Important Changes Introduced

It is now possible to optionally pass an Axios adapter to the HTTP clients as an argument.
It is now possible to pass a logger instance to the HTTP clients as an argument.
