### PR TITLE
fix: Gracefully handle `CardanoTokenRegistry` errors during `getAsset` request

### DIFF
--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -148,7 +148,15 @@ export class CardanoTokenRegistry implements TokenMetadataService {
         }
       }
     } catch (error) {
-      throw toProviderError(error, 'while fetching metadata from token registry');
+      if (axios.isAxiosError(error)) {
+        throw new ProviderError(
+          ProviderFailure.ConnectionFailure,
+          error,
+          'CardanoTokenRegistry failed to fetch asset metatada from the token registry server'
+        );
+      }
+
+      throw error;
     }
 
     return tokenMetadata;

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider.ts
@@ -66,8 +66,17 @@ export class DbSyncAssetProvider extends DbSyncProvider implements AssetProvider
     if (extraData?.history) await this.loadHistory(assetInfo);
     if (extraData?.nftMetadata)
       assetInfo.nftMetadata = await this.#dependencies.ntfMetadataService.getNftMetadata(assetInfo);
-    if (extraData?.tokenMetadata)
-      assetInfo.tokenMetadata = (await this.#dependencies.tokenMetadataService.getTokenMetadata([assetId]))[0];
+    if (extraData?.tokenMetadata) {
+      try {
+        assetInfo.tokenMetadata = (await this.#dependencies.tokenMetadataService.getTokenMetadata([assetId]))[0];
+      } catch (error) {
+        if (error instanceof ProviderError && error.reason === ProviderFailure.ConnectionFailure) {
+          assetInfo.tokenMetadata = undefined;
+        } else {
+          throw error;
+        }
+      }
+    }
 
     return assetInfo;
   }

--- a/packages/cardano-services/src/Asset/openApi.json
+++ b/packages/cardano-services/src/Asset/openApi.json
@@ -95,7 +95,9 @@
         }
       },
       "GetAssetRequest": {
-        "required": ["assetId"],
+        "required": [
+          "assetId"
+        ],
         "type": "object",
         "properties": {
           "assetId": {


### PR DESCRIPTION
# Context
`AssetInfo.tokenMetatdata` is stored in an off-chain registry, which cannot be depended on for returning a match for the given assetIds, nor it's service availability. Currently we’re rethrowing request errors as a Provider error, which is not ideal since it then couples our own service health, as opposed to the desired behaviour of omitting the metadata from the response. 
[cardano-js-sdk/CardanoTokenRegistry.ts at 8fe1cdd7683a7802bebd081616abead292488953 · input-output-hk/cardano-js-sdk](https://github.com/input-output-hk/cardano-js-sdk/blob/8fe1cdd7683a7802bebd081616abead292488953/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts#L151) 

This issue does raise an important question of how can a client differentiate between a response that included a `404` from the registry vs a `5xx` with our current shape of from  AssetInfo.tokenMetadata

# Proposed Solution

**Approach A)**
Introduce the suggested approach from the task description with minor diffs as follows:
```
interface TokenMetadataSource {
  type: MetadataSourceType; \\ enum to support: 'registry', 'on-chain' or 'referenced'  
  requestStatus: 'success' | 'fail'; 
}

export interface AssetInfo<Source> {
  ...
  tokenMetadata?: { data?: TokenMetadata | null, source?: Source } ;
  ...
}

// Provider interface use AssetInfo<unknown>
// cardano-services use AssetInfo<TokenMetadataSource>
```

Notes:
- `cached: boolean` is committed because it's not so related to the `Source` scope, however, it could be added easily with correct values within `CardanoTokenRegistry` easily
- `source?` property is nullable to keep the compatibility with the other providers which implement same`AssetProvider` such as `blockfrost`. Not sure what `source.type` in `blockfrost` should be since the tokenMetadata is [fetched](https://github.com/input-output-hk/cardano-js-sdk/blob/d08353bd3e8bc1d1a17db79757de007e82ddede7/packages/blockfrost/src/blockfrostAssetProvider.ts#L64) as part of the whole `blockfrost.assetsById()` response.
- in `cardano-services` is used `AssetInfo<TokenMetadataSource>`, everywhere else is `AssetInfo<unknown>`
- token metadata responses are adjusted based on the interface changes within the tests (wrapper into `data` obj and added `source` obj in `cardano-services`)

**Approach B)** Omitting the metadata from the response in case of 5xx error thrown by the external source (in our current situation - token metadata server)

Following the [CIP-0035](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/core/src/Asset/types/AssetInfo.ts#L25-L28) comment, the second approach could be simply to avoid the `AssetInfo` interface changes and to keep it as it is:
`tokenMetadata?: TokenMetadata | null;` with the only difference is to shallow the `ProviderError` in catch block and to omit `tokenMetadata` in case of network error by the external token server by returning simply `null`.

The downside here is losing the details of the source/origin of that data.


# Important Changes Introduced
