### PR TITLE
fix: invalid epoch number calculations when using testnet auto-upgrading configuration

### DIFF
--- a/packages/core/test/util/slotCalc.test.ts
+++ b/packages/core/test/util/slotCalc.test.ts
@@ -54,6 +54,40 @@ describe('slotCalc utils', () => {
   });
 
   describe('slotEpochCalc', () => {
+    describe('testnet with auto-upgrading eras', () => {
+      it('correctly computes epoch with multiple summaries starting from genesis', () => {
+        const eraSummaries: EraSummary[] = [
+          {
+            parameters: { epochLength: 100, slotLength: 3 },
+            start: { slot: 0, time: new Date(1_563_999_616_000) }
+          },
+          { parameters: { epochLength: 200, slotLength: 10 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
+          { parameters: { epochLength: 200, slotLength: 1 }, start: { slot: 0, time: new Date(1_563_999_616_000) } }
+        ];
+        const slotEpochCalc: SlotEpochCalc = createSlotEpochCalc(eraSummaries);
+
+        expect(slotEpochCalc(1031)).toEqual(5);
+      });
+      it('correctly computes epoch with summaries indicating an upgrade after genesis, from the same slotNo', () => {
+        const eraSummaries: EraSummary[] = [
+          {
+            parameters: { epochLength: 100, slotLength: 3 },
+            start: { slot: 0, time: new Date(1_563_999_616_000) }
+          },
+          {
+            parameters: { epochLength: 200, slotLength: 10 },
+            start: { slot: 301, time: new Date(1_563_999_716_000) }
+          },
+          {
+            parameters: { epochLength: 200, slotLength: 1 },
+            start: { slot: 301, time: new Date(1_563_999_716_000) }
+          }
+        ];
+        const slotEpochCalc: SlotEpochCalc = createSlotEpochCalc(eraSummaries);
+
+        expect(slotEpochCalc(1031)).toEqual(6);
+      });
+    });
     describe('testnet', () => {
       const slotEpochCalc: SlotEpochCalc = createSlotEpochCalc(testnetEraSummaries);
 


### PR DESCRIPTION
# Context
It's possible to configure when particular eras are upgraded, without an upgrade proposal, in testnet `cardano-node` configuration, including the specification of multiple eras in the same epoch.

Both of these configs are valid:
```json
  "TestAllegraHardForkAtEpoch": 0,
  "TestAlonzoHardForkAtEpoch": 0,
  "TestEnableDevelopmentHardForkEras": true,
  "TestMaryHardForkAtEpoch": 0,
  "TestShelleyHardForkAtEpoch": 0,
```

```json
  "TestAllegraHardForkAtEpoch": 2,
  "TestAlonzoHardForkAtEpoch": 4,
  "TestEnableDevelopmentHardForkEras": true,
  "TestMaryHardForkAtEpoch": 3,
  "TestShelleyHardForkAtEpoch": 1,
```


# Proposed Solution
Filter the era summaries that represent eras effectively being skipped, which is evidenced by a later era starting in the same slot.
