### PR TITLE
fix: Remove nullability of ProtocolParametersBabbage properties

### DIFF
--- a/packages/blockfrost/src/BlockfrostToCore.ts
+++ b/packages/blockfrost/src/BlockfrostToCore.ts
@@ -27,15 +27,36 @@ export const BlockfrostToCore = {
     blockfrost: Responses['epoch_param_content']
   ): ProtocolParametersRequiredByWallet => ({
     coinsPerUtxoByte: Number(blockfrost.coins_per_utxo_word),
+    collateralPercentage: Number(blockfrost.collateral_percent),
+    decentralizationParameter: String(blockfrost.decentralisation_param),
+    desiredNumberOfPools: blockfrost.n_opt,
+    maxBlockBodySize: blockfrost.max_block_size,
+    maxBlockHeaderSize: blockfrost.max_block_header_size,
     maxCollateralInputs: Number(blockfrost.max_collateral_inputs),
+    maxExecutionUnitsPerBlock: {
+      memory: Number(blockfrost.max_block_ex_mem),
+      steps: Number(blockfrost.max_block_ex_mem)
+    },
+    maxExecutionUnitsPerTransaction: {
+      memory: Number(blockfrost.max_tx_ex_mem),
+      steps: Number(blockfrost.max_tx_ex_steps)
+    },
     maxTxSize: Number(blockfrost.max_tx_size),
     maxValueSize: Number(blockfrost.max_val_size),
     minFeeCoefficient: blockfrost.min_fee_a,
     minFeeConstant: blockfrost.min_fee_b,
     minPoolCost: Number(blockfrost.min_pool_cost),
+    monetaryExpansion: String(blockfrost.rho),
     poolDeposit: Number(blockfrost.pool_deposit),
+    poolInfluence: String(blockfrost.a0),
+    poolRetirementEpochBound: blockfrost.e_max,
+    prices: {
+      memory: Number(blockfrost.price_mem),
+      steps: Number(blockfrost.price_step)
+    },
     protocolVersion: { major: blockfrost.protocol_major_ver, minor: blockfrost.protocol_minor_ver },
-    stakeKeyDeposit: Number(blockfrost.key_deposit)
+    stakeKeyDeposit: Number(blockfrost.key_deposit),
+    treasuryExpansion: String(blockfrost.tau)
   }),
 
   inputFromUtxo: (address: string, utxo: BlockfrostUtxo): BlockfrostInput => ({

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -42,21 +42,57 @@ export const toWalletProtocolParams = ({
   protocol_major,
   protocol_minor,
   min_fee_a,
-  min_fee_b
+  min_fee_b,
+  max_block_size,
+  max_bh_size,
+  optimal_pool_count,
+  influence,
+  monetary_expand_rate,
+  treasury_growth_rate,
+  decentralisation,
+  collateral_percent,
+  price_mem,
+  price_step,
+  max_tx_ex_mem,
+  max_tx_ex_steps,
+  max_block_ex_mem,
+  max_block_ex_steps,
+  max_epoch
 }: WalletProtocolParamsModel): ProtocolParametersRequiredByWallet => ({
   coinsPerUtxoByte: Number(coins_per_utxo_size),
+  collateralPercentage: collateral_percent,
+  decentralizationParameter: String(decentralisation),
+  desiredNumberOfPools: optimal_pool_count,
+  maxBlockBodySize: max_block_size,
+  maxBlockHeaderSize: max_bh_size,
   maxCollateralInputs: max_collateral_inputs,
+  maxExecutionUnitsPerBlock: {
+    memory: Number(max_block_ex_mem),
+    steps: Number(max_block_ex_steps)
+  },
+  maxExecutionUnitsPerTransaction: {
+    memory: Number(max_tx_ex_mem),
+    steps: Number(max_tx_ex_steps)
+  },
   maxTxSize: max_tx_size,
   maxValueSize: Number(max_val_size),
   minFeeCoefficient: min_fee_a,
   minFeeConstant: min_fee_b,
   minPoolCost: Number(min_pool_cost),
+  monetaryExpansion: String(monetary_expand_rate),
   poolDeposit: Number(pool_deposit),
+  poolInfluence: String(influence),
+  poolRetirementEpochBound: max_epoch,
+  prices: {
+    memory: price_mem,
+    steps: price_step
+  },
   protocolVersion: {
     major: protocol_major,
     minor: protocol_minor
   },
-  stakeKeyDeposit: Number(key_deposit)
+  stakeKeyDeposit: Number(key_deposit),
+  treasuryExpansion: String(treasury_growth_rate)
 });
 
 export const toGenesisParams = (genesis: GenesisData): Cardano.CompactGenesis => ({

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -56,7 +56,8 @@ export const findLedgerTip = `
 export const findCurrentWalletProtocolParams = `
     SELECT 
     min_fee_a, 
-    min_fee_b, max_tx_size, 
+    min_fee_b, 
+    max_tx_size,
     key_deposit, 
     pool_deposit, 
     protocol_major, 
@@ -64,7 +65,22 @@ export const findCurrentWalletProtocolParams = `
     min_pool_cost, 
     coins_per_utxo_size, 
     max_val_size, 
-    max_collateral_inputs
+    max_collateral_inputs,
+    max_block_size,
+    max_bh_size,
+    optimal_pool_count,
+    influence,
+    monetary_expand_rate,
+    treasury_growth_rate,
+    decentralisation,
+    collateral_percent,
+    price_mem,
+    price_step,
+    max_tx_ex_mem,
+    max_tx_ex_steps,
+    max_block_ex_mem,
+    max_block_ex_steps,
+    max_epoch
     FROM public.epoch_param
     ORDER BY epoch_no DESC NULLS LAST
     LIMIT 1;

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
@@ -38,6 +38,21 @@ export interface WalletProtocolParamsModel {
   min_fee_a: number;
   min_fee_b: number;
   max_collateral_inputs: number;
+  max_block_size: number;
+  max_bh_size: number;
+  optimal_pool_count: number;
+  influence: number;
+  monetary_expand_rate: number;
+  treasury_growth_rate: number;
+  decentralisation: number;
+  collateral_percent: number;
+  price_mem: number;
+  price_step: number;
+  max_tx_ex_mem: string;
+  max_tx_ex_steps: string;
+  max_block_ex_mem: string;
+  max_block_ex_steps: string;
+  max_epoch: number;
 }
 
 export interface GenesisData {

--- a/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
+++ b/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
@@ -7,16 +7,31 @@ exports[`NetworkInfoBuilder queryCirculatingSupply query circulating supply 1`] 
 exports[`NetworkInfoBuilder queryCurrentWalletProtocolParams query wallet protocol params from current epoch 1`] = `
 Object {
   "coins_per_utxo_size": "34482",
+  "collateral_percent": 150,
+  "decentralisation": 0,
+  "influence": 0.3,
   "key_deposit": "2000000",
+  "max_bh_size": 1100,
+  "max_block_ex_mem": "80000000",
+  "max_block_ex_steps": "40000000000",
+  "max_block_size": 98304,
   "max_collateral_inputs": 3,
+  "max_epoch": 18,
+  "max_tx_ex_mem": "16000000",
+  "max_tx_ex_steps": "10000000000",
   "max_tx_size": 16384,
   "max_val_size": "5000",
   "min_fee_a": 44,
   "min_fee_b": 155381,
   "min_pool_cost": "340000000",
+  "monetary_expand_rate": 0.003,
+  "optimal_pool_count": 500,
   "pool_deposit": "500000000",
+  "price_mem": 0.0577,
+  "price_step": 0.0000721,
   "protocol_major": 6,
   "protocol_minor": 0,
+  "treasury_growth_rate": 0.2,
 }
 `;
 

--- a/packages/cip2/src/types.ts
+++ b/packages/cip2/src/types.ts
@@ -110,7 +110,7 @@ export interface InputSelector {
 }
 
 export type ProtocolParametersForInputSelection = Pick<
-  Cardano.ProtocolParametersBabbage,
+  Cardano.ProtocolParameters,
   'coinsPerUtxoByte' | 'maxTxSize' | 'maxValueSize' | 'minFeeCoefficient' | 'minFeeConstant'
 >;
 

--- a/packages/core/src/Cardano/types/ProtocolParameters.ts
+++ b/packages/core/src/Cardano/types/ProtocolParameters.ts
@@ -6,9 +6,14 @@ export interface ProtocolVersion {
   minor: number;
   patch?: number;
 }
-export type CostModels = CostModel[];
 
-export type CostModel = number[];
+export type ModelKey = string;
+
+export type CostModel = {
+  [k: ModelKey]: number;
+};
+
+export type CostModels = CostModel[];
 
 export interface Prices {
   memory: number;
@@ -24,27 +29,73 @@ export interface ValidityInterval {
   invalidHereafter?: Slot;
 }
 
-export interface ProtocolParametersBabbage {
-  minFeeCoefficient?: number;
-  minFeeConstant?: number;
-  maxBlockBodySize?: number;
-  maxBlockHeaderSize?: number;
-  maxTxSize?: number;
-  stakeKeyDeposit?: number;
-  poolDeposit?: number;
-  poolRetirementEpochBound?: number;
-  desiredNumberOfPools?: number;
-  poolInfluence?: number;
-  monetaryExpansion?: number;
-  treasuryExpansion?: number;
-  minPoolCost?: number;
-  coinsPerUtxoByte?: number;
-  maxValueSize?: number;
-  collateralPercentage?: number;
-  maxCollateralInputs?: number;
-  protocolVersion?: ProtocolVersion;
-  costModels?: CostModels;
-  prices?: Prices;
-  maxExecutionUnitsPerTransaction?: ExUnits;
-  maxExecutionUnitsPerBlock?: ExUnits;
+export interface TxFeePolicy {
+  coefficient: string;
+  constant: number;
 }
+
+export interface SoftforkRule {
+  initThreshold: string;
+  minThreshold: string;
+  decrementThreshold: string;
+}
+
+type ProtocolParametersByron = {
+  heavyDlgThreshold: string;
+  maxBlockSize: number;
+  maxHeaderSize: number;
+  maxProposalSize: number;
+  maxTxSize: number;
+  mpcThreshold: string;
+  scriptVersion: number;
+  slotDuration: number;
+  unlockStakeEpoch: number;
+  updateProposalThreshold: string;
+  updateProposalTimeToLive: number;
+  updateVoteThreshold: string;
+  txFeePolicy: TxFeePolicy;
+  softforkRule: SoftforkRule;
+};
+
+type NewProtocolParamsInShelley = {
+  minFeeCoefficient: number;
+  minFeeConstant: number;
+  maxBlockBodySize: number;
+  maxBlockHeaderSize: number;
+  stakeKeyDeposit: number;
+  poolDeposit: number | null;
+  poolRetirementEpochBound: number;
+  desiredNumberOfPools: number;
+  poolInfluence: string;
+  monetaryExpansion: string;
+  treasuryExpansion: string;
+  decentralizationParameter: string;
+  minUtxoValue: number;
+  minPoolCost: number;
+  extraEntropy: 'neutral' | string;
+  protocolVersion: ProtocolVersion;
+};
+
+type ShelleyProtocolParams = Pick<ProtocolParametersByron, 'maxTxSize'> & NewProtocolParamsInShelley;
+
+type NewProtocolParamsInAlonzo = {
+  coinsPerUtxoWord: number;
+  maxValueSize: number;
+  collateralPercentage: number;
+  maxCollateralInputs: number;
+  costModels: CostModels;
+  prices: Prices;
+  maxExecutionUnitsPerTransaction: ExUnits;
+  maxExecutionUnitsPerBlock: ExUnits;
+};
+
+type AlonzoProtocolParams = Omit<ShelleyProtocolParams, 'minUtxoValue'> & NewProtocolParamsInAlonzo;
+
+type NewProtocolParamsInBabbage = {
+  coinsPerUtxoByte: number;
+};
+
+type BabbageProtocolParameters = Omit<AlonzoProtocolParams, 'coinsPerUtxoWord' | 'extraEntropy'> &
+  NewProtocolParamsInBabbage;
+
+export type ProtocolParameters = BabbageProtocolParameters;

--- a/packages/core/src/Cardano/types/Script.ts
+++ b/packages/core/src/Cardano/types/Script.ts
@@ -188,14 +188,14 @@ export type NativeScript =
  */
 export enum PlutusLanguageVersion {
   /**
-   * PlutusV1 was the initial version of Plutus, introduced in the Alonzo hard fork.
+   * V1 was the initial version of Plutus, introduced in the Alonzo hard fork.
    */
-  PlutusV1 = 1,
+  V1 = 0,
 
   /**
-   * PlutusV2 was introduced in the Vasil hard fork.
+   * V2 was introduced in the Vasil hard fork.
    *
-   * The main changes in PlutusV2 were to the interface to scripts. The ScriptContext was extended
+   * The main changes in V2 of Plutus were to the interface to scripts. The ScriptContext was extended
    * to include the following information:
    *
    *  - The full “redeemers” structure, which contains all the redeemers used in the transaction
@@ -203,7 +203,7 @@ export enum PlutusLanguageVersion {
    *  - Inline datums in the transaction (proposed in CIP-32)
    *  - Reference scripts in the transaction (proposed in CIP-33)
    */
-  PlutusV2 = 2
+  V2 = 1
 }
 
 /**

--- a/packages/core/src/Provider/NetworkInfoProvider/types.ts
+++ b/packages/core/src/Provider/NetworkInfoProvider/types.ts
@@ -1,20 +1,6 @@
 import { Cardano, EraSummary, Provider } from '../..';
 
-export type ProtocolParametersRequiredByWallet = Required<
-  Pick<
-    Cardano.ProtocolParametersBabbage,
-    | 'coinsPerUtxoByte'
-    | 'maxTxSize'
-    | 'maxValueSize'
-    | 'stakeKeyDeposit'
-    | 'maxCollateralInputs'
-    | 'minFeeCoefficient'
-    | 'minFeeConstant'
-    | 'minPoolCost'
-    | 'poolDeposit'
-    | 'protocolVersion'
-  >
->;
+export type ProtocolParametersRequiredByWallet = Omit<Cardano.ProtocolParameters, 'costModels'>;
 
 export type SupplySummary = {
   circulating: Cardano.Lovelace;


### PR DESCRIPTION
# Context

The type we’ve been inheriting from Ogmios as described by it’s name is invalid:

[refactor: removed Ogmios schema package dependency by AngelCastilloB · Pull Request #388 · input-output-hk/cardano-js-sdk](https://github.com/input-output-hk/cardano-js-sdk/pull/388#discussion_r953396868) 

The reason for this loose nullability is due to context within Ogmios. It’s the type specified for both protocol update objects and the current parameters, which, while it works, is not an accurate model.

We should make each parameter non-nullable, remove the now unnecessary [casting](https://github.com/input-output-hk/cardano-js-sdk/blob/141f2caa1b845d73616437bc9b6ddbd33268f3d0/packages/core/src/Provider/NetworkInfoProvider/types.ts#L3), and fix any tests that are only checking for a limited set of properties. In the future, if needing to model the update type,  we can define it as ProtocolParametersBabbageUpdate = Partial<ProtocolParametersBabbage>
# Proposed Solution

To introduce a more declarative way of all parameter updates in time between eras so we can benefit by following the protocol parameter updates in time easily

The goal with this approach is to have a type that represents the new params being introduced, which then represents the (current) protocol params when composed with the prior era, considering deprecations

# Important Changes Introduced

- (core): compose new `ProtocolParameters` type composed by prev eras
- (cardano-services): extend `db-sync` query with current protocol params
- (cardano-services): align DB model type and mappings
- (cardano-services): update snapshot tests with all protocol params
- (blockfrost): update `currentWalletProtocolParameters` mapping

# Note:
Keep an eye on that almost all protocol parameters are marked with `Nullable...` with is equal to `type` | `null` in Ogmios schema, for instance [ProtocolParametersBabbage](https://github.com/CardanoSolutions/ogmios/blob/master/clients/TypeScript/packages/schema/src/index.ts#L1244-L1267) which makes me think that potentially some of them could be fetched as `null` in theory which is against our ProtocolParameters type with all required fields on it. 
This is about only the ts types, but not sure if some of the data sources (`blockfrost` or `db-sync`) return `null` as value for some of the protocol parameters.