### PR TITLE
fix: messenger connect race

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -170,7 +170,7 @@ export class SingleAddressWallet implements ObservableWallet {
       connectionStatusTracker$ = createSimpleConnectionStatusTracker()
     }: SingleAddressWalletDependencies
   ) {
-    this.#logger = contextLogger(logger, this.name);
+    this.#logger = contextLogger(logger, name);
 
     this.#inputSelector = inputSelector;
 

--- a/packages/web-extension/src/messaging/BackgroundMessenger.ts
+++ b/packages/web-extension/src/messaging/BackgroundMessenger.ts
@@ -32,7 +32,7 @@ export const createBackgroundMessenger = ({ logger, runtime }: MessengerDependen
     return channel;
   };
   const onPortMessage = (data: unknown, port: MessengerPort) => {
-    logger.debug('[BackgroundMessenger] Port message', data, port);
+    logger.debug(`[BackgroundMessenger(${port.name})] message`, data);
     const { message$ } = channels.get(port.name)!;
     message$.next({ data, port });
   };
@@ -43,7 +43,7 @@ export const createBackgroundMessenger = ({ logger, runtime }: MessengerDependen
     const newPorts = new Set(ports$.value);
     newPorts.delete(port);
     ports$.next(newPorts);
-    logger.debug('[BackgroundMessenger] Port disconnected', port);
+    logger.debug(`[BackgroundMessenger(${port.name})] disconnected`, port);
   };
   const onConnect = (port: MessengerPort) => {
     const { ports$ } = getChannel(port.name);
@@ -52,7 +52,7 @@ export const createBackgroundMessenger = ({ logger, runtime }: MessengerDependen
     port.onMessage.addListener(onPortMessage);
     port.onDisconnect.addListener(onPortDisconnected);
     ports$.next(newPorts);
-    logger.debug('[BackgroundMessenger] Port connected', port);
+    logger.debug(`[BackgroundMessenger(${port.name})] connected`);
   };
   runtime.onConnect.addListener(onConnect);
   return {

--- a/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
+++ b/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
@@ -1,6 +1,6 @@
 // only tested in ../e2e tests
 /* eslint-disable no-use-before-define */
-import { BehaviorSubject, Observable, Subject, debounceTime, filter, first, map, takeWhile, tap } from 'rxjs';
+import { BehaviorSubject, Observable, ReplaySubject, debounceTime, filter, first, map, takeWhile, tap } from 'rxjs';
 import { Messenger, MessengerDependencies, MessengerPort, PortMessage, ReconnectConfig } from './types';
 import { deriveChannelName } from './util';
 import { isNotNil } from '@cardano-sdk/util';
@@ -26,7 +26,12 @@ export const createNonBackgroundMessenger = (
   let delay = initialDelay;
   let isDestroyed = false;
   const port$ = new BehaviorSubject<MessengerPort | null | 'destroyed'>(null);
-  const message$ = new Subject<PortMessage>();
+  // Originally this was a 'new Subject()', but there seems to be a race between
+  // - when it receives a value from 'onMessage'
+  // - when message$ is subscribed to through `remoteApi`
+  // It is most likely because event listener to onMessage is added during
+  // createNonBackgroundMessenger and messenger on the other end emits immediately upon connection.
+  const message$ = new ReplaySubject<PortMessage>(1);
   const connect = () => {
     if (typeof port$.value === 'string' || port$.value) return;
     // assuming this doesn't throw

--- a/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
+++ b/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
@@ -47,12 +47,12 @@ export const createNonBackgroundMessenger = (
     reconnectTimeout = setTimeout(connect, delay);
   };
   const onMessage = (data: unknown, port: MessengerPort) => {
-    logger.debug(`[NonBackgroundMessenger(${channel})] receive message`, data, port);
+    logger.debug(`[NonBackgroundMessenger(${channel})] message`, data);
     delay = initialDelay;
     message$.next({ data, port });
   };
   const onDisconnect = (port: MessengerPort) => {
-    logger.debug(`[NonBackgroundMessenger(${channel})] disconnected`, port);
+    logger.debug(`[NonBackgroundMessenger(${channel})] disconnected`);
     port!.onMessage.removeListener(onMessage);
     port!.onDisconnect.removeListener(onDisconnect);
     port$.next(isDestroyed ? 'destroyed' : null);

--- a/packages/web-extension/src/messaging/remoteApi.ts
+++ b/packages/web-extension/src/messaging/remoteApi.ts
@@ -116,13 +116,12 @@ export const consumeMessengerRemoteApi = <T extends object>(
               if (error) throw error;
             })
           );
-          return (receiver[prop] = messageData$
-            .pipe(
-              filter(isEmitMessage),
-              map(({ emit }) => emit),
-              shareReplay(1)
-            )
-            .pipe(takeUntil(unsubscribe$)));
+          return (receiver[prop] = messageData$.pipe(
+            takeUntil(unsubscribe$),
+            filter(isEmitMessage),
+            map(({ emit }) => emit),
+            shareReplay(1)
+          ));
         }
       },
       has(_, p) {


### PR DESCRIPTION
# Context

web-extension messaging sometimes works unreliably (observable doesn't emit)

# Proposed Solution

Problem seems to be that `message$` emits before it is subscribed to (probably synchronously). Replacing `Subject` with `ReplaySubject(1)` seems to fix the issue. 2095fc944c6d1eea47b400d9eaaf507f232aa704

# Important Changes Introduced

- [fix(wallet): create contextLogger with non-undefined 'name'](https://github.com/input-output-hk/cardano-js-sdk/commit/89a93bd417fa0940fa9b09028d71a8da7900bc72)
- [feat(web-extension): slightly improve messengers log output](https://github.com/input-output-hk/cardano-js-sdk/commit/6d3b82b380959d6d0f5047059a0e1539e4f71e0a)
- Consolidate 2 `pipe` calls into 1 (not part of the main fix in 2095fc944c6d1eea47b400d9eaaf507f232aa704)
