### PR TITLE
fix: correct hardcoded era summary offset

### DIFF
--- a/packages/core/src/util/slotCalc.ts
+++ b/packages/core/src/util/slotCalc.ts
@@ -33,7 +33,7 @@ export const testnetEraSummaries: EraSummary[] = [
   { parameters: { epochLength: 21_600, slotLength: 20_000 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
   {
     parameters: { epochLength: 432_000, slotLength: 1000 },
-    start: { slot: 1_598_400, time: new Date(1_595_964_016_000) }
+    start: { slot: 1_598_400, time: new Date(1_595_967_616_000) }
   }
 ];
 

--- a/packages/core/test/util/slotCalc.test.ts
+++ b/packages/core/test/util/slotCalc.test.ts
@@ -34,13 +34,16 @@ describe('slotCalc utils', () => {
         expect(slotTimeCalc(1_598_399)).toEqual(new Date(1_595_967_596_000)));
 
       it('correctly computes date of the 1st Shelley block', () =>
-        expect(slotTimeCalc(1_598_400)).toEqual(new Date(1_595_964_016_000)));
+        expect(slotTimeCalc(1_598_400)).toEqual(new Date('2020/07/28 20:20:16 UTC')));
 
       it('correctly computes date of the 2nd Shelley block', () =>
-        expect(slotTimeCalc(1_598_420)).toEqual(new Date(1_595_964_036_000)));
+        expect(slotTimeCalc(1_598_420)).toEqual(new Date('2020/07/28 20:20:36 UTC')));
 
       it('correctly computes date of some Shelley block', () =>
-        expect(slotTimeCalc(8_078_371)).toEqual(new Date(1_602_443_987_000)));
+        expect(slotTimeCalc(8_078_371)).toEqual(new Date(new Date('2020/10/11 20:19:47 UTC'))));
+
+      it('correctly computes date of some Alonzo block', () =>
+        expect(slotTimeCalc(67_951_416)).toEqual(new Date('2022-09-04 19:43:52 UTC')));
 
       it('throws with invalid slot', () => expect(() => slotTimeCalc(-1)).toThrowError(EraSummaryError));
     });


### PR DESCRIPTION
# Context

Hardcoded `testnetEraSummaries` have wrong `{start: {time}}` of shelley era (offset by 1h)

# Proposed Solution

8489da9da98e90e9e3a2198ee19b662ed3475772