### PR TITLE
feat: cip2 mint support

### DIFF
--- a/packages/blockfrost/test/blockfrostChainHistoryProvider.test.ts
+++ b/packages/blockfrost/test/blockfrostChainHistoryProvider.test.ts
@@ -79,13 +79,7 @@ describe('blockfrostChainHistoryProvider', () => {
         }
       ]
     };
-    const protocolParametersResponse = {
-      data: {
-        key_deposit: '2000000',
-        pool_deposit: '500000000'
-      }
-    };
-    BlockFrostAPI.prototype.axiosInstance = jest.fn().mockResolvedValue(protocolParametersResponse) as any;
+
     BlockFrostAPI.prototype.txsUtxos = jest.fn().mockResolvedValue(txsUtxosResponse);
 
     it('without extra tx properties', async () => {
@@ -221,10 +215,6 @@ describe('blockfrostChainHistoryProvider', () => {
           }
         },
         id: Cardano.TransactionId('4123d70f66414cc921f6ffc29a899aafc7137a99a0fd453d6b200863ef5702d6'),
-        implicitCoin: {
-          deposit: 0n,
-          input: 0n
-        },
         index: 1,
         txSize: 433
       } as Cardano.TxAlonzo);

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
@@ -1,5 +1,5 @@
 import * as Queries from './queries';
