### PR TITLE
test(e2e): refactor delegation e2e test to use a dynamic pool selection

### DIFF
--- a/packages/e2e/env/.env.wallet
+++ b/packages/e2e/env/.env.wallet
@@ -15,7 +15,3 @@ TX_SUBMIT_PROVIDER=blockfrost
 UTXO_PROVIDER=blockfrost
 WALLET_PROVIDER=blockfrost
 STAKE_POOL_PROVIDER=stub
-
-# Test Params
-POOL_ID_1=pool1euf2nh92ehqfw7rpd4s9qgq34z8dg4pvfqhjmhggmzk95gcd402
-POOL_ID_2=pool1fghrkl620rl3g54ezv56weeuwlyce2tdannm2hphs62syf3vyyh

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -345,9 +345,39 @@ export type GetWalletProps = {
  * Create a single wallet instance given the environment variables.
  *
  * @param props Wallet configuration parameters.
+ * @returns an object containing the wallet and providers passed to it
  */
 export const getWallet = async (props: GetWalletProps) => {
   const logger = props.env.LOGGER_MIN_SEVERITY ? getLogger(props.env.LOGGER_MIN_SEVERITY) : dummyLogger;
+  const providers = {
+    assetProvider: await assetProviderFactory.create(props.env.ASSET_PROVIDER, props.env.ASSET_PROVIDER_PARAMS, logger),
+    chainHistoryProvider: await chainHistoryProviderFactory.create(
+      props.env.CHAIN_HISTORY_PROVIDER,
+      props.env.CHAIN_HISTORY_PROVIDER_PARAMS,
+      logger
+    ),
+    networkInfoProvider: await networkInfoProviderFactory.create(
+      props.env.NETWORK_INFO_PROVIDER,
+      props.env.NETWORK_INFO_PROVIDER_PARAMS,
+      logger
+    ),
+    rewardsProvider: await rewardsProviderFactory.create(
+      props.env.REWARDS_PROVIDER,
+      props.env.REWARDS_PROVIDER_PARAMS,
+      logger
+    ),
+    stakePoolProvider: await stakePoolProviderFactory.create(
+      props.env.STAKE_POOL_PROVIDER,
+      props.env.STAKE_POOL_PROVIDER_PARAMS,
+      logger
+    ),
+    txSubmitProvider: await txSubmitProviderFactory.create(
+      props.env.TX_SUBMIT_PROVIDER,
+      props.env.TX_SUBMIT_PROVIDER_PARAMS,
+      logger
+    ),
+    utxoProvider: await utxoProviderFactory.create(props.env.UTXO_PROVIDER, props.env.UTXO_PROVIDER_PARAMS, logger)
+  };
   const { wallet } = await setupWallet({
     createKeyAgent: await keyManagementFactory.create(
       props.env.KEY_MANAGEMENT_PROVIDER,
@@ -358,45 +388,14 @@ export const getWallet = async (props: GetWalletProps) => {
       new SingleAddressWallet(
         { name: props.name, polling: props.polling },
         {
-          assetProvider: await assetProviderFactory.create(
-            props.env.ASSET_PROVIDER,
-            props.env.ASSET_PROVIDER_PARAMS,
-            logger
-          ),
-          chainHistoryProvider: await chainHistoryProviderFactory.create(
-            props.env.CHAIN_HISTORY_PROVIDER,
-            props.env.CHAIN_HISTORY_PROVIDER_PARAMS,
-            logger
-          ),
+          ...providers,
           keyAgent,
-          networkInfoProvider: await networkInfoProviderFactory.create(
-            props.env.NETWORK_INFO_PROVIDER,
-            props.env.NETWORK_INFO_PROVIDER_PARAMS,
-            logger
-          ),
-          rewardsProvider: await rewardsProviderFactory.create(
-            props.env.REWARDS_PROVIDER,
-            props.env.REWARDS_PROVIDER_PARAMS,
-            logger
-          ),
-          stakePoolProvider: await stakePoolProviderFactory.create(
-            props.env.STAKE_POOL_PROVIDER,
-            props.env.STAKE_POOL_PROVIDER_PARAMS,
-            logger
-          ),
-          stores: props.stores,
-          txSubmitProvider: await txSubmitProviderFactory.create(
-            props.env.TX_SUBMIT_PROVIDER,
-            props.env.TX_SUBMIT_PROVIDER_PARAMS,
-            logger
-          ),
-          utxoProvider: await utxoProviderFactory.create(
-            props.env.UTXO_PROVIDER,
-            props.env.UTXO_PROVIDER_PARAMS,
-            logger
-          )
+          stores: props.stores
         }
       )
   });
-  return wallet;
+  return {
+    providers,
+    wallet
+  };
 };

--- a/packages/e2e/test/cardano-services/load/load.test.ts
+++ b/packages/e2e/test/cardano-services/load/load.test.ts
@@ -138,7 +138,7 @@ describe('load', () => {
   let address: Cardano.Address;
 
   const prepareWallets = async () => {
-    wallet = await getWallet({ env, name: 'Test Wallet' });
+    wallet = (await getWallet({ env, name: 'Test Wallet' })).wallet;
     ({ address } = (await firstValueFrom(wallet.addresses$))[0]);
 
     logger.debug('Waiting to settle wallet status');

--- a/packages/e2e/test/local-network/local-network.test.ts
+++ b/packages/e2e/test/local-network/local-network.test.ts
@@ -55,8 +55,10 @@ describe('Local Network', () => {
     const amountFromFaucet = 100_000_000;
     const tAdaToSend = 50_000_000n;
 
-    const wallet1: SingleAddressWallet = await getWallet({ env, name: 'Sending Wallet', polling: { interval: 50 } });
-    const wallet2: SingleAddressWallet = await getWallet({ env, name: 'Receiving Wallet', polling: { interval: 50 } });
+    const wallet1: SingleAddressWallet = (await getWallet({ env, name: 'Sending Wallet', polling: { interval: 50 } }))
+      .wallet;
+    const wallet2: SingleAddressWallet = (await getWallet({ env, name: 'Receiving Wallet', polling: { interval: 50 } }))
+      .wallet;
 
     await firstValueFrom(wallet1.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)));
     await firstValueFrom(wallet2.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)));

--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -67,8 +67,8 @@ const waitForTx = async (wallet: ObservableWallet, { hash }: Transaction.TxInter
 };
 
 describe('SingleAddressWallet/delegation', () => {
-  let wallet1: ObservableWallet;
-  let wallet2: ObservableWallet;
+  let wallet1: Awaited<ReturnType<typeof getWallet>>;
+  let wallet2: Awaited<ReturnType<typeof getWallet>>;
 
   beforeAll(async () => {
     jest.setTimeout(180_000);
@@ -79,19 +79,21 @@ describe('SingleAddressWallet/delegation', () => {
   });
 
   afterAll(() => {
-    wallet1.shutdown();
-    wallet2.shutdown();
+    wallet1.wallet.shutdown();
+    wallet2.wallet.shutdown();
   });
 
   const chooseWallets = async (): Promise<[ObservableWallet, ObservableWallet]> => {
-    const wallet1Balance = await firstValueFrom(wallet1.balance.utxo.available$);
-    const wallet2Balance = await firstValueFrom(wallet2.balance.utxo.available$);
-    return wallet1Balance.coins > wallet2Balance.coins ? [wallet1, wallet2] : [wallet2, wallet1];
+    const wallet1Balance = await firstValueFrom(wallet1.wallet.balance.utxo.available$);
+    const wallet2Balance = await firstValueFrom(wallet2.wallet.balance.utxo.available$);
+    return wallet1Balance.coins > wallet2Balance.coins
+      ? [wallet1.wallet, wallet2.wallet]
+      : [wallet2.wallet, wallet1.wallet];
   };
 
   test('delegation preconditions', async () => {
-    const addresses = await firstValueFrom(wallet1.addresses$);
-    const currentEpoch = await firstValueFrom(wallet1.currentEpoch$);
+    const addresses = await firstValueFrom(wallet1.wallet.addresses$);
+    const currentEpoch = await firstValueFrom(wallet1.wallet.currentEpoch$);
     expect(addresses[0].rewardAccount).toBeTruthy();
     expect(currentEpoch.epochNo).toBeGreaterThan(0);
   });

--- a/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
@@ -10,7 +10,7 @@ describe('SingleAddressWallet/metadata', () => {
   let ownAddress: Cardano.Address;
 
   beforeAll(async () => {
-    wallet = await getWallet({ env, name: 'Test Wallet' });
+    wallet = (await getWallet({ env, name: 'Test Wallet' })).wallet;
     ownAddress = (await firstValueFrom(wallet.addresses$))[0].address;
   });
 

--- a/packages/e2e/test/wallet/SingleAddressWallet/pouchdbWalletStores.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/pouchdbWalletStores.test.ts
@@ -14,7 +14,7 @@ describe('SingleAddressWallet/pouchdbWalletStores', () => {
   });
 
   it('stores and restores SingleAddressWallet, continues sync after initial load', async () => {
-    const wallet1 = await getWallet({ env, name: 'Test Wallet', stores: stores1 });
+    const wallet1 = (await getWallet({ env, name: 'Test Wallet', stores: stores1 })).wallet;
     // wallet1 fetched all responses from wallet provider
     await waitForWalletStateSettle(wallet1);
     // give it a second to store data to pouchdb, this is technically a race condition
@@ -24,7 +24,8 @@ describe('SingleAddressWallet/pouchdbWalletStores', () => {
     const wallet1RewardsHistory = await firstValueFrom(wallet1.delegation.rewardsHistory$);
     wallet1.shutdown();
     // create a new wallet, with new stores sharing the underlying database
-    const wallet2 = await getWallet({ env, name: walletName, stores: storage.createPouchdbWalletStores(walletName) });
+    const wallet2 = (await getWallet({ env, name: walletName, stores: storage.createPouchdbWalletStores(walletName) }))
+      .wallet;
     const tip = await firstValueFrom(wallet2.tip$);
     expect(await firstValueFrom(wallet2.delegation.rewardsHistory$)).toEqual(wallet1RewardsHistory);
     expect(await firstValueFrom(wallet1.delegation.rewardAccounts$)).toEqual(wallet1RewardAccounts);

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
@@ -10,7 +10,7 @@ describe('SingleAddressWallet', () => {
 
   beforeAll(async () => {
     jest.setTimeout(180_000);
-    wallet = await getWallet({ env, name: 'Test Wallet' });
+    wallet = (await getWallet({ env, name: 'Test Wallet' })).wallet;
     await waitForWalletStateSettle(wallet);
   });
 

--- a/packages/e2e/test/wallet/environment.ts
+++ b/packages/e2e/test/wallet/environment.ts
@@ -11,8 +11,6 @@ export const env = envalid.cleanEnv(process.env, {
   LOGGER_MIN_SEVERITY: envalid.str({ default: 'info' }),
   NETWORK_INFO_PROVIDER: envalid.str(),
   NETWORK_INFO_PROVIDER_PARAMS: envalid.json({ default: {} }),
-  POOL_ID_1: envalid.str(),
-  POOL_ID_2: envalid.str(),
   REWARDS_PROVIDER: envalid.str(),
   REWARDS_PROVIDER_PARAMS: envalid.json({ default: {} }),
   STAKE_POOL_PROVIDER: envalid.str(),


### PR DESCRIPTION
# Context
The current implementation using a configurable pair of pool IDs was done when we had the `StakePoolProvider` mocked. Since this is no longer a condition, we can now fetch active pools in the network to delegate to.

# Proposed Solution
- Refactor the `getWallet` function to return the provider instances, enabling tests to also use them directly.
- Query the StakePoolProvider to select an active one randomly, filtering the ensure it's not the same as the current delegation.

# Important Changes Introduced
- `POOL_ID_1` and `POOL_ID_2` are no longer required, so you can now remove from git ignored `.env`s