### PR TITLE
ci: build before publishing nightly packages

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -49,6 +49,7 @@ jobs:
     - name: Publish
       if: steps.precondition.outputs.changed > 0
       run: |
+        yarn build
         yarn publish:nightly --loglevel silly
       env:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false


### PR DESCRIPTION
# Context

Nightly CI publishes have been failing recently.

# Proposed Solution

The error seems to be inconsistent, so I'm guessing it's a CI resources issue when trying to build all packages. Running `yarn build` before `lerna publish` seems to help ([tried to publish once and it worked](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/3053057180/jobs/4923194329)). The idea is that `tsc` will prime some cache to use when building in `prepack` scripts.