-import { Cardano, ProtocolParametersRequiredByWallet, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import {
   CertificateModel,
   DelegationCertModel,
@@ -7,7 +7,6 @@ import {
   MultiAssetModel,
   PoolRegisterCertModel,
   PoolRetireCertModel,
-  ProtocolParamsModel,
   RedeemerModel,
   StakeCertModel,
   TransactionDataMap,
@@ -25,7 +24,6 @@ import { Pool, QueryResult } from 'pg';
 import { hexStringToBuffer } from '../../util';
 import {
   mapCertificate,
-  mapProtocolParams,
   mapRedeemer,
   mapTxIn,
   mapTxOut,
@@ -157,14 +155,5 @@ export class ChainHistoryBuilder {
       certsMap.set(txId, certs);
     }
     return certsMap;
-  }
-
-  public async queryProtocolParams(): Promise<ProtocolParametersRequiredByWallet> {
-    this.#logger.debug('About to find protocol parameters');
-    const results: QueryResult<ProtocolParamsModel> = await this.#db.query(Queries.findProtocolParameters);
-    if (results.rows.length === 0) {
-      throw new ProviderError(ProviderFailure.Unknown, null, "Couldn't fetch protocol parameters");
-    }
-    return mapProtocolParams(results.rows[0]);
   }
 }

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -51,18 +51,16 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider implements ChainH
     this.#logger.debug('About to find transactions with hashes:', byteHashes);
     const txResults: QueryResult<TxModel> = await this.db.query(Queries.findTransactionsByHashes, [byteHashes]);
     if (txResults.rows.length === 0) return [];
-    const [inputs, outputs, mints, withdrawals, redeemers, metadata, collaterals, certificates, protocolParams] =
-      await Promise.all([
-        this.#builder.queryTransactionInputsByHashes(hashes),
-        this.#builder.queryTransactionOutputsByHashes(hashes),
-        this.#builder.queryTxMintByHashes(hashes),
-        this.#builder.queryWithdrawalsByHashes(hashes),
-        this.#builder.queryRedeemersByHashes(hashes),
-        this.#metadataService.queryTxMetadataByHashes(hashes),
-        this.#builder.queryTransactionInputsByHashes(hashes, true),
-        this.#builder.queryCertificatesByHashes(hashes),
-        this.#builder.queryProtocolParams()
-      ]);
+    const [inputs, outputs, mints, withdrawals, redeemers, metadata, collaterals, certificates] = await Promise.all([
+      this.#builder.queryTransactionInputsByHashes(hashes),
+      this.#builder.queryTransactionOutputsByHashes(hashes),
+      this.#builder.queryTxMintByHashes(hashes),
+      this.#builder.queryWithdrawalsByHashes(hashes),
+      this.#builder.queryRedeemersByHashes(hashes),
+      this.#metadataService.queryTxMetadataByHashes(hashes),
+      this.#builder.queryTransactionInputsByHashes(hashes, true),
+      this.#builder.queryCertificatesByHashes(hashes)
+    ]);
     return txResults.rows.map((tx) => {
       const txId = Cardano.TransactionId(tx.id.toString('hex'));
       const txInputs = orderBy(
@@ -84,7 +82,6 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider implements ChainH
         metadata: metadata.get(txId),
         mint: mints.get(txId),
         outputs: txOutputs,
-        protocolParams,
         redeemers: redeemers.get(txId),
         withdrawals: withdrawals.get(txId)
       });

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -1,11 +1,10 @@
-import { Asset, Cardano, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { Asset, Cardano } from '@cardano-sdk/core';
 import { BigIntMath } from '@cardano-sdk/util';
 import {
   BlockModel,
   BlockOutputModel,
   CertificateModel,
   MultiAssetModel,
-  ProtocolParamsModel,
   RedeemerModel,
   TipModel,
   TxInOutModel,
@@ -137,26 +136,9 @@ export const mapCertificate = (
   return null;
 };
 
-export const mapProtocolParams = (protocolParamsModel: ProtocolParamsModel): ProtocolParametersRequiredByWallet => ({
-  coinsPerUtxoByte: Number(protocolParamsModel.coin_per_utxo_size),
-  maxCollateralInputs: protocolParamsModel.max_collateral_inputs,
-  maxTxSize: protocolParamsModel.max_tx_size,
-  maxValueSize: Number(protocolParamsModel.max_val_size),
-  minFeeCoefficient: protocolParamsModel.min_fee_coefficient,
-  minFeeConstant: protocolParamsModel.min_fee_constant,
-  minPoolCost: Number(protocolParamsModel.min_pool_cost),
-  poolDeposit: Number(protocolParamsModel.pool_deposit),
-  protocolVersion: {
-    major: protocolParamsModel.protocol_major,
-    minor: protocolParamsModel.protocol_minor
-  },
-  stakeKeyDeposit: Number(protocolParamsModel.key_deposit)
-});
-
 interface TxAlonzoData {
   inputs: Cardano.TxIn[];
   outputs: Cardano.TxOut[];
-  protocolParams: ProtocolParametersRequiredByWallet;
   mint?: Cardano.TokenMap;
   withdrawals?: Cardano.Withdrawal[];
   redeemers?: Cardano.Redeemer[];
@@ -167,7 +149,7 @@ interface TxAlonzoData {
 
 export const mapTxAlonzo = (
   txModel: TxModel,
-  { inputs, outputs, mint, withdrawals, redeemers, metadata, collaterals, certificates, protocolParams }: TxAlonzoData
+  { inputs, outputs, mint, withdrawals, redeemers, metadata, collaterals, certificates }: TxAlonzoData
 ): Cardano.TxAlonzo => ({
   auxiliaryData:
     metadata && metadata.size > 0
@@ -196,10 +178,6 @@ export const mapTxAlonzo = (
     withdrawals
   },
   id: Cardano.TransactionId(txModel.id.toString('hex')),
-  implicitCoin: Cardano.util.computeImplicitCoin(protocolParams, {
-    certificates,
-    withdrawals
-  }),
   index: txModel.index,
   txSize: txModel.size,
   witness: {

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -60,23 +60,6 @@ export const findTip = `
 	ORDER BY block.block_no DESC NULLS LAST
 	LIMIT 1`;
 
-export const findProtocolParameters = `
-	SELECT 
-		coins_per_utxo_size,
-		max_collateral_inputs,
-		max_tx_size,
-		max_val_size,
-		min_fee_a AS min_fee_coefficient,
-		min_fee_b AS min_fee_constant,
-		min_pool_cost,
-		pool_deposit,
-		protocol_major,
-		protocol_minor,
-		key_deposit
-	FROM epoch_param
-	ORDER BY epoch_no DESC
-	LIMIT 1`;
-
 export const findBlocksByHashes = `
 	SELECT
 		block.hash AS hash,

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -116,17 +116,3 @@ export interface DelegationCertModel extends CertificateModel {
   address: string;
   pool_id: string;
 }
-
-export interface ProtocolParamsModel {
-  coin_per_utxo_size: string;
-  max_collateral_inputs: number;
-  max_tx_size: number;
-  max_val_size: string;
-  min_fee_coefficient: number;
-  min_fee_constant: number;
-  min_pool_cost: string;
-  pool_deposit: string;
-  protocol_major: number;
-  protocol_minor: number;
-  key_deposit: string;
-}

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/ChainHistoryBuilder.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/ChainHistoryBuilder.test.ts
@@ -163,13 +163,6 @@ describe('ChainHistoryBuilder', () => {
     });
   });
 
-  describe('queryProtocolParams', () => {
-    test('query protocol parameters from last epoch', async () => {
-      const result = await builder.queryProtocolParams();
-      expect(result).toMatchSnapshot();
-    });
-  });
-
   describe('queryCertificatesByHashes', () => {
     test('query certificates by tx hashes', async () => {
       const result = await builder.queryCertificatesByHashes([

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/__snapshots__/ChainHistoryBuilder.test.ts.snap
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/__snapshots__/ChainHistoryBuilder.test.ts.snap
@@ -97,24 +97,6 @@ Map {
 }
 `;
 
-exports[`ChainHistoryBuilder queryProtocolParams query protocol parameters from last epoch 1`] = `
-Object {
-  "coinsPerUtxoByte": NaN,
-  "maxCollateralInputs": 3,
-  "maxTxSize": 16384,
-  "maxValueSize": 5000,
-  "minFeeCoefficient": 44,
-  "minFeeConstant": 155381,
-  "minPoolCost": 340000000,
-  "poolDeposit": 500000000,
-  "protocolVersion": Object {
-    "major": 6,
-    "minor": 0,
-  },
-  "stakeKeyDeposit": 2000000,
-}
-`;
-
 exports[`ChainHistoryBuilder queryRedeemersByHashes query transaction redeemers by tx hashes 1`] = `
 Map {
   "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3" => Array [

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -9,7 +9,6 @@ import {
   MultiAssetModel,
   PoolRegisterCertModel,
   PoolRetireCertModel,
-  ProtocolParamsModel,
   RedeemerModel,
   StakeCertModel,
   TipModel,
@@ -250,39 +249,6 @@ describe('chain history mappers', () => {
       });
     });
   });
-  describe('mapProtocolParams', () => {
-    const protocolParams: ProtocolParamsModel = {
-      coin_per_utxo_size: '4310',
-      key_deposit: '20000000',
-      max_collateral_inputs: 2,
-      max_tx_size: 20,
-      max_val_size: '40000000000',
-      min_fee_coefficient: 23,
-      min_fee_constant: 44,
-      min_pool_cost: '500000',
-      pool_deposit: '20000000',
-      protocol_major: 2,
-      protocol_minor: 1
-    };
-    test('map ProtocolParamsModel to Cardano.ProtocolParametersBabbage', () => {
-      const result = mappers.mapProtocolParams(protocolParams);
-      expect(result).toEqual<Cardano.ProtocolParametersBabbage>({
-        coinsPerUtxoByte: 4310,
-        maxCollateralInputs: 2,
-        maxTxSize: 20,
-        maxValueSize: 40_000_000_000,
-        minFeeCoefficient: 23,
-        minFeeConstant: 44,
-        minPoolCost: 500_000,
-        poolDeposit: 20_000_000,
-        protocolVersion: {
-          major: 2,
-          minor: 1
-        },
-        stakeKeyDeposit: 20_000_000
-      });
-    });
-  });
   describe('mapRedeemer', () => {
     const redeemerModel: RedeemerModel = {
       index: 1,
@@ -310,18 +276,6 @@ describe('chain history mappers', () => {
       { address: Cardano.Address(address), index: 1, txId: Cardano.TransactionId(transactionHash) }
     ];
     const outputs: Cardano.TxOut[] = [{ address: Cardano.Address(address), value: { assets, coins: 20_000_000n } }];
-    const protocolParams = {
-      coinsPerUtxoByte: 4310,
-      maxCollateralInputs: 2,
-      maxTxSize: 20,
-      maxValueSize: 40_000_000_000,
-      minFeeCoefficient: 23,
-      minFeeConstant: 44,
-      minPoolCost: 500_000,
-      poolDeposit: 2_000_000,
-      protocolVersion: { major: 2, minor: 1 },
-      stakeKeyDeposit: 2_000_000
-    };
     const redeemers: Cardano.Redeemer[] = [
       {
         executionUnits: { memory: 1, steps: 2 },
@@ -343,19 +297,18 @@ describe('chain history mappers', () => {
       blockHeader: { blockNo: 200, hash: Cardano.BlockId(blockHash), slot: 250 },
       body: { fee: 170_000n, inputs, outputs, validityInterval: { invalidBefore: 300, invalidHereafter: 500 } },
       id: Cardano.TransactionId(transactionHash),
-      implicitCoin: { deposit: 0n, input: 0n },
       index: 1,
       txSize: 20,
       witness: { signatures: new Map() }
     };
     test('map TxModel to Cardano.TxAlonzo with minimal data', () => {
-      const result = mappers.mapTxAlonzo(txModel, { inputs, outputs, protocolParams });
+      const result = mappers.mapTxAlonzo(txModel, { inputs, outputs });
       expect(result).toEqual<Cardano.TxAlonzo>(expected);
     });
     test('map TxModel with null fields to Cardano.TxAlonzo', () => {
       const result = mappers.mapTxAlonzo(
         { ...txModel, invalid_before: null, invalid_hereafter: null },
-        { inputs, outputs, protocolParams }
+        { inputs, outputs }
       );
       expect(result).toEqual<Cardano.TxAlonzo>({ ...expected, body: { ...expected.body, validityInterval: {} } });
     });
@@ -367,7 +320,6 @@ describe('chain history mappers', () => {
         metadata,
         mint: assets,
         outputs,
-        protocolParams,
         redeemers,
         withdrawals
       });
@@ -375,7 +327,6 @@ describe('chain history mappers', () => {
         ...expected,
         auxiliaryData: { body: { blob: metadata } },
         body: { ...expected.body, certificates, collaterals: inputs, mint: assets, withdrawals },
-        implicitCoin: { deposit: 2_000_000n, input: 200n },
         witness: { ...expected.witness, redeemers }
       });
     });

--- a/packages/cardano-services/test/ChainHistory/__snapshots__/ChainHistoryHttpService.test.ts.snap
+++ b/packages/cardano-services/test/ChainHistory/__snapshots__/ChainHistoryHttpService.test.ts.snap
@@ -93,10 +93,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "8fd14baca91c674fafae59701b7dc0eda1266202ec8445bad3244bd8669a7fb5",
-    "implicitCoin": Object {
-      "deposit": 500000000n,
-      "input": 0n,
-    },
     "index": 0,
     "txSize": 736,
     "witness": Object {
@@ -162,10 +158,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "3d4cd09885d39673125c3a15f8acb45d92fde137f9effe7a5131f6cc7241d960",
-    "implicitCoin": Object {
-      "deposit": 500000000n,
-      "input": 0n,
-    },
     "index": 0,
     "txSize": 780,
     "witness": Object {
@@ -235,10 +227,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 11,
     "txSize": 640,
     "witness": Object {
@@ -306,10 +294,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "caaada4c53256a9bcba2d006b3f427f089d43372442a550a7349627a46682375",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 1,
     "txSize": 591,
     "witness": Object {
@@ -365,10 +349,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "49fa6b7245674fd11727cfb4d47ec7fad380c198a2a975b0423c5f6c255488f9",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 3,
     "txSize": 554,
     "witness": Object {
@@ -424,10 +404,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "a7eda535edc983139cc1053d074106aef54b25e9c9ee9de6bf1bf69709dabfd4",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 5,
     "txSize": 554,
     "witness": Object {
@@ -493,10 +469,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "b46c48229336aec327a5f537bcbf1ca8fa6a3afbf60aa66880aa6a234e5fce92",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 7,
     "txSize": 700,
     "witness": Object {
@@ -559,10 +531,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "56caf0441c4f0e209195b86b95e5304b338ca38ec232252c194153e8a3440c28",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 8,
     "txSize": 592,
     "witness": Object {
@@ -618,10 +586,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "3d8e3e7c6d0929812abc40d29a3b1e4f470f6d04e9d4b3c521f1f87f74f7ab88",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 10,
     "txSize": 553,
     "witness": Object {
@@ -686,10 +650,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "6eec4e9691e0fc2442e5c9bf22847998b80a1625b18a882a4e7b9e0cdda48dc3",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 11,
     "txSize": 640,
     "witness": Object {
@@ -752,10 +712,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "0dbbc0e6d13549a1960476aae42fd492a7a19fba856f9cc9695ecc5c84fe87e9",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 13,
     "txSize": 591,
     "witness": Object {
@@ -897,10 +853,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 14,
     "txSize": 10662,
     "witness": Object {
@@ -1105,10 +1057,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "a08e293256180196de69ff025321be2f7ce5911ce4e3a96406b7c62de0e19bb2",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 15,
     "txSize": 11003,
     "witness": Object {
@@ -1302,10 +1250,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "34186a836e81a0852e583a870863535ded787ef63f7d3bc80380d306f8a9fb40",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 16,
     "txSize": 10025,
     "witness": Object {
@@ -1454,10 +1398,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "3d2278e9cef71c79720a11bc3e08acbbd5f2175f7015d358c867fc9b419ae0b2",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 9,
     "txSize": 639,
     "witness": Object {
@@ -1514,10 +1454,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "face165bd7aa8d0d661cf1ceaa4e35d7611be3b1c7997da378c547aa2464a4fd",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 500000000n,
-    },
     "index": 1,
     "txSize": 361,
     "witness": Object {
@@ -1573,10 +1509,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "19251f57476d7af2777252270413c01383d9503110a68b4fde1a239c119c4f5d",
-    "implicitCoin": Object {
-      "deposit": 500000000n,
-      "input": 0n,
-    },
     "index": 2,
     "txSize": 737,
     "witness": Object {
@@ -1697,10 +1629,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "5acd6efb1b66299f1c5a2c4221af4bcaa4ba9929e8e6aa0e3f48707fa1796fc3",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 12,
     "txSize": 4763,
     "witness": Object {
@@ -1783,10 +1711,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 0,
     "txSize": 509,
     "witness": Object {
@@ -1858,10 +1782,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 30,
     "txSize": 711,
     "witness": Object {
@@ -2008,10 +1928,6 @@ Array [
       "withdrawals": undefined,
     },
     "id": "24e75c64a309fd8fb400933795b2522ca818cba80a3838c2ff14cec2cc8ffe4e",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 0n,
-    },
     "index": 14,
     "txSize": 10662,
     "witness": Object {
@@ -2133,10 +2049,6 @@ Array [
       ],
     },
     "id": "cb66e0f5778718f8bfcfd043712f37d9993f4703b254a7a4d954d34225fe2f99",
-    "implicitCoin": Object {
-      "deposit": 0n,
-      "input": 1638694n,
-    },
     "index": 2,
     "txSize": 629,
     "witness": Object {

--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -11,7 +11,7 @@ interface ChangeComputationArgs {
   utxoSelection: UtxoSelection;
   outputValues: Cardano.Value[];
   uniqueOutputAssetIDs: Cardano.AssetId[];
-  implicitCoin: Required<Cardano.ImplicitCoin>;
+  implicitCoin: Required<Cardano.util.ImplicitCoin>;
   estimateTxFee: EstimateTxFeeWithOriginalOutputs;
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity;
   tokenBundleSizeExceedsLimit: TokenBundleSizeExceedsLimit;
@@ -122,7 +122,7 @@ const computeRequestedAssetChangeBundles = (
   utxoSelected: Cardano.Utxo[],
   outputValues: Cardano.Value[],
   uniqueOutputAssetIDs: Cardano.AssetId[],
-  implicitCoin: Required<Cardano.ImplicitCoin>,
+  implicitCoin: Required<Cardano.util.ImplicitCoin>,
   fee: Cardano.Lovelace
 ): Cardano.Value[] => {
   const assetTotals: Map<Cardano.AssetId, { selected: bigint; requested: bigint }> = new Map();
@@ -235,7 +235,7 @@ const computeChangeBundles = ({
   utxoSelection: UtxoSelection;
   outputValues: Cardano.Value[];
   uniqueOutputAssetIDs: Cardano.AssetId[];
-  implicitCoin: Required<Cardano.ImplicitCoin>;
+  implicitCoin: Required<Cardano.util.ImplicitCoin>;
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity;
   fee?: bigint;
 }): (UtxoSelection & { changeBundles: Cardano.Value[] }) | false => {

--- a/packages/cip2/src/RoundRobinRandomImprove/change.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/change.ts
@@ -1,7 +1,8 @@
 import { Cardano } from '@cardano-sdk/core';
 import { ComputeMinimumCoinQuantity, TokenBundleSizeExceedsLimit } from '../types';
 import { InputSelectionError, InputSelectionFailure } from '../InputSelectionError';
-import { UtxoSelection, assetQuantitySelector, getCoinQuantity, toValues } from './util';
+import { RequiredImplicitValue, UtxoSelection, assetQuantitySelector, getCoinQuantity, toValues } from './util';
+import minBy from 'lodash/minBy';
 import orderBy from 'lodash/orderBy';
 import pick from 'lodash/pick';
 
@@ -10,8 +11,8 @@ type EstimateTxFeeWithOriginalOutputs = (utxo: Cardano.Utxo[], change: Cardano.V
 interface ChangeComputationArgs {
   utxoSelection: UtxoSelection;
   outputValues: Cardano.Value[];
-  uniqueOutputAssetIDs: Cardano.AssetId[];
-  implicitCoin: Required<Cardano.util.ImplicitCoin>;
+  uniqueTxAssetIDs: Cardano.AssetId[];
+  implicitValue: RequiredImplicitValue;
   estimateTxFee: EstimateTxFeeWithOriginalOutputs;
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity;
   tokenBundleSizeExceedsLimit: TokenBundleSizeExceedsLimit;
@@ -25,7 +26,7 @@ interface ChangeComputationResult {
   fee: Cardano.Lovelace;
 }
 
-const getLeftoverAssets = (utxoSelected: Cardano.Utxo[], uniqueOutputAssetIDs: Cardano.AssetId[]) => {
+const getLeftoverAssets = (utxoSelected: Cardano.Utxo[], uniqueTxAssetIDs: Cardano.AssetId[]) => {
   const leftovers: Map<Cardano.AssetId, Array<bigint>> = new Map();
   for (const [
     _,
@@ -34,7 +35,7 @@ const getLeftoverAssets = (utxoSelected: Cardano.Utxo[], uniqueOutputAssetIDs: C
     }
   ] of utxoSelected) {
     if (assets) {
-      const leftoverAssetKeys = [...assets.keys()].filter((id) => !uniqueOutputAssetIDs.includes(id));
+      const leftoverAssetKeys = [...assets.keys()].filter((id) => !uniqueTxAssetIDs.includes(id));
       for (const assetKey of leftoverAssetKeys) {
         const quantity = assets.get(assetKey)!;
         if (quantity === 0n) continue;
@@ -56,9 +57,9 @@ const getLeftoverAssets = (utxoSelected: Cardano.Utxo[], uniqueOutputAssetIDs: C
 const redistributeLeftoverAssets = (
   utxoSelected: Cardano.Utxo[],
   requestedAssetChangeBundles: Cardano.Value[],
-  uniqueOutputAssetIDs: Cardano.AssetId[]
+  uniqueTxAssetIDs: Cardano.AssetId[]
 ) => {
-  const leftovers = getLeftoverAssets(utxoSelected, uniqueOutputAssetIDs);
+  const leftovers = getLeftoverAssets(utxoSelected, uniqueTxAssetIDs);
   // Distribute leftovers to result bundles
   const resultBundles = [...requestedAssetChangeBundles];
   for (const assetId of leftovers.keys()) {
@@ -111,6 +112,23 @@ const createBundlePerOutput = (
 };
 
 /**
+ * Creates a new bundle if there are none (mutates 'bundles' object passed as arg).
+ * Creates a new token map if there is none (mutates bundle.assets).
+ *
+ * @returns bundle with smallest token bundle.
+ */
+const smallestBundleTokenMap = (bundles: Cardano.Value[]) => {
+  if (bundles.length === 0) {
+    const bundle = { assets: new Map(), coins: 0n };
+    bundles.push(bundle);
+    return bundle.assets!;
+  }
+  const bundle = minBy(bundles, ({ assets }) => assets?.size || 0)!;
+  if (!bundle.assets) bundle.assets = new Map();
+  return bundle.assets!;
+};
+
+/**
  * Divide any excess token quantities (inputs − outputs) into change bundles, where:
  * - there is exactly one change bundle for each output.
  * - the quantity of a given token in a change bundle
@@ -121,16 +139,16 @@ const createBundlePerOutput = (
 const computeRequestedAssetChangeBundles = (
   utxoSelected: Cardano.Utxo[],
   outputValues: Cardano.Value[],
-  uniqueOutputAssetIDs: Cardano.AssetId[],
-  implicitCoin: Required<Cardano.util.ImplicitCoin>,
+  uniqueTxAssetIDs: Cardano.AssetId[],
+  { implicitCoin, implicitTokens }: RequiredImplicitValue,
   fee: Cardano.Lovelace
 ): Cardano.Value[] => {
   const assetTotals: Map<Cardano.AssetId, { selected: bigint; requested: bigint }> = new Map();
   const utxoSelectedValues = toValues(utxoSelected);
-  for (const assetId of uniqueOutputAssetIDs) {
+  for (const assetId of uniqueTxAssetIDs) {
     assetTotals.set(assetId, {
-      requested: assetQuantitySelector(assetId)(outputValues),
-      selected: assetQuantitySelector(assetId)(utxoSelectedValues)
+      requested: assetQuantitySelector(assetId)(outputValues) + implicitTokens.spend(assetId),
+      selected: assetQuantitySelector(assetId)(utxoSelectedValues) + implicitTokens.input(assetId)
     });
   }
   const coinTotalSelected = getCoinQuantity(utxoSelectedValues) + implicitCoin.input;
@@ -153,12 +171,15 @@ const computeRequestedAssetChangeBundles = (
       bundles[0].coins += coinLost;
     }
   }
-  for (const assetId of uniqueOutputAssetIDs) {
+  for (const assetId of uniqueTxAssetIDs) {
     const assetTotal = assetTotals.get(assetId)!;
-    const assetLost = assetTotal.selected - assetTotal.requested - totalAssetsBundled.get(assetId)!;
+    const bundled = totalAssetsBundled.get(assetId) || 0n;
+    const assetLost = assetTotal.selected - assetTotal.requested - bundled;
     if (assetLost > 0n) {
-      const anyBundle = bundles.find(({ assets }) => assets?.has(assetId))!;
-      anyBundle.assets?.set(assetId, anyBundle.assets!.get(assetId)! + assetLost);
+      const anyChangeTokenBundle =
+        bundles.find(({ assets }) => assets?.has(assetId))?.assets || smallestBundleTokenMap(bundles);
+      const assetQuantityAlreadyInBundle = anyChangeTokenBundle.get(assetId) || 0n;
+      anyChangeTokenBundle.set(assetId, assetQuantityAlreadyInBundle + assetLost);
     }
   }
 
@@ -227,29 +248,29 @@ const coalesceChangeBundlesForMinCoinRequirement = (
 const computeChangeBundles = ({
   utxoSelection,
   outputValues,
-  uniqueOutputAssetIDs,
-  implicitCoin,
+  uniqueTxAssetIDs,
+  implicitValue,
   computeMinimumCoinQuantity,
   fee = 0n
 }: {
   utxoSelection: UtxoSelection;
   outputValues: Cardano.Value[];
-  uniqueOutputAssetIDs: Cardano.AssetId[];
-  implicitCoin: Required<Cardano.util.ImplicitCoin>;
+  uniqueTxAssetIDs: Cardano.AssetId[];
+  implicitValue: RequiredImplicitValue;
   computeMinimumCoinQuantity: ComputeMinimumCoinQuantity;
   fee?: bigint;
 }): (UtxoSelection & { changeBundles: Cardano.Value[] }) | false => {
   const requestedAssetChangeBundles = computeRequestedAssetChangeBundles(
     utxoSelection.utxoSelected,
     outputValues,
-    uniqueOutputAssetIDs,
-    implicitCoin,
+    uniqueTxAssetIDs,
+    implicitValue,
     fee
   );
   const requestedAssetChangeBundlesWithLeftoverAssets = redistributeLeftoverAssets(
     utxoSelection.utxoSelected,
     requestedAssetChangeBundles,
-    uniqueOutputAssetIDs
+    uniqueTxAssetIDs
   );
   const changeBundles = coalesceChangeBundlesForMinCoinRequirement(
     requestedAssetChangeBundlesWithLeftoverAssets,
@@ -290,8 +311,8 @@ export const computeChangeAndAdjustForFee = async ({
   tokenBundleSizeExceedsLimit,
   estimateTxFee,
   outputValues,
-  uniqueOutputAssetIDs,
-  implicitCoin,
+  uniqueTxAssetIDs,
+  implicitValue,
   random,
   utxoSelection
 }: ChangeComputationArgs): Promise<ChangeComputationResult> => {
@@ -300,11 +321,11 @@ export const computeChangeAndAdjustForFee = async ({
       return computeChangeAndAdjustForFee({
         computeMinimumCoinQuantity,
         estimateTxFee,
-        implicitCoin,
+        implicitValue,
         outputValues,
         random,
         tokenBundleSizeExceedsLimit,
-        uniqueOutputAssetIDs,
+        uniqueTxAssetIDs,
         utxoSelection: pickExtraRandomUtxo(currentUtxoSelection, random)
       });
     }
@@ -317,9 +338,9 @@ export const computeChangeAndAdjustForFee = async ({
 
   const selectionWithChangeAndFee = computeChangeBundles({
     computeMinimumCoinQuantity,
-    implicitCoin,
+    implicitValue,
     outputValues,
-    uniqueOutputAssetIDs,
+    uniqueTxAssetIDs,
     utxoSelection
   });
   if (!selectionWithChangeAndFee) return recomputeChangeAndAdjustForFeeWithExtraUtxo(utxoSelection);
@@ -333,8 +354,9 @@ export const computeChangeAndAdjustForFee = async ({
   );
 
   // Ensure fee quantity is covered by current selection
-  const totalOutputCoin = getCoinQuantity(outputValues) + fee + implicitCoin.deposit;
-  const totalInputCoin = getCoinQuantity(toValues(selectionWithChangeAndFee.utxoSelected)) + implicitCoin.input;
+  const totalOutputCoin = getCoinQuantity(outputValues) + fee + implicitValue.implicitCoin.deposit;
+  const totalInputCoin =
+    getCoinQuantity(toValues(selectionWithChangeAndFee.utxoSelected)) + implicitValue.implicitCoin.input;
   if (totalOutputCoin > totalInputCoin) {
     if (selectionWithChangeAndFee.utxoRemaining.length === 0) {
       throw new InputSelectionError(InputSelectionFailure.UtxoBalanceInsufficient);
@@ -346,9 +368,9 @@ export const computeChangeAndAdjustForFee = async ({
   const finalSelection = computeChangeBundles({
     computeMinimumCoinQuantity,
     fee,
-    implicitCoin,
+    implicitValue,
     outputValues,
-    uniqueOutputAssetIDs,
+    uniqueTxAssetIDs,
     utxoSelection: pick(selectionWithChangeAndFee, ['utxoRemaining', 'utxoSelected'])
   });
 

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -16,12 +16,12 @@ export const roundRobinRandomImprove = ({
     utxo: utxoSet,
     outputs: outputSet,
     constraints: { computeMinimumCost, computeSelectionLimit, computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit },
-    implicitCoin: implicitCoinAsNumber
+    implicitValue = {}
   }: InputSelectionParameters): Promise<SelectionResult> => {
     const { utxo, outputs, uniqueOutputAssetIDs, implicitCoin } = preprocessArgs(
       utxoSet,
       outputSet,
-      implicitCoinAsNumber
+      implicitValue.coin
     );
 
     assertIsBalanceSufficient(uniqueOutputAssetIDs, utxo, outputs, implicitCoin);

--- a/packages/cip2/src/RoundRobinRandomImprove/index.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/index.ts
@@ -1,6 +1,6 @@
 import { InputSelectionError, InputSelectionFailure } from '../InputSelectionError';
 import { InputSelectionParameters, InputSelector, SelectionResult } from '../types';
-import { assertIsBalanceSufficient, preprocessArgs, toValues } from './util';
+import { assertIsBalanceSufficient, preProcessArgs, toValues } from './util';
 import { computeChangeAndAdjustForFee } from './change';
 import { cslUtil } from '@cardano-sdk/core';
 import { roundRobinSelection } from './roundRobin';
@@ -16,21 +16,17 @@ export const roundRobinRandomImprove = ({
     utxo: utxoSet,
     outputs: outputSet,
     constraints: { computeMinimumCost, computeSelectionLimit, computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit },
-    implicitValue = {}
+    implicitValue: partialImplicitValue = {}
   }: InputSelectionParameters): Promise<SelectionResult> => {
-    const { utxo, outputs, uniqueOutputAssetIDs, implicitCoin } = preprocessArgs(
-      utxoSet,
-      outputSet,
-      implicitValue.coin
-    );
+    const { utxo, outputs, uniqueTxAssetIDs, implicitValue } = preProcessArgs(utxoSet, outputSet, partialImplicitValue);
 
-    assertIsBalanceSufficient(uniqueOutputAssetIDs, utxo, outputs, implicitCoin);
+    assertIsBalanceSufficient(uniqueTxAssetIDs, utxo, outputs, implicitValue);
 
     const roundRobinSelectionResult = roundRobinSelection({
-      implicitCoin,
+      implicitValue,
       outputs,
       random,
-      uniqueOutputAssetIDs,
+      uniqueTxAssetIDs,
       utxo
     });
 
@@ -43,11 +39,11 @@ export const roundRobinRandomImprove = ({
           inputs: new Set(utxos),
           outputs: outputSet
         }),
-      implicitCoin,
+      implicitValue,
       outputValues: toValues(outputs),
       random,
       tokenBundleSizeExceedsLimit,
-      uniqueOutputAssetIDs,
+      uniqueTxAssetIDs,
       utxoSelection: roundRobinSelectionResult
     });
 

--- a/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
@@ -31,7 +31,7 @@ const improvesSelection = (
 const listTokensWithin = (
   uniqueOutputAssetIDs: Cardano.AssetId[],
   outputs: Cardano.TxOut[],
-  implicitCoin: Required<Cardano.ImplicitCoin>
+  implicitCoin: Required<Cardano.util.ImplicitCoin>
 ) => [
   ...uniqueOutputAssetIDs.map((id) => {
     const getQuantity = assetQuantitySelector(id);

--- a/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/roundRobin.ts
@@ -1,6 +1,13 @@
 import { BigIntMath } from '@cardano-sdk/util';
 import { Cardano } from '@cardano-sdk/core';
-import { RoundRobinRandomImproveArgs, UtxoSelection, assetQuantitySelector, getCoinQuantity, toValues } from './util';
+import {
+  RequiredImplicitValue,
+  RoundRobinRandomImproveArgs,
+  UtxoSelection,
+  assetQuantitySelector,
+  getCoinQuantity,
+  toValues
+} from './util';
 
 const improvesSelection = (
   utxoAlreadySelected: Cardano.Utxo[],
@@ -31,10 +38,12 @@ const improvesSelection = (
 const listTokensWithin = (
   uniqueOutputAssetIDs: Cardano.AssetId[],
   outputs: Cardano.TxOut[],
-  implicitCoin: Required<Cardano.util.ImplicitCoin>
+  { implicitCoin, implicitTokens }: RequiredImplicitValue
 ) => [
   ...uniqueOutputAssetIDs.map((id) => {
     const getQuantity = assetQuantitySelector(id);
+    const implicitInput = implicitTokens.input(id);
+    const implicitSpend = implicitTokens.spend(id);
     return {
       filterUtxo: (utxo: Cardano.Utxo[]) =>
         utxo.filter(
@@ -45,8 +54,8 @@ const listTokensWithin = (
             }
           ]) => assets?.get(id)
         ),
-      getTotalSelectedQuantity: (utxo: Cardano.Utxo[]) => getQuantity(toValues(utxo)),
-      minimumTarget: getQuantity(toValues(outputs))
+      getTotalSelectedQuantity: (utxo: Cardano.Utxo[]) => getQuantity(toValues(utxo)) + implicitInput,
+      minimumTarget: getQuantity(toValues(outputs)) + implicitSpend
     };
   }),
   {
@@ -66,16 +75,16 @@ const listTokensWithin = (
 export const roundRobinSelection = ({
   utxo: utxosWithValue,
   outputs: outputsWithValue,
-  uniqueOutputAssetIDs,
+  uniqueTxAssetIDs,
   random,
-  implicitCoin
+  implicitValue
 }: RoundRobinRandomImproveArgs): UtxoSelection => {
   // The subset of the UTxO that has already been selected:
   const utxoSelected: Cardano.Utxo[] = [];
   // The subset of the UTxO that remains available for selection:
   const utxoRemaining = [...utxosWithValue];
   // The set of tokens that we still need to cover:
-  const tokensRemaining = listTokensWithin(uniqueOutputAssetIDs, outputsWithValue, implicitCoin);
+  const tokensRemaining = listTokensWithin(uniqueTxAssetIDs, outputsWithValue, implicitValue);
   while (tokensRemaining.length > 0) {
     // Consider each token in round-robin fashion:
     for (const [tokenIdx, { filterUtxo, minimumTarget, getTotalSelectedQuantity }] of tokensRemaining.entries()) {

--- a/packages/cip2/src/RoundRobinRandomImprove/util.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/util.ts
@@ -1,39 +1,68 @@
 /* eslint-disable func-style */
 import { BigIntMath } from '@cardano-sdk/util';
 import { Cardano } from '@cardano-sdk/core';
+import { ImplicitValue } from '../types';
 import { InputSelectionError, InputSelectionFailure } from '../InputSelectionError';
 import uniq from 'lodash/uniq';
+
+export interface ImplicitTokens {
+  spend(assetId: Cardano.AssetId): bigint;
+  input(assetId: Cardano.AssetId): bigint;
+}
+
+export interface RequiredImplicitValue {
+  implicitCoin: Required<Cardano.util.ImplicitCoin>;
+  implicitTokens: ImplicitTokens;
+}
 
 export interface RoundRobinRandomImproveArgs {
   utxo: Cardano.Utxo[];
   outputs: Cardano.TxOut[];
-  uniqueOutputAssetIDs: Cardano.AssetId[];
-  implicitCoin: Required<Cardano.util.ImplicitCoin>;
+  uniqueTxAssetIDs: Cardano.AssetId[];
+  implicitValue: RequiredImplicitValue;
   random: typeof Math.random;
 }
+
+export type PreProcessedArgs = Omit<RoundRobinRandomImproveArgs, 'random'>;
 
 export interface UtxoSelection {
   utxoSelected: Cardano.Utxo[];
   utxoRemaining: Cardano.Utxo[];
 }
 
-const noImplicitCoin = {
-  deposit: 0n,
-  input: 0n
+export const mintToImplicitTokens = (mintMap: Cardano.TokenMap = new Map()) => {
+  const mint = [...mintMap.entries()];
+  const implicitTokensInput = new Map(mint.filter(([_, quantity]) => quantity > 0));
+  const implicitTokensSpend = new Map(
+    mint.filter(([_, quantity]) => quantity < 0).map(([assetId, quantity]) => [assetId, -quantity])
+  );
+  return { implicitTokensInput, implicitTokensSpend };
 };
 
-export const preprocessArgs = (
+export const preProcessArgs = (
   availableUtxo: Set<Cardano.Utxo>,
   outputSet: Set<Cardano.TxOut>,
-  partialImplicitCoin: Cardano.util.ImplicitCoin = noImplicitCoin
-): Omit<RoundRobinRandomImproveArgs, 'random'> => {
+  partialImplicitValue?: ImplicitValue
+): PreProcessedArgs => {
   const outputs = [...outputSet];
-  const uniqueOutputAssetIDs = uniq(outputs.flatMap(({ value: { assets } }) => [...(assets?.keys() || [])]));
   const implicitCoin: Required<Cardano.util.ImplicitCoin> = {
-    deposit: partialImplicitCoin.deposit || 0n,
-    input: partialImplicitCoin.input || 0n
+    deposit: partialImplicitValue?.coin?.deposit || 0n,
+    input: partialImplicitValue?.coin?.input || 0n
   };
-  return { implicitCoin, outputs, uniqueOutputAssetIDs, utxo: [...availableUtxo] };
+  const mintMap: Cardano.TokenMap = partialImplicitValue?.mint || new Map();
+  const { implicitTokensInput, implicitTokensSpend } = mintToImplicitTokens(mintMap);
+  const implicitTokens: ImplicitTokens = {
+    input: (assetId) => implicitTokensInput.get(assetId) || 0n,
+    spend: (assetId) => implicitTokensSpend.get(assetId) || 0n
+  };
+  const uniqueOutputAssetIDs = uniq(outputs.flatMap(({ value: { assets } }) => [...(assets?.keys() || [])]));
+  const uniqueTxAssetIDs = uniq([...uniqueOutputAssetIDs, ...mintMap.keys()]);
+  return {
+    implicitValue: { implicitCoin, implicitTokens },
+    outputs,
+    uniqueTxAssetIDs,
+    utxo: [...availableUtxo]
+  };
 };
 
 const isUtxoArray = (outputsOrUtxo: Cardano.TxOut[] | Cardano.Utxo[]): outputsOrUtxo is Cardano.Utxo[] =>
@@ -78,21 +107,21 @@ export const assertIsCoinBalanceSufficient = (
  * @throws InputSelectionError { UtxoBalanceInsufficient }
  */
 export const assertIsBalanceSufficient = (
-  uniqueOutputAssetIDs: Cardano.AssetId[],
+  uniqueTxAssetIDs: Cardano.AssetId[],
   utxo: Cardano.Utxo[],
   outputs: Cardano.TxOut[],
-  implicitCoin: Required<Cardano.util.ImplicitCoin>
+  { implicitCoin, implicitTokens }: RequiredImplicitValue
 ): void => {
   if (utxo.length === 0) {
     throw new InputSelectionError(InputSelectionFailure.UtxoBalanceInsufficient);
   }
   const utxoValues = toValues(utxo);
   const outputsValues = toValues(outputs);
-  for (const assetId of uniqueOutputAssetIDs) {
+  for (const assetId of uniqueTxAssetIDs) {
     const getAssetQuantity = assetQuantitySelector(assetId);
     const utxoTotal = getAssetQuantity(utxoValues);
     const outputsTotal = getAssetQuantity(outputsValues);
-    if (outputsTotal > utxoTotal) {
+    if (outputsTotal + implicitTokens.spend(assetId) > utxoTotal + implicitTokens.input(assetId)) {
       throw new InputSelectionError(InputSelectionFailure.UtxoBalanceInsufficient);
     }
   }

--- a/packages/cip2/src/RoundRobinRandomImprove/util.ts
+++ b/packages/cip2/src/RoundRobinRandomImprove/util.ts
@@ -8,7 +8,7 @@ export interface RoundRobinRandomImproveArgs {
   utxo: Cardano.Utxo[];
   outputs: Cardano.TxOut[];
   uniqueOutputAssetIDs: Cardano.AssetId[];
-  implicitCoin: Required<Cardano.ImplicitCoin>;
+  implicitCoin: Required<Cardano.util.ImplicitCoin>;
   random: typeof Math.random;
 }
 
@@ -25,11 +25,11 @@ const noImplicitCoin = {
 export const preprocessArgs = (
   availableUtxo: Set<Cardano.Utxo>,
   outputSet: Set<Cardano.TxOut>,
-  partialImplicitCoin: Cardano.ImplicitCoin = noImplicitCoin
+  partialImplicitCoin: Cardano.util.ImplicitCoin = noImplicitCoin
 ): Omit<RoundRobinRandomImproveArgs, 'random'> => {
   const outputs = [...outputSet];
   const uniqueOutputAssetIDs = uniq(outputs.flatMap(({ value: { assets } }) => [...(assets?.keys() || [])]));
-  const implicitCoin: Required<Cardano.ImplicitCoin> = {
+  const implicitCoin: Required<Cardano.util.ImplicitCoin> = {
     deposit: partialImplicitCoin.deposit || 0n,
     input: partialImplicitCoin.input || 0n
   };
@@ -62,7 +62,7 @@ export const getCoinQuantity = (quantities: Cardano.Value[]): bigint =>
 export const assertIsCoinBalanceSufficient = (
   utxoValues: Cardano.Value[],
   outputValues: Cardano.Value[],
-  implicitCoin: Required<Cardano.ImplicitCoin>
+  implicitCoin: Required<Cardano.util.ImplicitCoin>
 ) => {
   const utxoCoinTotal = getCoinQuantity(utxoValues);
   const outputsCoinTotal = getCoinQuantity(outputValues);
@@ -81,7 +81,7 @@ export const assertIsBalanceSufficient = (
   uniqueOutputAssetIDs: Cardano.AssetId[],
   utxo: Cardano.Utxo[],
   outputs: Cardano.TxOut[],
-  implicitCoin: Required<Cardano.ImplicitCoin>
+  implicitCoin: Required<Cardano.util.ImplicitCoin>
 ): void => {
   if (utxo.length === 0) {
     throw new InputSelectionError(InputSelectionFailure.UtxoBalanceInsufficient);

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -80,9 +80,14 @@ export interface InputSelectionParameters {
    */
   constraints: SelectionConstraints;
   /**
-   * Implicit coin quantities used in the transaction
+   * Implicit input or spent value
    */
-  implicitCoin?: Cardano.util.ImplicitCoin;
+  implicitValue?: {
+    /**
+     * Implicit coin quantities used in the transaction
+     */
+    coin?: Cardano.util.ImplicitCoin;
+  };
 }
 
 export interface InputSelector {

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -66,6 +66,21 @@ export interface SelectionConstraints {
   computeSelectionLimit: ComputeSelectionLimit;
 }
 
+/**
+ * Implicit input or spent value
+ */
+export interface ImplicitValue {
+  /**
+   * Implicit coin quantities used in the transaction
+   */
+  coin?: Cardano.util.ImplicitCoin;
+  /**
+   * Positive quantity = mint (implicit input)
+   * Negative quantity = burn (implicit spend)
+   */
+  mint?: Cardano.TokenMap;
+}
+
 export interface InputSelectionParameters {
   /**
    * The set of inputs available for selection.
@@ -82,12 +97,7 @@ export interface InputSelectionParameters {
   /**
    * Implicit input or spent value
    */
-  implicitValue?: {
-    /**
-     * Implicit coin quantities used in the transaction
-     */
-    coin?: Cardano.util.ImplicitCoin;
-  };
+  implicitValue?: ImplicitValue;
 }
 
 export interface InputSelector {

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -82,7 +82,7 @@ export interface InputSelectionParameters {
   /**
    * Implicit coin quantities used in the transaction
    */
-  implicitCoin?: Cardano.ImplicitCoin;
+  implicitCoin?: Cardano.util.ImplicitCoin;
 }
 
 export interface InputSelector {

--- a/packages/cip2/test/RoundRobinRandomImprove.test.ts
+++ b/packages/cip2/test/RoundRobinRandomImprove.test.ts
@@ -51,7 +51,7 @@ describe('RoundRobinRandomImprove', () => {
         const outputs = new Set([TxTestUtil.createOutput({ coins: 1_000_000n })]);
         const results = await roundRobinRandomImprove().select({
           constraints: SelectionConstraints.NO_CONSTRAINTS,
-          implicitCoin: { input: 2_000_000n },
+          implicitValue: { coin: { input: 2_000_000n } },
           outputs,
           utxo
         });
@@ -223,7 +223,7 @@ describe('RoundRobinRandomImprove', () => {
           try {
             const results = await algorithm.select({
               constraints: SelectionConstraints.mockConstraintsToConstraints(constraints),
-              implicitCoin,
+              implicitValue: { coin: implicitCoin },
               outputs,
               utxo: new Set(utxo)
             });

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -36,7 +36,7 @@ const inputSelectionTotals = ({
 }: {
   results: SelectionResult;
   outputs: Set<Cardano.TxOut>;
-  implicitCoin?: Cardano.ImplicitCoin;
+  implicitCoin?: Cardano.util.ImplicitCoin;
 }) => {
   const vSelectedUtxo = totalUtxosValue(results);
   const vSelected = {
@@ -64,7 +64,7 @@ export const assertInputSelectionProperties = ({
   outputs: Set<Cardano.TxOut>;
   utxo: Set<Cardano.Utxo>;
   constraints: SelectionConstraints.MockSelectionConstraints;
-  implicitCoin?: Cardano.ImplicitCoin;
+  implicitCoin?: Cardano.util.ImplicitCoin;
 }) => {
   const { vSelected, vRequested, vChange } = inputSelectionTotals({ implicitCoin, outputs, results });
 
@@ -109,7 +109,7 @@ export const assertFailureProperties = ({
   utxoAmounts: Cardano.Value[];
   outputsAmounts: Cardano.Value[];
   constraints: SelectionConstraints.MockSelectionConstraints;
-  implicitCoin?: Cardano.ImplicitCoin;
+  implicitCoin?: Cardano.util.ImplicitCoin;
 }) => {
   const availableQuantities = Cardano.util.coalesceValueQuantities([
     ...utxoAmounts,
@@ -186,7 +186,7 @@ export const generateSelectionParams = (() => {
         );
       });
 
-  const generateImplicitCoin: Arbitrary<Cardano.ImplicitCoin | undefined> = fc.oneof(
+  const generateImplicitCoin: Arbitrary<Cardano.util.ImplicitCoin | undefined> = fc.oneof(
     fc.constant(void 0),
     fc.record({
       deposit: fc.oneof(
@@ -215,7 +215,7 @@ export const generateSelectionParams = (() => {
     utxoAmounts: Cardano.Value[];
     outputsAmounts: Cardano.Value[];
     constraints: SelectionConstraints.MockSelectionConstraints;
-    implicitCoin?: Cardano.ImplicitCoin;
+    implicitCoin?: Cardano.util.ImplicitCoin;
   }> =>
     generateImplicitCoin.chain((implicitCoin) =>
       fc.record({

--- a/packages/cip2/test/util/properties.ts
+++ b/packages/cip2/test/util/properties.ts
@@ -1,8 +1,9 @@
 import * as SelectionConstraints from './selectionConstraints';
+import { Asset, Cardano, cslUtil } from '@cardano-sdk/core';
 import { AssetId } from '@cardano-sdk/util-dev';
-import { Cardano, cslUtil } from '@cardano-sdk/core';
+import { ImplicitValue, SelectionResult } from '../../src/types';
 import { InputSelectionError, InputSelectionFailure } from '../../src/InputSelectionError';
-import { SelectionResult } from '../../src/types';
+import { mintToImplicitTokens } from '../../src/RoundRobinRandomImprove/util';
 import fc, { Arbitrary } from 'fast-check';
 
 const assertExtraChangeProperties = (
@@ -32,22 +33,23 @@ const totalUtxosValue = (results: SelectionResult) =>
 const inputSelectionTotals = ({
   results,
   outputs,
-  implicitCoin
+  implicitValue
 }: {
   results: SelectionResult;
   outputs: Set<Cardano.TxOut>;
-  implicitCoin?: Cardano.util.ImplicitCoin;
+  implicitValue?: ImplicitValue;
 }) => {
+  const { implicitTokensInput, implicitTokensSpend } = mintToImplicitTokens(implicitValue?.mint);
   const vSelectedUtxo = totalUtxosValue(results);
   const vSelected = {
-    ...vSelectedUtxo,
-    coins: vSelectedUtxo.coins + BigInt(implicitCoin?.input || 0)
+    assets: Asset.util.coalesceTokenMaps([vSelectedUtxo.assets, implicitTokensInput]),
+    coins: vSelectedUtxo.coins + BigInt(implicitValue?.coin?.input || 0)
   };
   const vRequestedOutputs = totalOutputsValue(outputs);
   const vFee = results.selection.fee;
   const vRequested = {
-    ...vRequestedOutputs,
-    coins: vRequestedOutputs.coins + BigInt(implicitCoin?.deposit || 0) + vFee
+    assets: Asset.util.coalesceTokenMaps([vRequestedOutputs.assets, implicitTokensSpend]),
+    coins: vRequestedOutputs.coins + BigInt(implicitValue?.coin?.deposit || 0) + vFee
   };
   const vChange = Cardano.util.coalesceValueQuantities([...results.selection.change]);
   return { vChange, vRequested, vSelected };
@@ -58,15 +60,15 @@ export const assertInputSelectionProperties = ({
   outputs,
   utxo,
   constraints,
-  implicitCoin
+  implicitValue
 }: {
   results: SelectionResult;
   outputs: Set<Cardano.TxOut>;
   utxo: Set<Cardano.Utxo>;
   constraints: SelectionConstraints.MockSelectionConstraints;
-  implicitCoin?: Cardano.util.ImplicitCoin;
+  implicitValue?: ImplicitValue;
 }) => {
-  const { vSelected, vRequested, vChange } = inputSelectionTotals({ implicitCoin, outputs, results });
+  const { vSelected, vRequested, vChange } = inputSelectionTotals({ implicitValue, outputs, results });
 
   // Coverage of Payments
   expect(vSelected.coins).toBeGreaterThanOrEqual(vRequested.coins);
@@ -103,22 +105,23 @@ export const assertFailureProperties = ({
   constraints,
   utxoAmounts,
   outputsAmounts,
-  implicitCoin
+  implicitValue
 }: {
   error: InputSelectionError;
   utxoAmounts: Cardano.Value[];
   outputsAmounts: Cardano.Value[];
   constraints: SelectionConstraints.MockSelectionConstraints;
-  implicitCoin?: Cardano.util.ImplicitCoin;
+  implicitValue?: ImplicitValue;
 }) => {
+  const { implicitTokensInput, implicitTokensSpend } = mintToImplicitTokens(implicitValue?.mint);
   const availableQuantities = Cardano.util.coalesceValueQuantities([
     ...utxoAmounts,
-    { coins: BigInt(implicitCoin?.input || 0) }
+    { assets: implicitTokensInput, coins: BigInt(implicitValue?.coin?.input || 0) }
   ]);
   const maxPossibleFee = constraints.minimumCostCoefficient * BigInt(utxoAmounts.length);
   const requestedQuantities = Cardano.util.coalesceValueQuantities([
     ...outputsAmounts,
-    { coins: BigInt(implicitCoin?.deposit || 0) + maxPossibleFee }
+    { assets: implicitTokensSpend, coins: BigInt(implicitValue?.coin?.deposit || 0) + maxPossibleFee }
   ]);
   switch (error.failure) {
     case InputSelectionFailure.UtxoBalanceInsufficient: {
@@ -150,6 +153,14 @@ export const assertFailureProperties = ({
   throw error;
 };
 
+const generateTokenMap = (minQuantity: bigint, maxQuantity: bigint) =>
+  fc
+    .uniqueArray(fc.oneof(...AssetId.All.map((asset) => fc.constant(asset))), { comparator: 'IsStrictlyEqual' })
+    .chain((assets) =>
+      fc.tuple(...assets.map((asset) => fc.bigInt(minQuantity, maxQuantity).map((amount) => ({ amount, asset }))))
+    )
+    .map((assets) => new Map<Cardano.AssetId, Cardano.Lovelace>(assets.map(({ amount, asset }) => [asset, amount])));
+
 /**
  * @returns {Arbitrary} fast-check arbitrary that generates valid sets of UTxO and outputs for input selection.
  */
@@ -161,18 +172,7 @@ export const generateSelectionParams = (() => {
     fc
       .array(
         fc.record<Cardano.Value>({
-          assets: fc.oneof(
-            fc
-              .set(fc.oneof(...AssetId.All.map((asset) => fc.constant(asset))))
-              .chain((assets) =>
-                fc.tuple(...assets.map((asset) => fc.bigInt(1n, cslUtil.MAX_U64).map((amount) => ({ amount, asset }))))
-              )
-              .map(
-                (assets) =>
-                  new Map<Cardano.AssetId, Cardano.Lovelace>(assets.map(({ amount, asset }) => [asset, amount]))
-              ),
-            fc.constant(void 0)
-          ),
+          assets: fc.oneof(generateTokenMap(1n, cslUtil.MAX_U64), fc.constant(void 0)),
           coins: fc.bigInt(1n, cslUtil.MAX_U64 - implicitCoin)
         }),
         { maxLength: 11 }
@@ -186,28 +186,33 @@ export const generateSelectionParams = (() => {
         );
       });
 
-  const generateImplicitCoin: Arbitrary<Cardano.util.ImplicitCoin | undefined> = fc.oneof(
+  const generateImplicitCoin: Arbitrary<Cardano.util.ImplicitCoin> = fc.record({
+    deposit: fc.oneof(
+      fc.constant(void 0),
+      fc
+        .tuple(fc.bigUint(2n), fc.bigUint(2n))
+        .map(([numKeyDeposits, numPoolDeposits]) => numKeyDeposits * 2_000_000n + numPoolDeposits * 500_000_000n)
+    ),
+    input: fc.oneof(
+      fc.constant(void 0),
+      fc
+        .tuple(
+          fc.bigUint(2n),
+          fc.bigUint(2n),
+          fc.oneof(fc.constant(0n), fc.constant(1n), fc.constant(200_000n), fc.constant(2_000_003n))
+        )
+        .map(
+          ([numKeyDeposits, numPoolDeposits, withdrawals]) =>
+            numKeyDeposits * 2_000_000n + numPoolDeposits * 500_000_000n + withdrawals
+        )
+    )
+  });
+
+  const generateImplicitValue: Arbitrary<ImplicitValue | undefined> = fc.oneof(
     fc.constant(void 0),
-    fc.record({
-      deposit: fc.oneof(
-        fc.constant(void 0),
-        fc
-          .tuple(fc.bigUint(2n), fc.bigUint(2n))
-          .map(([numKeyDeposits, numPoolDeposits]) => numKeyDeposits * 2_000_000n + numPoolDeposits * 500_000_000n)
-      ),
-      input: fc.oneof(
-        fc.constant(void 0),
-        fc
-          .tuple(
-            fc.bigUint(2n),
-            fc.bigUint(2n),
-            fc.oneof(fc.constant(0n), fc.constant(1n), fc.constant(200_000n), fc.constant(2_000_003n))
-          )
-          .map(
-            ([numKeyDeposits, numPoolDeposits, withdrawals]) =>
-              numKeyDeposits * 2_000_000n + numPoolDeposits * 500_000_000n + withdrawals
-          )
-      )
+    fc.record<ImplicitValue>({
+      coin: fc.oneof(fc.constant(void 0), generateImplicitCoin),
+      mint: fc.oneof(fc.constant(void 0), generateTokenMap(cslUtil.MIN_I64, cslUtil.MAX_I64))
     })
   );
 
@@ -215,9 +220,9 @@ export const generateSelectionParams = (() => {
     utxoAmounts: Cardano.Value[];
     outputsAmounts: Cardano.Value[];
     constraints: SelectionConstraints.MockSelectionConstraints;
-    implicitCoin?: Cardano.util.ImplicitCoin;
+    implicitValue?: ImplicitValue;
   }> =>
-    generateImplicitCoin.chain((implicitCoin) =>
+    generateImplicitValue.chain((implicitValue) =>
       fc.record({
         constraints: fc.record<SelectionConstraints.MockSelectionConstraints>({
           maxTokenBundleSize: fc.nat(AssetId.All.length),
@@ -225,9 +230,9 @@ export const generateSelectionParams = (() => {
           minimumCostCoefficient: fc.oneof(...[0n, 1n, 200_000n, 2_000_003n].map((n) => fc.constant(n))),
           selectionLimit: fc.oneof(...[0, 1, 2, 7, 30, Number.MAX_SAFE_INTEGER].map((n) => fc.constant(n)))
         }),
-        implicitCoin: fc.constant(implicitCoin),
-        outputsAmounts: arrayOfCoinAndAssets(implicitCoin?.deposit),
-        utxoAmounts: arrayOfCoinAndAssets(implicitCoin?.input)
+        implicitValue: fc.constant(implicitValue),
+        outputsAmounts: arrayOfCoinAndAssets(implicitValue?.coin?.deposit),
+        utxoAmounts: arrayOfCoinAndAssets(implicitValue?.coin?.input)
       })
     );
 })();

--- a/packages/cip2/test/util/tests.ts
+++ b/packages/cip2/test/util/tests.ts
@@ -1,7 +1,7 @@
 import * as SelectionConstraints from './selectionConstraints';
 import { Cardano } from '@cardano-sdk/core';
+import { ImplicitValue, InputSelector } from '../../src/types';
 import { InputSelectionError, InputSelectionFailure } from '../../src/InputSelectionError';
-import { InputSelector } from '../../src/types';
 import { assertInputSelectionProperties } from './properties';
 
 export interface InputSelectionPropertiesTestParams {
@@ -17,6 +17,10 @@ export interface InputSelectionPropertiesTestParams {
    * Transaction outputs
    */
   createOutputs: () => Cardano.TxOut[];
+  /**
+   * Transaction outputs
+   */
+  implicitValue?: ImplicitValue;
   /**
    * Input selection constraints passed to the algorithm.
    */
@@ -37,6 +41,7 @@ export const testInputSelectionFailureMode = async ({
   getAlgorithm,
   createUtxo,
   createOutputs,
+  implicitValue,
   expectedError,
   mockConstraints
 }: InputSelectionFailureModeTestParams) => {
@@ -44,7 +49,12 @@ export const testInputSelectionFailureMode = async ({
   const outputs = new Set(createOutputs());
   const algorithm = getAlgorithm();
   await expect(
-    algorithm.select({ constraints: SelectionConstraints.mockConstraintsToConstraints(mockConstraints), outputs, utxo })
+    algorithm.select({
+      constraints: SelectionConstraints.mockConstraintsToConstraints(mockConstraints),
+      implicitValue,
+      outputs,
+      utxo
+    })
   ).rejects.toThrowError(new InputSelectionError(expectedError));
 };
 
@@ -55,6 +65,7 @@ export const testInputSelectionProperties = async ({
   getAlgorithm,
   createUtxo,
   createOutputs,
+  implicitValue,
   mockConstraints
 }: InputSelectionPropertiesTestParams) => {
   const utxo = new Set(createUtxo());
@@ -62,6 +73,7 @@ export const testInputSelectionProperties = async ({
   const algorithm = getAlgorithm();
   const results = await algorithm.select({
     constraints: SelectionConstraints.mockConstraintsToConstraints(mockConstraints),
+    implicitValue,
     outputs,
     utxo
   });

--- a/packages/core/src/CSL/util.ts
+++ b/packages/core/src/CSL/util.ts
@@ -1,6 +1,10 @@
 import { BigNum } from '@emurgo/cardano-serialization-lib-nodejs';
 
 export const MAX_U64 = 18_446_744_073_709_551_615n;
+
+export const MIN_I64 = -9_223_372_036_854_775_808n;
+export const MAX_I64 = 9_223_372_036_854_775_807n;
+
 export const maxBigNum = BigNum.from_str(MAX_U64.toString());
 
 export type CslObject = { to_bytes: () => Uint8Array };

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -51,20 +51,6 @@ export interface NewTxBodyAlonzo extends Omit<TxBodyAlonzo, 'inputs' | 'collater
   collaterals?: Cardano.NewTxIn[];
 }
 
-/**
- * Implicit coin quantities used in the transaction
- */
-export interface ImplicitCoin {
-  /**
-   * Reward withdrawals + deposit reclaims
-   */
-  input?: Cardano.Lovelace;
-  /**
-   * Delegation registration deposit
-   */
-  deposit?: Cardano.Lovelace;
-}
-
 export enum RedeemerPurpose {
   spend = 'spend',
   mint = 'mint',
@@ -112,6 +98,5 @@ export interface TxAlonzo extends NewTxAlonzo<TxBodyAlonzo> {
   index: number;
   blockHeader: PartialBlockHeader;
   body: TxBodyAlonzo;
-  implicitCoin: ImplicitCoin;
   txSize: number;
 }

--- a/packages/core/src/Cardano/util/computeImplicitCoin.ts
+++ b/packages/core/src/Cardano/util/computeImplicitCoin.ts
@@ -2,12 +2,26 @@ import { BigIntMath } from '@cardano-sdk/util';
 import { Cardano, ProtocolParametersRequiredByWallet } from '../../';
 
 /**
+ * Implicit coin quantities used in the transaction
+ */
+export interface ImplicitCoin {
+  /**
+   * Reward withdrawals + deposit reclaims
+   */
+  input?: Cardano.Lovelace;
+  /**
+   * Delegation registration deposit
+   */
+  deposit?: Cardano.Lovelace;
+}
+
+/**
  * Implementation is the same as in CSL.get_implicit_input() and CSL.get_deposit().
  */
 export const computeImplicitCoin = (
   { stakeKeyDeposit, poolDeposit }: Pick<ProtocolParametersRequiredByWallet, 'stakeKeyDeposit' | 'poolDeposit'>,
   { certificates, withdrawals }: Pick<Cardano.TxBodyAlonzo, 'certificates' | 'withdrawals'>
-): Cardano.ImplicitCoin => {
+): ImplicitCoin => {
   const stakeKeyDepositBigint = stakeKeyDeposit && BigInt(stakeKeyDeposit);
   const poolDepositBigint = poolDeposit && BigInt(poolDeposit);
   const deposit = BigIntMath.sum(

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -361,7 +361,7 @@ export class SingleAddressWallet implements ObservableWallet {
     const { constraints, utxo, implicitCoin, validityInterval, changeAddress } = await this.#prepareTx(props);
     const { selection: inputSelection } = await this.#inputSelector.select({
       constraints,
-      implicitCoin,
+      implicitValue: { coin: implicitCoin },
       outputs: props.outputs || new Set(),
       utxo: new Set(utxo)
     });

--- a/packages/wallet/test/mocks/mockChainHistoryProvider.ts
+++ b/packages/wallet/test/mocks/mockChainHistoryProvider.ts
@@ -57,7 +57,6 @@ export const queryTransactionsResult: Cardano.TxAlonzo[] = [
       }
     },
     id: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a'),
-    implicitCoin: {},
     index: 0,
     txSize: 100_000,
     witness: {


### PR DESCRIPTION
# Context

Input selection does not take token mint/burn into consideration.

# Proposed Solution

Add mint/burn support as `InputSelectionParameters.implicitValue.mint`.

# Important Changes Introduced

- [feat(core): export cslUtil MIN_I64 and MAX_I64 consts](https://github.com/input-output-hk/cardano-js-sdk/commit/618eef04e7c9d2e27d2b0c5a9f1a172d340abde4)
- [refactor!: rm TxAlonzo.implicitCoin](https://github.com/input-output-hk/cardano-js-sdk/commit/167d205dd15c857b229f968ab53a6e52e5504d3f)
- [refactor!: rename InputSelectionParameters implicitCoin->implicitValue.coin](https://github.com/input-output-hk/cardano-js-sdk/commit/3242a0dc63da0e59c4f8536d16758ea19f58a2c0)