### PR TITLE
feat(core): narrow down BootstrapWitness types

### DIFF
--- a/packages/core/src/CSL/coreToCsl/coreToCsl.ts
+++ b/packages/core/src/CSL/coreToCsl/coreToCsl.ts
@@ -6,6 +6,8 @@ import {
   Assets,
   AuxiliaryData,
   BigNum,
+  BootstrapWitness,
+  BootstrapWitnesses,
   Certificates,
   Ed25519KeyHash,
   Ed25519KeyHashes,
@@ -365,6 +367,21 @@ export const txBody = (
   return cslBody;
 };
 
+export const txWitnessBootstrap = (bootstrap: Cardano.BootstrapWitness[]): BootstrapWitnesses => {
+  const witnesses = BootstrapWitnesses.new();
+  for (const coreWitness of bootstrap) {
+    witnesses.add(
+      BootstrapWitness.new(
+        Vkey.new(PublicKey.from_bytes(Buffer.from(coreWitness.key.toString(), 'hex'))),
+        Ed25519Signature.from_hex(coreWitness.signature.toString()),
+        Buffer.from(coreWitness.chainCode || '', 'hex'),
+        Buffer.from(coreWitness.addressAttributes || '', 'base64')
+      )
+    );
+  }
+  return witnesses;
+};
+
 export const witnessSet = (witness: Cardano.Witness): TransactionWitnessSet => {
   const cslWitnessSet = TransactionWitnessSet.new();
   const vkeyWitnesses = Vkeywitnesses.new();
@@ -382,6 +399,10 @@ export const witnessSet = (witness: Cardano.Witness): TransactionWitnessSet => {
     vkeyWitnesses.add(vkeyWitness);
   }
   cslWitnessSet.set_vkeys(vkeyWitnesses);
+
+  if (witness.bootstrap) {
+    cslWitnessSet.set_bootstraps(txWitnessBootstrap(witness.bootstrap));
+  }
 
   return cslWitnessSet;
 };

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Cardano from '.';
 import { AuxiliaryData } from './AuxiliaryData';
+import { Base64Blob, Hash32ByteBase16, HexBlob, OpaqueString, typedHex } from '../util';
 import { Ed25519PublicKey } from './Key';
-import { Hash32ByteBase16, HexBlob, OpaqueString, typedHex } from '../util';
 import { PartialBlockHeader } from './Block';
 
 /**
@@ -68,15 +68,15 @@ export interface Redeemer {
 export type Signatures = Map<Ed25519PublicKey, Ed25519Signature>;
 
 export type Signature = Ed25519Signature;
-export type ChainCode = string;
-export type AddressAttributes = string;
+export type ChainCode = HexBlob;
+export type AddressAttributes = Base64Blob;
 export type VerificationKey = Ed25519PublicKey;
 
 export interface BootstrapWitness {
-  signature?: Signature;
+  signature: Signature;
   chainCode?: ChainCode;
   addressAttributes?: AddressAttributes;
-  key?: VerificationKey;
+  key: VerificationKey;
 }
 
 export type Witness = {

--- a/packages/core/src/Cardano/util/primitives.ts
+++ b/packages/core/src/Cardano/util/primitives.ts
@@ -83,8 +83,23 @@ export const typedHex = <T>(value: string, length?: number): T => {
   return value as any as T;
 };
 
+/**
+ * https://www.ietf.org/rfc/rfc4648.txt
+ */
+export type Base64Blob = OpaqueString<'Base64Blob'>;
+export const Base64Blob = (target: string): Base64Blob => {
+  // eslint-disable-next-line wrap-regex
+  if (/^(?:[\d+/a-z]{4})*(?:[\d+/a-z]{2}==|[\d+/a-z]{3}=)?$/i.test(target)) {
+    return target as unknown as Base64Blob;
+  }
+  throw new InvalidStringError('expected base64 string');
+};
+Base64Blob.fromBytes = (bytes: Uint8Array) => Buffer.from(bytes).toString('base64') as unknown as Base64Blob;
+
 export type HexBlob = OpaqueString<'HexBlob'>;
 export const HexBlob = (target: string): HexBlob => typedHex(target);
+HexBlob.fromBytes = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex') as unknown as HexBlob;
+
 /**
  * Cast HexBlob it into another OpaqueString type.
  *

--- a/packages/core/test/CSL/cslToCore.test.ts
+++ b/packages/core/test/CSL/cslToCore.test.ts
@@ -97,4 +97,22 @@ describe('cslToCore', () => {
   it('newTx', () => {
     expect(cslToCore.newTx(coreToCsl.tx(tx))).toEqual(tx);
   });
+
+  it('txWitnessBootstrap', () => {
+    // values from ogmios.wsp.json
+    const bootstrap: Cardano.BootstrapWitness[] = [
+      {
+        addressAttributes: Cardano.Base64Blob('cA=='),
+        chainCode: Cardano.HexBlob('b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'),
+        key: Cardano.Ed25519PublicKey('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01'),
+        signature: Cardano.Ed25519Signature(
+          Buffer.from(
+            'ZGdic3hnZ3RvZ2hkanB0ZXR2dGtjb2N2eWZpZHFxZ2d1cmpocmhxYWlpc3BxcnVlbGh2eXBxeGVld3ByeWZ2dw==',
+            'base64'
+          ).toString('hex')
+        )
+      }
+    ];
+    expect(cslToCore.txWitnessBootstrap(coreToCsl.txWitnessBootstrap(bootstrap))).toEqual(bootstrap);
+  });
 });

--- a/packages/core/test/Cardano/util/primitives.test.ts
+++ b/packages/core/test/Cardano/util/primitives.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import {
+  Base64Blob,
   Hash28ByteBase16,
   Hash32ByteBase16,
   HexBlob,
@@ -84,6 +85,29 @@ describe('Cardano.util/primitives', () => {
     it('throws when string has an non base16 character', () => {
       expect(() => HexBlob(' 1234567890abcdef')).toThrowError(InvalidStringError);
       expect(() => HexBlob('1234567890abcdefg')).toThrowError(InvalidStringError);
+    });
+
+    it('fromBytes converts byte array into HexBlob', () => {
+      expect(HexBlob.fromBytes(new Uint8Array([112]))).toEqual('70');
+    });
+  });
+
+  describe('Base64Blob', () => {
+    it('allows an empty string', () => {
+      expect(() => Base64Blob('')).not.toThrow();
+    });
+
+    it('does not throw when asserting a valid base64 encoded string', () => {
+      expect(() => Base64Blob('cA==')).not.toThrowError();
+    });
+
+    it('throws when string doesnt match the base64 pattern defined in IETF RFC4648', () => {
+      expect(() => HexBlob('cA=')).toThrowError(InvalidStringError);
+      expect(() => HexBlob('!cA==')).toThrowError(InvalidStringError);
+    });
+
+    it('fromBytes converts byte array into Base64Blob', () => {
+      expect(Base64Blob.fromBytes(new Uint8Array([112]))).toEqual('cA==');
     });
   });
 


### PR DESCRIPTION
# Context

It is not clear what format/encoding the following strings use:

```ts
export type ChainCode = string;
export type AddressAttributes = string;
```

# Proposed Solution

See notes in commit message a217e00161e3e8b86fd1df5cc780fed20d213708