### PR TITLE
Feat/adp 2116 create native script

### DIFF
--- a/packages/core/src/Cardano/types/NativeScript.ts
+++ b/packages/core/src/Cardano/types/NativeScript.ts
@@ -1,0 +1,142 @@
+/* eslint-disable no-use-before-define */
+
+import { Ed25519KeyHash } from './Key';
+import { Slot } from '@cardano-ogmios/schema';
+
+/**
+ * Native script type.
+ */
+export enum NativeScriptType {
+  RequireAllOf = 'all',
+  RequireAnyOf = 'any',
+  RequireMOf = 'atLeast',
+  RequireSignature = 'sig',
+  RequireTimeAfter = 'after',
+  RequireTimeBefore = 'before'
+}
+
+/**
+ * This script evaluates to true if the transaction also includes a valid key witness
+ * where the witness verification key hashes to the given hash.
+ *
+ * In other words, this checks that the transaction is signed by a particular key, identified by its verification
+ * key hash.
+ */
+export interface RequireSignatureScript {
+  /**
+   * The hash of a verification key.
+   */
+  keyHash: Ed25519KeyHash;
+
+  /**
+   * Script type.
+   */
+  __type: NativeScriptType.RequireSignature;
+}
+
+/**
+ * This script evaluates to true if  all the sub-scripts evaluate to true.
+ *
+ * If the list of sub-scripts is empty, this script evaluates to true.
+ */
+export interface RequireAllOfScript {
+  /**
+   * The list of sub-scripts.
+   */
+  scripts: NativeScript[];
+
+  /**
+   * Script type.
+   */
+  __type: NativeScriptType.RequireAllOf;
+}
+
+/**
+ * This script evaluates to true if any the sub-scripts evaluate to true. That is, if one
+ * or more evaluate to true.
+ *
+ * If the list of sub-scripts is empty, this script evaluates to false.
+ */
+export interface RequireAnyOfScript {
+  /**
+   * The list of sub-scripts.
+   */
+  scripts: NativeScript[];
+
+  /**
+   * Script type.
+   */
+  __type: NativeScriptType.RequireAnyOf;
+}
+
+/**
+ * This script evaluates to true if at least M (required field) of the sub-scripts evaluate to true.
+ */
+export interface RequireAtLeastScript {
+  /**
+   * The number of sub-scripts that must evaluate to true for this script to evaluate to true.
+   */
+  required: number;
+
+  /**
+   * The list of sub-scripts.
+   */
+  scripts: NativeScript[];
+
+  /**
+   * Script type.
+   */
+  __type: NativeScriptType.RequireMOf;
+}
+
+/**
+ * This script evaluates to true if the upper bound of the transaction validity interval is a
+ * slot number Y, and X <= Y.
+ *
+ * This condition guarantees that the actual slot number in which the transaction is included is
+ * (strictly) less than slot number X.
+ */
+export interface RequireTimeBeforeScript {
+  /**
+   * The slot number specifying the upper bound of the validity interval.
+   */
+  slot: Slot;
+
+  /**
+   * Script type.
+   */
+  __type: NativeScriptType.RequireTimeBefore;
+}
+
+/**
+ * This script evaluates to true if the lower bound of the transaction validity interval is a
+ * slot number Y, and Y <= X.
+ *
+ * This condition guarantees that the actual slot number in which the transaction is included
+ * is greater than or equal to slot number X.
+ */
+export interface RequireTimeAfterScript {
+  /**
+   * The slot number specifying the lower bound of the validity interval.
+   */
+  slot: Slot;
+
+  /**
+   * Script type.
+   */
+  __type: NativeScriptType.RequireTimeAfter;
+}
+
+/**
+ * The Native scripts form an expression tree, the evaluation of the script produces either true or false.
+ *
+ * Note that it is recursive. There are no constraints on the nesting or size, except that imposed by the overall
+ * transaction size limit (given that the script must be included in the transaction in a script witnesses).
+ */
+export type NativeScript =
+  | RequireAllOfScript
+  | RequireSignatureScript
+  | RequireAnyOfScript
+  | RequireAtLeastScript
+  | RequireTimeBeforeScript
+  | RequireTimeAfterScript;

