### PR TITLE
refactor(cardano-services): live stake query

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -29,21 +29,11 @@ export const findTotalSupply = `
 
 // Live stake is the current epoch’s delegated stake that has yet to be snapshotted
 export const findLiveStake = `
-    WITH current_delegation AS (
-        SELECT DISTINCT ON (delegation.addr_id) delegation.addr_id,
-    delegation.pool_hash_id
-    FROM delegation
-    ORDER BY delegation.addr_id, delegation.slot_no DESC, delegation.pool_hash_id 
-    )
-
     SELECT CAST(COALESCE(SUM(tx_out.value), 0) AS BIGINT) AS live_stake
     FROM tx_out 
     LEFT JOIN tx_in ON tx_out.tx_id = tx_in.tx_out_id AND tx_out.index::smallint = tx_in.tx_out_index::smallint
-    LEFT JOIN current_delegation ON current_delegation.addr_id = tx_out.stake_address_id 
-    LEFT JOIN stake_address ON stake_address.id = current_delegation.addr_id 
-
-    WHERE 
-        tx_in.tx_in_id IS NULL
+    JOIN delegation ON delegation.addr_id = tx_out.stake_address_id 
+    WHERE tx_in.tx_in_id IS null
 `;
 
 // Active stake is the stake snapshot from n-1 epochs, where n = current epoch

--- a/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
+++ b/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
@@ -30,6 +30,6 @@ Object {
 }
 `;
 
-exports[`NetworkInfoBuilder queryLiveStake query live stake 1`] = `"42000004107749657"`;
+exports[`NetworkInfoBuilder queryLiveStake query live stake 1`] = `"2679979893"`;
 
 exports[`NetworkInfoBuilder queryTotalSupply query total supply 1`] = `"40408479600434778"`;


### PR DESCRIPTION
# Context

Improves `findLiveStake` query performance of `NetworkInfoHttpService`
