### PR TITLE
feat!: replace `NetworkInfoProvider.timeSettings` with `eraSummaries`

### DIFF
--- a/packages/blockfrost/src/blockfrostNetworkInfoProvider.ts
+++ b/packages/blockfrost/src/blockfrostNetworkInfoProvider.ts
@@ -1,7 +1,7 @@
 import { BlockFrostAPI } from '@blockfrost/blockfrost-js';
 import { BlockfrostToCore } from './BlockfrostToCore';
 import { NetworkInfoProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
-import { healthCheck, networkMagicToIdMap, timeSettings } from './util';
+import { eraSummaries, healthCheck, networkMagicToIdMap } from './util';
 
 /**
  * Connect to the [Blockfrost service](https://docs.blockfrost.io/)
@@ -63,11 +63,11 @@ export const blockfrostNetworkInfoProvider = (blockfrost: BlockFrostAPI): Networ
 
   return {
     currentWalletProtocolParameters,
+    eraSummaries,
     genesisParameters,
     healthCheck: healthCheck.bind(undefined, blockfrost),
     ledgerTip,
     lovelaceSupply,
-    stake,
-    timeSettings
+    stake
   };
 };

--- a/packages/blockfrost/src/util.ts
+++ b/packages/blockfrost/src/util.ts
@@ -10,7 +10,7 @@ import {
   ProviderError,
   ProviderFailure,
   ProviderUtil,
-  testnetTimeSettings
+  testnetEraSummaries
 } from '@cardano-sdk/core';
 import { PaginationOptions } from '@blockfrost/blockfrost-js/lib/types';
 
@@ -135,7 +135,7 @@ export const networkMagicToIdMap: { [key in number]: Cardano.NetworkId } = {
   [Cardano.CardanoNetworkMagic.Testnet]: Cardano.NetworkId.testnet
 };
 
-export const timeSettings: NetworkInfoProvider['timeSettings'] = async () => testnetTimeSettings;
+export const eraSummaries: NetworkInfoProvider['eraSummaries'] = async () => testnetEraSummaries;
 
 /**
  * Check health of the [Blockfrost service](https://docs.blockfrost.io/)

--- a/packages/blockfrost/test/blockfrostNetworkInfoProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostNetworkInfoProvider.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
 import { BlockFrostAPI, Responses } from '@blockfrost/blockfrost-js';
-import { Cardano, StakeSummary, SupplySummary, TimeSettings, testnetTimeSettings } from '@cardano-sdk/core';
+import { Cardano, EraSummary, StakeSummary, SupplySummary, testnetEraSummaries } from '@cardano-sdk/core';
 import { blockfrostNetworkInfoProvider } from '../src';
 
 jest.mock('@blockfrost/blockfrost-js');
@@ -69,12 +69,12 @@ describe('blockfrostNetworkInfoProvider', () => {
     });
   });
 
-  test('timeSettings', async () => {
+  test('eraSummaries', async () => {
     const blockfrost = new BlockFrostAPI({ isTestnet: true, projectId: apiKey });
     const client = blockfrostNetworkInfoProvider(blockfrost);
-    const response = await client.timeSettings();
+    const response = await client.eraSummaries();
 
-    expect(response).toMatchObject<TimeSettings[]>(testnetTimeSettings);
+    expect(response).toMatchObject<EraSummary[]>(testnetEraSummaries);
   });
 
   test('genesisParameters', async () => {

--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -6,12 +6,12 @@ import { NetworkInfoProvider } from '@cardano-sdk/core';
  */
 const paths: HttpProviderConfigPaths<NetworkInfoProvider> = {
   currentWalletProtocolParameters: '/current-wallet-protocol-parameters',
+  eraSummaries: '/era-summaries',
   genesisParameters: '/genesis-parameters',
   healthCheck: '/health',
   ledgerTip: '/ledger-tip',
   lovelaceSupply: '/lovelace-supply',
-  stake: '/stake',
-  timeSettings: '/time-settings'
+  stake: '/stake'
 };
 
 /**

--- a/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
@@ -35,10 +35,10 @@ describe('networkInfoHttpProvider', () => {
     await expect(provider.lovelaceSupply()).resolves.toEqual({});
   });
 
-  test('timeSettings does not throw', async () => {
+  test('eraSummaries does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
     const provider = networkInfoHttpProvider(config);
-    await expect(provider.timeSettings()).resolves.toEqual({});
+    await expect(provider.eraSummaries()).resolves.toEqual({});
   });
 
   test('ledgerTip does not throw', async () => {

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
@@ -2,11 +2,11 @@ import {
   Cardano,
   CardanoNode,
   CardanoNodeUtil,
+  EraSummary,
   NetworkInfoProvider,
   ProtocolParametersRequiredByWallet,
   StakeSummary,
-  SupplySummary,
-  TimeSettings
+  SupplySummary
 } from '@cardano-sdk/core';
 import { DbSyncProvider } from '../../DbSyncProvider';
 import { GenesisData } from './types';
@@ -17,14 +17,7 @@ import { NetworkInfoCacheKey } from '.';
 import { Pool } from 'pg';
 import { Shutdown } from '@cardano-sdk/util';
 import { epochPollService } from './utils';
-import {
-  loadGenesisData,
-  toGenesisParams,
-  toLedgerTip,
-  toSupply,
-  toTimeSettings,
-  toWalletProtocolParams
-} from './mappers';
+import { loadGenesisData, toGenesisParams, toLedgerTip, toSupply, toWalletProtocolParams } from './mappers';
 
 export interface NetworkInfoProviderProps {
   cardanoNodeConfigPath: string;
@@ -104,14 +97,12 @@ export class DbSyncNetworkInfoProvider extends DbSyncProvider implements Network
     };
   }
 
-  public async timeSettings(): Promise<TimeSettings[]> {
-    return (
-      await this.#cache.get(
-        NetworkInfoCacheKey.ERA_SUMMARIES,
-        () => this.#cardanoNode.eraSummaries(),
-        UNLIMITED_CACHE_TTL
-      )
-    ).map(toTimeSettings);
+  public async eraSummaries(): Promise<EraSummary[]> {
+    return await this.#cache.get(
+      NetworkInfoCacheKey.ERA_SUMMARIES,
+      () => this.#cardanoNode.eraSummaries(),
+      UNLIMITED_CACHE_TTL
+    );
   }
 
   async start(): Promise<void> {

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -1,11 +1,9 @@
 import {
   Cardano,
-  EraSummary,
   ProtocolParametersRequiredByWallet,
   ProviderError,
   ProviderFailure,
-  SupplySummary,
-  TimeSettings
+  SupplySummary
 } from '@cardano-sdk/core';
 import { GenesisData, LedgerTipModel, WalletProtocolParamsModel } from './types';
 import JSONbig from 'json-bigint';
@@ -21,13 +19,6 @@ export const networkIdMap = {
   Mainnet: Cardano.NetworkId.mainnet,
   Testnet: Cardano.NetworkId.testnet
 };
-
-export const toTimeSettings = (eraSummary: EraSummary): TimeSettings => ({
-  epochLength: eraSummary.parameters.epochLength,
-  fromSlotDate: eraSummary.start.time,
-  fromSlotNo: eraSummary.start.slot,
-  slotLength: eraSummary.parameters.slotLength
-});
 
 export const toSupply = ({ circulatingSupply, totalSupply }: ToLovalaceSupplyInput): SupplySummary => ({
   circulating: BigInt(circulatingSupply),

--- a/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
+++ b/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
@@ -41,8 +41,8 @@ export class NetworkInfoHttpService extends HttpService {
       )
     );
     router.post(
-      '/time-settings',
-      providerHandler(networkInfoProvider.timeSettings.bind(networkInfoProvider))(
+      '/era-summaries',
+      providerHandler(networkInfoProvider.eraSummaries.bind(networkInfoProvider))(
         HttpService.routeHandler(logger),
         logger
       )

--- a/packages/cardano-services/src/NetworkInfo/openApi.json
+++ b/packages/cardano-services/src/NetworkInfo/openApi.json
@@ -63,11 +63,11 @@
         }
       }
     },
-    "/network-info/time-settings": {
+    "/network-info/era-summaries": {
       "post": {
-        "summary": "fetch time settings info",
-        "description": "Fetch Time Settings Info",
-        "operationId": "timeSettings",
+        "summary": "fetch era summaries info",
+        "description": "Fetch Era Summaries Info",
+        "operationId": "eraSummaries",
         "requestBody": {
           "content": {
             "application/json": {}
@@ -75,13 +75,13 @@
         },
         "responses": {
           "200": {
-            "description": "time settings info fetched",
+            "description": "era summaries info fetched",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TimeSettings"
+                    "$ref": "#/components/schemas/EraSummary"
                   }
                 }
               }
@@ -207,29 +207,45 @@
           }
         }
       },
-      "TimeSettings": {
+      "EraSummary": {
         "required": [
-          "epochLength",
-          "fromSlotDate",
-          "fromSlotNo",
-          "slotLength"
+          "parameters",
+          "start"
         ],
         "type": "object",
         "properties": {
-          "epochLength": {
-            "type": "number",
-            "example": 21600
+          "parameters": {
+            "required": [
+              "epochLength",
+              "slotLength"
+            ],
+            "type": "object",
+            "properties": {
+              "epochLength": {
+                "type": "number",
+                "example": 21600
+              },
+              "slotLength": {
+                "type": "number",
+                "example": 1000
+              }
+            }
           },
-          "fromSlotDate": {
-            "$ref": "#/components/schemas/Date"
-          },
-          "fromSlotNo": {
-            "type": "number",
-            "example": 1200
-          },
-          "slotLength": {
-            "type": "number",
-            "example": 1000
+          "start": {
+            "required": [
+              "slot",
+              "time"
+            ],
+            "type": "object",
+            "properties": {
+              "slot": {
+                "type": "number",
+                "example": 1200
+              },
+              "time": {
+                "$ref": "#/components/schemas/Date"
+              }
+            }
           }
         }
       },

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -47,12 +47,12 @@ describe('NetworkInfoHttpService', () => {
       cardanoNode = mockCardanoNode();
       networkInfoProvider = {
         currentWalletProtocolParameters: jest.fn(),
+        eraSummaries: jest.fn(),
         genesisParameters: jest.fn(),
         healthCheck: jest.fn(() => Promise.resolve({ ok: false })),
         ledgerTip: jest.fn(),
         lovelaceSupply: jest.fn(),
-        stake: jest.fn(),
-        timeSettings: jest.fn()
+        stake: jest.fn()
       } as unknown as DbSyncNetworkInfoProvider;
     });
 
@@ -126,16 +126,16 @@ describe('NetworkInfoHttpService', () => {
       });
     });
 
-    describe('/time-settings', () => {
+    describe('/era-summaries', () => {
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/time-settings`, { args: [] })).status).toEqual(200);
+          expect((await axios.post(`${baseUrl}/era-summaries`, { args: [] })).status).toEqual(200);
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
           try {
             await axios.post(
-              `${baseUrl}/time-settings`,
+              `${baseUrl}/era-summaries`,
               { args: [] },
               { headers: { 'Content-Type': APPLICATION_CBOR } }
             );
@@ -147,8 +147,8 @@ describe('NetworkInfoHttpService', () => {
       });
 
       it('successful request', async () => {
-        const response = await provider.timeSettings();
-        expect(response[0].slotLength).toBeDefined();
+        const response = await provider.eraSummaries();
+        expect(response[0].parameters.slotLength).toBeDefined();
       });
     });
 

--- a/packages/core/src/Provider/NetworkInfoProvider/types.ts
+++ b/packages/core/src/Provider/NetworkInfoProvider/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, Provider, TimeSettings } from '../..';
+import { Cardano, EraSummary, Provider } from '../..';
 
 export type ProtocolParametersRequiredByWallet = Required<
   Pick<
@@ -32,5 +32,5 @@ export interface NetworkInfoProvider extends Provider {
   genesisParameters(): Promise<Cardano.CompactGenesis>;
   lovelaceSupply(): Promise<SupplySummary>;
   stake(): Promise<StakeSummary>;
-  timeSettings(): Promise<TimeSettings[]>;
+  eraSummaries(): Promise<EraSummary[]>;
 }

--- a/packages/core/test/util/slotCalc.test.ts
+++ b/packages/core/test/util/slotCalc.test.ts
@@ -3,21 +3,23 @@
 import {
   Cardano,
   EpochInfo,
+  EraSummary,
+  EraSummaryError,
   SlotEpochCalc,
   SlotEpochInfoCalc,
   SlotTimeCalc,
-  TimeSettings,
-  TimeSettingsError,
   createSlotEpochCalc,
   createSlotEpochInfoCalc,
   createSlotTimeCalc,
-  testnetTimeSettings
+  testnetEraSummaries
 } from '../../src';
+
+import merge from 'lodash/merge';
 
 describe('slotCalc utils', () => {
   describe('slotTimeCalc', () => {
     describe('testnet', () => {
-      const slotTimeCalc: SlotTimeCalc = createSlotTimeCalc(testnetTimeSettings);
+      const slotTimeCalc: SlotTimeCalc = createSlotTimeCalc(testnetEraSummaries);
 
       it('correctly computes date of the 1st block', () =>
         expect(slotTimeCalc(1031)).toEqual(new Date(1_564_020_236_000)));
@@ -40,20 +42,20 @@ describe('slotCalc utils', () => {
       it('correctly computes date of some Shelley block', () =>
         expect(slotTimeCalc(8_078_371)).toEqual(new Date(1_602_443_987_000)));
 
-      it('throws with invalid slot', () => expect(() => slotTimeCalc(-1)).toThrowError(TimeSettingsError));
+      it('throws with invalid slot', () => expect(() => slotTimeCalc(-1)).toThrowError(EraSummaryError));
     });
 
-    it('throws with invalid TimeSettings', () => {
+    it('throws with invalid EraSummary', () => {
       const slotTimeCalc = createSlotTimeCalc([
-        { ...testnetTimeSettings[0], fromSlotDate: new Date(), fromSlotNo: 5, slotLength: 1 }
+        merge({}, testnetEraSummaries[0], { parameters: { slotLength: 1 }, start: { slot: 5, time: new Date() } })
       ]);
-      expect(() => slotTimeCalc(4)).toThrowError(TimeSettingsError);
+      expect(() => slotTimeCalc(4)).toThrowError(EraSummaryError);
     });
   });
 
   describe('slotEpochCalc', () => {
     describe('testnet', () => {
-      const slotEpochCalc: SlotEpochCalc = createSlotEpochCalc(testnetTimeSettings);
+      const slotEpochCalc: SlotEpochCalc = createSlotEpochCalc(testnetEraSummaries);
 
       it('correctly computes epoch of the 1st block', () => expect(slotEpochCalc(1031)).toEqual(0));
 
@@ -69,85 +71,85 @@ describe('slotCalc utils', () => {
 
       it('correctly computes epoch of some Shelley block', () => expect(slotEpochCalc(8_078_371)).toBe(88));
 
-      it('throws with invalid slot', () => expect(() => slotEpochCalc(-1)).toThrowError(TimeSettingsError));
+      it('throws with invalid slot', () => expect(() => slotEpochCalc(-1)).toThrowError(EraSummaryError));
     });
 
-    it('throws with invalid TimeSettings', () => {
-      const slotEpochCalc = createSlotEpochCalc([{ ...testnetTimeSettings[0], fromSlotNo: 5 }]);
-      expect(() => slotEpochCalc(4)).toThrowError(TimeSettingsError);
+    it('throws with invalid EraSummary', () => {
+      const slotEpochCalc = createSlotEpochCalc([merge({}, testnetEraSummaries[0], { start: { slot: 5 } })]);
+      expect(() => slotEpochCalc(4)).toThrowError(EraSummaryError);
     });
   });
 
   describe('slotEpochInfoCalc ', () => {
     describe('testnet', () => {
-      const slotEpochInfoCalc: SlotEpochInfoCalc = createSlotEpochInfoCalc(testnetTimeSettings);
-      const byronTimeSettings = {
-        ...testnetTimeSettings[0],
+      const slotEpochInfoCalc: SlotEpochInfoCalc = createSlotEpochInfoCalc(testnetEraSummaries);
+      const byronEraSummary = {
+        ...testnetEraSummaries[0],
         firstEpoch: 0
       };
-      const shelleyTimeSettings = {
-        ...testnetTimeSettings[1],
+      const shelleyEraSummary = {
+        ...testnetEraSummaries[1],
         firstEpoch: 74
       };
 
       const assertNthEpochInfoValid = (
         expectedEpochNo: Cardano.Epoch,
         { epochNo, firstSlot, lastSlot }: EpochInfo,
-        epochTimeSettings: TimeSettings & { firstEpoch: number }
+        epochEraSummary: EraSummary & { firstEpoch: number }
       ) => {
         expect(epochNo).toEqual(expectedEpochNo);
-        const relativeEpoch = expectedEpochNo - epochTimeSettings.firstEpoch;
+        const relativeEpoch = expectedEpochNo - epochEraSummary.firstEpoch;
         expect(firstSlot).toEqual({
           date: new Date(
-            epochTimeSettings.fromSlotDate.getTime() +
-              epochTimeSettings.epochLength * epochTimeSettings.slotLength * relativeEpoch
+            epochEraSummary.start.time.getTime() +
+              epochEraSummary.parameters.epochLength * epochEraSummary.parameters.slotLength * relativeEpoch
           ),
-          slot: epochTimeSettings.fromSlotNo + epochTimeSettings.epochLength * relativeEpoch
+          slot: epochEraSummary.start.slot + epochEraSummary.parameters.epochLength * relativeEpoch
         });
         expect(lastSlot).toEqual({
           date: new Date(
-            epochTimeSettings.fromSlotDate.getTime() +
-              epochTimeSettings.epochLength * epochTimeSettings.slotLength * (relativeEpoch + 1) -
-              epochTimeSettings.slotLength
+            epochEraSummary.start.time.getTime() +
+              epochEraSummary.parameters.epochLength * epochEraSummary.parameters.slotLength * (relativeEpoch + 1) -
+              epochEraSummary.parameters.slotLength
           ),
-          slot: epochTimeSettings.fromSlotNo + epochTimeSettings.epochLength * (relativeEpoch + 1) - 1
+          slot: epochEraSummary.start.slot + epochEraSummary.parameters.epochLength * (relativeEpoch + 1) - 1
         });
       };
 
       it('correctly computes epoch info of the 1st block', () => {
-        assertNthEpochInfoValid(0, slotEpochInfoCalc(1031), byronTimeSettings);
+        assertNthEpochInfoValid(0, slotEpochInfoCalc(1031), byronEraSummary);
       });
 
       it('correctly computes epoch info of the genesis block', () => {
-        assertNthEpochInfoValid(0, slotEpochInfoCalc(0), byronTimeSettings);
+        assertNthEpochInfoValid(0, slotEpochInfoCalc(0), byronEraSummary);
       });
 
       it('correctly computes epoch info of some Byron block', () => {
-        assertNthEpochInfoValid(55, slotEpochInfoCalc(1_209_592), byronTimeSettings);
+        assertNthEpochInfoValid(55, slotEpochInfoCalc(1_209_592), byronEraSummary);
       });
 
       it('correctly computes epoch info of the last Byron block', () => {
-        assertNthEpochInfoValid(73, slotEpochInfoCalc(1_598_399), byronTimeSettings);
+        assertNthEpochInfoValid(73, slotEpochInfoCalc(1_598_399), byronEraSummary);
       });
 
       it('correctly computes epoch info of the 1st Shelley block', () => {
-        assertNthEpochInfoValid(74, slotEpochInfoCalc(1_598_400), shelleyTimeSettings);
+        assertNthEpochInfoValid(74, slotEpochInfoCalc(1_598_400), shelleyEraSummary);
       });
 
       it('correctly computes epoch info of the 2nd Shelley block', () => {
-        assertNthEpochInfoValid(74, slotEpochInfoCalc(1_598_420), shelleyTimeSettings);
+        assertNthEpochInfoValid(74, slotEpochInfoCalc(1_598_420), shelleyEraSummary);
       });
 
       it('correctly computes epoch of info some Shelley block', () => {
-        assertNthEpochInfoValid(88, slotEpochInfoCalc(8_078_371), shelleyTimeSettings);
+        assertNthEpochInfoValid(88, slotEpochInfoCalc(8_078_371), shelleyEraSummary);
       });
 
-      it('throws with invalid slot', () => expect(() => slotEpochInfoCalc(-1)).toThrowError(TimeSettingsError));
+      it('throws with invalid slot', () => expect(() => slotEpochInfoCalc(-1)).toThrowError(EraSummaryError));
     });
 
-    it('throws with invalid TimeSettings', () => {
-      const slotEpochInfoCalc = createSlotEpochInfoCalc([{ ...testnetTimeSettings[0], fromSlotNo: 5 }]);
-      expect(() => slotEpochInfoCalc(4)).toThrowError(TimeSettingsError);
+    it('throws with invalid EraSummary', () => {
+      const slotEpochInfoCalc = createSlotEpochInfoCalc([merge({}, testnetEraSummaries[0], { start: { slot: 5 } })]);
+      expect(() => slotEpochInfoCalc(4)).toThrowError(EraSummaryError);
     });
   });
 });

--- a/packages/ogmios/test/CardanoNode/mappers.test.ts
+++ b/packages/ogmios/test/CardanoNode/mappers.test.ts
@@ -9,7 +9,7 @@ describe('cardano node mappers', () => {
       parameters: { epochLength: 432_000, safeZone: 129_600, slotLength: 1 },
       start: { epoch: 74, slot: 1_598_400, time: 31_968_000 }
     };
-    test('map ogmios EraSummary to TimeSettings', () => {
+    it('maps ogmios EraSummary to core EraSummary', () => {
       const result = mappers.mapEraSummary(eraSummary, new Date(1_506_203_091_000));
       expect(result).toEqual<EraSummary>({
         parameters: {

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -1,5 +1,5 @@
 import { Assets } from '../../types';
-import { Cardano, EpochRewards, ProtocolParametersRequiredByWallet, TimeSettings } from '@cardano-sdk/core';
+import { Cardano, EpochRewards, EraSummary, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
 import { EMPTY, combineLatest, map } from 'rxjs';
 import { GroupedAddress } from '../../KeyManagement';
 import { InMemoryCollectionStore } from './InMemoryCollectionStore';
@@ -11,7 +11,7 @@ import { WalletStores } from '../types';
 export class InMemoryTipStore extends InMemoryDocumentStore<Cardano.Tip> {}
 export class InMemoryProtocolParametersStore extends InMemoryDocumentStore<ProtocolParametersRequiredByWallet> {}
 export class InMemoryGenesisParametersStore extends InMemoryDocumentStore<Cardano.CompactGenesis> {}
-export class InMemoryTimeSettingsStore extends InMemoryDocumentStore<TimeSettings[]> {}
+export class InMemoryEraSummariesStore extends InMemoryDocumentStore<EraSummary[]> {}
 
 export class InMemoryAssetsStore extends InMemoryDocumentStore<Assets> {}
 export class InMemoryAddressesStore extends InMemoryDocumentStore<GroupedAddress[]> {}
@@ -37,7 +37,7 @@ export const createInMemoryWalletStores = (): WalletStores => ({
         this.assets.destroy(),
         this.genesisParameters.destroy(),
         this.protocolParameters.destroy(),
-        this.timeSettings.destroy(),
+        this.eraSummaries.destroy(),
         this.unspendableUtxo.destroy(),
         this.rewardsBalances.destroy(),
         this.rewardsHistory.destroy(),
@@ -52,13 +52,13 @@ export const createInMemoryWalletStores = (): WalletStores => ({
     return EMPTY;
   },
   destroyed: false,
+  eraSummaries: new InMemoryEraSummariesStore(),
   genesisParameters: new InMemoryGenesisParametersStore(),
   inFlightTransactions: new InMemoryInFlightTransactionsStore(),
   protocolParameters: new InMemoryProtocolParametersStore(),
   rewardsBalances: new InMemoryRewardsBalancesStore(),
   rewardsHistory: new InMemoryRewardsHistoryStore(),
   stakePools: new InMemoryStakePoolsStore(),
-  timeSettings: new InMemoryTimeSettingsStore(),
   tip: new InMemoryTipStore(),
   transactions: new InMemoryTransactionsStore(),
   unspendableUtxo: new InMemoryUnspendableUtxoStore(),

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -1,5 +1,5 @@
 import { Assets } from '../../types';
-import { Cardano, EpochRewards, ProtocolParametersRequiredByWallet, TimeSettings } from '@cardano-sdk/core';
+import { Cardano, EpochRewards, EraSummary, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
 import { CreatePouchDbStoresDependencies } from './types';
 import { EMPTY, combineLatest, map } from 'rxjs';
 import { GroupedAddress } from '../../KeyManagement';
@@ -12,7 +12,7 @@ import { WalletStores } from '../types';
 export class PouchDbTipStore extends PouchDbDocumentStore<Cardano.Tip> {}
 export class PouchDbProtocolParametersStore extends PouchDbDocumentStore<ProtocolParametersRequiredByWallet> {}
 export class PouchDbGenesisParametersStore extends PouchDbDocumentStore<Cardano.CompactGenesis> {}
-export class PouchDbTimeSettingsStore extends PouchDbDocumentStore<TimeSettings[]> {}
+export class PouchDbEraSummariesStore extends PouchDbDocumentStore<EraSummary[]> {}
 
 export class PouchDbAssetsStore extends PouchDbDocumentStore<Assets> {}
 export class PouchDbAddressesStore extends PouchDbDocumentStore<GroupedAddress[]> {}
@@ -57,13 +57,13 @@ export const createPouchDbWalletStores = (
       return EMPTY;
     },
     destroyed: false,
+    eraSummaries: new PouchDbEraSummariesStore(docsDbName, 'EraSummaries', logger),
     genesisParameters: new PouchDbGenesisParametersStore(docsDbName, 'genesisParameters', logger),
     inFlightTransactions: new PouchDbInFlightTransactionsStore(docsDbName, 'newTransactions', logger),
     protocolParameters: new PouchDbProtocolParametersStore(docsDbName, 'protocolParameters', logger),
     rewardsBalances: new PouchDbRewardsBalancesStore(`${baseDbName}RewardsBalances`, logger),
     rewardsHistory: new PouchDbRewardsHistoryStore(`${baseDbName}RewardsHistory`, logger),
     stakePools: new PouchDbStakePoolsStore(`${baseDbName}StakePools`, logger),
-    timeSettings: new PouchDbTimeSettingsStore(docsDbName, 'timeSettings', logger),
     tip: new PouchDbTipStore(docsDbName, 'tip', logger),
     transactions: new PouchDbTransactionsStore(
       {

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -2,10 +2,10 @@ import { Assets } from '../types';
 import {
   Cardano,
   EpochRewards,
+  EraSummary,
   ProtocolParametersRequiredByWallet,
   StakeSummary,
-  SupplySummary,
-  TimeSettings
+  SupplySummary
 } from '@cardano-sdk/core';
 import { GroupedAddress } from '../KeyManagement';
 import { NewTxAlonzoWithSlot } from '../services';
@@ -88,7 +88,7 @@ export interface WalletStores extends Destroyable {
   stakePools: KeyValueStore<Cardano.PoolId, Cardano.StakePool>;
   protocolParameters: DocumentStore<ProtocolParametersRequiredByWallet>;
   genesisParameters: DocumentStore<Cardano.CompactGenesis>;
-  timeSettings: DocumentStore<TimeSettings[]>;
+  eraSummaries: DocumentStore<EraSummary[]>;
   assets: DocumentStore<Assets>;
   addresses: DocumentStore<GroupedAddress[]>;
 }

--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -1,4 +1,4 @@
-import { Cardano, ChainHistoryProvider, SlotEpochCalc, TimeSettings, createSlotEpochCalc } from '@cardano-sdk/core';
+import { Cardano, ChainHistoryProvider, EraSummary, SlotEpochCalc, createSlotEpochCalc } from '@cardano-sdk/core';
 import { DelegationTracker, TransactionsTracker } from '../types';
 import { Observable, combineLatest, map } from 'rxjs';
 import {
@@ -32,7 +32,7 @@ export interface DelegationTrackerProps {
   rewardsTracker: TrackedRewardsProvider;
   rewardAccountAddresses$: Observable<Cardano.RewardAccount[]>;
   stakePoolProvider: TrackedStakePoolProvider;
-  timeSettings$: Observable<TimeSettings[]>;
+  eraSummaries$: Observable<EraSummary[]>;
   epoch$: Observable<Cardano.Epoch>;
   transactionsTracker: TransactionsTracker;
   retryBackoffConfig: RetryBackoffConfig;
@@ -66,7 +66,7 @@ export const createDelegationTracker = ({
   rewardsTracker,
   retryBackoffConfig,
   transactionsTracker,
-  timeSettings$,
+  eraSummaries$,
   stakePoolProvider,
   stores,
   internals: {
@@ -78,7 +78,7 @@ export const createDelegationTracker = ({
       rewardsTracker,
       retryBackoffConfig
     ),
-    slotEpochCalc$ = timeSettings$.pipe(map((timeSettings) => createSlotEpochCalc(timeSettings)))
+    slotEpochCalc$ = eraSummaries$.pipe(map((eraSummaries) => createSlotEpochCalc(eraSummaries)))
   } = {}
 }: DelegationTrackerProps): DelegationTracker & Shutdown => {
   const transactions$ = certificateTransactionsWithEpochs(

--- a/packages/wallet/src/services/EpochTracker.ts
+++ b/packages/wallet/src/services/EpochTracker.ts
@@ -1,16 +1,16 @@
-import { Cardano, EpochInfo, TimeSettings, createSlotEpochInfoCalc } from '@cardano-sdk/core';
+import { Cardano, EpochInfo, EraSummary, createSlotEpochInfoCalc } from '@cardano-sdk/core';
 import { Observable, distinctUntilChanged, map, switchMap } from 'rxjs';
 import { TrackerSubject } from '@cardano-sdk/util-rxjs';
 import { epochInfoEquals } from './util';
 
 export const currentEpochTracker = (
   tip$: Observable<Cardano.Tip>,
-  timeSettings$: Observable<TimeSettings[]>
+  eraSummaries$: Observable<EraSummary[]>
 ): TrackerSubject<EpochInfo> =>
   new TrackerSubject(
-    timeSettings$.pipe(
-      switchMap((timeSettings) => {
-        const slotEpochInfoCalc = createSlotEpochInfoCalc(timeSettings);
+    eraSummaries$.pipe(
+      switchMap((eraSummaries) => {
+        const slotEpochInfoCalc = createSlotEpochInfoCalc(eraSummaries);
         return tip$.pipe(map(({ slot }) => slotEpochInfoCalc(slot)));
       }),
       distinctUntilChanged(epochInfoEquals)

--- a/packages/wallet/src/services/ProviderTracker/ProviderStatusTracker.ts
+++ b/packages/wallet/src/services/ProviderTracker/ProviderStatusTracker.ts
@@ -53,7 +53,7 @@ const getDefaultProviderSyncRelevantStats = ({
     networkInfoProvider.stats.ledgerTip$,
     networkInfoProvider.stats.currentWalletProtocolParameters$,
     networkInfoProvider.stats.genesisParameters$,
-    networkInfoProvider.stats.timeSettings$,
+    networkInfoProvider.stats.eraSummaries$,
     assetProvider.stats.getAsset$,
     txSubmitProvider.stats.submitTx$,
     stakePoolProvider.stats.queryStakePools$,

--- a/packages/wallet/src/services/ProviderTracker/TrackedWalletNetworkInfoProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedWalletNetworkInfoProvider.ts
@@ -4,20 +4,20 @@ import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTrac
 import { WalletNetworkInfoProvider } from '../../types';
 
 export class WalletNetworkInfoProviderStats {
-  readonly timeSettings$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly eraSummaries$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly currentWalletProtocolParameters$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly genesisParameters$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly ledgerTip$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
 
   shutdown() {
-    this.timeSettings$.complete();
+    this.eraSummaries$.complete();
     this.currentWalletProtocolParameters$.complete();
     this.genesisParameters$.complete();
     this.ledgerTip$.complete();
   }
 
   reset() {
-    this.timeSettings$.next(CLEAN_FN_STATS);
+    this.eraSummaries$.next(CLEAN_FN_STATS);
     this.currentWalletProtocolParameters$.next(CLEAN_FN_STATS);
     this.genesisParameters$.next(CLEAN_FN_STATS);
     this.ledgerTip$.next(CLEAN_FN_STATS);
@@ -29,7 +29,7 @@ export class WalletNetworkInfoProviderStats {
  */
 export class TrackedWalletNetworkInfoProvider extends ProviderTracker implements WalletNetworkInfoProvider {
   readonly stats = new WalletNetworkInfoProviderStats();
-  readonly timeSettings: WalletNetworkInfoProvider['timeSettings'];
+  readonly eraSummaries: WalletNetworkInfoProvider['eraSummaries'];
   readonly ledgerTip: WalletNetworkInfoProvider['ledgerTip'];
   readonly currentWalletProtocolParameters: WalletNetworkInfoProvider['currentWalletProtocolParameters'];
   readonly genesisParameters: WalletNetworkInfoProvider['genesisParameters'];
@@ -38,7 +38,7 @@ export class TrackedWalletNetworkInfoProvider extends ProviderTracker implements
     super();
     networkInfoProvider = networkInfoProvider;
 
-    this.timeSettings = () => this.trackedCall(networkInfoProvider.timeSettings, this.stats.timeSettings$);
+    this.eraSummaries = () => this.trackedCall(networkInfoProvider.eraSummaries, this.stats.eraSummaries$);
     this.ledgerTip = () => this.trackedCall(networkInfoProvider.ledgerTip, this.stats.ledgerTip$);
     this.currentWalletProtocolParameters = () =>
       this.trackedCall(

--- a/packages/wallet/src/services/util/equals.ts
+++ b/packages/wallet/src/services/util/equals.ts
@@ -1,4 +1,4 @@
-import { Cardano, EpochInfo, TimeSettings } from '@cardano-sdk/core';
+import { Cardano, EpochInfo, EraSummary } from '@cardano-sdk/core';
 import { GroupedAddress } from '../../KeyManagement';
 import isEqual from 'lodash/isEqual';
 
@@ -22,8 +22,8 @@ export const txInEquals = (a: Cardano.NewTxIn, b: Cardano.NewTxIn) => a.txId ===
 export const utxoEquals = (a: Cardano.Utxo[], b: Cardano.Utxo[]) =>
   arrayEquals(a, b, ([aTxIn], [bTxIn]) => txInEquals(aTxIn, bTxIn));
 
-export const timeSettingsEquals = (a: TimeSettings[], b: TimeSettings[]) =>
-  arrayEquals(a, b, (ts1, ts2) => ts1.fromSlotNo === ts2.fromSlotNo);
+export const eraSummariesEquals = (a: EraSummary[], b: EraSummary[]) =>
+  arrayEquals(a, b, (es1, es2) => es1.start.slot === es2.start.slot);
 
 const groupedAddressEquals = (a: GroupedAddress, b: GroupedAddress) => a.address === b.address;
 

--- a/packages/wallet/src/services/util/trigger.ts
+++ b/packages/wallet/src/services/util/trigger.ts
@@ -1,6 +1,6 @@
-import { Cardano, TimeSettings } from '@cardano-sdk/core';
+import { Cardano, EraSummary } from '@cardano-sdk/core';
 import { Observable, distinctUntilChanged, map } from 'rxjs';
-import { timeSettingsEquals } from './equals';
+import { eraSummariesEquals } from './equals';
 
 export const distinctBlock = (tip$: Observable<Cardano.Tip>) =>
   tip$.pipe(
@@ -8,8 +8,8 @@ export const distinctBlock = (tip$: Observable<Cardano.Tip>) =>
     distinctUntilChanged()
   );
 
-export const distinctTimeSettings = (timeSettings$: Observable<TimeSettings[]>) =>
-  timeSettings$.pipe(
-    map((timeSettings) => timeSettings),
-    distinctUntilChanged(timeSettingsEquals)
+export const distinctEraSummaries = (eraSummaries$: Observable<EraSummary[]>) =>
+  eraSummaries$.pipe(
+    map((eraSummaries) => eraSummaries),
+    distinctUntilChanged(eraSummariesEquals)
   );

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -2,9 +2,9 @@ import {
   Asset,
   Cardano,
   EpochInfo,
+  EraSummary,
   NetworkInfoProvider,
-  ProtocolParametersRequiredByWallet,
-  TimeSettings
+  ProtocolParametersRequiredByWallet
 } from '@cardano-sdk/core';
 import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/cip30';
@@ -80,7 +80,7 @@ export interface ObservableWallet {
   readonly transactions: TransactionsTracker;
   readonly tip$: Observable<Cardano.Tip>;
   readonly genesisParameters$: Observable<Cardano.CompactGenesis>;
-  readonly timeSettings$: Observable<TimeSettings[]>;
+  readonly eraSummaries$: Observable<EraSummary[]>;
   readonly currentEpoch$: Observable<EpochInfo>;
   readonly protocolParameters$: Observable<ProtocolParametersRequiredByWallet>;
   readonly addresses$: Observable<GroupedAddress[]>;
@@ -106,5 +106,5 @@ export interface ObservableWallet {
 
 export type WalletNetworkInfoProvider = Pick<
   NetworkInfoProvider,
-  'currentWalletProtocolParameters' | 'ledgerTip' | 'genesisParameters' | 'timeSettings'
+  'currentWalletProtocolParameters' | 'ledgerTip' | 'genesisParameters' | 'eraSummaries'
 >;

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -145,7 +145,7 @@ const assertWalletProperties2 = async (wallet: ObservableWallet) => {
   const walletGenesisParameters = await firstValueFrom(wallet.genesisParameters$);
   expect(walletGenesisParameters).toEqual(mocks.genesisParameters2);
 
-  expect(await firstValueFrom(wallet.timeSettings$)).toEqual(networkInfo.network.timeSettings);
+  expect(await firstValueFrom(wallet.eraSummaries$)).toEqual(networkInfo.network.eraSummaries);
 
   // delegation
   const rewardsHistory = await firstValueFrom(wallet.delegation.rewardsHistory$)!;

--- a/packages/wallet/test/integration/transactionTime.test.ts
+++ b/packages/wallet/test/integration/transactionTime.test.ts
@@ -12,8 +12,8 @@ describe('integration/transactionTime', () => {
 
   it('provides utils necessary for computing transaction time', async () => {
     const transactions = await firstValueFrom(wallet.transactions.history$);
-    const timeSettings = await firstValueFrom(wallet.timeSettings$);
-    const slotTimeCalc = createSlotTimeCalc(timeSettings);
+    const eraSummaries = await firstValueFrom(wallet.eraSummaries$);
+    const slotTimeCalc = createSlotTimeCalc(eraSummaries);
     const transactionTime = slotTimeCalc(transactions[0].blockHeader.slot);
     expect(typeof transactionTime.getTime()).toBe('number');
   });

--- a/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
+++ b/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { genesisParameters, ledgerTip, protocolParameters } from './mockData';
-import { testnetTimeSettings } from '@cardano-sdk/core';
+import { testnetEraSummaries } from '@cardano-sdk/core';
 
 export const networkInfo = {
   lovelaceSupply: {
@@ -8,8 +8,8 @@ export const networkInfo = {
     total: 40_267_211_394_073_980n
   },
   network: {
-    magic: 1_097_911_063,
-    timeSettings: testnetTimeSettings
+    eraSummaries: testnetEraSummaries,
+    magic: 1_097_911_063
   },
   stake: {
     active: 1_060_378_314_781_343n,
@@ -22,12 +22,12 @@ export const networkInfo = {
  */
 export const mockNetworkInfoProvider = () => ({
   currentWalletProtocolParameters: jest.fn().mockResolvedValue(protocolParameters),
+  eraSummaries: jest.fn().mockResolvedValue(networkInfo.network.eraSummaries),
   genesisParameters: jest.fn().mockResolvedValue(genesisParameters),
   healthCheck: jest.fn().mockResolvedValue({ ok: true }),
   ledgerTip: jest.fn().mockResolvedValue(ledgerTip),
   lovelaceSupply: jest.fn().mockResolvedValue(networkInfo.lovelaceSupply),
-  stake: jest.fn().mockResolvedValue(networkInfo.stake),
-  timeSettings: jest.fn().mockResolvedValue(networkInfo.network.timeSettings)
+  stake: jest.fn().mockResolvedValue(networkInfo.stake)
 });
 
 export type NetworkInfoProviderStub = ReturnType<typeof mockNetworkInfoProvider>;

--- a/packages/wallet/test/mocks/mockNetworkInfoProvider2.ts
+++ b/packages/wallet/test/mocks/mockNetworkInfoProvider2.ts
@@ -29,11 +29,11 @@ export const mockNetworkInfoProvider2 = (delayMs: number) => {
 
   return {
     currentWalletProtocolParameters: delayedJestFn(protocolParameters2),
+    eraSummaries: jest.fn().mockResolvedValue(networkInfo.network.eraSummaries),
     genesisParameters: delayedJestFn(genesisParameters2),
     healthCheck: delayedJestFn({ ok: true }),
     ledgerTip: delayedJestFn(ledgerTip2),
     lovelaceSupply: jest.fn().mockResolvedValue(networkInfo.lovelaceSupply),
-    stake: jest.fn().mockResolvedValue(networkInfo.stake),
-    timeSettings: jest.fn().mockResolvedValue(networkInfo.network.timeSettings)
+    stake: jest.fn().mockResolvedValue(networkInfo.stake)
   };
 };

--- a/packages/wallet/test/persistence/inMemoryStores.test.ts
+++ b/packages/wallet/test/persistence/inMemoryStores.test.ts
@@ -3,6 +3,7 @@ import {
   InMemoryAssetsStore,
   InMemoryCollectionStore,
   InMemoryDocumentStore,
+  InMemoryEraSummariesStore,
   InMemoryGenesisParametersStore,
   InMemoryInFlightTransactionsStore,
   InMemoryKeyValueStore,
@@ -12,7 +13,6 @@ import {
   InMemoryStakePoolsStore,
   InMemoryStakeSummaryStore,
   InMemorySupplySummaryStore,
-  InMemoryTimeSettingsStore,
   InMemoryTipStore,
   InMemoryTransactionsStore,
   InMemoryUtxoStore
@@ -126,7 +126,7 @@ describe('inMemoryStores', () => {
     expect(new InMemoryGenesisParametersStore()).toBeInstanceOf(InMemoryDocumentStore);
     expect(new InMemorySupplySummaryStore()).toBeInstanceOf(InMemoryDocumentStore);
     expect(new InMemoryStakeSummaryStore()).toBeInstanceOf(InMemoryDocumentStore);
-    expect(new InMemoryTimeSettingsStore()).toBeInstanceOf(InMemoryDocumentStore);
+    expect(new InMemoryEraSummariesStore()).toBeInstanceOf(InMemoryDocumentStore);
     expect(new InMemoryAssetsStore()).toBeInstanceOf(InMemoryDocumentStore);
     expect(new InMemoryAddressesStore()).toBeInstanceOf(InMemoryDocumentStore);
     expect(new InMemoryInFlightTransactionsStore()).toBeInstanceOf(InMemoryDocumentStore);

--- a/packages/wallet/test/services/EpochTracker.test.ts
+++ b/packages/wallet/test/services/EpochTracker.test.ts
@@ -1,18 +1,18 @@
-import { Cardano, TimeSettings, testnetTimeSettings } from '@cardano-sdk/core';
+import { Cardano, EraSummary, testnetEraSummaries } from '@cardano-sdk/core';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 import { currentEpochTracker } from '../../src/services';
 
 describe('currentEpochTracker', () => {
-  it('computes epoch info from timeSettings$ and tip$', () => {
+  it('computes epoch info from eraSummaries$ and tip$', () => {
     createTestScheduler().run(({ hot, expectObservable }) => {
       const tip$ = hot('-a-b', {
         a: { slot: 123_456 } as Cardano.Tip,
         b: { slot: 1_234_567 } as Cardano.Tip
       });
-      const timeSettings$ = hot('a---', {
-        a: testnetTimeSettings as TimeSettings[]
+      const eraSummaries$ = hot('a---', {
+        a: testnetEraSummaries as EraSummary[]
       });
-      const currentEpoch$ = currentEpochTracker(tip$, timeSettings$);
+      const currentEpoch$ = currentEpochTracker(tip$, eraSummaries$);
       expectObservable(currentEpoch$).toBe('-a-b', {
         a: {
           epochNo: 5,

--- a/packages/wallet/test/services/ProviderTracker/TrackedWalletNetworkInfoProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedWalletNetworkInfoProvider.test.ts
@@ -43,10 +43,10 @@ describe('TrackedNetworkInfoProvider', () => {
       };
 
     test(
-      'timeSettings',
+      'eraSummaries',
       testFunctionStats(
-        (provider) => provider.timeSettings(),
-        (stats) => stats.timeSettings$
+        (provider) => provider.eraSummaries(),
+        (stats) => stats.eraSummaries$
       )
     );
 

--- a/packages/wallet/test/services/util/equals.test.ts
+++ b/packages/wallet/test/services/util/equals.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Cardano, EpochInfo, TimeSettings } from '@cardano-sdk/core';
+import { Cardano, EpochInfo, EraSummary } from '@cardano-sdk/core';
 import { GroupedAddress } from '../../../src/KeyManagement';
 import {
   arrayEquals,
   deepEquals,
   epochInfoEquals,
+  eraSummariesEquals,
   groupedAddressesEquals,
   shallowArrayEquals,
   strictEquals,
-  timeSettingsEquals,
   tipEquals,
   transactionsEquals,
   txEquals,
@@ -63,9 +63,13 @@ describe('equals', () => {
     expect(utxoEquals([[{ index: 1, txId: 'tx1' }]] as any, [[{ index: 0, txId: 'tx1' }]] as any)).toBe(false);
   });
 
-  test('timeSettingsEquals compares fromSlotNo', () => {
-    expect(timeSettingsEquals([{ fromSlotNo: 1 } as TimeSettings], [{ fromSlotNo: 1 } as TimeSettings])).toBe(true);
-    expect(timeSettingsEquals([{ fromSlotNo: 1 } as TimeSettings], [{ fromSlotNo: 2 } as TimeSettings])).toBe(false);
+  test('eraSummariesEquals compares fromSlotNo', () => {
+    expect(eraSummariesEquals([{ start: { slot: 1 } } as EraSummary], [{ start: { slot: 1 } } as EraSummary])).toBe(
+      true
+    );
+    expect(eraSummariesEquals([{ start: { slot: 1 } } as EraSummary], [{ start: { slot: 2 } } as EraSummary])).toBe(
+      false
+    );
   });
 
   test('groupedAddressesEquals compares address', () => {

--- a/packages/wallet/test/services/util/trigger.test.ts
+++ b/packages/wallet/test/services/util/trigger.test.ts
@@ -1,6 +1,7 @@
-import { Cardano, TimeSettings, testnetTimeSettings } from '@cardano-sdk/core';
+import { Cardano, EraSummary, testnetEraSummaries } from '@cardano-sdk/core';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
-import { distinctBlock, distinctTimeSettings } from '../../../src/services/util';
+import { distinctBlock, distinctEraSummaries } from '../../../src/services/util';
+import merge from 'lodash/merge';
 
 describe('trigger', () => {
   it('distinctBlock subscribes to tip$ on each subscription and emits when tip$ has new blockNo', () => {
@@ -22,22 +23,25 @@ describe('trigger', () => {
     });
   });
 
-  it('distinctTimeSettings emits when timeSettings changes', () => {
+  it('distinctEraSummaries emits when eraSummaries changes', () => {
     createTestScheduler().run(({ cold, expectObservable }) => {
-      const timeSettings1 = testnetTimeSettings;
-      const latestTimeSettings = timeSettings1[timeSettings1.length - 1];
-      const timeSettings2 = [
-        ...testnetTimeSettings,
-        { ...latestTimeSettings, fromSlotNo: latestTimeSettings.fromSlotNo + 10_000 }
+      const eraSummaries1 = testnetEraSummaries;
+      const latestEraSummary = eraSummaries1[eraSummaries1.length - 1];
+      const eraSummaries2 = [
+        ...testnetEraSummaries,
+        merge({}, latestEraSummary, {
+          parameters: { epochLength: 1, slotLength: 1 },
+          start: { slot: latestEraSummary.start.slot + 10_000 }
+        })
       ];
-      const timeSettings$ = cold('-a--b-c', {
-        a: timeSettings1 as TimeSettings[],
-        b: [...timeSettings1] as TimeSettings[],
-        c: timeSettings2 as TimeSettings[]
+      const eraSummaries$ = cold('-a--b-c', {
+        a: eraSummaries1 as EraSummary[],
+        b: [...eraSummaries1] as EraSummary[],
+        c: eraSummaries2 as EraSummary[]
       });
-      expectObservable(distinctTimeSettings(timeSettings$)).toBe('-a----b', {
-        a: timeSettings1,
-        b: timeSettings2
+      expectObservable(distinctEraSummaries(eraSummaries$)).toBe('-a----b', {
+        a: eraSummaries1,
+        b: eraSummaries2
       });
     });
   });

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -22,6 +22,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
     rewardAccounts$: RemoteApiPropertyType.HotObservable,
     rewardsHistory$: RemoteApiPropertyType.HotObservable
   },
+  eraSummaries$: RemoteApiPropertyType.HotObservable,
   finalizeTx: RemoteApiPropertyType.MethodReturningPromise,
   genesisParameters$: RemoteApiPropertyType.HotObservable,
   getName: RemoteApiPropertyType.MethodReturningPromise,
@@ -34,7 +35,6 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
     isSettled$: RemoteApiPropertyType.HotObservable,
     isUpToDate$: RemoteApiPropertyType.HotObservable
   },
-  timeSettings$: RemoteApiPropertyType.HotObservable,
   tip$: RemoteApiPropertyType.HotObservable,
   transactions: {
     history$: RemoteApiPropertyType.HotObservable,


### PR DESCRIPTION
# Context
The `timeSettings` concept was named before becoming aware of the almost equivalent Ouroboros Local State Query that describes this as `eraSummaries`. It was [noted](https://github.com/input-output-hk/cardano-js-sdk/pull/298#pullrequestreview-1021022252) in a previous PR to perform this additional refactor when an opportunity arose based on other open branches, but since it's a breaking change, is best done sooner rather than later.

# Proposed Solution
This change replaces the widespread interface and removes the now redundant mapping of the results when fetched from `cardano-node`.

# Important Changes Introduced
This is a refactor that touches many files, however, it should be a fairly clean rebase target for other open branches, so I suggest to merge it ASAP.