### PR TITLE
Replace live stake DB query with Local State Query 

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
@@ -3,7 +3,6 @@ import {
   CirculatingSupplyModel,
   EpochModel,
   LedgerTipModel,
-  LiveStakeModel,
   TotalSupplyModel,
   WalletProtocolParamsModel
 } from './types';
@@ -30,11 +29,6 @@ export class NetworkInfoBuilder {
     this.#logger.debug('About to query total supply');
     const result: QueryResult<TotalSupplyModel> = await this.#db.query(Queries.findTotalSupply, [maxLovelaceSupply]);
     return result.rows[0].total_supply;
-  }
-  public async queryLiveStake() {
-    this.#logger.debug('About to query live stake');
-    const result: QueryResult<LiveStakeModel> = await this.#db.query(Queries.findLiveStake);
-    return result.rows[0].live_stake;
   }
 
   public async queryActiveStake() {

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -4,7 +4,6 @@ import {
   ProtocolParametersRequiredByWallet,
   ProviderError,
   ProviderFailure,
-  StakeSummary,
   SupplySummary,
   TimeSettings
 } from '@cardano-sdk/core';
@@ -16,11 +15,6 @@ import path from 'path';
 interface ToLovalaceSupplyInput {
   circulatingSupply: string;
   totalSupply: string;
-}
-
-interface ToStakeInput {
-  activeStake: string;
-  liveStake: string;
 }
 
 export const networkIdMap = {
@@ -38,11 +32,6 @@ export const toTimeSettings = (eraSummary: EraSummary): TimeSettings => ({
 export const toSupply = ({ circulatingSupply, totalSupply }: ToLovalaceSupplyInput): SupplySummary => ({
   circulating: BigInt(circulatingSupply),
   total: BigInt(totalSupply)
-});
-
-export const toStake = ({ liveStake, activeStake }: ToStakeInput): StakeSummary => ({
-  active: BigInt(activeStake),
-  live: BigInt(liveStake)
 });
 
 export const toLedgerTip = ({ block_no, slot_no, hash }: LedgerTipModel): Cardano.Tip => ({

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -27,25 +27,6 @@ export const findTotalSupply = `
     LIMIT 1
 `;
 
-// Live stake is the current epoch’s delegated stake that has yet to be snapshotted
-export const findLiveStake = `
-    WITH current_delegation AS (
-        SELECT DISTINCT ON (delegation.addr_id) delegation.addr_id,
-    delegation.pool_hash_id
-    FROM delegation
-    ORDER BY delegation.addr_id, delegation.slot_no DESC, delegation.pool_hash_id 
-    )
-
-    SELECT CAST(COALESCE(SUM(tx_out.value), 0) AS BIGINT) AS live_stake
-    FROM tx_out 
-    LEFT JOIN tx_in ON tx_out.tx_id = tx_in.tx_out_id AND tx_out.index::smallint = tx_in.tx_out_index::smallint
-    LEFT JOIN current_delegation ON current_delegation.addr_id = tx_out.stake_address_id 
-    LEFT JOIN stake_address ON stake_address.id = current_delegation.addr_id 
-
-    WHERE 
-        tx_in.tx_in_id IS NULL
-`;
-
 // Active stake is the stake snapshot from n-1 epochs, where n = current epoch
 // epoch_stake contains records of completed epochs
 export const findActiveStake = `
@@ -95,7 +76,6 @@ const Queries = {
   findCurrentWalletProtocolParams,
   findLatestCompleteEpoch,
   findLedgerTip,
-  findLiveStake,
   findTotalSupply
 };
 

--- a/packages/cardano-services/src/Program/services/ogmios.ts
+++ b/packages/cardano-services/src/Program/services/ogmios.ts
@@ -28,12 +28,12 @@ const recreateOgmiosCardanoNode = async (
 };
 
 /**
- * Creates a extended TxSubmitProvider instance :
+ * Creates an extended TxSubmitProvider instance :
  * - use passed srv service name in order to resolve the port
- * - make dealing with failovers (re-resolving the port) opaque
+ * - make dealing with fail-overs (re-resolving the port) opaque
  * - use exponential backoff retry internally with default timeout and factor
  * - intercept 'submitTx' operation and handle connection errors runtime
- * - all other operations are bind to pool object withoud modifications
+ * - all other operations are bind to pool object without modifications
  *
  * @returns TxSubmitProvider instance
  */
@@ -89,13 +89,13 @@ export const getOgmiosTxSubmitProvider = async (
 };
 
 /**
- * Creates a extended OgmiosCardanoNode instance :
+ * Creates an extended OgmiosCardanoNode instance :
  * - use passed srv service name in order to resolve the port
- * - make dealing with failovers (re-resolving the port) opaque
+ * - make dealing with fail-overs (re-resolving the port) opaque
  * - use exponential backoff retry internally with default timeout and factor
  * - intercept 'initialize' operation and handle connection errors on initialization
  * - intercept 'eraSummaries' operation and handle connection errors runtime
- * - all other operations are bind to pool object withoud modifications
+ * - all other operations are bind to pool object without modifications
  *
  * @returns OgmiosCardanoNode instance
  */

--- a/packages/cardano-services/src/Program/services/ogmios.ts
+++ b/packages/cardano-services/src/Program/services/ogmios.ts
@@ -10,8 +10,8 @@ import { ServiceNames } from '../ServiceNames';
 import { TxSubmitProvider } from '@cardano-sdk/core';
 import { isConnectionError } from '@cardano-sdk/util';
 
-const isCardanoNodeOperation = (prop: string | symbol): prop is 'eraSummaries' | 'systemStart' =>
-  ['eraSummaries', 'systemStart'].includes(prop as string);
+const isCardanoNodeOperation = (prop: string | symbol): prop is 'eraSummaries' | 'systemStart' | 'stakeDistribution' =>
+  ['eraSummaries', 'systemStart', 'stakeDistribution'].includes(prop as string);
 
 const recreateOgmiosCardanoNode = async (
   serviceName: string,

--- a/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.test.ts
@@ -31,14 +31,6 @@ describe('NetworkInfoBuilder', () => {
     });
   });
 
-  describe('queryLiveStake', () => {
-    test('query live stake', async () => {
-      const result = await builder.queryLiveStake();
-      expect(BigInt(result)).toBeGreaterThan(0n);
-      expect(result).toMatchSnapshot();
-    });
-  });
-
   describe('queryActiveStake', () => {
     test('query active stake', async () => {
       const result = await builder.queryActiveStake();

--- a/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
+++ b/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
@@ -30,6 +30,4 @@ Object {
 }
 `;
 
-exports[`NetworkInfoBuilder queryLiveStake query live stake 1`] = `"42000004107749657"`;
-
 exports[`NetworkInfoBuilder queryTotalSupply query total supply 1`] = `"40408479600434778"`;

--- a/packages/cardano-services/test/Program/services/ogmios.test.ts
+++ b/packages/cardano-services/test/Program/services/ogmios.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable max-len */
-import { Cardano, EraSummary, TxSubmitProvider } from '@cardano-sdk/core';
+import { Cardano, TxSubmitProvider } from '@cardano-sdk/core';
 import { Connection } from '@cardano-ogmios/client';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../../src/NetworkInfo';
 import {
@@ -22,6 +22,7 @@ import { createLogger } from 'bunyan';
 import { createMockOgmiosServer } from '../../../../ogmios/test/mocks/mockOgmiosServer';
 import { getPort, getRandomPort } from 'get-port-please';
 import { listenPromise, serverClosePromise } from '../../../src/util';
+import { mockCardanoNode } from '../../../../core/test/CardanoNode/mocks';
 import { types } from 'util';
 import axios from 'axios';
 import http from 'http';
@@ -46,19 +47,7 @@ describe('Service dependency abstractions', () => {
   const cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
   const logger = createLogger({ level: 'error', name: 'test' });
   const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
-  const mockEraSummaries: EraSummary[] = [
-    { parameters: { epochLength: 21_600, slotLength: 20_000 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
-    {
-      parameters: { epochLength: 432_000, slotLength: 1000 },
-      start: { slot: 1_598_400, time: new Date(1_595_964_016_000) }
-    }
-  ];
-  const cardanoNode = {
-    eraSummaries: jest.fn(() => Promise.resolve(mockEraSummaries)),
-    initialize: jest.fn(() => Promise.resolve()),
-    shutdown: jest.fn(() => Promise.resolve()),
-    systemStart: jest.fn(() => Promise.resolve(new Date(1_563_999_616_000)))
-  };
+  const cardanoNode = mockCardanoNode();
 
   describe('Ogmios-dependant services with service discovery', () => {
     let apiUrlBase: string;

--- a/packages/cardano-services/test/Program/services/postgres.test.ts
+++ b/packages/cardano-services/test/Program/services/postgres.test.ts
@@ -2,13 +2,13 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable max-len */
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../../src/NetworkInfo';
-import { EraSummary } from '@cardano-sdk/core';
 import { HttpServer, HttpServerConfig, createDnsResolver, getPool } from '../../../src';
 import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../../src/InMemoryCache';
 import { Pool } from 'pg';
 import { SrvRecord } from 'dns';
 import { createLogger } from 'bunyan';
 import { getPort, getRandomPort } from 'get-port-please';
+import { mockCardanoNode } from '../../../../core/test/CardanoNode/mocks';
 import { types } from 'util';
 import axios from 'axios';
 
@@ -28,19 +28,7 @@ describe('Service dependency abstractions', () => {
   const cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
   const logger = createLogger({ level: 'error', name: 'test' });
   const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
-  const mockEraSummaries: EraSummary[] = [
-    { parameters: { epochLength: 21_600, slotLength: 20_000 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
-    {
-      parameters: { epochLength: 432_000, slotLength: 1000 },
-      start: { slot: 1_598_400, time: new Date(1_595_964_016_000) }
-    }
-  ];
-  const cardanoNode = {
-    eraSummaries: jest.fn(() => Promise.resolve(mockEraSummaries)),
-    initialize: jest.fn(() => Promise.resolve()),
-    shutdown: jest.fn(() => Promise.resolve()),
-    systemStart: jest.fn(() => Promise.resolve(new Date(1_563_999_616_000)))
-  };
+  const cardanoNode = mockCardanoNode();
 
   describe('Postgres-dependant service with service discovery', () => {
     let httpServer: HttpServer;

--- a/packages/cardano-services/test/tsconfig.json
+++ b/packages/cardano-services/test/tsconfig.json
@@ -4,9 +4,9 @@
     "baseUrl": "."
   },
   "include": [
-    "../../ogmios/test",
-    "../../rabbitmq/test",
-    "../../wallet/test",
+    "../../core/test/CardanoNode/mocks",
+    "../../ogmios/test/mocks",
+    "../../rabbitmq/test/docker",
     "../../cip2/test/util",
   ],
   "rootDir": ".",
@@ -25,9 +25,6 @@
     },
     {
       "path": "../../util-dev/src"
-    },
-    {
-      "path": "../../wallet/src"
     },
     {
       "path": "../../ogmios/src"

--- a/packages/core/src/CardanoNode/types/CardanoNode.ts
+++ b/packages/core/src/CardanoNode/types/CardanoNode.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { CardanoNodeError, CardanoNodeNotInitializedError } from './CardanoNodeErrors';
+import { Lovelace, PoolId, VrfVkHex } from '../../Cardano';
 
 export interface EraSummary {
   parameters: {
@@ -12,6 +13,20 @@ export interface EraSummary {
     time: Date;
   };
 }
+
+/**
+ * Map of the live stake distribution, indexed by PoolId
+ */
+export type StakeDistribution = Map<
+  PoolId,
+  {
+    stake: {
+      pool: Lovelace;
+      supply: Lovelace;
+    };
+    vrf: VrfVkHex;
+  }
+>;
 
 export interface CardanoNode {
   /**
@@ -38,4 +53,11 @@ export interface CardanoNode {
    * @throws {CardanoNodeError}
    */
   systemStart: () => Promise<Date>;
+  /**
+   * Get the live stake distribution of the network.
+   *
+   * @returns {StakeDistribution}
+   * @throws {CardanoNodeError}
+   */
+  stakeDistribution: () => Promise<StakeDistribution>;
 }

--- a/packages/core/src/CardanoNode/util/index.ts
+++ b/packages/core/src/CardanoNode/util/index.ts
@@ -1,1 +1,2 @@
 export * from './cardanoNodeErrors';
+export * from './stakeDistribution';

--- a/packages/core/src/CardanoNode/util/stakeDistribution.ts
+++ b/packages/core/src/CardanoNode/util/stakeDistribution.ts
@@ -1,0 +1,11 @@
+import { Lovelace } from '../../Cardano';
+import { StakeDistribution } from '../types';
+
+/**
+ * Transforms StakeDistribution to a single live stake value of the network
+ *
+ * @param {StakeDistribution} stakeDistribution
+ */
+
+export const toLiveStake = (stakeDistribution: StakeDistribution): Lovelace =>
+  [...stakeDistribution.values()].reduce((accumulator, { stake }) => accumulator + stake.pool, BigInt(0));

--- a/packages/core/test/CardanoNode/mocks.ts
+++ b/packages/core/test/CardanoNode/mocks.ts
@@ -1,0 +1,57 @@
+import { Cardano, EraSummary, StakeDistribution } from '@cardano-sdk/core';
+
+const mockEraSummaries: EraSummary[] = [
+  { parameters: { epochLength: 21_600, slotLength: 20_000 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
+  {
+    parameters: { epochLength: 432_000, slotLength: 1000 },
+    start: { slot: 1_598_400, time: new Date(1_595_964_016_000) }
+  }
+];
+
+export const mockStakeDistribution: StakeDistribution = new Map([
+  [
+    Cardano.PoolId('pool1la4ghj4w4f8p4yk4qmx0qvqmzv6592ee9rs0vgla5w6lc2nc8w5'),
+    {
+      stake: { pool: 10_098_109_508n, supply: 40_453_712_883_332_027n },
+      vrf: Cardano.VrfVkHex('4e4a2e82dc455449bf5f1f6d249470963cf97389b5dc4d2118fe21625f50f518')
+    }
+  ],
+  [
+    Cardano.PoolId('pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg'),
+    {
+      stake: {
+        pool: 14_255_969_766n,
+        supply: 40_453_712_883_332_027n
+      },
+      vrf: Cardano.VrfVkHex('474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971')
+    }
+  ],
+  [
+    Cardano.PoolId('pool1llugtz5r4t6m7xz6es4qu7cszllm5y3uvx3ast5a9jzlv7h3xdu'),
+    {
+      stake: {
+        pool: 98_763_124_501_826n,
+        supply: 40_453_712_883_332_027n
+      },
+      vrf: Cardano.VrfVkHex('dc1c0fd7d2fd95b6e9bf0e50ab5cb722edbd7d6e85b7d53323884d429ec6a83c')
+    }
+  ],
+  [
+    Cardano.PoolId('pool1lu6ll4rcxm92059ggy6uym2p804s5hcwqyyn5vyqhy35kuxtn2f'),
+    {
+      stake: {
+        pool: 1_494_933_206n,
+        supply: 40_453_712_883_332_027n
+      },
+      vrf: Cardano.VrfVkHex('4a13d5e99a1868788057bf401fdb4379b7846290dd948918839981088059a564')
+    }
+  ]
+]);
+
+export const mockCardanoNode = () => ({
+  eraSummaries: jest.fn(() => Promise.resolve(mockEraSummaries)),
+  initialize: jest.fn(() => Promise.resolve()),
+  shutdown: jest.fn(() => Promise.resolve()),
+  stakeDistribution: jest.fn(() => Promise.resolve(mockStakeDistribution)),
+  systemStart: jest.fn(() => Promise.resolve(new Date(1_563_999_616_000)))
+});

--- a/packages/core/test/CardanoNode/util/stakeDistribution.test.ts
+++ b/packages/core/test/CardanoNode/util/stakeDistribution.test.ts
@@ -1,0 +1,24 @@
+import { Cardano, CardanoNodeUtil } from '@cardano-sdk/core';
+import { mockStakeDistribution } from '../mocks';
+
+describe('stakeDistribution', () => {
+  describe('toLiveStake', () => {
+    it('returns the live network stake from a given stake distribution', () => {
+      const liveStake = CardanoNodeUtil.toLiveStake(mockStakeDistribution);
+      expect(liveStake).toBe(
+        mockStakeDistribution.get(Cardano.PoolId('pool1la4ghj4w4f8p4yk4qmx0qvqmzv6592ee9rs0vgla5w6lc2nc8w5'))!.stake
+          .pool +
+          mockStakeDistribution.get(Cardano.PoolId('pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg'))!.stake
+            .pool +
+          mockStakeDistribution.get(Cardano.PoolId('pool1llugtz5r4t6m7xz6es4qu7cszllm5y3uvx3ast5a9jzlv7h3xdu'))!.stake
+            .pool +
+          mockStakeDistribution.get(Cardano.PoolId('pool1lu6ll4rcxm92059ggy6uym2p804s5hcwqyyn5vyqhy35kuxtn2f'))!.stake
+            .pool
+      );
+    });
+    it('returns 0 if the distribution contains no pools, rather than throwing', () => {
+      const liveStake = CardanoNodeUtil.toLiveStake(new Map());
+      expect(liveStake).toBe(0n);
+    });
+  });
+});

--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -88,7 +88,7 @@ describe('SingleAddressWallet/delegation', () => {
       pagination: { limit: 2, startAt: 0 }
     });
     return activePools.pageResults.filter(({ id }) => id !== delegateeBefore1stTx)[
-      Math.floor(Math.random() * activePools.pageResults.length)
+      Math.floor(Math.random() * activePools.pageResults.length) - 1
     ].id;
   };
 

--- a/packages/ogmios/test/CardanoNode/__snapshots__/OgmiosCardanoNode.test.ts.snap
+++ b/packages/ogmios/test/CardanoNode/__snapshots__/OgmiosCardanoNode.test.ts.snap
@@ -25,4 +25,37 @@ Array [
 ]
 `;
 
+exports[`OgmiosCardanoNode initialized stakeDistribution success resolves if successful 1`] = `
+Map {
+  "pool1la4ghj4w4f8p4yk4qmx0qvqmzv6592ee9rs0vgla5w6lc2nc8w5" => Object {
+    "stake": Object {
+      "pool": 10098109508n,
+      "supply": 40453712883332027n,
+    },
+    "vrf": "4e4a2e82dc455449bf5f1f6d249470963cf97389b5dc4d2118fe21625f50f518",
+  },
+  "pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg" => Object {
+    "stake": Object {
+      "pool": 14255969766n,
+      "supply": 40453712883332027n,
+    },
+    "vrf": "474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971",
+  },
+  "pool1llugtz5r4t6m7xz6es4qu7cszllm5y3uvx3ast5a9jzlv7h3xdu" => Object {
+    "stake": Object {
+      "pool": 98763124501826n,
+      "supply": 40453712883332027n,
+    },
+    "vrf": "dc1c0fd7d2fd95b6e9bf0e50ab5cb722edbd7d6e85b7d53323884d429ec6a83c",
+  },
+  "pool1lu6ll4rcxm92059ggy6uym2p804s5hcwqyyn5vyqhy35kuxtn2f" => Object {
+    "stake": Object {
+      "pool": 1494933206n,
+      "supply": 40453712883332027n,
+    },
+    "vrf": "4a13d5e99a1868788057bf401fdb4379b7846290dd948918839981088059a564",
+  },
+}
+`;
+
 exports[`OgmiosCardanoNode initialized systemStart success resolves if successful 1`] = `2017-09-23T21:44:51.000Z`;

--- a/packages/ogmios/test/mocks/mockOgmiosServer.ts
+++ b/packages/ogmios/test/mocks/mockOgmiosServer.ts
@@ -68,6 +68,14 @@ export interface MockOgmiosServerConfig {
         };
       };
     };
+    stakeDistribution?: {
+      response: {
+        success: boolean;
+        failWith?: {
+          type: 'queryUnavailableInEra';
+        };
+      };
+    };
   };
   submitTxHook?: (data?: Uint8Array) => void;
 }
@@ -94,7 +102,12 @@ const handleSubmitTx = async (config: MockOgmiosServerConfig, args: any, send: (
 };
 
 const handleQuery = async (query: string, config: MockOgmiosServerConfig, send: (result: unknown) => void) => {
-  let result: Schema.EraSummary[] | Date | 'QueryUnavailableInCurrentEra' | UnknownResultError;
+  let result:
+    | Schema.EraSummary[]
+    | Date
+    | 'QueryUnavailableInCurrentEra'
+    | Schema.PoolDistribution
+    | UnknownResultError;
   switch (query) {
     case 'eraSummaries':
       if (config.stateQuery?.eraSummaries?.response.success) {
@@ -122,6 +135,32 @@ const handleQuery = async (query: string, config: MockOgmiosServerConfig, send: 
       if (config.stateQuery?.systemStart?.response.success) {
         result = new Date(1_506_203_091_000);
       } else if (config.stateQuery?.systemStart?.response.failWith?.type === 'queryUnavailableInEra') {
+        result = 'QueryUnavailableInCurrentEra';
+      } else {
+        throw new Error('Unknown mock response');
+      }
+      break;
+    case 'stakeDistribution':
+      if (config.stateQuery?.stakeDistribution?.response.success) {
+        result = {
+          pool1la4ghj4w4f8p4yk4qmx0qvqmzv6592ee9rs0vgla5w6lc2nc8w5: {
+            stake: '10098109508/40453712883332027',
+            vrf: '4e4a2e82dc455449bf5f1f6d249470963cf97389b5dc4d2118fe21625f50f518'
+          },
+          pool1lad5j5kawu60qljfqh02vnazxrahtaaj6cpaz4xeluw5xf023cg: {
+            stake: '14255969766/40453712883332027',
+            vrf: '474a6d2a44b51add62d8f2fd8fe80abc722bf84478479b617ad05b39aaa84971'
+          },
+          pool1llugtz5r4t6m7xz6es4qu7cszllm5y3uvx3ast5a9jzlv7h3xdu: {
+            stake: '98763124501826/40453712883332027',
+            vrf: 'dc1c0fd7d2fd95b6e9bf0e50ab5cb722edbd7d6e85b7d53323884d429ec6a83c'
+          },
+          pool1lu6ll4rcxm92059ggy6uym2p804s5hcwqyyn5vyqhy35kuxtn2f: {
+            stake: '1494933206/40453712883332027',
+            vrf: '4a13d5e99a1868788057bf401fdb4379b7846290dd948918839981088059a564'
+          }
+        };
+      } else if (config.stateQuery?.stakeDistribution?.response.failWith?.type === 'queryUnavailableInEra') {
         result = 'QueryUnavailableInCurrentEra';
       } else {
         throw new Error('Unknown mock response');


### PR DESCRIPTION
# Context

Live stake is the current stake that will be used to determine the block leadership schedule of the epoch following the next, and can potentially change with each new chain tip.  Active stake is the stake snapshotted two epochs prior and is now playing a role in block production. Querying the cardano-db-sync schema for the network's live stake is an extremely inefficient operation requiring a multitude of joins and complexity that is very hard to grok, plus it cannot be practically offered with complete precision, only as a cached response. Querying active stake is very efficient, as the database contains a table for the snapshot results, and it also is static for the entire epoch.

# Proposed Solution

Ogmios has a[ LocalStateQuery](https://ogmios.dev/mini-protocols/local-state-query/) to return the current stake distribution in the form of a map that contains the fraction of stake each pool controls.  This can be reduced into a single value in around 270ms on testnet (as of time of writing).

- [x] Extend the [CardanoNode interface](https://github.com/input-output-hk/cardano-js-sdk/blob/5cf462d045301d664c7d1227f8c3067524dc8eef/packages/core/src/CardanoNode/types/CardanoNode.ts#L16-L41)
- [x] Extend the [OgmiosCardanoNode](https://github.com/input-output-hk/cardano-js-sdk/blob/5cf462d045301d664c7d1227f8c3067524dc8eef/packages/ogmios/src/CardanoNode/OgmiosCardanoNode.ts) class to implement the new method
- [x] Extend [this](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/cardano-services/src/Program/services/ogmios.ts#L13-L14)
- [x] Replace the [call to the DB ](https://github.com/input-output-hk/cardano-js-sdk/blob/5cf462d045301d664c7d1227f8c3067524dc8eef/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts#L95)with this.#cardanoNode  invocation
- [x] Remove the DB queries and other fragments
- [x] Extend [Ogmios mock](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/ogmios/test/mocks/mockOgmiosServer.ts)
- [x] Add `CardanoNodeUtil` to transform `stakeDistribution` to `liveStake`

# Important Changes Introduced
- Fixes a bug recently introduced in an e2e test - 592a2805ef879311fe98fa9345201e76ca3bc181