### PR TITLE
build: add yarn-project.nix to Dockerfile build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY \
   package.json \
   tsconfig.json \
   yarn.lock \
+  yarn-project.nix \
   /app/
 
 FROM nodejs-builder as cardano-services-builder


### PR DESCRIPTION
# Context
Currently, the nix lock file is not being included in the Docker build context, which will result in a new file being generated at built time.

# Proposed Solution
`COPY` the file in the Dockerfile `nodejs-builder` stage.
