### PR TITLE
fix: destroy messenger

### DIFF
--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -325,7 +325,7 @@ export class SingleAddressWallet implements ObservableWallet {
 
     this.utxo = createUtxoTracker({
       addresses$,
-      logger: contextLogger(logger, 'utxo'),
+      logger: contextLogger(this.#logger, 'utxo'),
       retryBackoffConfig,
       stores,
       tipBlockHeight$,
@@ -352,7 +352,7 @@ export class SingleAddressWallet implements ObservableWallet {
       createAssetsTracker({
         assetProvider: this.assetProvider,
         balanceTracker: this.balance,
-        logger: contextLogger(logger, 'assets$'),
+        logger: contextLogger(this.#logger, 'assets$'),
         retryBackoffConfig
       }),
       stores.assets

--- a/packages/web-extension/src/cip30/initializeBackgroundScript.ts
+++ b/packages/web-extension/src/cip30/initializeBackgroundScript.ts
@@ -23,7 +23,7 @@ export const initializeBackgroundScript = (
   const authenticator = exposeAuthenticatorApi(props, dependencies);
   const wallet = exposeWalletApi(props, dependencies);
   return () => {
-    wallet.unsubscribe();
-    authenticator.unsubscribe();
+    wallet.shutdown();
+    authenticator.shutdown();
   };
 };

--- a/packages/web-extension/src/messaging/index.ts
+++ b/packages/web-extension/src/messaging/index.ts
@@ -63,14 +63,19 @@ const _backgroundConsumeRemoteApi: ConsumeApi = <T extends object>(
 
 /**
  * Bind an API object to handle messages from other parts of extension.
- * Only compatible with interfaces where all methods return a Promise.
+ * Only compatible with interfaces where all members are either:
+ * - Methods that return a Promise
+ * - Observable
+ *
  * This can only used once per channelName per process.
  */
 export const exposeApi: ExposeApi = isInBackgroundProcess ? _backgroundExposeApi : _nonBackgroundExposeApi;
 
 /**
  * Create a client to remote api, exposed via `exposeApi`.
- * Only compatible with interfaces where all methods return a Promise.
+ * Only compatible with interfaces where all members are either:
+ * - Methods that return a Promise
+ * - Observable
  */
 export const consumeRemoteApi: ConsumeApi = isInBackgroundProcess
   ? _backgroundConsumeRemoteApi

--- a/packages/web-extension/src/messaging/remoteApi.ts
+++ b/packages/web-extension/src/messaging/remoteApi.ts
@@ -232,6 +232,8 @@ export const bindObservableChannels = <API extends object>(
  * Caches and replays (1) last emission upon remote subscription (unless item === null).
  *
  * In addition to errors thrown by the underlying API, methods can throw TypeError
+ *
+ * @returns object that can be used to destroy all ports (destroys 'messenger' dependency)
  */
 export const exposeMessengerApi = <API extends object>(
   { api, properties }: ExposeApiProps<API>,
@@ -270,6 +272,7 @@ export const exposeMessengerApi = <API extends object>(
       nestedObjChannelsSubscription.unsubscribe();
       observableChannelsSubscription.unsubscribe();
       methodHandlerSubscription.unsubscribe();
+      dependencies.messenger.destroy();
     }
   };
 };

--- a/packages/web-extension/src/messaging/types.ts
+++ b/packages/web-extension/src/messaging/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Events, Runtime } from 'webextension-polyfill';
-import { GetErrorPrototype } from '@cardano-sdk/util';
+import { GetErrorPrototype, Shutdown } from '@cardano-sdk/util';
 import { Logger } from 'ts-log';
 import { Observable } from 'rxjs';
 
@@ -122,13 +122,12 @@ export interface ConsumeRemoteApiOptions<T> {
   getErrorPrototype?: GetErrorPrototype;
 }
 
-export interface Messenger {
+export interface Messenger extends Shutdown {
   channel: ChannelName;
   connect$: Observable<MinimalPort>;
   postMessage(message: unknown): Observable<void>;
   message$: Observable<PortMessage>;
   deriveChannel(path: string): Messenger;
-  destroy(): void;
 }
 
 export interface MessengerApiDependencies {

--- a/packages/web-extension/src/messaging/types.ts
+++ b/packages/web-extension/src/messaging/types.ts
@@ -78,6 +78,10 @@ export interface PortMessage<Data = unknown> {
 }
 
 export enum RemoteApiPropertyType {
+  /**
+   * Methods might throw RemoteApiShutdownError when attempting
+   * to call a method on remote api object that was previously shutdown.
+   */
   MethodReturningPromise,
   /**
    * Exposing this observable:

--- a/packages/web-extension/test/messaging/remoteApi.test.ts
+++ b/packages/web-extension/test/messaging/remoteApi.test.ts
@@ -10,7 +10,7 @@ import {
   deriveChannelName,
   exposeMessengerApi
 } from '../../src/messaging';
-import { Observable, Subject, firstValueFrom, map, of, tap, throwError, timer, toArray } from 'rxjs';
+import { EmptyError, Observable, Subject, firstValueFrom, map, of, tap, throwError, timer, toArray } from 'rxjs';
 import { dummyLogger } from 'ts-log';
 import memoize from 'lodash/memoize';
 
@@ -146,7 +146,8 @@ const setUp = (someNumbers$: Observable<bigint> = of(0n), nestedSomeNumbers$ = o
       consumer.shutdown();
     },
     consumer,
-    hostMessenger
+    hostMessenger,
+    hostSubscription
   };
 };
 
@@ -164,6 +165,12 @@ describe('remoteApi', () => {
     sut = setUp();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((sut.consumer as any).addTwo).toBeUndefined();
+  });
+
+  it('unsubscribing exposed object destroys underlying messenger', async () => {
+    sut = setUp();
+    sut.hostSubscription.unsubscribe();
+    await expect(firstValueFrom(sut.hostMessenger.message$)).rejects.toThrowError(EmptyError);
   });
 
   describe('methods returning promise', () => {

--- a/packages/web-extension/test/messaging/remoteApi.test.ts
+++ b/packages/web-extension/test/messaging/remoteApi.test.ts
@@ -6,6 +6,7 @@ import {
   PortMessage,
   RemoteApiProperties,
   RemoteApiPropertyType,
+  RemoteApiShutdownError,
   consumeMessengerRemoteApi,
   deriveChannelName,
   exposeMessengerApi
@@ -220,6 +221,11 @@ describe('remoteApi', () => {
       //     }, 1);
       //   });
       // });
+    });
+
+    it('throws RemoteApiShutdownError when the remote object shutdown method is called more than once', async () => {
+      sut.consumer.shutdown();
+      await expect(sut.consumer.addOne(1n)).rejects.toThrowError(RemoteApiShutdownError);
     });
   });
 


### PR DESCRIPTION
# Context

Unsubscribing exposed web-extension object keeps a port open.

# Proposed Solution

[fix(web-extension): destroy messenger ports upon unsubscribing exposed object](https://github.com/input-output-hk/cardano-js-sdk/commit/905087b54218e061ae1e19a6377f1a262f8b47d2) 

# Important Changes Introduced

Some general improvements:
- [fix(wallet): set correct context for utxo and assets tracker loggers](https://github.com/input-output-hk/cardano-js-sdk/commit/7eaea77b8e3a6cc5342e5e8486e965fdb1f3ad99)
- [fix(web-extension): encapsulate potential EmptyError with a new RemoteApiShutdownError](https://github.com/input-output-hk/cardano-js-sdk/commit/d439f271a1784951d7aee72c5615d9ddee3a228d) 
- [refactor(web-extension)!: rename messaging destroy->shutdown for consistent naming](https://github.com/input-output-hk/cardano-js-sdk/commit/caec612382e09993f51f39f5feebad728360ea1a)