### PR TITLE
Uniform ttl parameter of InMemoryCache methods to be expressed in seconds

### DIFF
--- a/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
+++ b/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
@@ -7,17 +7,22 @@ export class InMemoryCache {
   #cache: NodeCache;
   #ttlDefault: number;
 
-  constructor(cacheTtlInMins: number, cache: NodeCache = new NodeCache()) {
-    this.#ttlDefault = cacheTtlInMins * 60;
+  /**
+   *
+   * @param ttl The default time to live in seconds
+   * @param cache The cache engine. It must extend NodeCache
+   */
+  constructor(ttl: number, cache: NodeCache = new NodeCache()) {
+    this.#ttlDefault = ttl;
     this.#cache = cache;
   }
 
   /**
    * Get a cached key value, if not found execute db query and cache the result with that key
    *
-   * @param key cache key
-   * @param asyncAction async function to get the value
-   * @param ttl cache duration in seconds
+   * @param key Cache key
+   * @param asyncAction Async function to get the value
+   * @param ttl The time to live in seconds
    * @returns The value stored with the key
    */
   public async get<T>(key: Key, asyncAction: AsyncAction<T>, ttl = this.#ttlDefault): Promise<T> {
@@ -38,7 +43,7 @@ export class InMemoryCache {
   /**
    * Get a cached key
    *
-   * @param key cache key
+   * @param key Cache key
    * @returns The value stored in the key
    */
   public getVal<T>(key: Key) {
@@ -50,7 +55,8 @@ export class InMemoryCache {
    *
    * @param key Cache key
    * @param value A value to cache
-   * @param ttl The time to live in seconds.
+   * @param ttl The time to live in seconds
+   * @returns The success state of the operation
    */
   public set<T>(key: Key, value: T, ttl = this.#ttlDefault) {
     return this.#cache.set<T>(key, value, ttl);

--- a/packages/cardano-services/src/InMemoryCache/defaults.ts
+++ b/packages/cardano-services/src/InMemoryCache/defaults.ts
@@ -1,4 +1,4 @@
-export const DB_CACHE_TTL_DEFAULT = 120;
+export const DB_CACHE_TTL_DEFAULT = 2 * 60 * 60; // Two hours
 
 export const CACHE_TTL_LOWER_LIMIT = 1;
 export const CACHE_TTL_UPPER_LIMIT = 2880;

--- a/packages/cardano-services/src/util/validators.ts
+++ b/packages/cardano-services/src/util/validators.ts
@@ -3,8 +3,11 @@ import { MissingProgramOption, ProgramOptionDescriptions, ServiceNames } from '.
 
 export const cacheTtlValidator = (ttl: string) => {
   const cacheTtl = Number.parseInt(ttl, 10);
+
   if (typeof cacheTtl === 'number' && cacheTtl >= CACHE_TTL_LOWER_LIMIT && cacheTtl <= CACHE_TTL_UPPER_LIMIT) {
-    return cacheTtl;
+    // The cli script accepts TTLs in minutes, but the underlying level express TTLs in seconds
+    return cacheTtl * 60;
   }
+
   throw new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.DbCacheTtl);
 };

--- a/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
+++ b/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
@@ -182,7 +182,7 @@ describe('CardanoTokenRegistry', () => {
     beforeAll(async () => {
       ({ closeMock, tokenMetadataServerUrl } = await mockTokenRegistry(() => ({})));
       tokenRegistry = new CardanoTokenRegistry(
-        { cache: new TestInMemoryCache(1), logger: dummyLogger },
+        { cache: new TestInMemoryCache(60), logger: dummyLogger },
         { tokenMetadataServerUrl }
       );
     });


### PR DESCRIPTION
# Context

Some methods of `InMemoryCache` class accept a `ttl` parameter; sometimes they expect it expressed in seconds sometimes in minutes.

# Proposed Solution

Changed the interface of `InMemoryCache` class to make all the methods to accept the `ttl` parameter expressed in seconds; 

# Changes Introduced

- Since the `cli` script accepts TTLs in minutes, to not make this breaking change for all the `cli` script users: the parameter validator converts the TTLs from minutes to seconds.