### PR TITLE
refactor(cardano-services): use client instead of http server on http…

### DIFF
--- a/packages/cardano-services/test/Asset/__snapshots__/AssetHttpService.test.ts.snap
+++ b/packages/cardano-services/test/Asset/__snapshots__/AssetHttpService.test.ts.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AssetHttpService healthy state /get-asset returns asset info for existing asset id 1`] = `
+Object {
+  "assetId": "50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65",
+  "fingerprint": "asset1f0azzptnr8dghzjh7egqvdjmt33e3lz5uy59th",
+  "mintOrBurnCount": 1,
+  "name": "6d616361726f6e2d63616b65",
+  "policyId": "50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb",
+  "quantity": 1n,
+}
+`;
+
+exports[`AssetHttpService healthy state /get-asset returns asset info with extra data when requested 1`] = `
+Object {
+  "assetId": "50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65",
+  "fingerprint": "asset1f0azzptnr8dghzjh7egqvdjmt33e3lz5uy59th",
+  "history": Array [
+    Object {
+      "quantity": 1n,
+      "transactionId": "f66791a0354c43d8c5a93671eb96d94633e3419f3ccbb0a00c00a152d3b6ca06",
+    },
+  ],
+  "mintOrBurnCount": 1,
+  "name": "6d616361726f6e2d63616b65",
+  "nftMetadata": Object {
+    "description": Array [
+      "This is my first NFT of the macaron cake",
+    ],
+    "files": undefined,
+    "image": Array [
+      "ipfs://QmcDAmZubQig7tGUgEwbWcgdvz4Aoa2EiRZyFoX3fXTVmr",
+    ],
+    "mediaType": undefined,
+    "name": "macaron cake token",
+    "otherProperties": Map {
+      "id" => 1n,
+    },
+    "version": "1.0",
+  },
+  "policyId": "50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb",
+  "quantity": 1n,
+  "tokenMetadata": Object {
+    "desc": "This is my first NFT of the macaron cake",
+    "name": "macaron cake token",
+  },
+}
+`;

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -2,21 +2,13 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  Cardano,
-  ChainHistoryProvider,
-  ProviderError,
-  ProviderFailure,
-  TransactionsByAddressesArgs
-} from '@cardano-sdk/core';
+import { Cardano, ChainHistoryProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider, HttpServer, HttpServerConfig } from '../../src';
 import { CreateHttpProviderConfig, chainHistoryHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { INFO, createLogger } from 'bunyan';
 import { Pool } from 'pg';
 import { createDbSyncMetadataService } from '../../src/Metadata';
-import { doServerRequest } from '../util';
 import { dummyLogger } from 'ts-log';
-import { fromSerializableObject } from '@cardano-sdk/util';
 import { getPort } from 'get-port-please';
 import axios from 'axios';
 
@@ -33,7 +25,7 @@ describe('ChainHistoryHttpService', () => {
   let baseUrl: string;
   let clientConfig: CreateHttpProviderConfig<ChainHistoryProvider>;
   let config: HttpServerConfig;
-  let doChainHistoryRequest: ReturnType<typeof doServerRequest>;
+  let provider: ChainHistoryProvider;
 
   beforeAll(async () => {
     port = await getPort();
@@ -41,7 +33,7 @@ describe('ChainHistoryHttpService', () => {
     clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }) };
     config = { listen: { port } };
     dbConnection = new Pool({ connectionString: process.env.POSTGRES_CONNECTION_STRING });
-    doChainHistoryRequest = doServerRequest(baseUrl);
+    provider = chainHistoryHttpProvider(clientConfig);
   });
 
   afterEach(async () => {
@@ -99,43 +91,38 @@ describe('ChainHistoryHttpService', () => {
 
     describe('/blocks/by-hashes', () => {
       const url = '/blocks/by-hashes';
-      it('returns a 200 coded response with a well formed HTTP request', async () => {
-        expect((await axios.post(`${baseUrl}${url}`, { args: [[]] })).status).toEqual(200);
+      describe('with Http Service', () => {
+        it('returns a 200 coded response with a well formed HTTP request', async () => {
+          expect((await axios.post(`${baseUrl}${url}`, { args: [[]] })).status).toEqual(200);
+        });
+
+        it('returns a 415 coded response if the wrong content type header is used', async () => {
+          try {
+            await axios.post(`${baseUrl}${url}`, { args: [[]] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+            throw new Error('fail');
+          } catch (error: any) {
+            expect(error.response.status).toBe(415);
+            expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+          }
+        });
       });
 
-      it('returns a 415 coded response if the wrong content type header is used', async () => {
-        try {
-          await axios.post(`${baseUrl}${url}`, { args: [[]] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
-          throw new Error('fail');
-        } catch (error: any) {
-          expect(error.response.status).toBe(415);
-          expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
-        }
+      it('returns an array of blocks', async () => {
+        const hashes: Cardano.BlockId[] = [
+          Cardano.BlockId('7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298'),
+          Cardano.BlockId('469cc6fbcc186de6b12c392ad0cc84a20c4d4774c1f9c3cfd80745de00856f4b')
+        ];
+        const response = await provider.blocksByHashes(hashes);
+        expect(response).toHaveLength(2);
       });
 
-      describe('with ChainHistoryProvider', () => {
-        let provider: ChainHistoryProvider;
-        beforeEach(() => {
-          provider = chainHistoryHttpProvider(clientConfig);
-        });
-
-        it('returns an array of blocks', async () => {
-          const hashes: Cardano.BlockId[] = [
-            Cardano.BlockId('7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298'),
-            Cardano.BlockId('469cc6fbcc186de6b12c392ad0cc84a20c4d4774c1f9c3cfd80745de00856f4b')
-          ];
-          const response = await provider.blocksByHashes(hashes);
-          expect(response).toHaveLength(2);
-        });
-
-        it('does not include blocks not found', async () => {
-          const hashes: Cardano.BlockId[] = [
-            Cardano.BlockId('7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298'),
-            Cardano.BlockId('0000000000000000000000000000000000000000000000000000000000000000')
-          ];
-          const response = await provider.blocksByHashes(hashes);
-          expect(response).toHaveLength(1);
-        });
+      it('does not include blocks not found', async () => {
+        const hashes: Cardano.BlockId[] = [
+          Cardano.BlockId('7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298'),
+          Cardano.BlockId('0000000000000000000000000000000000000000000000000000000000000000')
+        ];
+        const response = await provider.blocksByHashes(hashes);
+        expect(response).toHaveLength(1);
       });
 
       describe('server and snapshot testing', () => {
@@ -144,7 +131,7 @@ describe('ChainHistoryHttpService', () => {
             Cardano.BlockId('7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298'),
             Cardano.BlockId('469cc6fbcc186de6b12c392ad0cc84a20c4d4774c1f9c3cfd80745de00856f4b')
           ];
-          const response = await doChainHistoryRequest<[Cardano.BlockId[]], Cardano.Block[]>(url, [hashes]);
+          const response = await provider.blocksByHashes(hashes);
           expect(response.length).toEqual(2);
           expect(response).toMatchSnapshot();
         });
@@ -153,49 +140,44 @@ describe('ChainHistoryHttpService', () => {
 
     describe('/txs/by-hashes', () => {
       const url = '/txs/by-hashes';
-      it('returns a 200 coded response with a well formed HTTP request', async () => {
-        expect((await axios.post(`${baseUrl}${url}`, { args: [[]] })).status).toEqual(200);
+      describe('with Http Service', () => {
+        it('returns a 200 coded response with a well formed HTTP request', async () => {
+          expect((await axios.post(`${baseUrl}${url}`, { args: [[]] })).status).toEqual(200);
+        });
+
+        it('returns a 415 coded response if the wrong content type header is used', async () => {
+          try {
+            await axios.post(`${baseUrl}${url}`, { args: [[]] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+            throw new Error('fail');
+          } catch (error: any) {
+            expect(error.response.status).toBe(415);
+            expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+          }
+        });
       });
 
-      it('returns a 415 coded response if the wrong content type header is used', async () => {
-        try {
-          await axios.post(`${baseUrl}${url}`, { args: [[]] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
-          throw new Error('fail');
-        } catch (error: any) {
-          expect(error.response.status).toBe(415);
-          expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
-        }
+      it('returns an array of transactions', async () => {
+        const hashes: Cardano.TransactionId[] = [
+          Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819'),
+          Cardano.TransactionId('952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb'),
+          Cardano.TransactionId('cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99'),
+          Cardano.TransactionId('24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e'),
+          Cardano.TransactionId('3d2278e9cef71c79720a11bc3e08acbbd5f2175f7015d358c867fc9b419ae0b2'),
+          Cardano.TransactionId('5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3'),
+          Cardano.TransactionId('face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd'),
+          Cardano.TransactionId('19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d')
+        ];
+        const response = await provider.transactionsByHashes(hashes);
+        expect(response).toHaveLength(8);
       });
 
-      describe('with ChainHistoryProvider', () => {
-        let provider: ChainHistoryProvider;
-        beforeEach(() => {
-          provider = chainHistoryHttpProvider(clientConfig);
-        });
-
-        it('returns an array of transactions', async () => {
-          const hashes: Cardano.TransactionId[] = [
-            Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819'),
-            Cardano.TransactionId('952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb'),
-            Cardano.TransactionId('cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99'),
-            Cardano.TransactionId('24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e'),
-            Cardano.TransactionId('3d2278e9cef71c79720a11bc3e08acbbd5f2175f7015d358c867fc9b419ae0b2'),
-            Cardano.TransactionId('5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3'),
-            Cardano.TransactionId('face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd'),
-            Cardano.TransactionId('19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d')
-          ];
-          const response = await provider.transactionsByHashes(hashes);
-          expect(response).toHaveLength(8);
-        });
-
-        it('does not include transactions not found', async () => {
-          const hashes: Cardano.TransactionId[] = [
-            Cardano.TransactionId('295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7'),
-            Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
-          ];
-          const response = await provider.transactionsByHashes(hashes);
-          expect(response.length).toEqual(1);
-        });
+      it('does not include transactions not found', async () => {
+        const hashes: Cardano.TransactionId[] = [
+          Cardano.TransactionId('295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7'),
+          Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
+        ];
+        const response = await provider.transactionsByHashes(hashes);
+        expect(response.length).toEqual(1);
       });
 
       describe('server and snapshot testing', () => {
@@ -203,8 +185,8 @@ describe('ChainHistoryHttpService', () => {
           const hashes: Cardano.TransactionId[] = [
             Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819')
           ];
-          const response = await doChainHistoryRequest<[Cardano.TransactionId[]], Cardano.TxAlonzo[]>(url, [hashes]);
-          const tx: Cardano.TxAlonzo = fromSerializableObject(response[0]);
+          const response = await provider.transactionsByHashes(hashes);
+          const tx: Cardano.TxAlonzo = response[0];
           expect(response.length).toEqual(1);
           expect(tx.body.outputs[0].value.assets?.size).toBeGreaterThan(0);
           expect(response).toMatchSnapshot();
@@ -214,8 +196,8 @@ describe('ChainHistoryHttpService', () => {
           const hashes: Cardano.TransactionId[] = [
             Cardano.TransactionId('952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb')
           ];
-          const response = await doChainHistoryRequest<[Cardano.TransactionId[]], Cardano.TxAlonzo[]>(url, [hashes]);
-          const tx: Cardano.TxAlonzo = fromSerializableObject(response[0]);
+          const response = await provider.transactionsByHashes(hashes);
+          const tx: Cardano.TxAlonzo = response[0];
           expect(response.length).toEqual(1);
           expect(response).toMatchSnapshot();
           expect(tx.body.mint?.size).toBeGreaterThan(0);
@@ -225,8 +207,8 @@ describe('ChainHistoryHttpService', () => {
           const hashes: Cardano.TransactionId[] = [
             Cardano.TransactionId('cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99')
           ];
-          const response = await doChainHistoryRequest<[Cardano.TransactionId[]], Cardano.TxAlonzo[]>(url, [hashes]);
-          const tx: Cardano.TxAlonzo = fromSerializableObject(response[0]);
+          const response = await provider.transactionsByHashes(hashes);
+          const tx: Cardano.TxAlonzo = response[0];
           expect(response.length).toEqual(1);
           expect(response).toMatchSnapshot();
           expect(tx.body.withdrawals?.length).toBeGreaterThan(0);
@@ -236,8 +218,8 @@ describe('ChainHistoryHttpService', () => {
           const hashes: Cardano.TransactionId[] = [
             Cardano.TransactionId('24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e')
           ];
-          const response = await doChainHistoryRequest<[Cardano.TransactionId[]], Cardano.TxAlonzo[]>(url, [hashes]);
-          const tx: Cardano.TxAlonzo = fromSerializableObject(response[0]);
+          const response = await provider.transactionsByHashes(hashes);
+          const tx: Cardano.TxAlonzo = response[0];
           expect(response.length).toEqual(1);
           expect(response).toMatchSnapshot();
           expect(tx.witness.redeemers?.length).toBeGreaterThan(0);
@@ -247,8 +229,8 @@ describe('ChainHistoryHttpService', () => {
           const hashes: Cardano.TransactionId[] = [
             Cardano.TransactionId('3d2278e9cef71c79720a11bc3e08acbbd5f2175f7015d358c867fc9b419ae0b2')
           ];
-          const response = await doChainHistoryRequest<[Cardano.TransactionId[]], Cardano.TxAlonzo[]>(url, [hashes]);
-          const tx: Cardano.TxAlonzo = fromSerializableObject(response[0]);
+          const response = await provider.transactionsByHashes(hashes);
+          const tx: Cardano.TxAlonzo = response[0];
           expect(response.length).toEqual(1);
           expect(response).toMatchSnapshot();
           expect(tx.auxiliaryData).toBeDefined();
@@ -258,8 +240,8 @@ describe('ChainHistoryHttpService', () => {
           const hashes: Cardano.TransactionId[] = [
             Cardano.TransactionId('5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3')
           ];
-          const response = await doChainHistoryRequest<[Cardano.TransactionId[]], Cardano.TxAlonzo[]>(url, [hashes]);
-          const tx: Cardano.TxAlonzo = fromSerializableObject(response[0]);
+          const response = await provider.transactionsByHashes(hashes);
+          const tx: Cardano.TxAlonzo = response[0];
           expect(response.length).toEqual(1);
           expect(response).toMatchSnapshot();
           expect(tx.body.collaterals?.length).toBeGreaterThan(0);
@@ -270,9 +252,9 @@ describe('ChainHistoryHttpService', () => {
             Cardano.TransactionId('face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd'),
             Cardano.TransactionId('19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d')
           ];
-          const response = await doChainHistoryRequest<[Cardano.TransactionId[]], Cardano.TxAlonzo[]>(url, [hashes]);
-          const tx1: Cardano.TxAlonzo = fromSerializableObject(response[0]);
-          const tx2: Cardano.TxAlonzo = fromSerializableObject(response[1]);
+          const response = await provider.transactionsByHashes(hashes);
+          const tx1: Cardano.TxAlonzo = response[0];
+          const tx2: Cardano.TxAlonzo = response[1];
           expect(response.length).toEqual(2);
           expect(response).toMatchSnapshot();
           expect(tx1.body.certificates?.length).toBeGreaterThan(0);
@@ -283,64 +265,59 @@ describe('ChainHistoryHttpService', () => {
 
     describe('/txs/by-addresses', () => {
       const url = '/txs/by-addresses';
-      it('returns a 200 coded response with a well formed HTTP request', async () => {
-        expect((await axios.post(`${baseUrl}${url}`, { args: [{ addresses: [] }] })).status).toEqual(200);
+      describe('with Http Server', () => {
+        it('returns a 200 coded response with a well formed HTTP request', async () => {
+          expect((await axios.post(`${baseUrl}${url}`, { args: [{ addresses: [] }] })).status).toEqual(200);
+        });
+
+        it('returns a 415 coded response if the wrong content type header is used', async () => {
+          try {
+            await axios.post(`${baseUrl}${url}`, { args: [[]] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+            throw new Error('fail');
+          } catch (error: any) {
+            expect(error.response.status).toBe(415);
+            expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+          }
+        });
       });
 
-      it('returns a 415 coded response if the wrong content type header is used', async () => {
-        try {
-          await axios.post(`${baseUrl}${url}`, { args: [[]] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
-          throw new Error('fail');
-        } catch (error: any) {
-          expect(error.response.status).toBe(415);
-          expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
-        }
+      it('returns an array of transactions', async () => {
+        const addresses: Cardano.Address[] = [
+          Cardano.Address(
+            'addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc'
+          ),
+          Cardano.Address(
+            'addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg'
+          )
+        ];
+        const response = await provider.transactionsByAddresses({ addresses });
+        expect(response).toHaveLength(3);
       });
 
-      describe('with ChainHistoryProvider', () => {
-        let provider: ChainHistoryProvider;
-        beforeEach(() => {
-          provider = chainHistoryHttpProvider(clientConfig);
-        });
+      it('does not include transactions not found', async () => {
+        const addresses: Cardano.Address[] = [
+          Cardano.Address(
+            'addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc'
+          ),
+          Cardano.Address(
+            'addr1qy4t3dy78sawthpu3049rj4858jr73flal3a3p9lgyv7u0e2hz6fu0p6uhwrezl228920g0y8aznlmlrmzzt7sgeaclsfpu9gf'
+          )
+        ];
+        const response = await provider.transactionsByAddresses({ addresses });
+        expect(response).toHaveLength(1);
+      });
 
-        it('returns an array of transactions', async () => {
-          const addresses: Cardano.Address[] = [
-            Cardano.Address(
-              'addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc'
-            ),
-            Cardano.Address(
-              'addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg'
-            )
-          ];
-          const response = await provider.transactionsByAddresses({ addresses });
-          expect(response).toHaveLength(3);
-        });
-
-        it('does not include transactions not found', async () => {
-          const addresses: Cardano.Address[] = [
-            Cardano.Address(
-              'addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc'
-            ),
-            Cardano.Address(
-              'addr1qy4t3dy78sawthpu3049rj4858jr73flal3a3p9lgyv7u0e2hz6fu0p6uhwrezl228920g0y8aznlmlrmzzt7sgeaclsfpu9gf'
-            )
-          ];
-          const response = await provider.transactionsByAddresses({ addresses });
-          expect(response).toHaveLength(1);
-        });
-
-        it('does not include transactions before indicated block', async () => {
-          const addresses: Cardano.Address[] = [
-            Cardano.Address(
-              'addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg'
-            ),
-            Cardano.Address(
-              'addr_test1qrrgh4kuq2tlgcpawpta7e7t6dacelhkwh9wm0wzxdx2alv2fa9cu9sfmxem2d2jyzdukjh43dxh84elp9y64da67zvsasy6xs'
-            )
-          ];
-          const response = await provider.transactionsByAddresses({ addresses, sinceBlock: 1_654_555 });
-          expect(response).toHaveLength(2);
-        });
+      it('does not include transactions before indicated block', async () => {
+        const addresses: Cardano.Address[] = [
+          Cardano.Address(
+            'addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg'
+          ),
+          Cardano.Address(
+            'addr_test1qrrgh4kuq2tlgcpawpta7e7t6dacelhkwh9wm0wzxdx2alv2fa9cu9sfmxem2d2jyzdukjh43dxh84elp9y64da67zvsasy6xs'
+          )
+        ];
+        const response = await provider.transactionsByAddresses({ addresses, sinceBlock: 1_654_555 });
+        expect(response).toHaveLength(2);
       });
 
       describe('server and snapshot testing', () => {
@@ -350,9 +327,7 @@ describe('ChainHistoryHttpService', () => {
               'addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc'
             )
           ];
-          const response = await doChainHistoryRequest<[TransactionsByAddressesArgs], Cardano.TxAlonzo[]>(url, [
-            { addresses }
-          ]);
+          const response = await provider.transactionsByAddresses({ addresses });
           expect(response).toHaveLength(1);
           expect(response).toMatchSnapshot();
         });
@@ -361,9 +336,7 @@ describe('ChainHistoryHttpService', () => {
           const addresses: Cardano.Address[] = [
             Cardano.Address('addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg')
           ];
-          const response = await doChainHistoryRequest<[TransactionsByAddressesArgs], Cardano.TxAlonzo[]>(url, [
-            { addresses }
-          ]);
+          const response = await provider.transactionsByAddresses({ addresses });
           expect(response).toHaveLength(11);
           expect(response).toMatchSnapshot();
         });
@@ -377,9 +350,8 @@ describe('ChainHistoryHttpService', () => {
               'addr_test1qrrgh4kuq2tlgcpawpta7e7t6dacelhkwh9wm0wzxdx2alv2fa9cu9sfmxem2d2jyzdukjh43dxh84elp9y64da67zvsasy6xs'
             )
           ];
-          const response = await doChainHistoryRequest<[TransactionsByAddressesArgs], Cardano.TxAlonzo[]>(url, [
-            { addresses, sinceBlock: 1_654_555 }
-          ]);
+          const response = await provider.transactionsByAddresses({ addresses, sinceBlock: 1_654_555 });
+
           expect(response.length).toEqual(2);
           expect(response).toMatchSnapshot();
         });

--- a/packages/cardano-services/test/ChainHistory/__snapshots__/ChainHistoryHttpService.test.ts.snap
+++ b/packages/cardano-services/test/ChainHistory/__snapshots__/ChainHistoryHttpService.test.ts.snap
@@ -4,65 +4,39 @@ exports[`ChainHistoryHttpService healthy state /blocks/by-hashes server and snap
 Array [
   Object {
     "confirmations": 1957883,
-    "date": Object {
-      "__type": "Date",
-      "value": 1595995096000,
-    },
+    "date": 2020-07-29T03:58:16.000Z,
     "epoch": 74,
     "epochSlot": 27480,
-    "fees": Object {
-      "__type": "bigint",
-      "value": "0",
-    },
+    "fees": 0n,
     "header": Object {
       "blockNo": 1598507,
       "hash": "7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298",
       "slot": 1625880,
     },
-    "nextBlock": Object {
-      "__type": "undefined",
-    },
-    "previousBlock": Object {
-      "__type": "undefined",
-    },
+    "nextBlock": undefined,
+    "previousBlock": undefined,
     "size": 989,
     "slotLeader": "de665a71064706f946030505eae950583f08c316f0f58997961092b1",
-    "totalOutput": Object {
-      "__type": "bigint",
-      "value": "0",
-    },
+    "totalOutput": 0n,
     "txCount": 1,
     "vrf": "vrf_vk1wmmxg7swhx0raa2yddkt7ktlvh55dje8a5uwge2z90t5e7v4g5esp49zzk",
   },
   Object {
     "confirmations": 1901835,
-    "date": Object {
-      "__type": "Date",
-      "value": 1597132436000,
-    },
+    "date": 2020-08-11T07:53:56.000Z,
     "epoch": 76,
     "epochSlot": 300820,
-    "fees": Object {
-      "__type": "bigint",
-      "value": "0",
-    },
+    "fees": 0n,
     "header": Object {
       "blockNo": 1654555,
       "hash": "469cc6fbcc186de6b12c392ad0cc84a20c4d4774c1f9c3cfd80745de00856f4b",
       "slot": 2763220,
     },
-    "nextBlock": Object {
-      "__type": "undefined",
-    },
-    "previousBlock": Object {
-      "__type": "undefined",
-    },
+    "nextBlock": undefined,
+    "previousBlock": undefined,
     "size": 737,
     "slotLeader": "b0dca078b823cde627da136200d6618c49ad712b77972a1c5e135763",
-    "totalOutput": Object {
-      "__type": "bigint",
-      "value": "0",
-    },
+    "totalOutput": 0n,
     "txCount": 1,
     "vrf": "vrf_vk15nyl9g8sa4jkyjqm0jf9qm6n9ageea8z4duzssvkqz5ssrjfs7ksqhx8dk",
   },
@@ -72,9 +46,7 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-addresses server and snapshot testing does not include transactions before indicated block 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 1654555,
       "hash": "469cc6fbcc186de6b12c392ad0cc84a20c4d4774c1f9c3cfd80745de00856f4b",
@@ -93,10 +65,7 @@ Array [
         },
       ],
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "197929",
-      },
+      "fee": 197929n,
       "inputs": Array [
         Object {
           "address": "addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg",
@@ -104,65 +73,39 @@ Array [
           "txId": "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "999502622402",
-            },
+            "assets": undefined,
+            "coins": 999502622402n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 2764200,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 500000000n,
+      "input": 0n,
     },
     "index": 0,
     "txSize": 736,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 1912426,
       "hash": "1c87c4191424d3a3825f7717f327749f08ba5c1a95ca4dffd46b15db518b6876",
@@ -176,10 +119,7 @@ Array [
         },
       ],
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "205145",
-      },
+      "fee": 205145n,
       "inputs": Array [
         Object {
           "address": "addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg",
@@ -202,59 +142,35 @@ Array [
           "txId": "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1qr4m502gr9hnaxac5mxjln22jwavf7pcjmh9sw7fujdvgvj9ef6afquphwg7tj4mmm548m3t50hxfyygjuu222kx96eshcathg",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "10306556787917",
-            },
+            "assets": undefined,
+            "coins": 10306556787917n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 8064171,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 500000000n,
+      "input": 0n,
     },
     "index": 0,
     "txSize": 780,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
 ]
