### PR TITLE
fix(wallet): stop querying the `StakePoolProvider` for all pools when no current delegation

### DIFF
--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -1,11 +1,4 @@
-import {
-  Cardano,
-  ChainHistoryProvider,
-  SlotEpochCalc,
-  StakePoolProvider,
-  TimeSettings,
-  createSlotEpochCalc
-} from '@cardano-sdk/core';
+import { Cardano, ChainHistoryProvider, SlotEpochCalc, TimeSettings, createSlotEpochCalc } from '@cardano-sdk/core';
 import { DelegationTracker, TransactionsTracker } from '../types';
 import { Observable, combineLatest, map } from 'rxjs';
 import {
@@ -18,7 +11,7 @@ import {
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { RewardsHistoryProvider, createRewardsHistoryProvider, createRewardsHistoryTracker } from './RewardsHistory';
 import { Shutdown } from '@cardano-sdk/util';
-import { TrackedRewardsProvider } from '../ProviderTracker';
+import { TrackedRewardsProvider, TrackedStakePoolProvider } from '../ProviderTracker';
 import { TrackerSubject } from '@cardano-sdk/util-rxjs';
 import { TxWithEpoch } from './types';
 import { WalletStores } from '../../persistence';
@@ -38,7 +31,7 @@ export type BlockEpochProvider = ReturnType<typeof createBlockEpochProvider>;
 export interface DelegationTrackerProps {
   rewardsTracker: TrackedRewardsProvider;
   rewardAccountAddresses$: Observable<Cardano.RewardAccount[]>;
-  stakePoolProvider: StakePoolProvider;
+  stakePoolProvider: TrackedStakePoolProvider;
   timeSettings$: Observable<TimeSettings[]>;
   epoch$: Observable<Cardano.Epoch>;
   transactionsTracker: TransactionsTracker;


### PR DESCRIPTION
# Context
Undesirable behavior was observed during testing of a remote deployment of the HTTP server with restricted resources, where a wallet without a delegation was requesting all pools via an unbounded query, resulting in resource exhaustion. The fix is two-fold, one contained in this branch, and the other to reject such query as a `400` in the HTTP service (ADP-2120).

# Proposed Solution
This fix stops the observable returned from `createQueryStakePoolsProvider` querying the `StakePoolProvider` if an empty array of pool IDs is passed, as this indicates no data is required, rather than all.
