### PR TITLE
chore: Docker Compose config fixes

### DIFF
--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - postgres_db
     volumes:
       - ./config/network/${NETWORK:-mainnet}:/config
-      - db-sync-data:/var/lib/cdbsync
+      - db-sync-data:/var/lib/cexplorer
       - node-ipc:/node-ipc
     restart: on-failure
     logging:

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       - postgres_db
     volumes:
       - ./local-network/config/network:/config
+      - db-sync-data:/var/lib/cexplorer
       - node-ipc:/node-ipc
     restart: on-failure
     stop_signal: SIGINT


### PR DESCRIPTION
# Context
This is a change to support cardano-db-sync@13, but it was missed or lost in the process of
upgrading. The snapshot expects this new path, otherwise, it will fail during unpacking. This change will only cause existing containers to be rebuilt, which will happen next time the stack is started without intervention. There were also a couple of other issues that I've corrected, see the commit log for details. 