@@ -263,23 +179,16 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-addresses server and snapshot testing finds transactions with address within inputs 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "183761",
-      },
+      "fee": 183761n,
       "inputs": Array [
         Object {
           "address": "addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc",
@@ -292,9 +201,7 @@ Array [
           "txId": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -302,84 +209,41 @@ Array [
           "index": 0,
           "txId": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1678546",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 1678546n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "254640002",
-            },
+            "coins": 254640002n,
           },
         },
         Object {
           "address": "addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "661706",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 661706n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "38816239",
-            },
+            "coins": 38816239n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 11,
     "txSize": 640,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
 ]
@@ -388,23 +252,16 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-addresses server and snapshot testing finds transactions with address within outputs 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "181605",
-      },
+      "fee": 181605n,
       "inputs": Array [
         Object {
           "address": "addr_test1qp64f82kqyn934qtytqf2xhzqnasknqk5f5y88e3jh7s95cmtpwh9z5nwy2egezfnm7eddt4ysfp7tg87attl3ejgjns2qgy69",
@@ -417,9 +274,7 @@ Array [
           "txId": "caaada4c53256a9bcba2d006b3f427f089d43372442a550a7349627a46682375",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -427,95 +282,52 @@ Array [
           "index": 0,
           "txId": "caaada4c53256a9bcba2d006b3f427f089d43372442a550a7349627a46682375",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e",
-                  Object {
-                    "__type": "bigint",
-                    "value": "359387",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e" => 359387n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "201519044",
-            },
+            "coins": 201519044n,
           },
         },
         Object {
           "address": "addr_test1qp64f82kqyn934qtytqf2xhzqnasknqk5f5y88e3jh7s95cmtpwh9z5nwy2egezfnm7eddt4ysfp7tg87attl3ejgjns2qgy69",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "caaada4c53256a9bcba2d006b3f427f089d43372442a550a7349627a46682375",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "391939485",
-            },
+            "assets": undefined,
+            "coins": 391939485n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "caaada4c53256a9bcba2d006b3f427f089d43372442a550a7349627a46682375",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 1,
     "txSize": 591,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "179977",
-      },
+      "fee": 179977n,
       "inputs": Array [
         Object {
           "address": "addr_test1qr6sape30ttq8zahxmah2wzaqk3ldc0n0cehj8e408ejhwrq5hrg8xmfyakef5awud6g6uew447r6970evl9lzgrak0qgz3ejq",
@@ -523,9 +335,7 @@ Array [
           "txId": "49fa6b7245674fd11727cfb4d47ec7fad380c198a2a975b0423c5f6c255488f9",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -533,86 +343,50 @@ Array [
           "index": 0,
           "txId": "49fa6b7245674fd11727cfb4d47ec7fad380c198a2a975b0423c5f6c255488f9",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "23000000",
-            },
+            "assets": undefined,
+            "coins": 23000000n,
           },
         },
         Object {
           "address": "addr_test1qr6sape30ttq8zahxmah2wzaqk3ldc0n0cehj8e408ejhwrq5hrg8xmfyakef5awud6g6uew447r6970evl9lzgrak0qgz3ejq",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "49fa6b7245674fd11727cfb4d47ec7fad380c198a2a975b0423c5f6c255488f9",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "893280136",
-            },
+            "assets": undefined,
+            "coins": 893280136n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "49fa6b7245674fd11727cfb4d47ec7fad380c198a2a975b0423c5f6c255488f9",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 3,
     "txSize": 554,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "179977",
-      },
+      "fee": 179977n,
       "inputs": Array [
         Object {
           "address": "addr_test1qq75mx8z9sh8aucku2lwjp7c6fe2m3w90aqt9kw4rczjt8lj0rhad28c9f9cmcm64jyqpvths06w4tgwc0vnpx3veqvsj2953n",
@@ -620,9 +394,7 @@ Array [
           "txId": "a7eda535edc983139cc1053d074106aef54b25e9c9ee9de6bf1bf69709dabfd4",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -630,86 +402,50 @@ Array [
           "index": 0,
           "txId": "a7eda535edc983139cc1053d074106aef54b25e9c9ee9de6bf1bf69709dabfd4",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "154000000",
-            },
+            "assets": undefined,
+            "coins": 154000000n,
           },
         },
         Object {
           "address": "addr_test1qq75mx8z9sh8aucku2lwjp7c6fe2m3w90aqt9kw4rczjt8lj0rhad28c9f9cmcm64jyqpvths06w4tgwc0vnpx3veqvsj2953n",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "a7eda535edc983139cc1053d074106aef54b25e9c9ee9de6bf1bf69709dabfd4",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "612159447",
-            },
+            "assets": undefined,
+            "coins": 612159447n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "a7eda535edc983139cc1053d074106aef54b25e9c9ee9de6bf1bf69709dabfd4",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 5,
     "txSize": 554,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "186401",
-      },
+      "fee": 186401n,
       "inputs": Array [
         Object {
           "address": "addr_test1qry75qe2e5zez3ny5nuu2dsxrrwhxpl7mr7gdwpsgyfsvtgcgddl7qwm2vl7vedf3xp0vy7ya9ag7dqkcqqktv5403nspw962t",
@@ -722,9 +458,7 @@ Array [
           "txId": "b46c48229336aec327a5f537bcbf1ca8fa6a3afbf60aa66880aa6a234e5fce92",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -732,111 +466,55 @@ Array [
           "index": 0,
           "txId": "b46c48229336aec327a5f537bcbf1ca8fa6a3afbf60aa66880aa6a234e5fce92",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e",
-                  Object {
-                    "__type": "bigint",
-                    "value": "30000",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e" => 30000n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "20487995",
-            },
+            "coins": 20487995n,
           },
         },
         Object {
           "address": "addr_test1qry75qe2e5zez3ny5nuu2dsxrrwhxpl7mr7gdwpsgyfsvtgcgddl7qwm2vl7vedf3xp0vy7ya9ag7dqkcqqktv5403nspw962t",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "b46c48229336aec327a5f537bcbf1ca8fa6a3afbf60aa66880aa6a234e5fce92",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e",
-                  Object {
-                    "__type": "bigint",
-                    "value": "60704",
-                  },
-                ],
-                Array [
-                  "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779",
-                  Object {
-                    "__type": "bigint",
-                    "value": "194994",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e" => 60704n,
+              "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779" => 194994n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "591423467",
-            },
+            "coins": 591423467n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "b46c48229336aec327a5f537bcbf1ca8fa6a3afbf60aa66880aa6a234e5fce92",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 7,
     "txSize": 700,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "181649",
-      },
+      "fee": 181649n,
       "inputs": Array [
         Object {
           "address": "addr_test1qp2fxvmxlly62thlzmlrtf5tya2kay8lyucz40ns7xesrz2j8m73lvtj885qvfldxhadg5rsh5h79eczh6gu0deu96hqrrcz3e",
@@ -849,9 +527,7 @@ Array [
           "txId": "56caf0441c4f0e209195b86b95e5304b338ca38ec232252c194153e8a3440c28",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -859,95 +535,52 @@ Array [
           "index": 0,
           "txId": "56caf0441c4f0e209195b86b95e5304b338ca38ec232252c194153e8a3440c28",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7441444158",
-                  Object {
-                    "__type": "bigint",
-                    "value": "2086814",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7441444158" => 2086814n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "56670077",
-            },
+            "coins": 56670077n,
           },
         },
         Object {
           "address": "addr_test1qp2fxvmxlly62thlzmlrtf5tya2kay8lyucz40ns7xesrz2j8m73lvtj885qvfldxhadg5rsh5h79eczh6gu0deu96hqrrcz3e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "56caf0441c4f0e209195b86b95e5304b338ca38ec232252c194153e8a3440c28",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "736788144",
-            },
+            "assets": undefined,
+            "coins": 736788144n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "56caf0441c4f0e209195b86b95e5304b338ca38ec232252c194153e8a3440c28",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 8,
     "txSize": 592,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "179933",
-      },
+      "fee": 179933n,
       "inputs": Array [
         Object {
           "address": "addr_test1qquh3j3u2v54pe2t6ntt0lyqnvm38v6prryuk8yhk556yjjkgqwx367r8umqax3slc758afpqsy9fzv45rsvgff8me4qa5md5z",
@@ -955,9 +588,7 @@ Array [
           "txId": "3d8e3e7c6d0929812abc40d29a3b1e4f470f6d04e9d4b3c521f1f87f74f7ab88",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -965,86 +596,50 @@ Array [
           "index": 0,
           "txId": "3d8e3e7c6d0929812abc40d29a3b1e4f470f6d04e9d4b3c521f1f87f74f7ab88",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "204000000",
-            },
+            "assets": undefined,
+            "coins": 204000000n,
           },
         },
         Object {
           "address": "addr_test1qquh3j3u2v54pe2t6ntt0lyqnvm38v6prryuk8yhk556yjjkgqwx367r8umqax3slc758afpqsy9fzv45rsvgff8me4qa5md5z",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "3d8e3e7c6d0929812abc40d29a3b1e4f470f6d04e9d4b3c521f1f87f74f7ab88",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "510111262",
-            },
+            "assets": undefined,
+            "coins": 510111262n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "3d8e3e7c6d0929812abc40d29a3b1e4f470f6d04e9d4b3c521f1f87f74f7ab88",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 10,
     "txSize": 553,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "183761",
-      },
+      "fee": 183761n,
       "inputs": Array [
         Object {
           "address": "addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc",
@@ -1057,9 +652,7 @@ Array [
           "txId": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -1067,104 +660,54 @@ Array [
           "index": 0,
           "txId": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1678546",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 1678546n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "254640002",
-            },
+            "coins": 254640002n,
           },
         },
         Object {
           "address": "addr_test1qq7rv7r27wq5nz2q6htul8k55xrcjsz2tpxkhqfk5f6kfgfnqdurhe3e8zlltj63kwh78hg7ykrexmn6jxxn42egzs4skzyvvc",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "661706",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 661706n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "38816239",
-            },
+            "coins": 38816239n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 11,
     "txSize": 640,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "181605",
-      },
+      "fee": 181605n,
       "inputs": Array [
         Object {
           "address": "addr_test1qqt9fumrwz43e79rfjznn8nlnc05kdfyv7qrxx9ks2vacq8lxxtya039kqwxltw2q73wrdsvhgqrycllm0tg38c9nnkqxysjz6",
@@ -1177,9 +720,7 @@ Array [
           "txId": "0dbbc0e6d13549a1960476aae42fd492a7a19fba856f9cc9695ecc5c84fe87e9",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -1187,90 +728,50 @@ Array [
           "index": 0,
           "txId": "0dbbc0e6d13549a1960476aae42fd492a7a19fba856f9cc9695ecc5c84fe87e9",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e",
-                  Object {
-                    "__type": "bigint",
-                    "value": "726163",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e" => 726163n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "403099082",
-            },
+            "coins": 403099082n,
           },
         },
         Object {
           "address": "addr_test1qqt9fumrwz43e79rfjznn8nlnc05kdfyv7qrxx9ks2vacq8lxxtya039kqwxltw2q73wrdsvhgqrycllm0tg38c9nnkqxysjz6",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "0dbbc0e6d13549a1960476aae42fd492a7a19fba856f9cc9695ecc5c84fe87e9",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "194539380",
-            },
+            "assets": undefined,
+            "coins": 194539380n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "0dbbc0e6d13549a1960476aae42fd492a7a19fba856f9cc9695ecc5c84fe87e9",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 13,
     "txSize": 591,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
@@ -1278,10 +779,7 @@ Array [
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
         },
       ],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "1030338",
-      },
+      "fee": 1030338n,
       "inputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -1314,145 +812,67 @@ Array [
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
         },
       ],
-      "mint": Object {
-        "__type": "Map",
-        "value": Array [
-          Array [
-            "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114",
-            Object {
-              "__type": "bigint",
-              "value": "15355454",
-            },
-          ],
-        ],
+      "mint": Map {
+        "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114" => 15355454n,
       },
       "outputs": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "28178818258",
-            },
+            "assets": undefined,
+            "coins": 28178818258n,
           },
         },
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "10000000",
-            },
+            "coins": 10000000n,
           },
         },
         Object {
           "address": "addr_test1qq9gwfwevn5s96jx9xzclntlrd8m0mrs3ezzva7akkvyj9y7yjf2z5h4fealu2rktu38m3mfv68vsjrtrfwuym60dfyq0axz58",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 2,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1909",
-                  },
-                ],
-                Array [
-                  "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114",
-                  Object {
-                    "__type": "bigint",
-                    "value": "15355454",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 1909n,
+              "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114" => 15355454n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qqfleha26t47j6khuetrsjyxkwl4x2lya5jsmn24h53n6d6akgetsg2jxgxsqglg8k9m74c8uwl8gxen3hvxsupapqasdzvh6n",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 3,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "333305",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 333305n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qqvl0h49qke8yv8r5as3vrt3zaqdygjmfsfj63futhj803s2wkugrs72zdued30dtsce7mwclnd6n49a64q6f4mmcfksqaspe4",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 4,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "932541",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 932541n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
@@ -1461,59 +881,25 @@ Array [
           "index": 5,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1651585768",
-                  },
-                ],
-                Array [
-                  "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-                Array [
-                  "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 1651585768n,
+              "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114" => 1n,
+              "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "247344475554",
-            },
+            "coins": 247344475554n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 49033345,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 14,
     "txSize": 10662,
@@ -1565,25 +951,18 @@ Array [
           "scriptHash": "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130",
         },
       ],
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
@@ -1591,10 +970,7 @@ Array [
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
         },
       ],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "1130814",
