### PR TITLE
fix(cardano-services): initialize CardanoNode

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
@@ -105,11 +105,13 @@ export class DbSyncNetworkInfoProvider extends DbSyncProvider implements Network
   }
 
   async start(): Promise<void> {
+    await this.#cardanoNode.initialize();
     this.#epochRolloverDisposer = this.#epochMonitor.onEpochRollover(() => this.#cache.clear());
   }
 
   async close(): Promise<void> {
     this.#cache.shutdown();
+    await this.#cardanoNode.shutdown();
     this.#epochRolloverDisposer();
   }
 }


### PR DESCRIPTION
# Context

The extension loads but the test is still not passing on master, the error is related to the `NetworkInfo` service dependency `CardanoNode`, the test is trying to get the `eraSummaries` and the service is throwing an error:

`{"__type":"Error","value":{"reason":"UNHEALTHY","innerError":{"name":"CardanoNodeNotInitializedError","message":"eraSummaries cannot be called until CardanoNode is initialized","stack":"CardanoNodeNotInitializedError: eraSummaries cannot be called until CardanoNode is initialized\n    at OgmiosCardanoNode.eraSummaries`

# Proposed Solution
Revert the not intentional [removal](https://github.com/input-output-hk/cardano-js-sdk/commit/3b65972b74d410312005c9c60d1b48c269b81aaa#diff-93293b161f83ab2bf95474e66fcb0cd45438d4a6b4775fd2761964eb393902a5L109) of `CardanoNode`'s `initialize` and `shutdown` methods

# Important Changes Introduced
- revert a not intentional removal of CardanoNode initialize & shutdown
- commit hash of introduced bug: [3b6597](https://github.com/input-output-hk/cardano-js-sdk/commit/3b65972b74d410312005c9c60d1b48c269b81aaa#diff-93293b161f83ab2bf95474e66fcb0cd45438d4a6b4775fd2761964eb393902a5L109)
- cover the scenario with tests
