### PR TITLE
Feat/tx builder stake key dereg

### DIFF
--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -100,11 +100,11 @@ describe('SingleAddressWallet/delegation', () => {
     // Make a 1st tx with key registration (if not already registered) and stake delegation
     // Also send some coin to another wallet
     const destAddresses = (await firstValueFrom(destWallet.addresses$))[0].address;
-    const txBuilder = await buildTx(sourceWallet).delegate(poolId);
+    const txBuilder = buildTx(sourceWallet);
     const maybeValidTxOut = await txBuilder.buildOutput().address(destAddresses).coin(tx1OutputCoins).build();
     assertTxOutIsValid(maybeValidTxOut);
 
-    const tx = await txBuilder.addOutput(maybeValidTxOut.txOut).build();
+    const tx = await txBuilder.addOutput(maybeValidTxOut.txOut).delegate(poolId).build();
     assertTxIsValid(tx);
 
     const signedTx = await tx.sign();

--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -99,7 +99,7 @@ describe('SingleAddressWallet/delegation', () => {
     // Make a 1st tx with key registration (if not already registered) and stake delegation
     // Also send some coin to another wallet
     const destAddresses = (await firstValueFrom(destWallet.addresses$))[0].address;
-    const txBuilder = buildTx(sourceWallet);
+    const txBuilder = buildTx({ logger, observableWallet: sourceWallet });
 
     const tx = await txBuilder
       .addOutput(txBuilder.buildOutput().address(destAddresses).coin(tx1OutputCoins).toTxOut())
@@ -148,7 +148,7 @@ describe('SingleAddressWallet/delegation', () => {
     }
 
     // Make a 2nd tx with key deregistration
-    const txDeregister = await buildTx(sourceWallet).delegate().build();
+    const txDeregister = await buildTx({ logger, observableWallet: sourceWallet }).delegate().build();
     assertTxIsValid(txDeregister);
     const txDeregisterSigned = await txDeregister.sign();
     await txDeregisterSigned.submit();

--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -3,7 +3,7 @@ import { Awaited } from '@cardano-sdk/util';
 import { Cardano } from '@cardano-sdk/core';
 import { ObservableWallet, StakeKeyStatus, buildTx } from '@cardano-sdk/wallet';
 import { TX_TIMEOUT, firstValueFromTimed, waitForWalletStateSettle } from '../util';
-import { assertTxIsValid, assertTxOutIsValid } from '../../../../wallet/test/util';
+import { assertTxIsValid } from '../../../../wallet/test/util';
 import { env } from '../environment';
 import { getWallet } from '../../../src/factories';
 import { logger } from '@cardano-sdk/util-dev';
@@ -100,10 +100,11 @@ describe('SingleAddressWallet/delegation', () => {
     // Also send some coin to another wallet
     const destAddresses = (await firstValueFrom(destWallet.addresses$))[0].address;
     const txBuilder = buildTx(sourceWallet);
-    const maybeValidTxOut = await txBuilder.buildOutput().address(destAddresses).coin(tx1OutputCoins).build();
-    assertTxOutIsValid(maybeValidTxOut);
 
-    const tx = await txBuilder.addOutput(maybeValidTxOut.txOut).delegate(poolId).build();
+    const tx = await txBuilder
+      .addOutput(txBuilder.buildOutput().address(destAddresses).coin(tx1OutputCoins).toTxOut())
+      .delegate(poolId)
+      .build();
     assertTxIsValid(tx);
 
     const signedTx = await tx.sign();

--- a/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
@@ -22,7 +22,7 @@ describe('SingleAddressWallet/metadata', () => {
     const walletUtil = createWalletUtil(wallet);
     const { minimumCoin } = await walletUtil.validateValue({ coins: 0n });
 
-    const builtTx = await buildTx(wallet)
+    const builtTx = await buildTx({ logger, observableWallet: wallet })
       .addOutput({ address: ownAddress, value: { coins: minimumCoin } })
       .setMetadata(metadata)
       .build();

--- a/packages/wallet/src/TxBuilder/OutputBuilder.ts
+++ b/packages/wallet/src/TxBuilder/OutputBuilder.ts
@@ -11,6 +11,14 @@ import {
 import { OutputValidation } from '../types';
 import { OutputValidator } from '../services';
 
+/** Properties needed to construct an {@link ObservableWalletTxOutputBuilder} */
+export interface OutputBuilderProps {
+  /** This validator is normally created and passed as an arg here by the {@link TxBuilder.buildOutput} method */
+  outputValidator: OutputValidator;
+  /** Optional partial transaction output to use for initialization. */
+  txOut?: PartialTxOut;
+}
+
 /** Determines if the `PartialTxOut` arg have at least an address and coins. */
 const isViableTxOut = (txOut: PartialTxOut): txOut is Cardano.TxOut => !!(txOut?.address && txOut?.value?.coins);
 
@@ -31,22 +39,17 @@ const toOutputValidationError = (
 };
 
 /**
- * `OutputBuilder` implementation based on the minimal wallet type.
+ * `OutputBuilder` implementation based on the minimal wallet type: {@link ObservableWalletTxBuilderDependencies}.
  */
 export class ObservableWalletTxOutputBuilder implements OutputBuilder {
   /**
-   * Transaction output that is updated by `OutputBuilder` methods.
+   * Transaction output that is updated by `ObservableWalletTxOutputBuilder` methods.
    * Every method call recreates the `partialOutput`, thus updating it immutably.
    */
   #partialOutput: PartialTxOut;
   #outputValidator: OutputValidator;
 
-  /**
-   *
-   * @param outputValidator this validator is normally created and passed as an arg here, by the TxBuilder
-   * @param txOut optional partial transaction output to use for initialization.
-   */
-  constructor(outputValidator: OutputValidator, txOut?: PartialTxOut) {
+  constructor({ outputValidator, txOut }: OutputBuilderProps) {
     this.#partialOutput = { ...txOut };
     this.#outputValidator = outputValidator;
   }

--- a/packages/wallet/src/TxBuilder/index.ts
+++ b/packages/wallet/src/TxBuilder/index.ts
@@ -1,3 +1,3 @@
 export * from './types';
 export * from './buildTx';
-// intentionally excluded OutputBuilder from the exports because it should only be used as part of TxBuilder
+export * from './OutputBuilder';

--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -38,7 +38,7 @@ export type TxOutValidationError =
   | OutputValidationMissingRequiredError
   | OutputValidationMinimumCoinError
   | OutputValidationTokenBundleSizeError;
-export type TxBodyValidationError = TxOutValidationError | InputSelectionError;
+export type TxBodyValidationError = TxOutValidationError | InputSelectionError | IncompatibleWalletError;
 
 export type Valid<TValid> = TValid & {
   isValid: true;
@@ -148,14 +148,14 @@ export interface TxBuilder {
    */
   buildOutput(txOut?: PartialTxOut): OutputBuilder;
   /**
-   * Add StakeDelegation and (if needed) StakeKeyRegistration certificate to {@link partialTxBody}.
-   * If wallet contains multiple reward accounts, it will create certificates for all of them.
-   * The call returns a Promise because it waits for the reward accounts to be returned by the wallet.
+   * Configure transaction to include delegation.
+   * - On `build()`, StakeDelegation and (if needed) StakeKeyRegistration certificates are added in
+   *   the transaction body.
+   * - If wallet contains multiple reward accounts, it will create certificates for all of them.
    *
    * @param poolId Pool Id to delegate to.
-   * @throws `IncompatibleWalletError` if no reward accounts are provided by the wallet.
    */
-  delegate(poolId: Cardano.PoolId): Promise<TxBuilder>;
+  delegate(poolId: Cardano.PoolId): TxBuilder;
   /** Sets TxMetadata in {@link auxiliaryData} */
   setMetadata(metadata: Cardano.TxMetadata): TxBuilder;
   /** Sets extra signers in {@link extraSigners} */

--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -149,13 +149,14 @@ export interface TxBuilder {
   buildOutput(txOut?: PartialTxOut): OutputBuilder;
   /**
    * Configure transaction to include delegation.
-   * - On `build()`, StakeDelegation and (if needed) StakeKeyRegistration certificates are added in
-   *   the transaction body.
+   * - On `build()`, StakeKeyDeregistration or StakeDelegation and (if needed)
+   *   StakeKeyRegistration certificates are added in the transaction body.
+   * - Stake key deregister is done by not providing the `poolId` parameter: `delegate()`.
    * - If wallet contains multiple reward accounts, it will create certificates for all of them.
    *
-   * @param poolId Pool Id to delegate to.
+   * @param poolId Pool Id to delegate to. If undefined, stake key deregistration will be done.
    */
-  delegate(poolId: Cardano.PoolId): TxBuilder;
+  delegate(poolId?: Cardano.PoolId): TxBuilder;
   /** Sets TxMetadata in {@link auxiliaryData} */
   setMetadata(metadata: Cardano.TxMetadata): TxBuilder;
   /** Sets extra signers in {@link extraSigners} */

--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -66,9 +66,10 @@ export interface OutputBuilder {
    * Create transaction output snapshot, as it was configured until the point of calling this method.
    *
    * @returns {Cardano.TxOut} transaction output snapshot.
-   *  - It can be used in `TxBuilder.addOutput()`.
-   *  - It will be validated once `TxBuilder.build()` method is called.
-   * @throws {OutputValidationMissingRequiredError} if the mandatory fields 'address' or 'coins' are missing
+   *  - It can be used in {@link TxBuilder.addOutput}.
+   *  - It will be validated once {@link TxBuilder.build} method is called.
+   * @throws OutputValidationMissingRequiredError {@link OutputValidationMissingRequiredError} if
+   * the mandatory fields 'address' or 'coins' are missing
    */
   toTxOut(): Cardano.TxOut;
   /** Sets transaction output `value` field. Preexisting `value` is overwritten. */

--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -63,17 +63,19 @@ export type MaybeValidTxOut = ValidTxOut | InvalidTxOut;
  */
 export interface OutputBuilder {
   /**
-   * Transaction output that is updated by `OutputBuilder` methods.
-   * It should not be updated directly, but this is not restricted to allow experimental TxOutput changes that are not
-   * yet available in the OutputBuilder interface.
-   * Every method call recreates the `partialOutput`, thus updating it immutably.
+   * Create transaction output snapshot, as it was configured until the point of calling this method.
+   *
+   * @returns {Cardano.TxOut} transaction output snapshot.
+   *  - It can be used in `TxBuilder.addOutput()`.
+   *  - It will be validated once `TxBuilder.build()` method is called.
+   * @throws {OutputValidationMissingRequiredError} if the mandatory fields 'address' or 'coins' are missing
    */
-  partialOutput: PartialTxOut;
-  /** Sets {@link partialOutput} `value` field. Preexisting `value` is overwritten. */
+  toTxOut(): Cardano.TxOut;
+  /** Sets transaction output `value` field. Preexisting `value` is overwritten. */
   value(value: Cardano.Value): OutputBuilder;
-  /** Sets {@link partialOutput}.value `coins` field. */
+  /** Sets transaction output value `coins` field. */
   coin(coin: Cardano.Lovelace): OutputBuilder;
-  /** Sets {@link partialOutput}.value `assets` field. Preexisting assets are overwritten */
+  /** Sets transaction output value `assets` field. Preexisting assets are overwritten */
   assets(assets: Cardano.TokenMap): OutputBuilder;
   /**
    * Add/Remove/Update asset.
@@ -85,12 +87,12 @@ export interface OutputBuilder {
    * @param quantity To remove an asset, set quantity to 0
    */
   asset(assetId: Cardano.AssetId, quantity: bigint): OutputBuilder;
-  /** Sets {@link partialOutput} `address` field. */
+  /** Sets transaction output `address` field. */
   address(address: Cardano.Address): OutputBuilder;
-  /** Sets {@link partialOutput} `datum` field. */
+  /** Sets transaction output `datum` field. */
   datum(datum: Cardano.util.Hash32ByteBase16): OutputBuilder;
   /**
-   * Checks if the constructed `partialOutput` is complete and valid
+   * Checks if the transaction output is complete and valid
    *
    * @returns {Promise<MaybeValidTxOut>} When it is a `ValidTxOut` it can be used as input in `TxBuilder.addOutput()`.
    * In case of it is an `InvalidTxOut`, it embeds a TxOutValidationError with more details
@@ -141,7 +143,7 @@ export interface TxBuilder {
    */
   removeOutput(txOut: Cardano.TxOut): TxBuilder;
   /**
-   * Does *not* addOutput
+   * Does *not* addOutput.
    *
    * @param txOut optional partial transaction output to use for initialization.
    * @returns {OutputBuilder} {@link OutputBuilder} util for building transaction outputs.

--- a/packages/wallet/test/integration/buildTx.test.ts
+++ b/packages/wallet/test/integration/buildTx.test.ts
@@ -414,6 +414,32 @@ describe('buildTx', () => {
       assertTxIsValid(txDelegate);
       expect(txDelegate.body.certificates?.length).toBe(4);
     });
+
+    it('undefined poolId adds stake key deregister certificate if already registered', async () => {
+      wallet.delegation.rewardAccounts$ = of([
+        {
+          address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
+          delegatee: {
+            currentEpoch: undefined,
+            nextEpoch: undefined,
+            nextNextEpoch: undefined
+          },
+          keyStatus: StakeKeyStatus.Registered,
+          rewardBalance: 33_333n
+        }
+      ]);
+      const txDeregister = await txBuilder.delegate().build();
+      assertTxIsValid(txDeregister);
+      expect(txDeregister.body.certificates?.length).toBe(1);
+      const [deregisterCert] = txDeregister.body.certificates!;
+      expect(deregisterCert.__typename).toBe(Cardano.CertificateType.StakeKeyDeregistration);
+    });
+
+    it('undefined poolId does NOT add certificate if not registered', async () => {
+      const txDeregister = await txBuilder.delegate().build();
+      assertTxIsValid(txDeregister);
+      expect(txDeregister.body.certificates?.length).toBeFalsy();
+    });
   });
 
   it('can be used to build, sign and submit a tx', async () => {


### PR DESCRIPTION
# Context

1. TxBuilder `delegate(...)` call is async only because it fetches rewardAccounts in order to generate certificates.
This forces users to await for delegate call and check for errors.
1. User cannot deregister stake key using TxBuilder.
1. User can use OutputBuilder txOut snapshot in `addOutput`.

# Proposed Solution
1. Postpone fetching rewards accounts and adding certificates until `TxBuilder.build()`
`delegate(...)` is stored as an intent configuration in TxBuilder, which is inspected and applied at `build()` time.
1. Update api to allow calling `delegate()` with undefined `poolId`. Doing this is considered a `deregister` request, thus adding the Deregister certificate at build time. 
1. OutputBuilder `toTxOut()` can be used to get a snapshot of the transaction output built so far. This snapshot can be used in `txBuilder.addOutput(...)`. TxBuilder will validate the provided output(s) on `build` by calling the `OutputBuilder.build()` method on all outputs.

# Important Changes Introduced
- `delegate(...)` is no longer async.
- `OutputBuilder.partialOutput` is private.