### PR TITLE
feat(cardano-services): stake pools apy and margin averages

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
@@ -20,7 +20,7 @@ import {
   PoolRetirementModel,
   PoolUpdateModel,
   RelayModel,
-  StakePoolStatsModel,
+  StakePoolsQtyModel,
   SubQuery,
   TotalAdaModel,
   TotalCountModel
@@ -44,7 +44,7 @@ import Queries, {
   addSentenceToQuery,
   buildOrQueryFromClauses,
   findLastEpoch,
-  findPoolStats,
+  findPoolQty,
   getIdentifierFullJoinClause,
   getIdentifierWhereClause,
   getStatusWhereClause,
@@ -291,9 +291,13 @@ export class StakePoolBuilder {
 
   public async queryPoolStats(): Promise<StakePoolStats> {
     this.#logger.debug('About to get pool stats');
-    const result: QueryResult<StakePoolStatsModel> = await this.#db.query(findPoolStats);
-    const poolStats = result.rows[0];
-    if (!poolStats) throw new ProviderError(ProviderFailure.Unknown, null, "Couldn't fetch pool stats");
-    return mapPoolStats(poolStats);
+    const result: QueryResult<StakePoolsQtyModel> = await this.#db.query(findPoolQty);
+    const qty = result.rows[0];
+    if (!qty) throw new ProviderError(ProviderFailure.Unknown, null, "Couldn't fetch pool stats");
+    this.#logger.debug('About to get pool averages');
+    const averagesResult = await this.#db.query(Queries.findActivePoolsAverages);
+    const averages = averagesResult.rows[0];
+    if (!averages) throw new ProviderError(ProviderFailure.Unknown, null, "Couldn't fetch pools averages");
+    return mapPoolStats({ averages, qty });
   }
 }

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
@@ -22,8 +22,9 @@ import {
   PoolUpdateModel,
   PoolsToCache,
   RelayModel,
+  StakePoolAveragesModel,
   StakePoolResults,
-  StakePoolStatsModel
+  StakePoolsQtyModel
 } from './types';
 import { bufferToHexString, isNotNil } from '@cardano-sdk/util';
 import { divideBigIntToFloat } from './util';
@@ -269,8 +270,15 @@ export const mapPoolMetrics = (poolMetricsModel: PoolMetricsModel): PoolMetrics 
   }
 });
 
-export const mapPoolStats = (poolStats: StakePoolStatsModel): StakePoolStats => ({
-  qty: { active: Number(poolStats.active), retired: Number(poolStats.retired), retiring: Number(poolStats.retiring) }
+export const mapPoolStats = ({
+  qty,
+  averages
+}: {
+  qty: StakePoolsQtyModel;
+  averages: StakePoolAveragesModel;
+}): StakePoolStats => ({
+  averages: { apy: Number(averages.apy_average), margin: Number(averages.margin_average) },
+  qty: { active: Number(qty.active), retired: Number(qty.retired), retiring: Number(qty.retiring) }
 });
 
 export const mapPoolAPY = (poolAPYModel: PoolAPYModel): PoolAPY => ({

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
@@ -150,10 +150,15 @@ export interface TotalCountModel {
   total_count: number;
 }
 
-export interface StakePoolStatsModel {
+export interface StakePoolsQtyModel {
   active: string;
   retired: string;
   retiring: string;
+}
+
+export interface StakePoolAveragesModel {
+  apy_average: string;
+  margin_average: string;
 }
 
 export interface PoolAPYModel {

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -1518,6 +1518,10 @@ Array [
 
 exports[`StakePoolBuilder queryPoolStats returns active, retired and retiring pools count 1`] = `
 Object {
+  "averages": Object {
+    "apy": 0.0000158041676290942,
+    "margin": 0.000201057770545159,
+  },
   "qty": Object {
     "active": 8,
     "retired": 2,

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
@@ -407,7 +407,15 @@ describe('mappers', () => {
   });
 
   it('mapPoolStats', () => {
-    expect(mapPoolStats({ active: '20', retired: '0', retiring: '1' })).toEqual<StakePoolStats>({
+    const apyAverage = '0.00034';
+    const marginAverage = '00.1';
+    expect(
+      mapPoolStats({
+        averages: { apy_average: apyAverage, margin_average: marginAverage },
+        qty: { active: '20', retired: '0', retiring: '1' }
+      })
+    ).toEqual<StakePoolStats>({
+      averages: { apy: Number(apyAverage), margin: Number(marginAverage) },
       qty: { active: 20, retired: 0, retiring: 1 }
     });
   });

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -392,8 +392,8 @@ describe('StakePoolHttpService', () => {
           const response = await provider.queryStakePools(req);
           expect(response.pageResults).toEqual([]);
 
-          const secondRsponseCached = await provider.queryStakePools(req);
-          expect(response).toEqual(secondRsponseCached);
+          const secondResponseCached = await provider.queryStakePools(req);
+          expect(response).toEqual(secondResponseCached);
         });
         it('empty values ignores identifier filter', async () => {
           const req = {
@@ -1018,6 +1018,26 @@ describe('StakePoolHttpService', () => {
           expect(response.qty).toBeDefined();
           expect(response).toMatchSnapshot();
         });
+      });
+    });
+
+    describe('averages', () => {
+      it('/stats Vs /search comparison', async () => {
+        const searchResponse = await provider.queryStakePools({});
+        const statsResponse = await provider.stakePoolStats();
+        let activeCount = 0;
+        let totalApy = 0;
+        let totalMargin = 0;
+
+        for (const { margin, metrics, status } of searchResponse.pageResults)
+          if (status === 'active') {
+            activeCount++;
+            totalApy += metrics.apy!;
+            totalMargin += margin.numerator / margin.denominator;
+          }
+
+        expect(statsResponse.averages.apy).toBe(totalApy / activeCount);
+        expect(statsResponse.averages.margin).toBe(totalMargin / activeCount);
       });
     });
   });

--- a/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
@@ -17107,6 +17107,10 @@ Object {
 
 exports[`StakePoolHttpService healthy state /stats server and snapshot testing has active, retired and retiring stake pools count 1`] = `
 Object {
+  "averages": Object {
+    "apy": 0.0000158041676290942,
+    "margin": 0.000201057770545159,
+  },
   "qty": Object {
     "active": 8,
     "retired": 2,

--- a/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
+++ b/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
@@ -58,6 +58,17 @@ export interface StakePoolSearchResults {
 }
 
 export interface StakePoolStats {
+  averages: {
+    /**
+     * Average margin of active stake pools in latest Epoch
+     */
+    margin: Cardano.Percent;
+    /**
+     * Average Annual Percentage Yield (APY)
+     * of active stake pools in latest epoch
+     */
+    apy: Cardano.Percent;
+  };
   qty: {
     active: number;
     retired: number;

--- a/packages/util-dev/src/createStubStakePoolProvider.ts
+++ b/packages/util-dev/src/createStubStakePoolProvider.ts
@@ -66,6 +66,10 @@ export const createStubStakePoolProvider = (
   stakePoolStats: async () => {
     if (delayMs) await delay(delayMs);
     return {
+      averages: {
+        apy: 0.000_015,
+        margin: 0.0002
+      },
       qty: {
         active: stakePools.filter((pool) => pool.status === Cardano.StakePoolStatus.Active).length,
         retired: stakePools.filter((pool) => pool.status === Cardano.StakePoolStatus.Retired).length,


### PR DESCRIPTION
# Context

Provide average APY and margin of all active stake pools for latest epoch at StakePoolProvider
