### PR TITLE
build: fix interdependencies between tsconfig.json files

### DIFF
--- a/packages/blockfrost/src/tsconfig.json
+++ b/packages/blockfrost/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/cardano-services-client/src/tsconfig.json
+++ b/packages/cardano-services-client/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/cardano-services/src/tsconfig.json
+++ b/packages/cardano-services/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/cardano-services/test/tsconfig.json
+++ b/packages/cardano-services/test/tsconfig.json
@@ -4,10 +4,11 @@
     "baseUrl": "."
   },
   "include": [
-    "../../core/test/CardanoNode/mocks",
-    "../../ogmios/test/mocks",
-    "../../rabbitmq/test/docker",
+    "./**/*.ts",
     "../../cip2/test/util",
+    "../../core/test/CardanoNode",
+    "../../ogmios/test/mocks",
+    "../../rabbitmq/test"
   ],
   "references": [
     {

--- a/packages/cip2/src/tsconfig.json
+++ b/packages/cip2/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/cip30/src/tsconfig.json
+++ b/packages/cip30/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -33,7 +33,7 @@
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
     "prepack": "yarn build",
-    "test:build:verify": "tsc --build ./test",
+    "test:build:verify": "tsc --build ./test && tsc --build ./test/web-extension",
     "test:debug": "DEBUG=true yarn test",
     "generate-mnemonics": "ts-node src/util/mnemonic.ts"
   },

--- a/packages/e2e/src/tsconfig.json
+++ b/packages/e2e/src/tsconfig.json
@@ -1,10 +1,15 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
+    {
+      "path": "../../blockfrost/src"
+    },
+    {
+      "path": "../../cardano-services/src"
+    },
     {
       "path": "../../util-dev/src"
     },
@@ -13,9 +18,6 @@
     },
     {
       "path": "../../wallet/src"
-    },
-    {
-      "path": "../../cardano-services/src"
     }
   ]
 }

--- a/packages/e2e/test/blockfrost/getAsset.test.ts
+++ b/packages/e2e/test/blockfrost/getAsset.test.ts
@@ -1,6 +1,7 @@
 import * as envalid from 'envalid';
 import { Cardano } from '@cardano-sdk/core';
 import { assetProviderFactory } from '../../src/factories';
