### PR TITLE
feat: calculate stability window slots count in wallet

### DIFF
--- a/packages/core/src/util/calcStabilityWindow.ts
+++ b/packages/core/src/util/calcStabilityWindow.ts
@@ -1,0 +1,11 @@
+import { Cardano } from '..';
+
+/**
+ * 3k/f (where k is the security parameter in genesis, and f is the active slot co-efficient parameter
+ * in genesis that determines the probability for amount of blocks created in an epoch.)
+ */
+export const calculateStabilityWindowSlotsCount = ({
+  securityParameter,
+  activeSlotsCoefficient
+}: Pick<Cardano.CompactGenesis, 'securityParameter' | 'activeSlotsCoefficient'>): number =>
+  (3 * securityParameter) / activeSlotsCoefficient;

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -2,3 +2,4 @@ export * as util from './misc';
 export * from './slotCalc';
 export * from './txInspector';
 export * from './utxo';
+export * from './calcStabilityWindow';

--- a/packages/core/test/util/calcStabilityWindow.test.ts
+++ b/packages/core/test/util/calcStabilityWindow.test.ts
@@ -1,0 +1,12 @@
+import { calculateStabilityWindowSlotsCount } from '../../src/util';
+
+describe('calculateStabilityWindowSlotsCount', () => {
+  it('calculate stability window slots count', () => {
+    const securityParameter = 2160;
+    const activeSlotsCoefficient = 0.05;
+    const expectedStabilityWindowValue = 129_600;
+    expect(calculateStabilityWindowSlotsCount({ activeSlotsCoefficient, securityParameter })).toEqual(
+      expectedStabilityWindowValue
+    );
+  });
+});

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -307,6 +307,7 @@ export class SingleAddressWallet implements ObservableWallet {
 
     this.#resubmitSubscription = createTransactionReemitter({
       confirmed$: this.transactions.outgoing.confirmed$,
+      genesisParameters$: this.genesisParameters$,
       logger: contextLogger(this.#logger, 'transactionsReemitter'),
       rollback$: this.transactions.rollback$,
       store: stores.volatileTransactions,

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -115,7 +115,7 @@ const tx: Cardano.NewTxAlonzo = {
 };
 
 describe('SingleAddressWallet rollback', () => {
-  it('Rollback transaction is resubmitteed', async () => {
+  it('Rollback transaction is resubmitted', async () => {
     const stores = createInMemoryWalletStores();
     const rewardsProvider = mocks.mockRewardsProvider();
     const networkInfoProvider = mocks.mockNetworkInfoProvider();


### PR DESCRIPTION
# Context
The stability window must be calculated to determine which confirmed transactions might be subject to rollback.

[The formula to calculate this window is 3k/f (where k is the security parameter in genesis, and f is the active slot co-efficient parameter in genesis that determines the probability of amount of blocks created in an epoch.)](https://docs.cardano.org/learn/chain-confirmation-versus-transaction-confirmation)

Once NetworkInfo includes the parameters, it should be used to calculate the stability window and use it instead of the hardcoded value.

# Proposed Solution
Apply the stability window formula on the client (wallet) and provide the value as observable where it is needed.

# Important Changes Introduced
- extend `createTransactionReemitter` with `stabilityWindowSlotsCount$`
- apply the formula to calculate `stabilityWindowSlotsCount` value
- update marble tests