### PR TITLE
fix(ogmios): correctly map era summary slotLength

### DIFF
--- a/packages/ogmios/src/CardanoNode/mappers.ts
+++ b/packages/ogmios/src/CardanoNode/mappers.ts
@@ -4,7 +4,7 @@ import { Schema } from '@cardano-ogmios/client';
 export const mapEraSummary = (eraSummary: Schema.EraSummary, systemStart: Date): EraSummary => ({
   parameters: {
     epochLength: eraSummary.parameters.epochLength,
-    slotLength: eraSummary.parameters.slotLength
+    slotLength: eraSummary.parameters.slotLength * 1000
   },
   start: {
     slot: eraSummary.start.slot,

--- a/packages/ogmios/test/CardanoNode/__snapshots__/OgmiosCardanoNode.test.ts.snap
+++ b/packages/ogmios/test/CardanoNode/__snapshots__/OgmiosCardanoNode.test.ts.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "parameters": Object {
       "epochLength": 21600,
-      "slotLength": 20,
+      "slotLength": 20000,
     },
     "start": Object {
       "slot": 0,
@@ -15,7 +15,7 @@ Array [
   Object {
     "parameters": Object {
       "epochLength": 432000,
-      "slotLength": 1,
+      "slotLength": 1000,
     },
     "start": Object {
       "slot": 1598400,

--- a/packages/ogmios/test/CardanoNode/mappers.test.ts
+++ b/packages/ogmios/test/CardanoNode/mappers.test.ts
@@ -14,7 +14,7 @@ describe('cardano node mappers', () => {
       expect(result).toEqual<EraSummary>({
         parameters: {
           epochLength: 432_000,
-          slotLength: 1
+          slotLength: 1000
         },
         start: {
           slot: 1_598_400,


### PR DESCRIPTION
# Context

Slot date is computed incorrectly in SingleAddressWallet

# Proposed Solution

Correctly map `slotLength` returned by Ogmios