### PR TITLE
test(e2e): add balance check before running e2e tests

### DIFF
--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -2,7 +2,7 @@
 import { Awaited } from '@cardano-sdk/util';
 import { Cardano } from '@cardano-sdk/core';
 import { ObservableWallet, StakeKeyStatus, buildTx } from '@cardano-sdk/wallet';
-import { TX_TIMEOUT, firstValueFromTimed, waitForWalletStateSettle } from '../util';
+import { TX_TIMEOUT, firstValueFromTimed, waitForWalletStateSettle, walletReady } from '../util';
 import { assertTxIsValid } from '../../../../wallet/test/util';
 import { env } from '../environment';
 import { getWallet } from '../../../src/factories';
@@ -84,6 +84,8 @@ describe('SingleAddressWallet/delegation', () => {
   test('balance & transaction', async () => {
     // source wallet has the highest balance to begin with
     const [sourceWallet, destWallet] = await chooseWallets();
+
+    await walletReady(sourceWallet);
 
     const protocolParameters = await firstValueFrom(sourceWallet.protocolParameters$);
     const stakeKeyDeposit = BigInt(protocolParameters.stakeKeyDeposit);

--- a/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
@@ -5,6 +5,7 @@ import { filter, firstValueFrom, map } from 'rxjs';
 import { getWallet } from '../../../src/factories';
 import { isNotNil } from '@cardano-sdk/util';
 import { logger } from '@cardano-sdk/util-dev';
+import { walletReady } from '../util';
 
 describe('SingleAddressWallet/metadata', () => {
   let wallet: SingleAddressWallet;
@@ -13,6 +14,8 @@ describe('SingleAddressWallet/metadata', () => {
   beforeAll(async () => {
     wallet = (await getWallet({ env, logger, name: 'Test Wallet' })).wallet;
     ownAddress = (await firstValueFrom(wallet.addresses$))[0].address;
+
+    await walletReady(wallet);
   });
 
   afterAll(() => wallet.shutdown());

--- a/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
@@ -5,6 +5,7 @@ import { SingleAddressWallet } from '@cardano-sdk/wallet';
 import { env } from '../environment';
 import { filter, firstValueFrom } from 'rxjs';
 import { getLogger, getWallet } from '../../../src/factories';
+import { walletReady } from '../util';
 
 const logger = getLogger(env.LOGGER_MIN_SEVERITY);
 
@@ -35,7 +36,7 @@ describe('SingleAddressWallet/multisignature', () => {
   it('can create a transaction with multiple signatures to mint an asset', async () => {
     wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
-    await firstValueFrom(wallet.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)));
+    await walletReady(wallet);
 
     const params = await firstValueFrom(wallet.genesisParameters$);
 

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -5,6 +5,7 @@ import { SingleAddressWallet } from '@cardano-sdk/wallet';
 import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
 import { env } from '../environment';
 import { getLogger, getWallet } from '../../../src/factories';
+import { walletReady } from '../util';
 
 const logger = getLogger(env.LOGGER_MIN_SEVERITY);
 
@@ -26,7 +27,7 @@ describe('SingleAddressWallet.assets/nft', () => {
   beforeAll(async () => {
     wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
-    await firstValueFrom(wallet.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)));
+    await walletReady(wallet);
 
     const params = await firstValueFrom(wallet.genesisParameters$);
 

--- a/packages/e2e/test/wallet/SingleAddressWallet/pouchDbWalletStores.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/pouchDbWalletStores.test.ts
@@ -3,7 +3,7 @@ import { filter, firstValueFrom } from 'rxjs';
 import { getWallet } from '../../../src/factories';
 import { logger } from '@cardano-sdk/util-dev';
 import { storage } from '@cardano-sdk/wallet';
-import { waitForWalletStateSettle } from '../util';
+import { waitForWalletStateSettle, walletReady } from '../util';
 import delay from 'delay';
 
 describe('SingleAddressWallet/pouchDbWalletStores', () => {
@@ -16,8 +16,10 @@ describe('SingleAddressWallet/pouchDbWalletStores', () => {
 
   it('stores and restores SingleAddressWallet, continues sync after initial load', async () => {
     const wallet1 = (await getWallet({ env, logger, name: 'Test Wallet', stores: stores1 })).wallet;
+
     // wallet1 fetched all responses from wallet provider
-    await waitForWalletStateSettle(wallet1);
+    await walletReady(wallet1);
+
     // give it a second to store data to PouchDb, this is technically a race condition
     await delay(1000);
     // loading reward accounts involves loading many other pieces (transactions, stake pools etc.)

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
@@ -4,7 +4,7 @@ import { env } from '../environment';
 import { filter, firstValueFrom } from 'rxjs';
 import { getWallet } from '../../../src/factories';
 import { logger } from '@cardano-sdk/util-dev';
-import { waitForWalletStateSettle } from '../util';
+import { walletReady } from '../util';
 
 describe('SingleAddressWallet', () => {
   let wallet: ObservableWallet;
@@ -12,7 +12,8 @@ describe('SingleAddressWallet', () => {
   beforeAll(async () => {
     jest.setTimeout(180_000);
     wallet = (await getWallet({ env, logger, name: 'Test Wallet' })).wallet;
-    await waitForWalletStateSettle(wallet);
+
+    await walletReady(wallet);
   });
 
   afterAll(() => {

--- a/packages/e2e/test/wallet/util.ts
+++ b/packages/e2e/test/wallet/util.ts
@@ -1,10 +1,12 @@
-import { Observable, catchError, filter, firstValueFrom, throwError, timeout } from 'rxjs';
+import { Observable, catchError, combineLatest, filter, firstValueFrom, throwError, timeout } from 'rxjs';
 import { ObservableWallet } from '@cardano-sdk/wallet';
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 export const TX_TIMEOUT = 7 * MINUTE;
 const SYNC_TIMEOUT = 3 * MINUTE;
+const BALANCE_TIMEOUT = 3 * MINUTE;
+
 export const FAST_OPERATION_TIMEOUT = 15 * SECOND;
 
 export const firstValueFromTimed = <T>(
@@ -22,6 +24,22 @@ export const firstValueFromTimed = <T>(
 export const waitForWalletStateSettle = (wallet: ObservableWallet) =>
   firstValueFromTimed(
     wallet.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)),
-    'Took too long to load',
+    'Took too long to settle',
+    SYNC_TIMEOUT
+  );
+
+export const waitForWalletBalance = (wallet: ObservableWallet) =>
+  firstValueFromTimed(
+    wallet.balance.utxo.total$.pipe(filter(({ coins }) => coins > 0)),
+    'Took too long to load balance',
+    BALANCE_TIMEOUT
+  );
+
+export const walletReady = (wallet: ObservableWallet) =>
+  firstValueFromTimed(
+    combineLatest([wallet.syncStatus.isSettled$, wallet.balance.utxo.total$]).pipe(
+      filter(([isSettled, balance]) => isSettled && balance.coins > 0n)
+    ),
+    'Took too long to be ready',
     SYNC_TIMEOUT
   );


### PR DESCRIPTION
# Context

There is a race condition between starting the local test network and running the e2e tests, sometimes the e2e test can start before the state of the local test network is fully indexed by dbSync, which causes the tests to fail since the wallet balance is still not available. 

# Proposed Solution

Make the e2e test wallet for balance to be available at the beginning of the test.
