### PR TITLE
Chore/adp 1890 single address wallet logging

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -78,7 +78,7 @@ import { Cip30DataSignature } from '@cardano-sdk/cip30';
 import { InputSelector, defaultSelectionConstraints, roundRobinRandomImprove } from '@cardano-sdk/cip2';
 import { Logger } from 'ts-log';
 import { RetryBackoffConfig } from 'backoff-rxjs';
-import { Shutdown } from '@cardano-sdk/util';
+import { Shutdown, contextLogger } from '@cardano-sdk/util';
 import { TrackedUtxoProvider } from './services/ProviderTracker/TrackedUtxoProvider';
 import { TxInternals, createTransactionInternals, ensureValidityInterval } from './Transaction';
 import { WalletStores, createInMemoryWalletStores } from './persistence';
@@ -170,8 +170,10 @@ export class SingleAddressWallet implements ObservableWallet {
       connectionStatusTracker$ = createSimpleConnectionStatusTracker()
     }: SingleAddressWalletDependencies
   ) {
-    this.#logger = logger;
+    this.#logger = contextLogger(logger, this.name);
+
     this.#inputSelector = inputSelector;
+
     this.txSubmitProvider = new TrackedTxSubmitProvider(txSubmitProvider);
     this.utxoProvider = new TrackedUtxoProvider(utxoProvider);
     this.networkInfoProvider = new TrackedWalletNetworkInfoProvider(networkInfoProvider);
@@ -179,10 +181,12 @@ export class SingleAddressWallet implements ObservableWallet {
     this.assetProvider = new TrackedAssetProvider(assetProvider);
     this.chainHistoryProvider = new TrackedChainHistoryProvider(chainHistoryProvider);
     this.rewardsProvider = new TrackedRewardsProvider(rewardsProvider);
+
     this.syncStatus = createProviderStatusTracker(
       {
         assetProvider: this.assetProvider,
         chainHistoryProvider: this.chainHistoryProvider,
+        logger: contextLogger(this.#logger, 'syncStatus'),
         networkInfoProvider: this.networkInfoProvider,
         rewardsProvider: this.rewardsProvider,
         stakePoolProvider: this.stakePoolProvider,
@@ -191,6 +195,7 @@ export class SingleAddressWallet implements ObservableWallet {
       },
       { consideredOutOfSyncAfter }
     );
+
     this.keyAgent = keyAgent;
     this.addresses$ = new TrackerSubject<GroupedAddress[]>(
       concat(
@@ -199,21 +204,29 @@ export class SingleAddressWallet implements ObservableWallet {
           distinctUntilChanged(groupedAddressesEquals),
           tap(
             // derive an address if none available
-            (addresses) =>
-              addresses.length === 0 &&
-              void keyAgent
-                .deriveAddress({ index: 0, type: AddressType.External })
-                .catch(() => logger.error('SingleAddressWallet failed to derive address'))
+            (addresses) => {
+              if (addresses.length === 0) {
+                this.#logger.debug('No addresses available; deriving one');
+                void keyAgent
+                  .deriveAddress({ index: 0, type: AddressType.External })
+                  .catch(() => this.#logger.error('Failed to derive address'));
+              }
+            }
           ),
           filter((addresses) => addresses.length > 0),
           tap(stores.addresses.set.bind(stores.addresses))
         )
       )
     );
+
     this.name = name;
-    const cancel$ = connectionStatusTracker$.pipe(filter((status) => status === ConnectionStatus.down));
+    const cancel$ = connectionStatusTracker$.pipe(
+      tap((status) => (status === ConnectionStatus.up ? 'Connection UP' : 'Connection DOWN')),
+      filter((status) => status === ConnectionStatus.down)
+    );
     this.#tip$ = this.tip$ = new TipTracker({
       connectionStatus$: connectionStatusTracker$,
+      logger: contextLogger(this.#logger, 'tip$'),
       maxPollInterval: maxInterval,
       minPollInterval: pollInterval,
       provider$: coldObservableProvider({
@@ -234,16 +247,22 @@ export class SingleAddressWallet implements ObservableWallet {
         equals: deepEquals,
         provider: this.networkInfoProvider.eraSummaries,
         retryBackoffConfig,
-        trigger$: eraSummariesTrigger
+        trigger$: eraSummariesTrigger.pipe(tap(() => 'Trigger request era summaries'))
       }),
       stores.eraSummaries
     );
 
     // Epoch tracker triggers the first eraSummaries fetch from eraSummariesTrigger
     // Epoch changes also trigger refetch of eraSummaries
-    this.currentEpoch$ = currentEpochTracker(this.tip$, this.eraSummaries$);
+    this.currentEpoch$ = currentEpochTracker(
+      this.tip$,
+      this.eraSummaries$.pipe(tap((es) => this.#logger.debug('Era summaries are', es)))
+    );
     this.currentEpoch$.pipe(map(() => void 0)).subscribe(eraSummariesTrigger);
-    const epoch$ = this.currentEpoch$.pipe(map((epoch) => epoch.epochNo));
+    const epoch$ = this.currentEpoch$.pipe(
+      map((epoch) => epoch.epochNo),
+      tap((epoch) => this.#logger.debug(`Current epoch is ${epoch}`))
+    );
     this.protocolParameters$ = new PersistentDocumentTrackerSubject(
       coldObservableProvider({
         cancel$,
@@ -272,6 +291,7 @@ export class SingleAddressWallet implements ObservableWallet {
       addresses$,
       chainHistoryProvider: this.chainHistoryProvider,
       inFlightTransactionsStore: stores.inFlightTransactions,
+      logger: contextLogger(this.#logger, 'transactions'),
       newTransactions: this.#newTransactions,
       retryBackoffConfig,
       tip$: this.tip$,
@@ -280,7 +300,7 @@ export class SingleAddressWallet implements ObservableWallet {
 
     this.#resubmitSubscription = createTransactionReemitter({
       confirmed$: this.transactions.outgoing.confirmed$,
-      logger,
+      logger: contextLogger(this.#logger, 'transactionsReemiter'),
       rollback$: this.transactions.rollback$,
       store: stores.volatileTransactions,
       submitting$: this.transactions.outgoing.submitting$,
@@ -297,6 +317,7 @@ export class SingleAddressWallet implements ObservableWallet {
 
     this.utxo = createUtxoTracker({
       addresses$,
+      logger: contextLogger(logger, 'utxo'),
       retryBackoffConfig,
       stores,
       tipBlockHeight$,
@@ -307,6 +328,7 @@ export class SingleAddressWallet implements ObservableWallet {
     this.delegation = createDelegationTracker({
       epoch$,
       eraSummaries$,
+      logger: contextLogger(this.#logger, 'delegation'),
       retryBackoffConfig,
       rewardAccountAddresses$: this.addresses$.pipe(
         map((addresses) => addresses.map((groupedAddress) => groupedAddress.rewardAccount))
@@ -316,16 +338,19 @@ export class SingleAddressWallet implements ObservableWallet {
       stores,
       transactionsTracker: this.transactions
     });
+
     this.balance = createBalanceTracker(this.protocolParameters$, this.utxo, this.delegation);
     this.assets$ = new PersistentDocumentTrackerSubject(
       createAssetsTracker({
         assetProvider: this.assetProvider,
         balanceTracker: this.balance,
+        logger: contextLogger(logger, 'assets$'),
         retryBackoffConfig
       }),
       stores.assets
     );
     this.util = createWalletUtil(this);
+    this.#logger.debug('Created');
   }
 
   async getName(): Promise<string> {
@@ -354,6 +379,7 @@ export class SingleAddressWallet implements ObservableWallet {
     });
     return { body, hash, inputSelection };
   }
+
   async finalizeTx(
     tx: TxInternals,
     auxiliaryData?: Cardano.AuxiliaryData,
@@ -371,10 +397,13 @@ export class SingleAddressWallet implements ObservableWallet {
       witness: { signatures }
     };
   }
+
   async submitTx(tx: Cardano.NewTxAlonzo): Promise<void> {
+    this.#logger.debug(`Submitting transaction ${tx.id}`);
     this.#newTransactions.submitting$.next(tx);
     try {
       await this.txSubmitProvider.submitTx(coreToCsl.tx(tx).to_bytes());
+      this.#logger.debug(`Submitted transaction ${tx.id}`);
       this.#newTransactions.pending$.next(tx);
     } catch (error) {
       this.#newTransactions.failedToSubmit$.next({
@@ -414,6 +443,7 @@ export class SingleAddressWallet implements ObservableWallet {
     this.#newTransactions.pending$.complete();
     this.#newTransactions.submitting$.complete();
     this.#resubmitSubscription.unsubscribe();
+    this.#logger.debug('Shutdown');
   }
 
   #prepareTx(props: InitializeTxProps) {

--- a/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
@@ -1,6 +1,7 @@
 import { BigIntMath, isNotNil } from '@cardano-sdk/util';
 import { Cardano, EpochRewards, createTxInspector, signedCertificatesInspector } from '@cardano-sdk/core';
 import { KeyValueStore } from '../../persistence';
+import { Logger } from 'ts-log';
 import { Observable, concat, distinctUntilChanged, map, of, switchMap, tap } from 'rxjs';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { RewardsHistory } from '../types';
@@ -56,16 +57,19 @@ export const createRewardsHistoryTracker = (
   transactions$: Observable<TxWithEpoch[]>,
   rewardAccounts$: Observable<Cardano.RewardAccount[]>,
   rewardsHistoryProvider: RewardsHistoryProvider,
-  rewardsHistoryStore: KeyValueStore<Cardano.RewardAccount, EpochRewards[]>
+  rewardsHistoryStore: KeyValueStore<Cardano.RewardAccount, EpochRewards[]>,
+  logger: Logger
 ): Observable<RewardsHistory> =>
   rewardAccounts$
     .pipe(
+      tap((rewardsAccounts) => logger.debug(`Fetching rewards for ${rewardsAccounts.length} accounts`)),
       switchMap((rewardAccounts) =>
         concat(
           rewardsHistoryStore
             .getValues(rewardAccounts)
             .pipe(map((rewards) => new Map(rewardAccounts.map((rewardAccount, i) => [rewardAccount, rewards[i]])))),
           firstDelegationEpoch$(transactions$, rewardAccounts).pipe(
+            tap((firstEpoch) => logger.debug(`Fetching history rewards since epoch ${firstEpoch}`)),
             switchMap((firstEpoch) => rewardsHistoryProvider(rewardAccounts, firstEpoch)),
             tap((allRewards) =>
               rewardsHistoryStore.setAll([...allRewards.entries()].map(([key, value]) => ({ key, value })))
@@ -78,6 +82,7 @@ export const createRewardsHistoryTracker = (
       map((rewardsByAccount) => {
         const allRewards = flatten([...rewardsByAccount.values()]);
         if (allRewards.length === 0) {
+          logger.debug('No rewards found');
           return {
             all: [],
             avgReward: null,
@@ -90,12 +95,20 @@ export const createRewardsHistoryTracker = (
           .map((epoch) => Number(epoch))
           .sort();
         const all = epochs.map((epoch) => ({ epoch, rewards: sumRewards(rewardsByEpoch[epoch]) }));
-
-        return {
+        const rewardsHistory: RewardsHistory = {
           all,
           avgReward: avgReward(allRewards),
           lastReward: all[all.length - 1],
           lifetimeRewards: sumRewards(allRewards)
         };
+        logger.debug(
+          `Rewards between epochs ${rewardsHistory.all[0].epoch} and ${
+            rewardsHistory.all[rewardsHistory.all.length - 1].epoch
+          }`,
+          `average:${rewardsHistory.avgReward}`,
+          `lastRewards:${rewardsHistory.lastReward}`,
+          `lifetimeRewards:${rewardsHistory.lifetimeRewards}`
+        );
+        return rewardsHistory;
       })
     );

--- a/packages/wallet/test/services/AssetsTracker.test.ts
+++ b/packages/wallet/test/services/AssetsTracker.test.ts
@@ -8,6 +8,7 @@ import {
   TransactionalTracker,
   createAssetsTracker
 } from '../../src/services';
+import { dummyLogger } from 'ts-log';
 import { of } from 'rxjs';
 
 describe('createAssetsTracker', () => {
@@ -15,6 +16,7 @@ describe('createAssetsTracker', () => {
   let assetPxl: Asset.AssetInfo;
   let assetService: AssetService;
   let assetProvider: TrackedAssetProvider;
+  const logger = dummyLogger;
 
   beforeEach(() => {
     const nftMetadata = { name: 'nft' } as Asset.NftMetadata;
@@ -44,7 +46,7 @@ describe('createAssetsTracker', () => {
         }
       } as unknown as TransactionalTracker<BalanceTracker>;
 
-      const target$ = createAssetsTracker({ assetProvider, balanceTracker } as unknown as AssetsTrackerProps, {
+      const target$ = createAssetsTracker({ assetProvider, balanceTracker, logger } as unknown as AssetsTrackerProps, {
         assetService
       });
       expectObservable(target$).toBe('--b-c', {
@@ -77,7 +79,7 @@ describe('createAssetsTracker', () => {
         }
       } as unknown as TransactionalTracker<BalanceTracker>;
 
-      const target$ = createAssetsTracker({ assetProvider, balanceTracker } as unknown as AssetsTrackerProps, {
+      const target$ = createAssetsTracker({ assetProvider, balanceTracker, logger } as unknown as AssetsTrackerProps, {
         assetService
       });
       expectObservable(target$).toBe('--b-c', {

--- a/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
@@ -9,11 +9,13 @@ import {
 } from '../../../src/services';
 import { createStubTxWithCertificates } from './stub-tx';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
+import { dummyLogger } from 'ts-log';
 import { firstValueFrom, of } from 'rxjs';
 import { mockRewardsProvider, rewardAccount, rewardsHistory } from '../../mocks';
 
 describe('RewardsHistory', () => {
   const rewardAccounts = [rewardAccount];
+  const logger = dummyLogger;
 
   describe('createRewardsHistoryProvider', () => {
     let rewardsProvider: TrackedRewardsProvider;
@@ -62,7 +64,8 @@ describe('RewardsHistory', () => {
           }),
           of(rewardAccounts),
           getRewardsHistory,
-          new InMemoryRewardsHistoryStore()
+          new InMemoryRewardsHistoryStore(),
+          logger
         );
         expectObservable(target$).toBe('-a', {
           a: {
@@ -104,7 +107,8 @@ describe('RewardsHistory', () => {
           }),
           of(rewardAccounts),
           getRewardsHistory,
-          new InMemoryRewardsHistoryStore()
+          new InMemoryRewardsHistoryStore(),
+          logger
         );
         expectObservable(target$).toBe('-a', {
           a: {

--- a/packages/wallet/test/services/ProviderTracker/ProviderStatusTracker.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/ProviderStatusTracker.test.ts
@@ -13,6 +13,7 @@ import {
   createProviderStatusTracker
 } from '../../../src';
 import { createStubStakePoolProvider, createTestScheduler } from '@cardano-sdk/util-dev';
+import { dummyLogger } from 'ts-log';
 import {
   mockAssetProvider,
   mockChainHistoryProvider,
@@ -91,6 +92,7 @@ describe('createProviderStatusTracker', () => {
         {
           assetProvider,
           chainHistoryProvider,
+          logger: dummyLogger,
           networkInfoProvider,
           rewardsProvider,
           stakePoolProvider,
@@ -122,6 +124,7 @@ describe('createProviderStatusTracker', () => {
         {
           assetProvider,
           chainHistoryProvider,
+          logger: dummyLogger,
           networkInfoProvider,
           rewardsProvider,
           stakePoolProvider,
@@ -150,6 +153,7 @@ describe('createProviderStatusTracker', () => {
         {
           assetProvider,
           chainHistoryProvider,
+          logger: dummyLogger,
           networkInfoProvider,
           rewardsProvider,
           stakePoolProvider,
@@ -178,6 +182,7 @@ describe('createProviderStatusTracker', () => {
         {
           assetProvider,
           chainHistoryProvider,
+          logger: dummyLogger,
           networkInfoProvider,
           rewardsProvider,
           stakePoolProvider,

--- a/packages/wallet/test/services/TipTracker.test.ts
+++ b/packages/wallet/test/services/TipTracker.test.ts
@@ -4,6 +4,7 @@ import { InMemoryDocumentStore } from '../../src/persistence';
 import { Milliseconds, SyncStatus } from '../../src';
 import { Observable, firstValueFrom, of } from 'rxjs';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
+import { dummyLogger } from 'ts-log';
 
 const stubObservableProvider = <T>(...calls: Observable<T>[]) => {
   let numCall = 0;
@@ -26,6 +27,7 @@ describe('TipTracker', () => {
   const pollInterval: Milliseconds = 1; // delays emission after trigger
   let store: InMemoryDocumentStore<Cardano.Tip>;
   let connectionStatus$: Observable<ConnectionStatus>;
+  const logger = dummyLogger;
 
   beforeEach(() => {
     store = new InMemoryDocumentStore();
@@ -43,6 +45,7 @@ describe('TipTracker', () => {
       );
       const tracker$ = new TipTracker({
         connectionStatus$,
+        logger,
         maxPollInterval: Number.MAX_VALUE,
         minPollInterval: pollInterval,
         provider$,
@@ -63,6 +66,7 @@ describe('TipTracker', () => {
       const provider$ = cold<Cardano.PartialBlockHeader>('|');
       const tracker$ = new TipTracker({
         connectionStatus$: connectionStatusOffOn$,
+        logger,
         maxPollInterval: Number.MAX_VALUE,
         minPollInterval: pollInterval,
         provider$,
@@ -88,6 +92,7 @@ describe('TipTracker', () => {
       );
       const tracker$ = new TipTracker({
         connectionStatus$,
+        logger,
         maxPollInterval: Number.MAX_VALUE,
         minPollInterval: pollInterval,
         provider$,
@@ -110,6 +115,7 @@ describe('TipTracker', () => {
       );
       const tracker$ = new TipTracker({
         connectionStatus$,
+        logger,
         maxPollInterval: 6,
         minPollInterval: pollInterval,
         provider$,
@@ -132,6 +138,7 @@ describe('TipTracker', () => {
       const provider$ = stubObservableProvider<Cardano.Tip>(cold('x|', mockTips), cold('a|', mockTips));
       const tracker$ = new TipTracker({
         connectionStatus$: connectionStatusMock$,
+        logger,
         maxPollInterval: Number.MAX_VALUE,
         minPollInterval: 0,
         provider$,
@@ -149,6 +156,7 @@ describe('TipTracker', () => {
       const provider$ = cold('x|', mockTips);
       const tracker$ = new TipTracker({
         connectionStatus$: connectionStatusMock$,
+        logger,
         maxPollInterval: 6,
         minPollInterval: 0,
         provider$,

--- a/packages/wallet/test/services/TransactionReemiter.test.ts
+++ b/packages/wallet/test/services/TransactionReemiter.test.ts
@@ -1,14 +1,16 @@
 import { Cardano } from '@cardano-sdk/core';
 import { InMemoryVolatileTransactionsStore, WalletStores } from '../../src/persistence';
-import { Logger, dummyLogger as logger } from 'ts-log';
+import { Logger, dummyLogger } from 'ts-log';
 import { NewTxAlonzoWithSlot, TransactionReemitErrorCode, createTransactionReemitter } from '../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 
 describe('TransactionReemiter', () => {
   let store: WalletStores['volatileTransactions'];
   let volatileTransactions: NewTxAlonzoWithSlot[];
+  let logger: Logger;
 
   beforeEach(() => {
+    logger = dummyLogger;
     store = new InMemoryVolatileTransactionsStore();
     store.set = jest.fn();
     volatileTransactions = [
@@ -138,7 +140,6 @@ describe('TransactionReemiter', () => {
     const rollbackD: Cardano.TxAlonzo = { body: volatileD.body, id: volatileD.id } as Cardano.TxAlonzo;
 
     // eslint-disable-next-line @typescript-eslint/no-shadow
-    const logger = {} as Logger;
     logger.error = jest.fn();
 
     createTestScheduler().run(({ hot, cold, expectObservable }) => {
@@ -169,7 +170,7 @@ describe('TransactionReemiter', () => {
     const [volatileA, volatileB, volatileC] = volatileTransactions;
     const rollbackC: Cardano.TxAlonzo = { body: volatileC.body, id: volatileC.id } as Cardano.TxAlonzo;
     // eslint-disable-next-line @typescript-eslint/no-shadow
-    const logger = {} as Logger;
+    const logger = dummyLogger;
     logger.error = jest.fn();
 
     createTestScheduler().run(({ hot, cold, expectObservable }) => {

--- a/packages/wallet/test/services/TransactionsTracker.test.ts
+++ b/packages/wallet/test/services/TransactionsTracker.test.ts
@@ -5,9 +5,12 @@ import { FailedTx, TransactionFailure, createAddressTransactionsProvider, create
 import { InMemoryInFlightTransactionsStore, InMemoryTransactionsStore, WalletStores } from '../../src/persistence';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
+import { dummyLogger } from 'ts-log';
 import delay from 'delay';
 
 describe('TransactionsTracker', () => {
+  const logger = dummyLogger;
+
   describe('createAddressTransactionsProvider', () => {
     let store: InMemoryTransactionsStore;
     let chainHistoryProvider: ChainHistoryProviderStub;
@@ -25,6 +28,7 @@ describe('TransactionsTracker', () => {
       const provider$ = createAddressTransactionsProvider({
         addresses$: of(addresses),
         chainHistoryProvider,
+        logger,
         retryBackoffConfig,
         store,
         tipBlockHeight$
@@ -42,6 +46,7 @@ describe('TransactionsTracker', () => {
       const provider$ = createAddressTransactionsProvider({
         addresses$: of(addresses),
         chainHistoryProvider,
+        logger,
         retryBackoffConfig,
         store,
         tipBlockHeight$
@@ -67,6 +72,7 @@ describe('TransactionsTracker', () => {
       const provider$ = createAddressTransactionsProvider({
         addresses$: of(addresses),
         chainHistoryProvider,
+        logger,
         retryBackoffConfig,
         store,
         tipBlockHeight$
@@ -123,6 +129,7 @@ describe('TransactionsTracker', () => {
             addresses$,
             chainHistoryProvider,
             inFlightTransactionsStore,
+            logger,
             newTransactions: {
               failedToSubmit$,
               pending$,
@@ -167,6 +174,7 @@ describe('TransactionsTracker', () => {
             addresses$,
             chainHistoryProvider,
             inFlightTransactionsStore,
+            logger,
             newTransactions: {
               failedToSubmit$,
               pending$,
@@ -210,6 +218,7 @@ describe('TransactionsTracker', () => {
             addresses$,
             chainHistoryProvider,
             inFlightTransactionsStore,
+            logger,
             newTransactions: {
               failedToSubmit$,
               pending$,
@@ -255,6 +264,7 @@ describe('TransactionsTracker', () => {
             addresses$,
             chainHistoryProvider,
             inFlightTransactionsStore,
+            logger,
             newTransactions: {
               failedToSubmit$,
               pending$,
@@ -316,6 +326,7 @@ describe('TransactionsTracker', () => {
             addresses$,
             chainHistoryProvider,
             inFlightTransactionsStore,
+            logger,
             newTransactions: {
               failedToSubmit$,
               pending$,
@@ -387,6 +398,7 @@ describe('TransactionsTracker', () => {
             addresses$,
             chainHistoryProvider,
             inFlightTransactionsStore,
+            logger,
             newTransactions: {
               failedToSubmit$,
               pending$,

--- a/packages/wallet/test/services/TransactionsTracker.test.ts
+++ b/packages/wallet/test/services/TransactionsTracker.test.ts
@@ -11,7 +11,7 @@ describe('TransactionsTracker', () => {
   describe('createAddressTransactionsProvider', () => {
     let store: InMemoryTransactionsStore;
     let chainHistoryProvider: ChainHistoryProviderStub;
-    const tip$ = of(300);
+    const tipBlockHeight$ = of(300);
     const retryBackoffConfig = { initialInterval: 1 }; // not relevant
     const addresses = [queryTransactionsResult[0].body.inputs[0].address!];
 
@@ -22,13 +22,13 @@ describe('TransactionsTracker', () => {
     });
 
     it('if store is empty, stores and emits transactions resolved by ChainHistoryProvider', async () => {
-      const provider$ = createAddressTransactionsProvider(
+      const provider$ = createAddressTransactionsProvider({
+        addresses$: of(addresses),
         chainHistoryProvider,
-        of(addresses),
         retryBackoffConfig,
-        tip$,
-        store
-      ).transactionsSource$;
+        store,
+        tipBlockHeight$
+      }).transactionsSource$;
       expect(await firstValueFrom(provider$)).toEqual(queryTransactionsResult);
       expect(store.setAll).toBeCalledTimes(1);
       expect(store.setAll).toBeCalledWith(queryTransactionsResult);
@@ -39,13 +39,13 @@ describe('TransactionsTracker', () => {
       chainHistoryProvider.transactionsByAddresses = jest
         .fn()
         .mockImplementation(() => delay(50).then(() => queryTransactionsResult));
-      const provider$ = createAddressTransactionsProvider(
+      const provider$ = createAddressTransactionsProvider({
+        addresses$: of(addresses),
         chainHistoryProvider,
-        of(addresses),
         retryBackoffConfig,
-        tip$,
-        store
-      ).transactionsSource$;
+        store,
+        tipBlockHeight$
+      }).transactionsSource$;
       expect(await firstValueFrom(provider$.pipe(bufferCount(2)))).toEqual([
         [queryTransactionsResult[0]],
         queryTransactionsResult
@@ -64,13 +64,13 @@ describe('TransactionsTracker', () => {
         .fn()
         .mockImplementationOnce(() => delay(50).then(() => []))
         .mockImplementationOnce(() => delay(50).then(() => [queryTransactionsResult[0]]));
-      const provider$ = createAddressTransactionsProvider(
+      const provider$ = createAddressTransactionsProvider({
+        addresses$: of(addresses),
         chainHistoryProvider,
-        of(addresses),
         retryBackoffConfig,
-        tip$,
-        store
-      ).transactionsSource$;
+        store,
+        tipBlockHeight$
+      }).transactionsSource$;
       expect(await firstValueFrom(provider$.pipe(bufferCount(2)))).toEqual([
         queryTransactionsResult,
         [queryTransactionsResult[0]]

--- a/packages/wallet/test/services/UtxoTracker.test.ts
+++ b/packages/wallet/test/services/UtxoTracker.test.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { PersistentCollectionTrackerSubject, createUtxoTracker } from '../../src/services';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
+import { dummyLogger } from 'ts-log';
 import { utxo } from '../mocks';
 
 describe('createUtxoTracker', () => {
@@ -11,6 +12,7 @@ describe('createUtxoTracker', () => {
   let retryBackoffConfig: RetryBackoffConfig;
   let tipBlockHeight$: Observable<number>;
   let utxoProvider: UtxoProvider;
+  const logger = dummyLogger;
 
   it(`fetches utxo from UtxoProvider;
       includes change from a transaction in flight;
@@ -72,6 +74,7 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [ownAddress!] }),
+          logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,
@@ -112,6 +115,7 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [address!] }),
+          logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,
@@ -150,6 +154,7 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [address!] }),
+          logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,


### PR DESCRIPTION
# Context

SingleAddressWallet issues can be difficult to troubleshoot as it’s doing a lot of things internally. Add logger.debug statements to impove this.

# Proposed Solution
- Add logger parameter to trackers constructed by SingleAddressWallet.
- Context is added by SingleAddressWallet before passing logger to tracker builders (e.g. [SingleAddressWallet|SyncStatus]), so that context is the one in which SingleAddressWallet is using the tracker.
-Since most of the logic is in rxjs observable streams, use tap() to add debug logs: e.g. statsReady$...pipe(tap(() => logger.debug('Stats are ready').

# Important Changes Introduced
Add `logger` parameter to many tracker builders.