### PR TITLE
chore: add e2e publish config

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -59,6 +59,9 @@
     "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
   ],
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@cardano-foundation/ledgerjs-hw-app-cardano": "5.0.0",
     "@cardano-ogmios/client": "^5.5.2",


### PR DESCRIPTION
# Context

`e2e` package is not being published

# Proposed Solution

[chore(e2e): add package.json publishConfig](https://github.com/input-output-hk/cardano-js-sdk/commit/109ffdc212bdd86ce8ad5b2b302399f5d2f9a7aa)

# Important Changes Introduced

[chore: regenerate yarn-project.nix](https://github.com/input-output-hk/cardano-js-sdk/commit/159a89a0b83e3dabb03dc3a121d9ac94a6f6e4ed)