### PR TITLE
ci: fix dirty yarn-project.nix in nightly publish workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,7 +35,9 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
-      run: yarn install --immutable --inline-builds --mode=skip-build
+      run: |
+        yarn install --immutable --inline-builds --mode=skip-build
+        git checkout yarn-project.nix
 
     - name: Check if any packages changed
       id: precondition

--- a/lerna.json
+++ b/lerna.json
@@ -23,6 +23,9 @@
     "name": "conventionalcommits",
     "preMajor": true
   },
+  "ignoreChanges": [
+    "packages/*/test/**"
+  ],
   "useWorkspaces": true,
   "version": "independent"
 }


### PR DESCRIPTION
# Context

Scheduled `nightly` workflow run [failed](https://github.com/input-output-hk/cardano-js-sdk/runs/7551048091?check_suite_focus=true) due to `yarn-project.nix` changing with `yarn install --immutable`.

# Proposed Solution

`git checkout yarn-project.nix` after running `yarn install`. It will be regenerated and git added in a later step (after bumping the packages).

Failed build has [succeeded](https://github.com/input-output-hk/cardano-js-sdk/runs/7553812425?check_suite_focus=true) using workflow from this branch.

# Other changes

[ignore changes under /test when determining version bumps](https://github.com/input-output-hk/cardano-js-sdk/pull/361/commits/2a82349afe4f16cee9d86a96e0e2ba4f3ed0c070)