-      },
+      "fee": 1130814n,
       "inputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -1632,171 +1008,79 @@ Array [
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
         },
       ],
-      "mint": Object {
-        "__type": "Map",
-        "value": Array [
-          Array [
-            "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779",
-            Object {
-              "__type": "bigint",
-              "value": "13542175",
-            },
-          ],
-        ],
+      "mint": Map {
+        "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779" => 13542175n,
       },
       "outputs": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "28185687444",
-            },
+            "assets": undefined,
+            "coins": 28185687444n,
           },
         },
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "10000000",
-            },
+            "coins": 10000000n,
           },
         },
         Object {
           "address": "addr_test1qp620qa3rqzd5fxj3hy4dughv7xx2dt9gu9de70jf8hagdcvmqt35f2psxv7ajj5jnh4ajlc752rert8f9msffxdl45qyjefw8",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 2,
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e",
-                  Object {
-                    "__type": "bigint",
-                    "value": "70",
-                  },
-                ],
-                Array [
-                  "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779",
-                  Object {
-                    "__type": "bigint",
-                    "value": "780407",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e" => 70n,
+              "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779" => 780407n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qryz24mkq35j8s67fdrm44pe8na7n3tqkmyzy3sgnjq3d7szlx56h6fkjl8y3p73zpyce04eku9w943rcr6rgznp8cwq2axy9q",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 3,
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779",
-                  Object {
-                    "__type": "bigint",
-                    "value": "11598880",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779" => 11598880n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "4854535",
-            },
+            "coins": 4854535n,
           },
         },
         Object {
           "address": "addr_test1qq75mx8z9sh8aucku2lwjp7c6fe2m3w90aqt9kw4rczjt8lj0rhad28c9f9cmcm64jyqpvths06w4tgwc0vnpx3veqvsj2953n",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 4,
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e",
-                  Object {
-                    "__type": "bigint",
-                    "value": "90699",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e" => 90699n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qpps0d880t3w6q8hu99nudrgrtzmexk9g9czflg4s06rnrwq6k380kzqphzpaj6pfcqaxjqj8ghcxc9cr9qlsp9xa56qu3c9ma",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 5,
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1162888",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779" => 1162888n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2286437",
-            },
+            "coins": 2286437n,
           },
         },
         Object {
@@ -1805,59 +1089,25 @@ Array [
           "index": 6,
           "txId": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e",
-                  Object {
-                    "__type": "bigint",
-                    "value": "3280594639",
-                  },
-                ],
-                Array [
-                  "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-                Array [
-                  "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744d494e" => 3280594639n,
+              "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0cb6de817be83e93a5771e6c98ee305e1012bae70d9eb9dff70e2d71e4b611779" => 1n,
+              "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1803114201564",
-            },
+            "coins": 1803114201564n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 49033345,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 15,
     "txSize": 11003,
@@ -1918,25 +1168,18 @@ Array [
           "scriptHash": "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130",
         },
       ],
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
@@ -1944,10 +1187,7 @@ Array [
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
         },
       ],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "979374",
