### PR TITLE
test(e2e): wallet nft test was made network agnostic

### DIFF
--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -1,83 +1,173 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Cardano } from '@cardano-sdk/core';
-import { KeyManagement, ObservableWallet, SingleAddressWallet, setupWallet } from '@cardano-sdk/wallet';
-import {
-  assetProviderFactory,
-  chainHistoryProviderFactory,
-  getLogger,
-  keyAgentById,
-  networkInfoProviderFactory,
-  rewardsProviderFactory,
-  stakePoolProviderFactory,
-  txSubmitProviderFactory,
-  utxoProviderFactory
-} from '../../../src/factories';
-import { combineLatest, filter, firstValueFrom, map, of } from 'rxjs';
+import { KeyManagement, SingleAddressWallet } from '@cardano-sdk/wallet';
+import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
 import { env } from '../environment';
+import { getLogger, getWallet } from '../../../src/factories';
 
 const logger = getLogger(env.LOGGER_MIN_SEVERITY);
 
 describe('SingleAddressWallet.assets/nft', () => {
-  let wallet: ObservableWallet;
+  const TOKEN_METADATA_1_INDEX = 0;
+  const TOKEN_METADATA_2_INDEX = 1;
+  const TOKEN_BRUN_INDEX = 2;
+
+  let wallet: SingleAddressWallet;
+  let policySigner: KeyManagement.TransactionSigner;
+  let policyId: Cardano.PolicyId;
+  let policyScript: Cardano.NativeScript;
+  let assetIds: Cardano.AssetId[];
+  let fingerprints: Cardano.AssetFingerprint[];
+  const assetNames = ['4e46542d66696c6573', '4e46542d303031', '4e46542d303032'];
+
+  let walletAddress: Cardano.Address;
 
   beforeAll(async () => {
-    ({ wallet } = await setupWallet({
-      createKeyAgent: async (dependencies) => {
-        const createKeyAgent = await keyAgentById(0, env.KEY_MANAGEMENT_PROVIDER, env.KEY_MANAGEMENT_PARAMS);
-        const keyAgent = await createKeyAgent(dependencies);
-        keyAgent.knownAddresses$ = of([
-          {
-            accountIndex: 0,
-            address: Cardano.Address(
-              // eslint-disable-next-line max-len
-              'addr_test1qpapna8hhj2hx2q2s9mdp7995a3hgundyvvvj0v0yq68lt8e6dgndgyep9stycsnejcnu8vm7a6dtqqhmf362z7fy5ksg46rum'
-            ),
-            index: 0,
-            networkId: Cardano.NetworkId.testnet,
-            rewardAccount: Cardano.RewardAccount('stake_test1uruax5fk5zvsjc9jvgfuevf7rkdlwax4sqta5ca9p0yj2tg4cf29e'),
-            type: KeyManagement.AddressType.External
-          }
-        ]);
-        return keyAgent;
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+
+    await firstValueFrom(wallet.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)));
+
+    const params = await firstValueFrom(wallet.genesisParameters$);
+
+    const keyAgent = await KeyManagement.InMemoryKeyAgent.fromBip39MnemonicWords(
+      {
+        getPassword: async () => Buffer.from(''),
+        mnemonicWords: KeyManagement.util.generateMnemonicWords(),
+        networkId: params.networkId
       },
-      createWallet: async (keyAgent) =>
-        new SingleAddressWallet(
-          {
-            name: 'Test Wallet'
-          },
-          {
-            assetProvider: await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS, logger),
-            chainHistoryProvider: await chainHistoryProviderFactory.create(
-              env.CHAIN_HISTORY_PROVIDER,
-              env.CHAIN_HISTORY_PROVIDER_PARAMS,
-              logger
-            ),
-            keyAgent,
-            logger,
-            networkInfoProvider: await networkInfoProviderFactory.create(
-              env.NETWORK_INFO_PROVIDER,
-              env.NETWORK_INFO_PROVIDER_PARAMS,
-              logger
-            ),
-            rewardsProvider: await rewardsProviderFactory.create(
-              env.REWARDS_PROVIDER,
-              env.REWARDS_PROVIDER_PARAMS,
-              logger
-            ),
-            stakePoolProvider: await stakePoolProviderFactory.create(
-              env.STAKE_POOL_PROVIDER,
-              env.STAKE_POOL_PROVIDER_PARAMS,
-              logger
-            ),
-            txSubmitProvider: await txSubmitProviderFactory.create(
-              env.TX_SUBMIT_PROVIDER,
-              env.TX_SUBMIT_PROVIDER_PARAMS,
-              logger
-            ),
-            utxoProvider: await utxoProviderFactory.create(env.UTXO_PROVIDER, env.UTXO_PROVIDER_PARAMS, logger)
+      { inputResolver: { resolveInputAddress: async () => null } }
+    );
+
+    const pubKey = await keyAgent.derivePublicKey({
+      index: 0,
+      role: KeyManagement.KeyRole.External
+    });
+
+    const keyHash = Cardano.Ed25519KeyHash.fromKey(pubKey);
+
+    policySigner = new KeyManagement.util.KeyAgentTransactionSigner(keyAgent, {
+      index: 0,
+      role: KeyManagement.KeyRole.External
+    });
+
+    policyScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireAllOf,
+      scripts: [
+        {
+          __type: Cardano.ScriptType.Native,
+          keyHash,
+          kind: Cardano.NativeScriptKind.RequireSignature
+        }
+      ]
+    };
+
+    policyId = Cardano.util.nativeScriptPolicyId(policyScript);
+
+    assetIds = [
+      Cardano.AssetId(`${policyId}${assetNames[TOKEN_METADATA_1_INDEX]}`),
+      Cardano.AssetId(`${policyId}${assetNames[TOKEN_METADATA_2_INDEX]}`),
+      Cardano.AssetId(`${policyId}${assetNames[TOKEN_BRUN_INDEX]}`)
+    ];
+
+    const tokens = new Map([
+      [assetIds[TOKEN_METADATA_1_INDEX], 1n],
+      [assetIds[TOKEN_METADATA_2_INDEX], 1n],
+      [assetIds[TOKEN_BRUN_INDEX], 1n]
+    ]);
+
+    fingerprints = [
+      Cardano.AssetFingerprint.fromParts(policyId, Cardano.AssetName(assetNames[TOKEN_METADATA_1_INDEX])),
+      Cardano.AssetFingerprint.fromParts(policyId, Cardano.AssetName(assetNames[TOKEN_METADATA_2_INDEX])),
+      Cardano.AssetFingerprint.fromParts(policyId, Cardano.AssetName(assetNames[TOKEN_BRUN_INDEX]))
+    ];
+
+    walletAddress = (await firstValueFrom(wallet.addresses$))[0].address;
+
+    const txMetadatum = Cardano.util.metadatum.jsonToMetadatum({
+      [policyId.toString()]: {
+        'NFT-001': {
+          image: ['ipfs://some_hash1'],
+          name: 'One',
+          version: '1.0'
+        },
+        'NFT-002': {
+          image: ['ipfs://some_hash2'],
+          name: 'Two',
+          version: '1.0'
+        },
+        'NFT-files': {
+          description: ['NFT with different types of files'],
+          files: [
+            {
+              mediaType: 'video/mp4',
+              name: 'some name',
+              src: ['file://some_video_file']
+            },
+            {
+              mediaType: 'audio/mpeg',
+              name: 'some name',
+              src: ['file://some_audio_file', 'file://another_audio_file']
+            }
+          ],
+          id: '1',
+          image: ['ipfs://somehash'],
+          mediaType: 'image/png',
+          name: 'NFT with files',
+          version: '1.0'
+        }
+      }
+    });
+
+    const auxiliaryData = {
+      body: {
+        blob: new Map([[721n, txMetadatum]])
+      }
+    };
+
+    const txProps = {
+      auxiliaryData,
+      extraSigners: [policySigner],
+      mint: tokens,
+      outputs: new Set([
+        {
+          address: walletAddress,
+          value: {
+            assets: tokens,
+            coins: 50_000_000n
           }
+        }
+      ]),
+      scripts: [policyScript]
+    };
+
+    const unsignedTx = await wallet.initializeTx(txProps);
+
+    const finalizeProps = {
+      auxiliaryData,
+      extraSigners: [policySigner],
+      scripts: [policyScript],
+      tx: unsignedTx
+    };
+
+    const signedTx = await wallet.finalizeTx(finalizeProps);
+    await wallet.submitTx(signedTx);
+
+    // Wait until wallet is aware of the minted tokens.
+    await firstValueFrom(
+      wallet.balance.utxo.total$.pipe(
+        filter(({ assets }) => (assets ? assetIds.every((element) => assets.has(element)) : false))
+      )
+    );
+
+    await firstValueFrom(
+      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+        filter(([assets, balance]) => assets.size === balance.assets?.size),
+        map(([assets]) =>
+          [...assets.values()].filter((asset) => (asset ? asset.nftMetadata?.name === 'NFT with files' : false))
         )
-    }));
+      )
+    );
   });
 
   afterAll(() => {
@@ -91,21 +181,23 @@ describe('SingleAddressWallet.assets/nft', () => {
         map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
       )
     );
-    expect(nfts.find((nft) => nft.nftMetadata!.name === 'One')).toEqual({
-      assetId: 'd1ac67dcebc491ce17635d3d9c8775eb739325ce522f6eac733489aa4e4654303031',
-      fingerprint: 'asset15wsawsn72dw07m33fqp42suze636mv2k4agxvs',
+
+    expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_2_INDEX])).toMatchObject({
+      assetId: assetIds[TOKEN_METADATA_2_INDEX],
+      fingerprint: fingerprints[TOKEN_METADATA_2_INDEX],
       mintOrBurnCount: 1,
-      name: '4e4654303031',
+      name: assetNames[TOKEN_METADATA_2_INDEX],
       nftMetadata: {
         image: ['ipfs://some_hash1'],
         name: 'One',
+        otherProperties: new Map([['version', '1.0']]),
         version: '1.0'
       },
-      policyId: 'd1ac67dcebc491ce17635d3d9c8775eb739325ce522f6eac733489aa',
+      policyId: policyId.toString(),
       quantity: 1n,
       tokenMetadata: null
     });
-    expect(nfts.find((nft) => nft.nftMetadata!.name === 'Two')).toBeDefined();
+    expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_1_INDEX])).toBeDefined();
   });
 
   it('parses CIP-25 NFT metadata with files', async () => {
@@ -115,11 +207,11 @@ describe('SingleAddressWallet.assets/nft', () => {
         map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
       )
     );
-    expect(nfts.find((nft) => nft.nftMetadata!.name === 'NFT with files')).toEqual({
-      assetId: 'e80c05f27dec74e8c04f27bdf711dff8ae03167dda9b7760b7d92cef4e46542d66696c6573',
-      fingerprint: 'asset16w7fcptllh5qfgux8hmp3wymne7xh5y65vxueh',
+    expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_1_INDEX])).toMatchObject({
+      assetId: assetIds[TOKEN_METADATA_1_INDEX],
+      fingerprint: fingerprints[TOKEN_METADATA_1_INDEX],
       mintOrBurnCount: 1,
-      name: '4e46542d66696c6573',
+      name: assetNames[TOKEN_METADATA_1_INDEX],
       nftMetadata: {
         description: ['NFT with different types of files'],
         files: [
@@ -137,12 +229,58 @@ describe('SingleAddressWallet.assets/nft', () => {
         image: ['ipfs://somehash'],
         mediaType: 'image/png',
         name: 'NFT with files',
-        otherProperties: new Map([['id', '1']]),
+        otherProperties: new Map([
+          ['id', '1'],
+          ['version', '1.0']
+        ]),
         version: '1.0'
       },
-      policyId: 'e80c05f27dec74e8c04f27bdf711dff8ae03167dda9b7760b7d92cef',
+      policyId: policyId.toString(),
       quantity: 1n,
       tokenMetadata: null
     });
+  });
+
+  it('supports burning tokens', async () => {
+    const txProps = {
+      extraSigners: [policySigner],
+      mint: new Map([[assetIds[TOKEN_BRUN_INDEX], -1n]]),
+      outputs: new Set([
+        {
+          address: walletAddress,
+          value: {
+            coins: 50_000_000n
+          }
+        }
+      ]),
+      scripts: [policyScript]
+    };
+
+    const unsignedTx = await wallet.initializeTx(txProps);
+
+    const finalizeProps = {
+      extraSigners: [policySigner],
+      scripts: [policyScript],
+      tx: unsignedTx
+    };
+
+    const signedTx = await wallet.finalizeTx(finalizeProps);
+    await wallet.submitTx(signedTx);
+
+    // Wait until wallet is aware of the burned token.
+    await firstValueFrom(
+      wallet.balance.utxo.total$.pipe(
+        filter(({ assets }) => (assets ? !assets.has(assetIds[TOKEN_BRUN_INDEX]) : false))
+      )
+    );
+
+    const nfts = await firstValueFrom(
+      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+        filter(([assets, balance]) => assets.size === balance.assets?.size),
+        map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
+      )
+    );
+
+    expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_BRUN_INDEX])).toBeUndefined();
   });
 });


### PR DESCRIPTION
# Context

The NFT test on the wallet e2e test suite is querying data in the old test network. We must make this test network agnostic to run in any test and production environment.

# Proposed Solution

The test must mints the tokens is going to query
