### PR TITLE
fix(e2e): add missing logger param

### DIFF
--- a/packages/e2e/test/blockfrost/getAsset.test.ts
+++ b/packages/e2e/test/blockfrost/getAsset.test.ts
@@ -1,6 +1,7 @@
 import * as envalid from 'envalid';
 import { Cardano } from '@cardano-sdk/core';
 import { assetProviderFactory } from '../../src/factories';
+import { logger } from '@cardano-sdk/util-dev';
 
 // Verify environment.
 export const env = envalid.cleanEnv(process.env, {
@@ -11,7 +12,7 @@ export const env = envalid.cleanEnv(process.env, {
 describe('blockfrostAssetProvider', () => {
   test('getAsset', async () => {
     const asset = await (
-      await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS)
+      await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS, logger)
     ).getAsset(Cardano.AssetId('6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa7'), {
       history: true,
       nftMetadata: true,

--- a/packages/e2e/test/blockfrost/queryTransactions.test.ts
+++ b/packages/e2e/test/blockfrost/queryTransactions.test.ts
@@ -1,6 +1,7 @@
 import * as envalid from 'envalid';
 import { Cardano, ChainHistoryProvider, InvalidStringError } from '@cardano-sdk/core';
 import { chainHistoryProviderFactory } from '../../src/factories';
+import { logger } from '@cardano-sdk/util-dev';
 
 // Verify environment.
 export const env = envalid.cleanEnv(process.env, {
@@ -14,7 +15,8 @@ describe('blockfrostChainHistoryProvider', () => {
   beforeAll(async () => {
     chainHistoryProvider = await chainHistoryProviderFactory.create(
       env.CHAIN_HISTORY_PROVIDER,
-      env.CHAIN_HISTORY_PROVIDER_PARAMS
+      env.CHAIN_HISTORY_PROVIDER_PARAMS,
+      logger
     );
   });
 

--- a/packages/e2e/test/web-extension/extension/background/config.ts
+++ b/packages/e2e/test/web-extension/extension/background/config.ts
@@ -130,7 +130,7 @@ export const txSubmitProvider = (async () => {
         tls: env.TX_SUBMIT_PROVIDER_PARAMS.url?.protocol === 'wss'
       };
 
-      return ogmiosTxSubmitProvider(createConnectionObject(connectionConfig));
+      return ogmiosTxSubmitProvider(createConnectionObject(connectionConfig), logger);
     }
     default: {
       throw new Error(`TX_SUBMIT_PROVIDER unsupported: ${env.TX_SUBMIT_PROVIDER}`);
@@ -180,7 +180,7 @@ export const networkInfoProvider = (async () => {
 export const chainHistoryProvider = (async () => {
   switch (env.CHAIN_HISTORY_PROVIDER) {
     case 'blockfrost': {
-      return blockfrostChainHistoryProvider(await blockfrostApi!);
+      return blockfrostChainHistoryProvider(await blockfrostApi!, logger);
     }
     case 'http': {
       return chainHistoryHttpProvider({


### PR DESCRIPTION
# Context

Blockfrost e2e tests update after logger mandatory param was added