-      },
+      "fee": 979374n,
       "inputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -1980,129 +1220,64 @@ Array [
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "28190708070",
-            },
+            "assets": undefined,
+            "coins": 28190708070n,
           },
         },
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "10000000",
-            },
+            "coins": 10000000n,
           },
         },
         Object {
           "address": "addr_test1qq670vd7x8m3qr0kfzjtrxnzprgkcqu4uhfpznpvs8x9556ewgmuhmsn8nvd5a8ugl4t3wqj4xk63jjyfpqrxmuwklzs42j7cp",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 2,
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51",
-                  Object {
-                    "__type": "bigint",
-                    "value": "64697",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51" => 64697n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qpps0d880t3w6q8hu99nudrgrtzmexk9g9czflg4s06rnrwq6k380kzqphzpaj6pfcqaxjqj8ghcxc9cr9qlsp9xa56qu3c9ma",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 3,
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51",
-                  Object {
-                    "__type": "bigint",
-                    "value": "225522",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51" => 225522n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qp5jds8hszuh3l84p6vangr702r4da04wmcpqlpcp5u4dqqslc0zqn9k3f5teyhxvwr62gh0waxr5pjm38hn0ct7lsnsezf9n6",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 4,
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51",
-                  Object {
-                    "__type": "bigint",
-                    "value": "55771",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51" => 55771n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
@@ -2111,59 +1286,25 @@ Array [
           "index": 5,
           "txId": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51",
-                  Object {
-                    "__type": "bigint",
-                    "value": "3177821999",
-                  },
-                ],
-                Array [
-                  "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0b2ab12019a6d74df56c8056f6a5fe6f4b6cd5135d99ffe46b9a6b4864018ff6f",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-                Array [
-                  "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f744c51" => 3177821999n,
+              "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0b2ab12019a6d74df56c8056f6a5fe6f4b6cd5135d99ffe46b9a6b4864018ff6f" => 1n,
+              "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "140501471364",
-            },
+            "coins": 140501471364n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 49033345,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 16,
     "txSize": 10025,
@@ -2206,10 +1347,7 @@ Array [
           "scriptHash": "6e4664e3f6acc48e849eacf4e3607ee6ae2758d6d8b80fa9d8fdd761",
         },
       ],
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "signatures": Map {},
     },
   },
 ]
@@ -2220,183 +1358,63 @@ Array [
   Object {
     "auxiliaryData": Object {
       "body": Object {
-        "blob": Object {
-          "__type": "Map",
-          "value": Array [
-            Array [
-              Object {
-                "__type": "bigint",
-                "value": "1968",
-              },
-              Object {
-                "__type": "Map",
-                "value": Array [
-                  Array [
-                    "LQADA",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "0.00006725",
-                          ],
-                          Array [
-                            "source",
-                            "muesliswap",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "ADABTC",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "0.00002789",
-                          ],
-                          Array [
-                            "source",
-                            "coinGecko",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "ADAEUR",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "0.934303",
-                          ],
-                          Array [
-                            "source",
-                            "coinGecko",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "ADAJPY",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "119.97",
-                          ],
-                          Array [
-                            "source",
-                            "coinGecko",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "ADAUSD",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "1.04",
-                          ],
-                          Array [
-                            "source",
-                            "coinGecko",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "WMTADA",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "7.95e-7",
-                          ],
-                          Array [
-                            "source",
-                            "muesliswap",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "BTCDIFF",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "26643185256535.46",
-                          ],
-                          Array [
-                            "source",
-                            "trezor",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "HoskyADA",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "5.9e-8",
-                          ],
-                          Array [
-                            "source",
-                            "muesliswap",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                  Array [
-                    "SpacecoinsADA",
-                    Array [
-                      Object {
-                        "__type": "Map",
-                        "value": Array [
-                          Array [
-                            "value",
-                            "0.00955",
-                          ],
-                          Array [
-                            "source",
-                            "muesliswap",
-                          ],
-                        ],
-                      },
-                    ],
-                  ],
-                ],
+        "blob": Map {
+          1968n => Map {
+            "LQADA" => Array [
+              Map {
+                "value" => "0.00006725",
+                "source" => "muesliswap",
               },
             ],
-          ],
+            "ADABTC" => Array [
+              Map {
+                "value" => "0.00002789",
+                "source" => "coinGecko",
+              },
+            ],
+            "ADAEUR" => Array [
+              Map {
+                "value" => "0.934303",
+                "source" => "coinGecko",
+              },
+            ],
+            "ADAJPY" => Array [
+              Map {
+                "value" => "119.97",
+                "source" => "coinGecko",
+              },
+            ],
+            "ADAUSD" => Array [
+              Map {
+                "value" => "1.04",
+                "source" => "coinGecko",
+              },
+            ],
+            "WMTADA" => Array [
+              Map {
+                "value" => "7.95e-7",
+                "source" => "muesliswap",
+              },
+            ],
+            "BTCDIFF" => Array [
+              Map {
+                "value" => "26643185256535.46",
+                "source" => "trezor",
+              },
+            ],
+            "HoskyADA" => Array [
+              Map {
+                "value" => "5.9e-8",
+                "source" => "muesliswap",
+              },
+            ],
+            "SpacecoinsADA" => Array [
+              Map {
+                "value" => "0.00955",
+                "source" => "muesliswap",
+              },
+            ],
+          },
         },
       },
     },
@@ -2406,14 +1424,9 @@ Array [
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "183673",
-      },
+      "fee": 183673n,
       "inputs": Array [
         Object {
           "address": "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp",
@@ -2421,61 +1434,35 @@ Array [
           "txId": "3d2278e9cef71c79720a11bc3e08acbbd5f2175f7015d358c867fc9b419ae0b2",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "3d2278e9cef71c79720a11bc3e08acbbd5f2175f7015d358c867fc9b419ae0b2",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1477211770",
-            },
+            "assets": undefined,
+            "coins": 1477211770n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "3d2278e9cef71c79720a11bc3e08acbbd5f2175f7015d358c867fc9b419ae0b2",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 9,
     "txSize": 639,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
 ]
@@ -2484,9 +1471,7 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-hashes server and snapshot testing has certificates 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 2972717,
       "hash": "05fbc6f8a26c8e16d731dd86880be59b123d17b7ebc7271b8d9dedb4152888c2",
@@ -2501,10 +1486,7 @@ Array [
         },
       ],
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "179493",
-      },
+      "fee": 179493n,
       "inputs": Array [
         Object {
           "address": "addr_test1qpcnmvyjmxmsm75f747u566gw7ewz4mesdw7yl278uf9r3f5l7d7dpx2ymfwlm3e56flupga8yamjr2kwdt7dw77ktyqqtx2r7",
@@ -2512,65 +1494,39 @@ Array [
           "txId": "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1qpcnmvyjmxmsm75f747u566gw7ewz4mesdw7yl278uf9r3f5l7d7dpx2ymfwlm3e56flupga8yamjr2kwdt7dw77ktyqqtx2r7",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1497444361",
-            },
+            "assets": undefined,
+            "coins": 1497444361n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 39233846,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "deposit": 0n,
+      "input": 500000000n,
     },
     "index": 1,
     "txSize": 361,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3087425,
       "hash": "2d64f08b80b2f2afffa0887bf6421c3bacf863c70017ef78289340bc45bae1c5",
@@ -2589,10 +1545,7 @@ Array [
         },
       ],
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "197973",
-      },
+      "fee": 197973n,
       "inputs": Array [
         Object {
           "address": "addr_test1qpcnmvyjmxmsm75f747u566gw7ewz4mesdw7yl278uf9r3f5l7d7dpx2ymfwlm3e56flupga8yamjr2kwdt7dw77ktyqqtx2r7",
@@ -2600,59 +1553,35 @@ Array [
           "txId": "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1qpcnmvyjmxmsm75f747u566gw7ewz4mesdw7yl278uf9r3f5l7d7dpx2ymfwlm3e56flupga8yamjr2kwdt7dw77ktyqqtx2r7",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1497246388",
-            },
+            "assets": undefined,
+            "coins": 1497246388n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 43018365,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 500000000n,
+      "input": 0n,
     },
     "index": 2,
     "txSize": 737,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
 ]
@@ -2661,18 +1590,14 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-hashes server and snapshot testing has collateral inputs 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [
         Object {
           "address": "addr_test1vpmwgcd7xuqr60ej3qnlfeyy5qhaudhmnmxey6str7v4rrcd3t2q4",
@@ -2680,10 +1605,7 @@ Array [
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
         },
       ],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "774103",
-      },
+      "fee": 774103n,
       "inputs": Array [
         Object {
           "address": "addr_test1vpmwgcd7xuqr60ej3qnlfeyy5qhaudhmnmxey6str7v4rrcd3t2q4",
@@ -2701,153 +1623,83 @@ Array [
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1vpmwgcd7xuqr60ej3qnlfeyy5qhaudhmnmxey6str7v4rrcd3t2q4",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "448931056",
-            },
+            "assets": undefined,
+            "coins": 448931056n,
           },
         },
         Object {
           "address": "addr_test1vq6pv6z64ldwflq5zxllfyjzxwdsgajhwg00guhrjmwq2gs0s97am",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "8000000",
-            },
+            "assets": undefined,
+            "coins": 8000000n,
           },
         },
         Object {
           "address": "addr_test1vpmwgcd7xuqr60ej3qnlfeyy5qhaudhmnmxey6str7v4rrcd3t2q4",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 2,
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "d6cfdbedd242056674c0e51ead01785497e3a48afbbb146dc72ee1e2123456",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "d6cfdbedd242056674c0e51ead01785497e3a48afbbb146dc72ee1e2123456" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1724100",
-            },
+            "coins": 1724100n,
           },
         },
         Object {
           "address": "addr_test1vzal5wcx2cnfvux84kf8clcj65ej2qklhtahecr5caytrdqr0jl5z",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 3,
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1000000",
-            },
+            "assets": undefined,
+            "coins": 1000000n,
           },
         },
         Object {
           "address": "addr_test1vqfn7fxr9wlraeymtcfvn6nlkyndp4ry0uryyk3vk73wlzsk8y0yd",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 4,
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1000000",
-            },
+            "assets": undefined,
+            "coins": 1000000n,
           },
         },
         Object {
           "address": "addr_test1vpmwgcd7xuqr60ej3qnlfeyy5qhaudhmnmxey6str7v4rrcd3t2q4",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 5,
           "txId": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "d6cfdbedd242056674c0e51ead01785497e3a48afbbb146dc72ee1e2123456",
-                  Object {
-                    "__type": "bigint",
-                    "value": "3",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "d6cfdbedd242056674c0e51ead01785497e3a48afbbb146dc72ee1e2123456" => 3n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "3000000",
-            },
+            "coins": 3000000n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 12,
     "txSize": 4763,
@@ -2863,10 +1715,7 @@ Array [
           "scriptHash": "9f244c64c6ca8e495f4d0ac48f106a1dbdf20b0821d598ebbcd1c57d",
         },
       ],
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "signatures": Map {},
     },
   },
 ]
@@ -2875,23 +1724,16 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-hashes server and snapshot testing has mint operations 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3157934,
       "hash": "f03084089ec7e74a79e69a5929b2d3c0836d6f12279bd103d0875847c740ae27",
       "slot": 45286016,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "177777",