--- a/packages/core/src/Cardano/types/NativeScriptType.ts
+++ b/packages/core/src/Cardano/types/NativeScriptType.ts
@@ -1,1 +1,0 @@
-export { Any, All, NOf } from '@cardano-ogmios/schema';

--- a/packages/core/src/Cardano/types/index.ts
+++ b/packages/core/src/Cardano/types/index.ts
@@ -17,7 +17,7 @@ export * from './Asset';
 export * from './AuxiliaryData';
 export * from './Key';
 export * from './TxSubmissionErrors';
-export * as NativeScriptType from './NativeScriptType';
+export * from './NativeScript';
 
 export type ProtocolParametersBabbage = OptionalUndefined<
   RecursivelyReplaceNullWithUndefined<Ogmios.ProtocolParametersBabbage>

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -22,7 +22,8 @@ export enum SerializationFailure {
   InvalidType = 'INVALID_TYPE',
   Overflow = 'OVERFLOW',
   InvalidAddress = 'INVALID_ADDRESS',
-  MaxLengthLimit = 'MAX_LENGTH_LIMIT'
+  MaxLengthLimit = 'MAX_LENGTH_LIMIT',
+  InvalidNativeScriptType = 'INVALID_NATIVE_SCRIPT_TYPE'
 }
 
 export class SerializationError extends CustomError {

--- a/packages/core/test/CSL/cslToCore.test.ts
+++ b/packages/core/test/CSL/cslToCore.test.ts
@@ -1,4 +1,6 @@
 import { Cardano, coreToCsl, cslToCore } from '../../src';
+import { Ed25519KeyHash, NativeScriptType } from '../../src/Cardano';
+import { NativeScript } from '@emurgo/cardano-serialization-lib-nodejs';
 import { mintTokenMap, tx, txBody, txIn, txInWithAddress, txOut, valueCoinOnly, valueWithAssets } from './testData';
 
 describe('cslToCore', () => {
@@ -6,7 +8,7 @@ describe('cslToCore', () => {
     it('coin only', () => {
       expect(cslToCore.value(coreToCsl.value(valueCoinOnly))).toEqual(valueCoinOnly);
     });
-    it('csltOCore coin with assets', () => {
+    it('cslToCore coin with assets', () => {
       expect(cslToCore.value(coreToCsl.value(valueWithAssets))).toEqual(valueWithAssets);
     });
   });
@@ -34,6 +36,47 @@ describe('cslToCore', () => {
 
   it('txMint', () => {
     expect(cslToCore.txMint(coreToCsl.txMint(mintTokenMap))).toEqual(mintTokenMap);
+  });
+
+  it('NativeScript', () => {
+    const cslScript: NativeScript = NativeScript.from_bytes(
+      Uint8Array.from(
+        Buffer.from(
+          // eslint-disable-next-line max-len
+          '8202828200581cb275b08c999097247f7c17e77007c7010cd19f20cc086ad99d3985388201838205190bb88200581c966e394a544f242081e41d1965137b1bb412ac230d40ed5407821c378204190fa0',
+          'hex'
+        )
+      )
+    );
+
+    const coreScript = {
+      __type: NativeScriptType.RequireAnyOf,
+      scripts: [
+        {
+          __type: NativeScriptType.RequireSignature,
+          keyHash: Ed25519KeyHash('b275b08c999097247f7c17e77007c7010cd19f20cc086ad99d398538')
+        },
+        {
+          __type: NativeScriptType.RequireAllOf,
+          scripts: [
+            {
+              __type: NativeScriptType.RequireTimeBefore,
+              slot: 3000
+            },
+            {
+              __type: NativeScriptType.RequireSignature,
+              keyHash: Ed25519KeyHash('966e394a544f242081e41d1965137b1bb412ac230d40ed5407821c37')
+            },
+            {
+              __type: NativeScriptType.RequireTimeAfter,
+              slot: 4000
+            }
+          ]
+        }
+      ]
+    };
+
+    expect(cslToCore.nativeScript(cslScript)).toStrictEqual(coreScript);
   });
 
   describe('txAuxiliaryData', () => {


### PR DESCRIPTION
# Context

We must allow users who wishes to mint & burn (and perform other functionality like multisig) to construct a native script that guards the minting of a new native asset.

# Proposed Solution

Define a core type for a native script and create mapping functions to the CSL.

# Important Changes Introduced

Adds a new native script core type and mapping functions from and to the CLS.