+import { logger } from '@cardano-sdk/util-dev';
 
 // Verify environment.
 export const env = envalid.cleanEnv(process.env, {
@@ -11,7 +12,7 @@ export const env = envalid.cleanEnv(process.env, {
 describe('blockfrostAssetProvider', () => {
   test('getAsset', async () => {
     const asset = await (
-      await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS)
+      await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS, logger)
     ).getAsset(Cardano.AssetId('6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa7'), {
       history: true,
       nftMetadata: true,

--- a/packages/e2e/test/blockfrost/queryTransactions.test.ts
+++ b/packages/e2e/test/blockfrost/queryTransactions.test.ts
@@ -1,6 +1,7 @@
 import * as envalid from 'envalid';
 import { Cardano, ChainHistoryProvider, InvalidStringError } from '@cardano-sdk/core';
 import { chainHistoryProviderFactory } from '../../src/factories';
+import { logger } from '@cardano-sdk/util-dev';
 
 // Verify environment.
 export const env = envalid.cleanEnv(process.env, {
@@ -14,7 +15,8 @@ describe('blockfrostChainHistoryProvider', () => {
   beforeAll(async () => {
     chainHistoryProvider = await chainHistoryProviderFactory.create(
       env.CHAIN_HISTORY_PROVIDER,
-      env.CHAIN_HISTORY_PROVIDER_PARAMS
+      env.CHAIN_HISTORY_PROVIDER_PARAMS,
+      logger
     );
   });
 

--- a/packages/e2e/test/tsconfig.json
+++ b/packages/e2e/test/tsconfig.json
@@ -3,11 +3,13 @@
   "compilerOptions": {
     "baseUrl": "."
   },
+  "exclude": ["./web-extension"],
   "include": [
+    "./**/*.ts",
     "../../ogmios/test",
     "../../rabbitmq/test",
     "../../wallet/test",
-    "../../cip2/test/util",
+    "../../cip2/test/util"
   ],
   "references": [
     {

--- a/packages/e2e/test/web-extension/extension/background/config.ts
+++ b/packages/e2e/test/web-extension/extension/background/config.ts
@@ -130,7 +130,7 @@ export const txSubmitProvider = (async () => {
         tls: env.TX_SUBMIT_PROVIDER_PARAMS.url?.protocol === 'wss'
       };
 
-      return ogmiosTxSubmitProvider(createConnectionObject(connectionConfig));
+      return ogmiosTxSubmitProvider(createConnectionObject(connectionConfig), logger);
     }
     default: {
       throw new Error(`TX_SUBMIT_PROVIDER unsupported: ${env.TX_SUBMIT_PROVIDER}`);
@@ -180,7 +180,7 @@ export const networkInfoProvider = (async () => {
 export const chainHistoryProvider = (async () => {
   switch (env.CHAIN_HISTORY_PROVIDER) {
     case 'blockfrost': {
-      return blockfrostChainHistoryProvider(await blockfrostApi!);
+      return blockfrostChainHistoryProvider(await blockfrostApi!, logger);
     }
     case 'http': {
       return chainHistoryHttpProvider({

--- a/packages/e2e/test/web-extension/tsconfig.json
+++ b/packages/e2e/test/web-extension/tsconfig.json
@@ -1,7 +1,6 @@
 {
-  "extends": "../../../../tsconfig.json",
+  "extends": "../../../../test/tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "baseUrl": "./extension",
     "types": [
       "node",

--- a/packages/golden-test-generator/src/tsconfig.json
+++ b/packages/golden-test-generator/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/ogmios/src/tsconfig.json
+++ b/packages/ogmios/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/rabbitmq/src/tsconfig.json
+++ b/packages/rabbitmq/src/tsconfig.json
@@ -1,9 +1,14 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "noUnusedLocals": false,
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
-  "references": [{ "path": "../../core/src" }, { "path": "../../util/src" }]
+  "references": [
+    {
+      "path": "../../core/src"
+    },
+    {
+      "path": "../../util/src"
+    }
+  ]
 }

--- a/packages/rabbitmq/test/TxSubmitWorker.test.ts
+++ b/packages/rabbitmq/test/TxSubmitWorker.test.ts
@@ -113,7 +113,7 @@ describe('TxSubmitWorker', () => {
         await listenPromise(failMock, port);
 
         // Enqueue a tx
-        const providerClosePromise = container.enqueueTx();
+        const providerClosePromise = container.enqueueTx(logger);
 
         // Actually create the TxSubmitWorker
         worker = new TxSubmitWorker({ rabbitmqUrl, ...options }, { logger, txSubmitProvider });
@@ -160,7 +160,7 @@ describe('TxSubmitWorker', () => {
         await worker.start();
 
         // Tx submission by RabbitMqTxSubmitProvider must reject with the same error got by TxSubmitWorker
-        await expect(container.enqueueTx(0, logger)).rejects.toBeInstanceOf(
+        await expect(container.enqueueTx(logger, 0)).rejects.toBeInstanceOf(
           Cardano.TxSubmissionErrors.EraMismatchError
         );
       };

--- a/packages/rabbitmq/test/tsconfig.json
+++ b/packages/rabbitmq/test/tsconfig.json
@@ -3,13 +3,19 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "include": ["./**/*.ts", "../../ogmios/test/mocks"],
+  "include": [
+    "./**/*.ts",
+    "../../ogmios/test/mocks"
+  ],
   "references": [
     {
       "path": "../../core/src"
     },
     {
       "path": "../../ogmios/src"
+    },
+    {
+      "path": "../../util/src"
     },
     {
       "path": "../../util-dev/src"

--- a/packages/util-dev/src/tsconfig.json
+++ b/packages/util-dev/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/util-rxjs/src/tsconfig.json
+++ b/packages/util-rxjs/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   }
 }

--- a/packages/util/src/tsconfig.json
+++ b/packages/util/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   }
 }

--- a/packages/wallet/src/tsconfig.json
+++ b/packages/wallet/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/packages/wallet/test/tsconfig.json
+++ b/packages/wallet/test/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": "."
   },
   "include": [
+    "./**/*.ts",
     "../../cip2/test/util"
   ],
   "references": [

--- a/packages/web-extension/src/tsconfig.json
+++ b/packages/web-extension/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/cjs",
-    "rootDir": "."
+    "outDir": "../dist/cjs"
   },
   "references": [
     {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": false,
     "noEmit": true
   }
 }


### PR DESCRIPTION
# Context

- `yarn test:build:verify` is not detecting all compile errors. The reason is: in some of our unit tests we are including files from `test` directories of other packages and we achieve this through the `include` root field of `packages/*/test/tsconfig.json` files with a list of `test` directories of other packages from which we need to import files. 
- We experienced some build inconsistencies between build environments. `rootDir` seems to take part in the reason (AFAIK still not perfectly identified) of these inconsistencies.

While investigating the problems I checked the relationships between following `tsconfig.json` options.

- `include`: this is the list of **all the files which compose the project**.  When it appears in our `test` directories it do not includes the files from the directory itself: this makes `yarn test:build:verify` to not check the same directory.
- `compilerOptions.composite`: allows the project to be target of `references.path` from another project. We have this set to `true` in all the projects of our repos, as it is set in the root `tsconfig.json` files and never modified in other files extending it directly or indirectly.
- `references.path`: allows the project to import files from other packages whose files are available on our disk and using these files rather than those present in the `npm` registry (i.e. other `@cardano-sdk` packages). The target package needs following configuration:
  ```json
  {
    "compilerOptions": {
      "composite": true,
      "noEmit": true
    }
  }
  ```
  Being the meaning of `"composite": true` "I want to makes this project target of some `references.path`" and being this not possible when `"noEmit": true` following configuration makes no sense:
  ```json
  {
    "compilerOptions": {
      "composite": true,
      "noEmit": true
    }
  }
  ```
  but it is exactly the configuration of our `test/tsconfig.json` file which is extended by all `packages/*/test/**/tsconfig.json` files.
- `compilerOptions.rootDir`: specifies the root directory within which all the files composing the project must be. Its default value is interesting:
  - when `"composite": true`: the directory of the `packege.json` file itself; i.e. `tsc` set it correctly;
  - when `"composite": false`: the longest path common to all the files `include`d in the project; i.e. `tsc` computes it correctly;

# Proposed Solution

- Added `"./**/*.ts"` to the `include` root filed of all `packages/*/test/tsconfig.json` files which defines it to solve the `yarn test:build:verify` problem.
- Set `"composite": false` in `test/tsconfig.json`:
  - it is useless since `"noEmit": true`;
  - removing it makes `tsc` to compute the right `rootDir` value (the default value) in all `packages/*/test/**/tsconfig.json` files.
- Simplified a bit the configuration of our project removing all the occurrences of `rootDir` as now its default value is correct both in `packages/*/src/tsconfig.json` files (`"composite": true`) and in `packages/*/test/**/tsconfig.json` files (`"composite": false`).

# Still missing

With this configuration, the `yarn test:build:verify` do not checks only the files in the right directory, but also in all the other `include`d `test` directories.
Simply a small waste of resources? No, a possible source of problems as well.
Let's take in exam the `packages/rabbitmq/test/tsconfig.json` file, it `include`s `packages/ogmios/test/mocks`.
This means that files in `packages/ogmios/test/mocks` directory are checked by `yarn test:build:verify` in `ogmios` workspace correctly using the `packages/ogmios/test/tsconfig.json` file **and** by `yarn test:build:verify` in `rabbitmq` workspace but using the `packages/rabbitmq/test/tsconfig.json` file.
So far it hasn't been a problem because all `packages/*/test/tsconfig.json` files have the same `compilerOptions`, but if we need to `include` `packages/e2e/test/` directory from another test directory we will simultaneously need at least to `exclude` `packages/e2e/test/web-extension` as its files requires different `compilerOptions`; or if we need to change `compilerOptions` in some `packages/*/test/**/tsconfig.json` files we need to take care whether this directory is `include`d or not in other tests...

To solve this I see two options:

1. moving all the features common to at least tests of two workspaces into the `@cardano-sdk/util-dev` package;
2. changing the `test/tsconfig.json` to make all `packages/*/test/` valid target of `references.path`