-      },
+      "fee": 177777n,
       "inputs": Array [
         Object {
           "address": "addr_test1qr74u5d3d07x53pq37acghulu7wvjt794s53xp2fz343drhx2aghqc4747n2yhu0dht5xz0t5j6n0fju3rs8mfj83tzqly49jr",
@@ -2899,152 +1741,57 @@ Array [
           "txId": "952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb",
         },
       ],
-      "mint": Object {
-        "__type": "Map",
-        "value": Array [
-          Array [
-            "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43",
-            Object {
-              "__type": "bigint",
-              "value": "10000000",
-            },
-          ],
-          Array [
-            "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54",
-            Object {
-              "__type": "bigint",
-              "value": "5000000000",
-            },
-          ],
-          Array [
-            "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259",
-            Object {
-              "__type": "bigint",
-              "value": "1000000000",
-            },
-          ],
-          Array [
-            "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259",
-            Object {
-              "__type": "bigint",
-              "value": "2000000000",
-            },
-          ],
-          Array [
-            "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c",
-            Object {
-              "__type": "bigint",
-              "value": "15000000",
-            },
-          ],
-        ],
+      "mint": Map {
+        "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43" => 10000000n,
+        "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54" => 5000000000n,
+        "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259" => 1000000000n,
+        "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 2000000000n,
+        "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c" => 15000000n,
       },
       "outputs": Array [
         Object {
           "address": "addr_test1qr74u5d3d07x53pq37acghulu7wvjt794s53xp2fz343drhx2aghqc4747n2yhu0dht5xz0t5j6n0fju3rs8mfj83tzqly49jr",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "5528822746696",
-            },
+            "assets": undefined,
+            "coins": 5528822746696n,
           },
         },
         Object {
           "address": "addr_test1qzmpmxyl7prdf0pazt0futtrg6k9drcay3ednatxqm5ky854nqdumcu3xny9qu5sk9m0wm0ypyty84kxj0gwd9seppfqzs9z2n",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43",
-                  Object {
-                    "__type": "bigint",
-                    "value": "10000000",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54",
-                  Object {
-                    "__type": "bigint",
-                    "value": "5000000000",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1000000000",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259",
-                  Object {
-                    "__type": "bigint",
-                    "value": "2000000000",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c",
-                  Object {
-                    "__type": "bigint",
-                    "value": "15000000",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652243484f43" => 10000000n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54" => 5000000000n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259" => 1000000000n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 2000000000n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c" => 15000000n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "1000000000",
-            },
+            "coins": 1000000000n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 0,
     "txSize": 509,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
 ]
@@ -3053,23 +1800,16 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-hashes server and snapshot testing has outputs with multi-assets 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3157934,
       "hash": "f03084089ec7e74a79e69a5929b2d3c0836d6f12279bd103d0875847c740ae27",
       "slot": 45286016,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "191109",
-      },
+      "fee": 191109n,
       "inputs": Array [
         Object {
           "address": "addr_test1qpvl4gf5r5h5w4yjrf58rt8slltem9tqfge36zqhsz5kgc8f2tc4ydn4zz9p0eymajqa4vj87he7yz6ssmh9x9h685hst9rgvk",
@@ -3077,9 +1817,7 @@ Array [
           "txId": "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1wrsexavz37208qda7mwwu4k7hcpg26cz0ce86f5e9kul3hqzlh22t",
@@ -3087,133 +1825,48 @@ Array [
           "index": 0,
           "txId": "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259",
-                  Object {
-                    "__type": "bigint",
-                    "value": "10000000",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 10000000n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "7420514",
-            },
+            "coins": 7420514n,
           },
         },
         Object {
           "address": "addr_test1qpvl4gf5r5h5w4yjrf58rt8slltem9tqfge36zqhsz5kgc8f2tc4ydn4zz9p0eymajqa4vj87he7yz6ssmh9x9h685hst9rgvk",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "22be35160908d953c25b30d1ad59876cbf073a8b31ef7a4f77468355414141",
-                  Object {
-                    "__type": "bigint",
-                    "value": "4208",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1914111968",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1000000000",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1990000000",
-                  },
-                ],
-                Array [
-                  "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c",
-                  Object {
-                    "__type": "bigint",
-                    "value": "15000000",
-                  },
-                ],
-                Array [
-                  "cd9d85fe5c8a1684c42ae0082e7e912fb7a7cca0900c5a3915eb1c3442454e59",
-                  Object {
-                    "__type": "bigint",
-                    "value": "2819431",
-                  },
-                ],
-                Array [
-                  "d311d3488cc4fef19d05634adce8534977a3bc6fc18136ad65df1d4f6c71202e01",
-                  Object {
-                    "__type": "bigint",
-                    "value": "100000000",
-                  },
-                ],
-                Array [
-                  "d311d3488cc4fef19d05634adce8534977a3bc6fc18136ad65df1d4f6c712038",
-                  Object {
-                    "__type": "bigint",
-                    "value": "172696733",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "22be35160908d953c25b30d1ad59876cbf073a8b31ef7a4f77468355414141" => 4208n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf39165224d494e54" => 1914111968n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522524245525259" => 1000000000n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259" => 1990000000n,
+              "57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf391652256414e494c" => 15000000n,
+              "cd9d85fe5c8a1684c42ae0082e7e912fb7a7cca0900c5a3915eb1c3442454e59" => 2819431n,
+              "d311d3488cc4fef19d05634adce8534977a3bc6fc18136ad65df1d4f6c71202e01" => 100000000n,
+              "d311d3488cc4fef19d05634adce8534977a3bc6fc18136ad65df1d4f6c712038" => 172696733n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "850065083",
-            },
+            "coins": 850065083n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 30,
     "txSize": 711,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
 ]
@@ -3222,18 +1875,14 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-hashes server and snapshot testing has redeemers 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
       "slot": 49032415,
     },
     "body": Object {
-      "certificates": Object {
-        "__type": "undefined",
-      },
+      "certificates": undefined,
       "collaterals": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
@@ -3241,10 +1890,7 @@ Array [
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
         },
       ],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "1030338",
-      },
+      "fee": 1030338n,
       "inputs": Array [
         Object {
           "address": "addr_test1wphyve8r76kvfr5yn6k0fcmq0mn2uf6c6mvtsrafmr7awcg0vnzpg",
@@ -3277,145 +1923,67 @@ Array [
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
         },
       ],
-      "mint": Object {
-        "__type": "Map",
-        "value": Array [
-          Array [
-            "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114",
-            Object {
-              "__type": "bigint",
-              "value": "15355454",
-            },
-          ],
-        ],
+      "mint": Map {
+        "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114" => 15355454n,
       },
       "outputs": Array [
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "28178818258",
-            },
+            "assets": undefined,
+            "coins": 28178818258n,
           },
         },
         Object {
           "address": "addr_test1qqemvcq8wdt9cv0sxsghv497zjsjzyzkekpw4vlvea44kdgy720vc4ggn5u4y39cc2wctg2u6sgackadnl78lxqq3m9q47wq8e",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "ccc526143b6d41d56036248dbaa79440d68653f5b6a1919aa2c9e06131363732343139363030303033" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "10000000",
-            },
+            "coins": 10000000n,
           },
         },
         Object {
           "address": "addr_test1qq9gwfwevn5s96jx9xzclntlrd8m0mrs3ezzva7akkvyj9y7yjf2z5h4fealu2rktu38m3mfv68vsjrtrfwuym60dfyq0axz58",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 2,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1909",
-                  },
-                ],
-                Array [
-                  "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114",
-                  Object {
-                    "__type": "bigint",
-                    "value": "15355454",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 1909n,
+              "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114" => 15355454n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qqfleha26t47j6khuetrsjyxkwl4x2lya5jsmn24h53n6d6akgetsg2jxgxsqglg8k9m74c8uwl8gxen3hvxsupapqasdzvh6n",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 3,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "333305",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 333305n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
           "address": "addr_test1qqvl0h49qke8yv8r5as3vrt3zaqdygjmfsfj63futhj803s2wkugrs72zdued30dtsce7mwclnd6n49a64q6f4mmcfksqaspe4",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 4,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "932541",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 932541n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "2000000",
-            },
+            "coins": 2000000n,
           },
         },
         Object {
@@ -3424,59 +1992,25 @@ Array [
           "index": 5,
           "txId": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
           "value": Object {
-            "assets": Object {
-              "__type": "Map",
-              "value": Array [
-                Array [
-                  "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1651585768",
-                  },
-                ],
-                Array [
-                  "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-                Array [
-                  "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150",
-                  Object {
-                    "__type": "bigint",
-                    "value": "1",
-                  },
-                ],
-              ],
+            "assets": Map {
+              "126b8676446c84a5cd6e3259223b16a2314c5676b88ae1c1f8579a8f7453554e444145" => 1651585768n,
+              "75ac961881fd5d8d0008d54b4f6914eb6a712faa3403dc32097379b0f32324c10a93fe1962cf7470543932cc064482c3495fe3de7502f9edd84ca114" => 1n,
+              "95b7f0bbaa0b327e6b822840b0f7f7ee1c949e618f0aaeb6c5321cc34d494e53574150" => 1n,
             },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "247344475554",
-            },
+            "coins": 247344475554n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
         "invalidHereafter": 49033345,
       },
-      "withdrawals": Object {
-        "__type": "undefined",
-      },
+      "withdrawals": undefined,
     },
     "id": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
+      "deposit": 0n,
+      "input": 0n,
     },
     "index": 14,
     "txSize": 10662,
@@ -3528,10 +2062,7 @@ Array [
           "scriptHash": "22c3b86a5b88a78b5de52f4aed2831d1483b3b7681f1ee2569538130",
         },
       ],
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "signatures": Map {},
     },
   },
 ]
