### PR TITLE
fix(cardano-services): fixed a division by 0 on APY calculation

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
@@ -83,6 +83,7 @@ export class StakePoolBuilder {
     return result.rows.length > 0 ? result.rows.map(mapAddressOwner) : [];
   }
   public async queryPoolRewards(hashesIds: number[], limit?: number) {
+    this.#logger.debug('About to query pool rewards');
     return Promise.all(
       hashesIds.map(async (hashId) => {
         const result: QueryResult<EpochRewardModel> = await this.#db.query(Queries.findPoolEpochRewards(limit), [

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -347,7 +347,7 @@ export const findPoolAPY = (limit?: number) => `
   avg_daily_roi AS (
     SELECT 
       hash_id,
-      SUM(member_roi / (epoch_length / 86400000)) / count(1) AS avg_roi
+      SUM(COALESCE(member_roi / NULLIF(epoch_length / 86400000, 0.0), 0.0)) / count(1) AS avg_roi
     FROM epoch_rewards
     GROUP BY hash_id
   ),
@@ -356,7 +356,7 @@ export const findPoolAPY = (limit?: number) => `
       epochs.hash_id,
       POWER(
         1 + (avg_daily_roi.avg_roi * (epochs.epoch_length / 86400000)), 
-        365 / (epochs.epoch_length / 86400000)
+        COALESCE(365 / NULLIF(epochs.epoch_length / 86400000, 0), 0)
       ) - 1 AS apy
     FROM epoch_rewards AS epochs
     JOIN (


### PR DESCRIPTION
# Context

If the network is configured to have an epoch length duration of less than one day, the APY calculation query throws a division by 0 error.

# Proposed Solution

Make sure the division by zero can not occur in the query.

# Important Changes Introduced

A small change in the query was introduced to avoid the division by 0.