### PR TITLE
build: move docker-compose service ENVs into compose files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,6 @@ ENV \
   API_URL="http://0.0.0.0:3000" \
   CARDANO_NODE_CONFIG_PATH=/config/cardano-node/config.json \
   NETWORK=${NETWORK} \
-  OGMIOS_URL="ws://cardano-node-ogmios:1337" \
   POSTGRES_DB_FILE=/run/secrets/postgres_db \
   POSTGRES_HOST=postgres \
   POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password \
@@ -72,8 +71,5 @@ HEALTHCHECK --interval=15s --timeout=15s \
 CMD ["node", "dist/cjs/cli.js", "start-server"]
 
 FROM cardano-services as worker
-ENV \
-  OGMIOS_URL="ws://cardano-node-ogmios:1337" \
-  RABBITMQ_URL='amqp://rabbitmq:5672'
 WORKDIR /app/packages/cardano-services
 CMD ["node", "dist/cjs/cli.js", "start-worker"]

--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -113,6 +113,8 @@ services:
       - DB_CACHE_TTL=${DB_CACHE_TTL:-120}
       - ENABLE_METRICS=${ENABLE_METRICS:-false}
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
+      - OGMIOS_URL=ws://cardano-node-ogmios:1337
+      - RABBITMQ_URL=amqp://rabbitmq:5672
       - SERVICE_NAMES=${SERVICE_NAMES:-asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo}
       - USE_QUEUE=${USE_QUEUE:-false}
     ports:
@@ -139,9 +141,11 @@ services:
         condition: service_healthy
     environment:
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
+      - OGMIOS_URL=ws://cardano-node-ogmios:1337
       - PARALLEL=${PARALLEL:-false}
       - PARALLEL_TX=${PARALLEL_TX:-3}
       - POLLING_CYCLE=${POLLING_CYCLE:-500}
+      - RABBITMQ_URL=amqp://rabbitmq:5672
     restart: on-failure
     logging:
       driver: "json-file"

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -140,10 +140,12 @@ services:
       context: ../../
       target: http-server
     environment:
-      - EPOCH_POLL_INTERVAL=${EPOCH_POLL_INTERVAL:-10000}
       - DB_CACHE_TTL=${DB_CACHE_TTL:-120}
+      - EPOCH_POLL_INTERVAL=${EPOCH_POLL_INTERVAL:-10000}
       - ENABLE_METRICS=${ENABLE_METRICS:-false}
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
+      - OGMIOS_URL=ws://cardano-node-ogmios:1337
+      - RABBITMQ_URL=amqp://rabbitmq:5672
       - SERVICE_NAMES=${SERVICE_NAMES:-asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo}
       - USE_QUEUE=${USE_QUEUE:-false}
     ports:
@@ -169,9 +171,11 @@ services:
       target: worker
     environment:
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
+      - OGMIOS_URL=ws://cardano-node-ogmios:1337
       - PARALLEL=${PARALLEL:-false}
       - PARALLEL_TX=${PARALLEL_TX:-3}
       - POLLING_CYCLE=${POLLING_CYCLE:-500}
+      - RABBITMQ_URL=amqp://rabbitmq:5672
     restart: on-failure
     depends_on:
       cardano-node-ogmios:


### PR DESCRIPTION
# Context
Setting the Compose-specific ENV values within the Dockerfile is the wrong context.

# Proposed Solution
Move the relevant ENVs from the Dockerfile to each Compose file.

# Important Changes Introduced
This change also fixes the missing `RABBITMQ_URL` from the `http-server` service