@@ -3540,9 +2071,7 @@ Array [
 exports[`ChainHistoryHttpService healthy state /txs/by-hashes server and snapshot testing has withdrawals 1`] = `
 Array [
   Object {
-    "auxiliaryData": Object {
-      "__type": "undefined",
-    },
+    "auxiliaryData": undefined,
     "blockHeader": Object {
       "blockNo": 3274726,
       "hash": "5caede44f4a5a775443095159cd42c8a64f35494086957ab3e04624015a6e13c",
@@ -3557,10 +2086,7 @@ Array [
         },
       ],
       "collaterals": Array [],
-      "fee": Object {
-        "__type": "bigint",
-        "value": "183233",
-      },
+      "fee": 183233n,
       "inputs": Array [
         Object {
           "address": "addr_test1qq8n7qxxlau6dt0v47fya55pyfz42ul86tyuy8al5rg4crgeq9dceusu9snpw8hrugasdcp00akqvtfjfr3hrsv0pa4sxqg7e2",
@@ -3568,91 +2094,54 @@ Array [
           "txId": "cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99",
         },
       ],
-      "mint": Object {
-        "__type": "undefined",
-      },
+      "mint": undefined,
       "outputs": Array [
         Object {
           "address": "addr_test1qre8ns5ahywhp3c3y3tx94d3mlefhz5z52gzyl5rhypjfdseq9dceusu9snpw8hrugasdcp00akqvtfjfr3hrsv0pa4scxxqx6",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 0,
           "txId": "cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "489109783",
-            },
+            "assets": undefined,
+            "coins": 489109783n,
           },
         },
         Object {
           "address": "addr_test1qr66d9smqd69upk9pkkl0ll7pchzfr60zc496xzatln48ewrd7syppw2gqywrvfcdsu2mlqyrngnlxdyhlffjrlm5jkqqw05lr",
-          "datum": Object {
-            "__type": "undefined",
-          },
+          "datum": undefined,
           "index": 1,
           "txId": "cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99",
           "value": Object {
-            "assets": Object {
-              "__type": "undefined",
-            },
-            "coins": Object {
-              "__type": "bigint",
-              "value": "512345678",
-            },
+            "assets": undefined,
+            "coins": 512345678n,
           },
         },
       ],
       "validityInterval": Object {
-        "invalidBefore": Object {
-          "__type": "undefined",
-        },
-        "invalidHereafter": Object {
-          "__type": "undefined",
-        },
+        "invalidBefore": undefined,
+        "invalidHereafter": undefined,
       },
       "withdrawals": Array [
         Object {
-          "quantity": Object {
-            "__type": "bigint",
-            "value": "1409612",
-          },
+          "quantity": 1409612n,
           "stakeAddress": "stake_test1uqvszkuv7gwzcfshrm37ywcxuqhh7mqx95ey3cm3cx8s76c7w97f8",
         },
         Object {
-          "quantity": Object {
-            "__type": "bigint",
-            "value": "229082",
-          },
+          "quantity": 229082n,
           "stakeAddress": "stake_test1urpklgzqsh9yqz8pkyuxcw9dlszpe5flnxjtl55epla6ftqktdyfz",
         },
       ],
     },
     "id": "cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99",
     "implicitCoin": Object {
-      "deposit": Object {
-        "__type": "bigint",
-        "value": "0",
-      },
-      "input": Object {
-        "__type": "bigint",
-        "value": "1638694",
-      },
+      "deposit": 0n,
+      "input": 1638694n,
     },
     "index": 2,
     "txSize": 629,
     "witness": Object {
-      "redeemers": Object {
-        "__type": "undefined",
-      },
-      "signatures": Object {
-        "__type": "Map",
-        "value": Array [],
-      },
+      "redeemers": undefined,
+      "signatures": Map {},
     },
   },
 ]

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -60,6 +60,7 @@ describe('StakePoolHttpService', () => {
   let clientConfig: CreateHttpProviderConfig<StakePoolProvider>;
   let config: HttpServerConfig;
   let doStakePoolRequest: ReturnType<typeof doServerRequest>;
+  let provider: StakePoolProvider;
 
   beforeAll(async () => {
     port = await getPort();
@@ -104,6 +105,7 @@ describe('StakePoolHttpService', () => {
       httpServer = new HttpServer(config, { services: [service] });
       await httpServer.initialize();
       await httpServer.start();
+      provider = stakePoolHttpProvider(clientConfig);
     });
 
     afterAll(async () => {
@@ -123,53 +125,45 @@ describe('StakePoolHttpService', () => {
 
     describe('/search', () => {
       const url = '/search';
-      it('returns a 200 coded response with a well formed HTTP request', async () => {
-        expect((await axios.post(`${baseUrl}${url}`, { args: [] })).status).toEqual(200);
-      });
-
-      it('returns a 415 coded response if the wrong content type header is used', async () => {
-        try {
-          await axios.post(`${baseUrl}${url}`, undefined, { headers: { 'Content-Type': APPLICATION_CBOR } });
-          throw new Error('fail');
-        } catch (error: any) {
-          expect(error.response.status).toBe(415);
-          expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
-        }
-      });
-
-      describe('with StakePoolHttpProvider', () => {
-        let provider: StakePoolProvider;
-        beforeEach(() => {
-          provider = stakePoolHttpProvider(clientConfig);
+      describe('with Http Server', () => {
+        it('returns a 200 coded response with a well formed HTTP request', async () => {
+          expect((await axios.post(`${baseUrl}${url}`, { args: [] })).status).toEqual(200);
         });
 
-        it('response is an array of stake pools', async () => {
-          const options: StakePoolQueryOptions = {
-            filters: {
-              identifier: {
-                _condition: 'or',
-                values: [
-                  { name: 'banderini' },
-                  { id: Cardano.PoolId('pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70') }
-                ]
-              }
+        it('returns a 415 coded response if the wrong content type header is used', async () => {
+          try {
+            await axios.post(`${baseUrl}${url}`, undefined, { headers: { 'Content-Type': APPLICATION_CBOR } });
+            throw new Error('fail');
+          } catch (error: any) {
+            expect(error.response.status).toBe(415);
+            expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+          }
+        });
+      });
+
+      it('response is an array of stake pools', async () => {
+        const options: StakePoolQueryOptions = {
+          filters: {
+            identifier: {
+              _condition: 'or',
+              values: [
+                { name: 'banderini' },
+                { id: Cardano.PoolId('pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70') }
+              ]
             }
-          };
-          const response = await provider.queryStakePools(options);
-          expect(response.pageResults).toHaveLength(2);
-          expect(response.totalResultCount).toEqual(2);
-        });
+          }
+        };
+        const response = await provider.queryStakePools(options);
+        expect(response.pageResults).toHaveLength(2);
+        expect(response.totalResultCount).toEqual(2);
       });
 
       describe('pagination', () => {
         it('should paginate response', async () => {
           const req: StakePoolQueryOptions = {};
           const reqWithPagination: StakePoolQueryOptions = { pagination: { limit: 2, startAt: 1 } };
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
-          const responseWithPagination = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [reqWithPagination]
-          );
+          const responseWithPagination = await provider.queryStakePools(reqWithPagination);
+          const response = await provider.queryStakePools(req);
           expect(response.pageResults.length).toEqual(10);
           expect(responseWithPagination.pageResults.length).toEqual(2);
           expect(response.pageResults[0]).not.toEqual(responseWithPagination.pageResults[0]);
@@ -177,11 +171,8 @@ describe('StakePoolHttpService', () => {
         it('should paginate response with or condition', async () => {
           const req: StakePoolQueryOptions = { filters: { _condition: 'or' } };
           const reqWithPagination: StakePoolQueryOptions = { ...req, pagination: { limit: 2, startAt: 1 } };
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
-          const responseWithPagination = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [reqWithPagination]
-          );
+          const responseWithPagination = await provider.queryStakePools(reqWithPagination);
+          const response = await provider.queryStakePools(req);
           expect(response.pageResults.length).toEqual(10);
           expect(responseWithPagination.pageResults.length).toEqual(2);
           expect(response.pageResults[0]).not.toEqual(responseWithPagination.pageResults[0]);
@@ -189,22 +180,16 @@ describe('StakePoolHttpService', () => {
         it('should paginate rewards response', async () => {
           const req = { pagination: { limit: 1, startAt: 1 } };
           const reqWithRewardsPagination = { pagination: { limit: 1, startAt: 1 }, rewardsHistoryLimit: 0 };
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
-          const responseWithPagination = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [reqWithRewardsPagination]
-          );
+          const responseWithPagination = await provider.queryStakePools(reqWithRewardsPagination);
+          const response = await provider.queryStakePools(req);
           expect(response.pageResults[0].epochRewards.length).toEqual(1);
           expect(responseWithPagination.pageResults[0].epochRewards.length).toEqual(0);
         });
         it('should paginate rewards response with or condition', async () => {
           const req: StakePoolQueryOptions = { filters: { _condition: 'or' }, pagination: { limit: 1, startAt: 1 } };
           const reqWithRewardsPagination = { pagination: { limit: 1, startAt: 1 }, rewardsHistoryLimit: 0 };
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
-          const responseWithPagination = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [reqWithRewardsPagination]
-          );
+          const responseWithPagination = await provider.queryStakePools(reqWithRewardsPagination);
+          const response = await provider.queryStakePools(req);
           expect(response.pageResults[0].epochRewards.length).toEqual(1);
           expect(responseWithPagination.pageResults[0].epochRewards.length).toEqual(0);
         });
@@ -226,14 +211,8 @@ describe('StakePoolHttpService', () => {
               }
             }
           };
-          const responseWithOrCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [setFilterCondition(req, 'or')]
-          );
-          const responseWithAndCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [req]
-          );
+          const responseWithOrCondition = await provider.queryStakePools(setFilterCondition(req, 'or'));
+          const responseWithAndCondition = await provider.queryStakePools(req);
           expect(responseWithOrCondition).toMatchSnapshot();
           expect(responseWithAndCondition).toEqual(responseWithOrCondition);
         });
@@ -250,14 +229,8 @@ describe('StakePoolHttpService', () => {
               }
             }
           };
-          const responseWithOrCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [setFilterCondition(req, 'or')]
-          );
-          const responseWithAndCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [req]
-          );
+          const responseWithOrCondition = await provider.queryStakePools(setFilterCondition(req, 'or'));
+          const responseWithAndCondition = await provider.queryStakePools(req);
           expect(responseWithOrCondition).toMatchSnapshot();
           expect(responseWithAndCondition).toEqual(responseWithAndCondition);
         });
@@ -270,7 +243,7 @@ describe('StakePoolHttpService', () => {
               }
             }
           };
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
+          const response = await provider.queryStakePools(req);
           expect(response.pageResults).toEqual([]);
         });
       });
@@ -281,11 +254,8 @@ describe('StakePoolHttpService', () => {
               status: [Cardano.StakePoolStatus.Active]
             }
           };
-          const responseWithOrCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [setFilterCondition(req, 'or')]
-          );
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
+          const responseWithOrCondition = await provider.queryStakePools(setFilterCondition(req, 'or'));
+          const response = await provider.queryStakePools(req);
           expect(responseWithOrCondition).toMatchSnapshot();
           expect(response).toEqual(responseWithOrCondition);
         });
@@ -296,7 +266,7 @@ describe('StakePoolHttpService', () => {
               status: [Cardano.StakePoolStatus.Activating]
             }
           };
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
+          const response = await provider.queryStakePools(req);
           expect(response).toMatchSnapshot();
         });
         it('search by retired status', async () => {
@@ -305,11 +275,8 @@ describe('StakePoolHttpService', () => {
               status: [Cardano.StakePoolStatus.Retired]
             }
           };
-          const responseWithOrCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [setFilterCondition(req, 'or')]
-          );
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
+          const responseWithOrCondition = await provider.queryStakePools(setFilterCondition(req, 'or'));
+          const response = await provider.queryStakePools(req);
           expect(responseWithOrCondition).toMatchSnapshot();
           expect(response).toEqual(responseWithOrCondition);
         });
@@ -319,15 +286,13 @@ describe('StakePoolHttpService', () => {
               status: [Cardano.StakePoolStatus.Retiring]
             }
           };
-          const responseWithOrCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [setFilterCondition(req, 'or')]
-          );
-          const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [req]);
+          const responseWithOrCondition = await provider.queryStakePools(setFilterCondition(req, 'or'));
+          const response = await provider.queryStakePools(req);
           expect(responseWithOrCondition).toMatchSnapshot();
           expect(response).toEqual(responseWithOrCondition);
         });
       });
+
       describe('search pools by pledge met', () => {
         it('search by pledge met on true', async () => {
           const req: StakePoolQueryOptions = {
@@ -351,18 +316,13 @@ describe('StakePoolHttpService', () => {
               pledgeMet: false
             }
           };
-          const responseWithOrCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [setFilterCondition(req, 'or')]
-          );
+          const responseWithOrCondition = await provider.queryStakePools(setFilterCondition(req, 'or'));
+          const responseWithAndCondition = await provider.queryStakePools(req);
           expect(responseWithOrCondition).toMatchSnapshot();
-          const responseWithAndCondition = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(
-            url,
-            [req]
-          );
           expect(responseWithAndCondition).toEqual(responseWithAndCondition);
         });
       });
+
       describe('search pools by multiple filters', () => {
         const req: StakePoolQueryOptions = {
           filters: {
@@ -391,170 +351,158 @@ describe('StakePoolHttpService', () => {
         };
         describe('identifier & status filters', () => {
           it('active with or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Active)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('active with and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              addStatusFilter(req, Cardano.StakePoolStatus.Active)
-            ]);
+            const response = await provider.queryStakePools(addStatusFilter(req, Cardano.StakePoolStatus.Active));
             expect(response).toMatchSnapshot();
           });
           it('activating with or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Activating)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('activating with and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              addStatusFilter(req, Cardano.StakePoolStatus.Activating)
-            ]);
+            const response = await provider.queryStakePools(addStatusFilter(req, Cardano.StakePoolStatus.Activating));
             expect(response).toMatchSnapshot();
           });
           it('retired with or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Retired)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('retired with and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              addStatusFilter(req, Cardano.StakePoolStatus.Retired)
-            ]);
+            const response = await provider.queryStakePools(addStatusFilter(req, Cardano.StakePoolStatus.Retired));
             expect(response).toMatchSnapshot();
           });
           it('retiring with or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Retiring)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('retiring with and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              addStatusFilter(req, Cardano.StakePoolStatus.Retiring)
-            ]);
+            const response = await provider.queryStakePools(addStatusFilter(req, Cardano.StakePoolStatus.Retiring));
             expect(response).toMatchSnapshot();
           });
         });
         describe('identifier & status  & pledgeMet filters', () => {
           it('pledgeMet true, active,  or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Active), true)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, active,  or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Active), false)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet true, status active, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Active), true)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, status active, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Active), false)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet true, status activating, or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(
                 addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Activating),
                 true
               )
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, status activating, or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(
                 addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Activating),
                 false
               )
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet true, status activating, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Activating), true)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, status activating, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Activating), false)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet true, status retired, or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Retired), true)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, status retired, or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Retired), false)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet true, status retired, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Retired), true)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, status retired, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Retired), false)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet true, status retiring, or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Retiring), true)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, status retiring, or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(
                 addStatusFilter(setFilterCondition(req, 'or'), Cardano.StakePoolStatus.Retiring),
                 false
               )
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet true, status retiring, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Retiring), true)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet false, status retiring, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               addPledgeMetFilter(addStatusFilter(req, Cardano.StakePoolStatus.Retiring), false)
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet, multiple status, or condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              reqWithMultipleFilters
-            ]);
+            const response = await provider.queryStakePools(reqWithMultipleFilters);
             expect(response).toMatchSnapshot();
           });
           it('pledgeMet, multiple status, and condition', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setFilterCondition(reqWithMultipleFilters, 'and')
-            ]);
+            const response = await provider.queryStakePools(setFilterCondition(reqWithMultipleFilters, 'and'));
             expect(response).toMatchSnapshot();
           });
         });
@@ -584,22 +532,17 @@ describe('StakePoolHttpService', () => {
 
         describe('sort by name', () => {
           it('desc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'desc', 'name')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'desc', 'name'));
             expect(response).toMatchSnapshot();
           });
 
           it('asc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'asc', 'name')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'asc', 'name'));
             expect(response).toMatchSnapshot();
           });
 
           it('if sort not provided, defaults to order by name and then by poolId asc', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [{}]);
-
+            const response = await provider.queryStakePools({});
             const resultSortedCopy = [...response.pageResults].sort(sortByNameThenByPoolId);
 
             expect(response.pageResults).toEqual(resultSortedCopy);
@@ -633,9 +576,10 @@ describe('StakePoolHttpService', () => {
                 fistNoMetadataPoolId,
                 secondNoMetadataPoolId
               ];
-              const { pageResults } = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-                { ...reqOptions, sort: { field: 'name', order: 'asc' } }
-              ]);
+              const { pageResults } = await provider.queryStakePools({
+                ...reqOptions,
+                sort: { field: 'name', order: 'asc' }
+              });
 
               expect(pageResults.length).toEqual(4);
               expect(pageResults[0].metadata?.name).toEqual('CLIO1');
@@ -650,10 +594,10 @@ describe('StakePoolHttpService', () => {
                 fistNoMetadataPoolId,
                 secondNoMetadataPoolId
               ];
-              const { pageResults } = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-                { ...reqOptions, sort: { field: 'name', order: 'desc' } }
-              ]);
-
+              const { pageResults } = await provider.queryStakePools({
+                ...reqOptions,
+                sort: { field: 'name', order: 'desc' }
+              });
               expect(pageResults.length).toEqual(4);
               expect(pageResults[0].metadata?.name).toEqual('Farts');
               expect(pageResults[pageResults.length - 1].metadata?.name).toBeUndefined();
@@ -662,33 +606,33 @@ describe('StakePoolHttpService', () => {
           });
 
           it('with applied filters', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               setSortCondition(setFilterCondition(filterArgs, 'or'), 'desc', 'name')
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
 
           it('asc order with applied pagination', async () => {
-            const firstPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const firstPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 0, 3), 'asc', 'name')
-            ]);
+            );
 
-            const secondPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const secondPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 3, 3), 'asc', 'name')
-            ]);
+            );
 
             expect(firstPageResultSet).toMatchSnapshot();
             expect(secondPageResultSet).toMatchSnapshot();
           });
 
           it('asc order with applied pagination, with change sort order on next page', async () => {
-            const firstPageResponse = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const firstPageResponse = await provider.queryStakePools(
               setSortCondition(setPagination({}, 0, 5), 'asc', 'name')
-            ]);
+            );
 
-            const secondPageResponse = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const secondPageResponse = await provider.queryStakePools(
               setSortCondition(setPagination({}, 5, 5), 'asc', 'name')
-            ]);
+            );
             const firstPageIds = firstPageResponse.pageResults.map(({ id }) => id);
 
             const hasDuplicatedIdsBetweenPages = firstPageIds.some((id) =>
@@ -701,9 +645,9 @@ describe('StakePoolHttpService', () => {
           });
 
           it('asc order with applied pagination and filters', async () => {
-            const responsePage = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const responsePage = await provider.queryStakePools(
               setSortCondition(setPagination(setFilterCondition(filterArgs, 'or'), 0, 5), 'asc', 'name')
-            ]);
+            );
 
             expect(responsePage).toMatchSnapshot();
           });
@@ -711,30 +655,26 @@ describe('StakePoolHttpService', () => {
 
         describe('sort by saturation', () => {
           it('desc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'desc', 'saturation')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'desc', 'saturation'));
             expect(response).toMatchSnapshot();
           });
           it('asc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'asc', 'saturation')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'asc', 'saturation'));
             expect(response).toMatchSnapshot();
           });
           it('with applied filters', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               setSortCondition(setFilterCondition(filterArgs, 'or'), 'asc', 'saturation')
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('with applied pagination', async () => {
-            const firstPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const firstPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 0, 3), 'asc', 'saturation')
-            ]);
-            const secondPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            );
+            const secondPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 3, 3), 'asc', 'saturation')
-            ]);
+            );
 
             expect(firstPageResultSet).toMatchSnapshot();
             expect(secondPageResultSet).toMatchSnapshot();
@@ -743,30 +683,26 @@ describe('StakePoolHttpService', () => {
 
         describe('sort by APY', () => {
           it('desc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'desc', 'apy')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'desc', 'apy'));
             expect(response).toMatchSnapshot();
           });
           it('asc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'asc', 'apy')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'asc', 'apy'));
             expect(response).toMatchSnapshot();
           });
           it('with applied filters', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               setSortCondition(setFilterCondition(filterArgs, 'or'), 'asc', 'apy')
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('with applied pagination', async () => {
-            const firstPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const firstPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 0, 3), 'desc', 'apy')
-            ]);
-            const secondPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            );
+            const secondPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 3, 3), 'desc', 'apy')
-            ]);
+            );
             expect(firstPageResultSet).toMatchSnapshot();
             expect(secondPageResultSet).toMatchSnapshot();
           });
@@ -774,30 +710,26 @@ describe('StakePoolHttpService', () => {
 
         describe('sort by cost and margin', () => {
           it('desc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'desc', 'cost')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'desc', 'cost'));
             expect(response).toMatchSnapshot();
           });
           it('asc order', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
-              setSortCondition({}, 'asc', 'cost')
-            ]);
+            const response = await provider.queryStakePools(setSortCondition({}, 'asc', 'cost'));
             expect(response).toMatchSnapshot();
           });
           it('with applied filters', async () => {
-            const response = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const response = await provider.queryStakePools(
               setSortCondition(setFilterCondition(filterArgs, 'or'), 'asc', 'cost')
-            ]);
+            );
             expect(response).toMatchSnapshot();
           });
           it('with applied pagination', async () => {
-            const firstPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            const firstPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 0, 3), 'desc', 'cost')
-            ]);
-            const secondPageResultSet = await doStakePoolRequest<[StakePoolQueryOptions], StakePoolSearchResults>(url, [
+            );
+            const secondPageResultSet = await provider.queryStakePools(
               setSortCondition(setPagination({}, 3, 3), 'desc', 'cost')
-            ]);
+            );
             expect(firstPageResultSet).toMatchSnapshot();
             expect(secondPageResultSet).toMatchSnapshot();
           });
@@ -807,32 +739,27 @@ describe('StakePoolHttpService', () => {
 
     describe('/stats', () => {
       const url = '/stats';
-      it('returns a 200 coded response with a well formed HTTP request', async () => {
-        expect((await axios.post(`${baseUrl}${url}`, { args: [] })).status).toEqual(200);
-      });
-
-      it('returns a 415 coded response if the wrong content type header is used', async () => {
-        try {
-          await axios.post(`${baseUrl}${url}`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
-          throw new Error('fail');
-        } catch (error: any) {
-          expect(error.response.status).toBe(415);
-          expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
-        }
-      });
-
-      describe('with StakePoolHttpProvider', () => {
-        let provider: StakePoolProvider;
-        beforeEach(() => {
-          provider = stakePoolHttpProvider(clientConfig);
+      describe('with Http Server', () => {
+        it('returns a 200 coded response with a well formed HTTP request', async () => {
+          expect((await axios.post(`${baseUrl}${url}`, { args: [] })).status).toEqual(200);
         });
 
-        it('response is an object with stake pool stats', async () => {
-          const response = await provider.stakePoolStats();
-          expect(response.qty.active).toBe(8);
-          expect(response.qty.retired).toBe(2);
-          expect(response.qty.retiring).toBe(0);
+        it('returns a 415 coded response if the wrong content type header is used', async () => {
+          try {
+            await axios.post(`${baseUrl}${url}`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+            throw new Error('fail');
+          } catch (error: any) {
+            expect(error.response.status).toBe(415);
+            expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+          }
         });
+      });
+
+      it('response is an object with stake pool stats', async () => {
+        const response = await provider.stakePoolStats();
+        expect(response.qty.active).toBe(8);
+        expect(response.qty.retired).toBe(2);
+        expect(response.qty.retiring).toBe(0);
       });
 
       describe('server and snapshot testing', () => {

--- a/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
@@ -4,27 +4,15 @@ exports[`StakePoolHttpService healthy state /search search pools by identifier f
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -47,33 +35,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -102,27 +78,15 @@ exports[`StakePoolHttpService healthy state /search search pools by identifier f
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -145,33 +109,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -190,27 +142,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -233,33 +173,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -280,27 +208,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -323,33 +239,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -369,27 +273,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -412,33 +304,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -466,27 +346,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -509,33 +377,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -554,27 +410,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -597,33 +441,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -644,27 +476,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -687,33 +507,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -736,27 +544,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -779,33 +575,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -825,27 +609,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -868,33 +640,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -912,27 +672,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -955,33 +703,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1001,27 +737,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -1044,33 +768,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1090,27 +802,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -1127,33 +827,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1173,27 +861,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -1210,34 +886,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -1293,27 +957,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -1336,33 +988,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -1381,27 +1021,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -1424,33 +1052,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1471,27 +1087,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -1514,33 +1118,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -1560,27 +1152,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -1603,33 +1183,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1649,27 +1217,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -1692,33 +1248,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1746,27 +1290,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -1789,33 +1321,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1835,27 +1355,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -1878,33 +1386,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -1939,27 +1435,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -1982,33 +1466,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -2027,27 +1499,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -2070,33 +1530,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -2117,27 +1565,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -2160,33 +1596,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -2206,27 +1630,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -2249,33 +1661,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -2295,27 +1695,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -2338,33 +1726,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -2384,27 +1760,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -2421,33 +1785,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -2482,27 +1834,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -2525,33 +1865,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -2570,27 +1898,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -2613,33 +1929,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -2660,27 +1964,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -2703,33 +1995,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -2749,27 +2029,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -2792,33 +2060,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -2838,27 +2094,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -2881,33 +2125,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -2935,27 +2167,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -2978,33 +2198,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -3023,27 +2231,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -3066,33 +2262,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -3113,27 +2297,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -3156,33 +2328,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -3205,27 +2365,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -3248,33 +2396,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -3292,27 +2428,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -3335,33 +2459,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -3381,27 +2493,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -3424,33 +2524,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -3470,27 +2558,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -3507,33 +2583,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -3553,27 +2617,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -3590,34 +2642,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -3673,27 +2713,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -3716,33 +2744,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -3761,27 +2777,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -3804,33 +2808,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -3851,27 +2843,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -3894,33 +2874,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -3943,27 +2911,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -3986,33 +2942,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4032,27 +2976,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -4075,33 +3007,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4121,27 +3041,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -4158,33 +3066,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4212,27 +3108,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -4255,33 +3139,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -4300,27 +3172,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -4343,33 +3203,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4405,27 +3253,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -4448,33 +3284,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -4493,27 +3317,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -4536,33 +3348,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4583,27 +3383,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -4626,33 +3414,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4675,27 +3451,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -4718,33 +3482,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -4764,27 +3516,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -4807,33 +3547,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4853,27 +3581,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -4896,33 +3612,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -4942,27 +3646,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -4979,33 +3671,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5025,27 +3705,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -5062,33 +3730,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -5123,27 +3779,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -5166,33 +3810,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -5211,27 +3843,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -5254,33 +3874,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5301,27 +3909,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -5344,33 +3940,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5393,27 +3977,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -5436,33 +4008,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5482,27 +4042,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -5525,33 +4073,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5571,27 +4107,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -5608,33 +4132,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5662,27 +4174,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -5705,33 +4205,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -5750,27 +4238,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -5793,33 +4269,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5840,27 +4304,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -5883,33 +4335,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -5929,27 +4369,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -5972,33 +4400,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -6026,27 +4442,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -6069,33 +4473,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -6114,27 +4506,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -6157,33 +4537,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -6204,27 +4572,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -6247,33 +4603,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -6296,27 +4640,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -6339,33 +4671,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -6385,27 +4705,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -6428,33 +4736,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -6472,27 +4768,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -6515,33 +4799,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -6561,27 +4833,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -6604,33 +4864,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -6650,27 +4898,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -6687,33 +4923,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -6733,27 +4957,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -6770,34 +4982,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -6838,27 +5038,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -6875,33 +5063,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -6936,27 +5112,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -6979,33 +5143,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -7024,27 +5176,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -7067,33 +5207,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7114,27 +5242,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -7157,33 +5273,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7203,27 +5307,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -7246,33 +5338,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7300,27 +5380,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -7343,33 +5411,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -7388,27 +5444,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -7431,33 +5475,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7478,27 +5510,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -7521,33 +5541,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7567,27 +5575,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -7610,33 +5606,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7664,27 +5648,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -7707,33 +5679,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -7752,27 +5712,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -7795,33 +5743,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7842,27 +5778,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -7885,33 +5809,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -7934,27 +5846,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -7977,33 +5877,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -8021,27 +5909,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -8064,33 +5940,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -8110,27 +5974,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -8153,33 +6005,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -8199,27 +6039,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -8236,33 +6064,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -8282,27 +6098,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -8319,34 +6123,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -8402,27 +6194,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -8445,33 +6225,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -8490,27 +6258,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -8533,33 +6289,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -8580,27 +6324,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -8623,33 +6355,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -8669,27 +6389,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -8712,33 +6420,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -8758,27 +6454,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -8801,33 +6485,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -8847,27 +6519,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -8884,33 +6544,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -8945,27 +6593,15 @@ exports[`StakePoolHttpService healthy state /search search pools by multiple fil
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -8988,33 +6624,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -9033,27 +6657,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -9076,33 +6688,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -9123,27 +6723,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -9166,33 +6754,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -9212,27 +6788,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -9255,33 +6819,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -9309,27 +6861,15 @@ exports[`StakePoolHttpService healthy state /search search pools by pledge met s
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -9352,33 +6892,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -9398,27 +6926,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -9441,33 +6957,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -9487,27 +6991,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -9530,33 +7022,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -9591,27 +7071,15 @@ exports[`StakePoolHttpService healthy state /search search pools by status searc
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -9634,33 +7102,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -9679,27 +7135,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -9722,33 +7166,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -9769,27 +7201,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -9812,33 +7232,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -9861,27 +7269,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -9904,33 +7300,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -9948,27 +7332,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -9991,33 +7363,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -10037,27 +7397,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -10080,33 +7428,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -10126,27 +7462,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -10163,33 +7487,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -10209,27 +7521,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -10246,34 +7546,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -10322,27 +7610,15 @@ exports[`StakePoolHttpService healthy state /search search pools by status searc
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -10365,33 +7641,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -10411,27 +7675,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -10448,33 +7700,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -10509,27 +7749,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by APY
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -10546,33 +7774,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -10592,27 +7808,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -10629,33 +7833,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -10675,27 +7867,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -10718,33 +7898,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -10764,27 +7932,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -10807,33 +7963,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -10853,27 +7997,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -10896,33 +8028,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -10941,27 +8061,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -10978,34 +8086,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -11046,27 +8142,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -11089,33 +8173,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -11138,27 +8210,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -11181,33 +8241,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -11227,27 +8275,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -11270,33 +8306,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -11314,27 +8338,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -11357,33 +8369,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -11412,27 +8412,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by APY
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -11455,33 +8443,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -11502,27 +8478,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -11539,33 +8503,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -11585,27 +8537,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -11622,33 +8562,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -11668,27 +8596,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -11711,33 +8627,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -11757,27 +8661,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -11800,33 +8692,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -11846,27 +8726,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -11889,33 +8757,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -11934,27 +8790,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -11971,34 +8815,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -12039,27 +8871,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -12082,33 +8902,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -12131,27 +8939,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -12174,33 +8970,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -12220,27 +9004,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -12263,33 +9035,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -12315,27 +9075,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by APY
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -12358,33 +9106,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -12404,27 +9140,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -12447,33 +9171,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -12493,27 +9205,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -12536,33 +9236,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -12591,27 +9279,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by APY
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -12634,33 +9310,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -12681,27 +9345,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -12718,33 +9370,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -12764,27 +9404,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -12801,33 +9429,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -12855,27 +9471,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by APY
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -12898,33 +9502,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -12944,27 +9536,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -12987,33 +9567,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -13033,27 +9601,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -13076,33 +9632,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -13129,27 +9673,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by cos
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -13172,33 +9704,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -13216,27 +9736,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -13259,33 +9767,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -13308,27 +9804,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -13351,33 +9835,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -13396,27 +9868,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -13439,33 +9899,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -13486,27 +9934,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -13523,33 +9959,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -13569,27 +9993,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -13606,34 +10018,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -13674,27 +10074,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -13717,33 +10105,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -13763,27 +10139,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -13806,33 +10170,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -13852,27 +10204,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -13889,33 +10229,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -13935,27 +10263,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -13978,33 +10294,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -14032,27 +10336,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by cos
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -14075,33 +10367,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -14121,27 +10401,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -14158,33 +10426,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -14204,27 +10460,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -14247,33 +10491,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -14293,27 +10525,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -14336,33 +10556,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -14382,27 +10590,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -14419,34 +10615,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -14487,27 +10671,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -14524,33 +10696,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -14570,27 +10730,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -14613,33 +10761,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -14660,27 +10796,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -14703,33 +10827,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -14748,27 +10860,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -14791,33 +10891,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -14835,27 +10923,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -14878,33 +10954,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -14935,27 +10999,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by cos
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -14978,33 +11030,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -15025,27 +11065,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -15068,33 +11096,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -15114,27 +11130,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -15157,33 +11161,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -15211,27 +11203,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by cos
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -15254,33 +11234,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -15300,27 +11268,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -15337,33 +11293,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -15383,27 +11327,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -15426,33 +11358,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -15480,27 +11400,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by cos
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -15523,33 +11431,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -15569,27 +11465,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -15606,34 +11490,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -15674,27 +11546,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -15711,33 +11571,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -15765,27 +11613,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -15808,33 +11644,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -15853,27 +11677,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -15896,33 +11708,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -15943,27 +11743,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -15986,33 +11774,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -16035,27 +11811,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -16078,33 +11842,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -16124,27 +11876,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -16167,33 +11907,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -16211,27 +11939,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -16254,33 +11970,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -16300,27 +12004,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -16343,33 +12035,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -16389,27 +12069,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -16426,33 +12094,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -16472,27 +12128,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -16509,34 +12153,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -16577,27 +12209,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -16614,33 +12234,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -16668,27 +12276,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -16711,33 +12307,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -16756,27 +12340,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -16799,33 +12371,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -16846,27 +12406,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -16889,33 +12437,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -16946,27 +12482,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -16989,33 +12513,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -17035,27 +12547,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -17078,33 +12578,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -17122,27 +12610,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -17165,33 +12641,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -17219,27 +12683,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -17262,33 +12714,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -17309,27 +12749,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -17352,33 +12780,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -17398,27 +12814,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -17441,33 +12845,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -17495,27 +12887,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -17538,33 +12918,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -17583,27 +12951,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -17626,33 +12982,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -17673,27 +13017,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -17716,33 +13048,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -17765,27 +13085,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -17808,33 +13116,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -17854,27 +13150,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -17897,33 +13181,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -17949,27 +13221,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -17992,33 +13252,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -18038,27 +13286,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -18081,33 +13317,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -18127,27 +13351,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -18164,33 +13376,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -18210,27 +13410,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -18247,34 +13435,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -18315,27 +13491,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -18352,33 +13516,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -18406,27 +13558,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -18449,33 +13589,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -18495,27 +13623,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -18538,33 +13654,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -18584,27 +13688,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -18627,33 +13719,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -18671,27 +13751,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -18714,33 +13782,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -18760,27 +13816,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -18803,33 +13847,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -18852,27 +13884,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -18895,33 +13915,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -18942,27 +13950,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -18985,33 +13981,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -19030,27 +14014,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -19067,33 +14039,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -19113,27 +14073,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -19150,34 +14098,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -19218,27 +14154,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -19255,33 +14179,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -19309,27 +14221,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -19352,33 +14252,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -19397,27 +14285,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -19440,33 +14316,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -19487,27 +14351,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -19530,33 +14382,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -19579,27 +14419,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -19622,33 +14450,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -19668,27 +14484,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -19711,33 +14515,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -19755,27 +14547,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -19798,33 +14578,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -19844,27 +14612,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -19887,33 +14643,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -19933,27 +14677,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -19970,33 +14702,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20016,27 +14736,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -20053,34 +14761,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -20121,27 +14817,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -20158,33 +14842,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -20212,27 +14884,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by nam
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -20255,33 +14915,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20301,27 +14949,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -20344,33 +14980,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20390,27 +15014,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -20433,33 +15045,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20488,27 +15088,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by sat
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -20531,33 +15119,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20580,27 +15156,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -20617,33 +15181,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20663,27 +15215,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -20706,33 +15246,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20752,27 +15280,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -20789,34 +15305,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -20857,27 +15361,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -20900,33 +15392,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -20946,27 +15426,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -20989,33 +15457,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -21034,27 +15490,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -21077,33 +15521,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -21121,27 +15553,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -21164,33 +15584,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -21210,27 +15618,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -21247,33 +15643,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -21293,27 +15677,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -21336,33 +15708,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -21391,27 +15751,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by sat
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -21434,33 +15782,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -21481,27 +15817,15 @@ Object {
       "vrf": "0a164c03ef34f26ffda7242b36db0a57ab7b23e230ea8802e50695f1f664de42",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1004862928388",
-          },
+          "activeStake": 1004862928388n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "22a8dc80b6fb4852150960c2e3896fa0a03498f514afc474c33152b6",
@@ -21518,33 +15842,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "999999828559",
-        },
+        "livePledge": 999999828559n,
         "saturation": "0.01190475869946979847",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "999999828559",
-          },
+          "active": 0n,
+          "live": 999999828559n,
         },
       },
       "owners": Array [
         "stake_test1urryfvusd49ej55gvf3cxtje4pqmtcdswwqxw37g6uclhnsqj7d5w",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1000000000000",
-      },
+      "pledge": 1000000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -21564,27 +15876,15 @@ Object {
       "vrf": "43a78f2b4811cdb2e52c13b6ad6a1732a9fb44d3d64adeb1fc2b4867116881b8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "345000000",
-      },
+      "cost": 345000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
+          "activeStake": 321928331851n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "331e12b25988de55f70a56ee89c10f38f69dd006eb50894d3304702a",
@@ -21607,33 +15907,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "2080157396",
-        },
+        "livePledge": 2080157396n,
         "saturation": "0.00385724354235498005",
         "size": Object {
           "active": "0.99357992933816544990",
           "live": "0.00642007066183455010",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "321928331851",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "2080157396",
-          },
+          "active": 321928331851n,
+          "live": 2080157396n,
         },
       },
       "owners": Array [
         "stake_test1uq60lxlxsn9zd5h0acu6dyl7q5wnjwaep4t8x4lxh00t9jqjg39tv",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000000",
-      },
+      "pledge": 10000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -21653,27 +15941,15 @@ Object {
       "vrf": "4ca2ca84f4a9696942f1c36345575dbdecc352eff37ec747b2349e48a9a182e8",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
+          "activeStake": 10021869680n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "7c40ba1d2537e03f10bd98a3f9901ac06f535d441d4031af11a6bed1",
@@ -21696,33 +15972,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1099603790",
-        },
+        "livePledge": 1099603790n,
         "saturation": "0.00011930796071220870",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "10021869680",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 10021869680n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1upmtm6pqzrnhn0u0w786x6j4c5nn4h8966k7c6axl9e342gdmxnla",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByNameMultihost",
@@ -21740,27 +16004,15 @@ Object {
       "vrf": "6cce40bd7f16a63ea418c03b07a31f1616b1e9a94bde9cfa3aa6cf6cff2dc3af",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -21783,33 +16035,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -21828,27 +16068,15 @@ Object {
       "vrf": "c062fabfeb7a68c61c34532e6f441b999c6a5a30b409d24c93174f047d4d935a",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -21871,33 +16099,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -21917,27 +16133,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -21954,34 +16158,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -22022,27 +16214,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -22065,33 +16245,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22111,27 +16279,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -22148,33 +16304,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22194,27 +16338,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -22237,33 +16369,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22294,27 +16414,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by sat
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -22337,33 +16445,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22383,27 +16479,15 @@ Object {
       "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -22426,33 +16510,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22472,27 +16544,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
+          "activeStake": 50153400814617n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "961d329fba1807eef89db767ba405aec0c5426501c6b1df20f5c0995",
@@ -22515,33 +16575,21 @@ Object {
         "apy": 0.00186615265931667,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "22623299531669",
-        },
+        "livePledge": 22623299531669n,
         "saturation": "0.73179327290380795796",
         "size": Object {
           "active": "0.81589194534120782856",
           "live": "0.18410805465879217144",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "50153400814617",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "11317240121350",
-          },
+          "active": 50153400814617n,
+          "live": 11317240121350n,
         },
       },
       "owners": Array [
         "stake_test1upzu5aw5swqmhy09e2aaa62nac468mnyjzyfww999trzavccrj7pw",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "1010000000000",
-      },
+      "pledge": 1010000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22570,27 +16618,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by sat
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "activeStake": 0n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "d1da50fd3ffb523d6c324140a5902c56f5d7dcd5e5107b27b53e9aeb",
@@ -22613,33 +16649,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "1988240000",
-        },
+        "livePledge": 1988240000n,
         "saturation": "0.000005917380373640066663",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "497060000",
-          },
+          "active": 0n,
+          "live": 497060000n,
         },
       },
       "owners": Array [
         "stake_test1uq83dgu9a6el4fwld3gkd8p75mceecf0sqwd56qv7qzcatczwezeg",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "pledge": 400000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22662,27 +16686,15 @@ Object {
       "vrf": "788e09e86e30ab83af34f1d976281014df86b3776cf3037329fb8605f27bac44",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "497443657",
-          },
+          "activeStake": 497443657n,
           "epoch": 77,
           "epochLength": 431980000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5685f37bca393c683cf03e428280312c6c4ea485188672a2a0b3195c",
@@ -22699,33 +16711,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "997623150",
-        },
+        "livePledge": 997623150n,
         "saturation": "0.000011876464909867984289",
         "size": Object {
           "active": "0.0000000000000000000000000000",
           "live": "1.00000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "997623150",
-          },
+          "active": 0n,
+          "live": 997623150n,
         },
       },
       "owners": Array [
         "stake_test1up32f2hrv5ytqk8ad6e4apss5zrrjjlrkjhrksypn5g08fqrqf9gr",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "10000000",
-      },
+      "pledge": 10000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22745,27 +16745,15 @@ Object {
       "vrf": "3409a1bebeaa47e6d99e0748a99f65dee60b7f7e9a64dc865d52b4fb445b98ab",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "4321000000",
-      },
+      "cost": 4321000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
+          "activeStake": 1335568619n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "ff5b4952dd7734f07e4905dea64fa230fb75f7b2d603d154d9ff1d43",
@@ -22788,33 +16776,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "199806239",
-        },
+        "livePledge": 199806239n,
         "saturation": "0.000018278270331367650376",
         "size": Object {
           "active": "0.86986484899181539157",
           "live": "0.13013515100818460843",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1335568619",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "199806239",
-          },
+          "active": 1335568619n,
+          "live": 199806239n,
         },
       },
       "owners": Array [
         "stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "70000000000",
-      },
+      "pledge": 70000000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -22842,27 +16818,15 @@ exports[`StakePoolHttpService healthy state /search stake pools sort sort by sat
 Object {
   "pageResults": Array [
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
+          "activeStake": 1614945000n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5631ede662cfb10fd5fd69b4667101dd289568e12bcf5f64d1c406fc",
@@ -22879,34 +16843,22 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "0",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "497325000",
-        },
+        "livePledge": 497325000n,
         "saturation": "0.000019225533833959999712",
         "size": Object {
           "active": "1.00000000000000000000",
           "live": "0.0000000000000000000000000000",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "1614945000",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "active": 1614945000n,
+          "live": 0n,
         },
       },
       "owners": Array [
         "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq",
         "stake_test1uqa87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygfvlkaz",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",
@@ -22947,27 +16899,15 @@ Object {
       "vrf": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "400000000",
-      },
+      "cost": 400000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
+          "activeStake": 2499703578n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5ee7591bf30eaa4f5dce70b4a676eb02d5be8012d188f04fe3beffb0",
@@ -22990,33 +16930,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "487464117",
-        },
+        "livePledge": 487464117n,
         "saturation": "0.000035561516700528380262",
         "size": Object {
           "active": "0.83681394324934275242",
           "live": "0.16318605675065724758",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2499703578",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "487464117",
-          },
+          "active": 2499703578n,
+          "live": 487464117n,
         },
       },
       "owners": Array [
         "stake_test1uz9y7juwzcyanva4x4fzpx7tft6ckntn6ulsjjd2k7a0pxgldmzp5",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "500000000",
-      },
+      "pledge": 500000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByAddress",
@@ -23036,27 +16964,15 @@ Object {
       "vrf": "83a817519ec34d3c637db8f9d46fcf6f7f9e826093d1b9a8158c89da4b47a801",
     },
     Object {
-      "cost": Object {
-        "__type": "bigint",
-        "value": "340000000",
-      },
+      "cost": 340000000n,
       "epochRewards": Array [
         Object {
-          "activeStake": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
+          "activeStake": 2986376991n,
           "epoch": 205,
           "epochLength": 431850000,
           "memberROI": 0,
-          "operatorFees": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
-          "totalRewards": Object {
-            "__type": "bigint",
-            "value": "0",
-          },
+          "operatorFees": 0n,
+          "totalRewards": 0n,
         },
       ],
       "hexId": "5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1",
@@ -23079,33 +16995,21 @@ Object {
         "apy": 0,
         "blocksCreated": "0",
         "delegators": "1",
-        "livePledge": Object {
-          "__type": "bigint",
-          "value": "495463149",
-        },
+        "livePledge": 495463149n,
         "saturation": "0.000041450473803138820302",
         "size": Object {
           "active": "0.85770077629124006825",
           "live": "0.14229922370875993175",
         },
         "stake": Object {
-          "active": Object {
-            "__type": "bigint",
-            "value": "2986376991",
-          },
-          "live": Object {
-            "__type": "bigint",
-            "value": "495463149",
-          },
+          "active": 2986376991n,
+          "live": 495463149n,
         },
       },
       "owners": Array [
         "stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt",
       ],
-      "pledge": Object {
-        "__type": "bigint",
-        "value": "100000000",
-      },
+      "pledge": 100000000n,
       "relays": Array [
         Object {
           "__typename": "RelayByName",


### PR DESCRIPTION
… service tests

# Context

Making raw HTTP requests is useful to make assertions about the HTTP server, but for domain tests, we can be using the cardano-services-client modules to abstract the transport concerns.

# Proposed Solution

Replace tests that were using HTTP request and not making assertions about the HTTP server per the corresponding cardano-service-client module
