### PR TITLE
fix: stake pool search with applied pledge met filter

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
@@ -167,8 +167,8 @@ export const toStakePoolResults = (
 };
 
 export const mapPoolUpdate = (poolUpdateModel: PoolUpdateModel): PoolUpdate => ({
-  id: poolUpdateModel.id,
-  updateId: poolUpdateModel.update_id
+  id: Number(poolUpdateModel.id),
+  updateId: Number(poolUpdateModel.update_id)
 });
 
 const metadataKeys = new Set(['ticker', 'name', 'description', 'homepage']);
@@ -182,13 +182,13 @@ export const mapPoolData = (poolDataModel: PoolDataModel): PoolData => {
   const { n: numerator, d: denominator } = new Fraction(poolDataModel.margin);
   const toReturn: PoolData = {
     cost: BigInt(poolDataModel.fixed_cost),
-    hashId: poolDataModel.hash_id,
+    hashId: Number(poolDataModel.hash_id),
     hexId: Cardano.PoolIdHex(bufferToHexString(poolDataModel.pool_hash)),
     id: Cardano.PoolId(poolDataModel.pool_id),
     margin: { denominator, numerator },
     pledge: BigInt(poolDataModel.pledge),
     rewardAccount: Cardano.RewardAccount(poolDataModel.reward_address),
-    updateId: poolDataModel.update_id,
+    updateId: Number(poolDataModel.update_id),
     vrfKeyHash: Cardano.VrfVkHex(vrfAsHexString)
   };
   if (poolDataModel.metadata_hash) {
@@ -221,7 +221,7 @@ export const mapRelay = (relayModel: RelayModel): PoolRelay => {
       port: relayModel.port
     };
 
-  return { hashId: relayModel.hash_id, relay, updateId: relayModel.update_id };
+  return { hashId: Number(relayModel.hash_id), relay, updateId: Number(relayModel.update_id) };
 };
 
 export const mapEpoch = ({ no, pool_optimal_count }: EpochModel): Epoch => ({
@@ -243,23 +243,23 @@ export const mapEpochReward = (epochRewardModel: EpochRewardModel, hashId: numbe
 
 export const mapAddressOwner = (ownerAddressModel: OwnerAddressModel): PoolOwner => ({
   address: Cardano.RewardAccount(ownerAddressModel.address),
-  hashId: ownerAddressModel.hash_id
+  hashId: Number(ownerAddressModel.hash_id)
 });
 
 export const mapPoolRegistration = (poolRegistrationModel: PoolRegistrationModel): PoolRegistration => ({
   activeEpochNo: poolRegistrationModel.active_epoch_no,
-  hashId: poolRegistrationModel.hash_id,
+  hashId: Number(poolRegistrationModel.hash_id),
   transactionId: Cardano.TransactionId(bufferToHexString(poolRegistrationModel.tx_hash))
 });
 
 export const mapPoolRetirement = (poolRetirementModel: PoolRetirementModel): PoolRetirement => ({
-  hashId: poolRetirementModel.hash_id,
+  hashId: Number(poolRetirementModel.hash_id),
   retiringEpoch: poolRetirementModel.retiring_epoch,
   transactionId: Cardano.TransactionId(bufferToHexString(poolRetirementModel.tx_hash))
 });
 
 export const mapPoolMetrics = (poolMetricsModel: PoolMetricsModel): PoolMetrics => ({
-  hashId: poolMetricsModel.pool_hash_id,
+  hashId: Number(poolMetricsModel.pool_hash_id),
   metrics: {
     activeStake: BigInt(poolMetricsModel.active_stake),
     blocksCreated: poolMetricsModel.blocks_created,
@@ -275,5 +275,5 @@ export const mapPoolStats = (poolStats: StakePoolStatsModel): StakePoolStats => 
 
 export const mapPoolAPY = (poolAPYModel: PoolAPYModel): PoolAPY => ({
   apy: poolAPYModel.apy,
-  hashId: poolAPYModel.hash_id
+  hashId: Number(poolAPYModel.hash_id)
 });

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
@@ -1,7 +1,7 @@
 import { Cardano, StakePoolSearchResults } from '@cardano-sdk/core';
 export interface PoolUpdateModel {
-  id: number; // pool hash id
-  update_id: number;
+  id: string; // pool hash id
+  update_id: string;
 }
 
 export interface PoolUpdate {
@@ -27,8 +27,8 @@ export interface PoolData extends CommonPoolInfo {
 }
 
 export interface PoolDataModel {
-  hash_id: number;
-  update_id: number;
+  hash_id: string;
+  update_id: string;
   pool_id: string;
   reward_address: string;
   pledge: string;
@@ -43,8 +43,8 @@ export interface PoolDataModel {
 }
 
 export interface RelayModel {
-  hash_id: number;
-  update_id: number;
+  hash_id: string;
+  update_id: string;
   ipv4?: string;
   ipv6?: string;
   port?: number;
@@ -78,12 +78,12 @@ export interface EpochRewardModel {
 
 export interface OwnerAddressModel {
   address: string;
-  hash_id: number;
+  hash_id: string;
 }
 
 interface PoolTransactionModel {
   tx_hash: Buffer;
-  hash_id: number;
+  hash_id: string;
 }
 
 interface PoolTransaction extends CommonPoolInfo {
@@ -133,7 +133,7 @@ export interface PoolMetricsModel {
   saturation: number;
   active_stake_percentage: number;
   live_stake_percentage: number;
-  pool_hash_id: number;
+  pool_hash_id: string;
 }
 
 export interface PoolMetrics extends CommonPoolInfo {
@@ -157,7 +157,7 @@ export interface StakePoolStatsModel {
 }
 
 export interface PoolAPYModel {
-  hash_id: number;
+  hash_id: string;
   apy: number;
 }
 

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/util.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/util.ts
@@ -29,6 +29,7 @@ export enum StakePoolsSubQuery {
   OWNERS = 'owners',
   RETIREMENTS = 'retirements',
   TOTAL_ADA_AMOUNT = 'total_ada_amount',
+  TOTAL_POOLS_COUNT = 'total_stake_pools_count',
   POOL_HASHES = 'pool_hashes',
   POOLS_DATA_ORDERED = 'pools_data_ordered'
 }

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -823,7 +823,7 @@ exports[`StakePoolBuilder queryPoolAPY pagination with limit 1`] = `
 Array [
   Object {
     "apy": 0,
-    "hashId": "15",
+    "hashId": 15,
   },
 ]
 `;
@@ -832,11 +832,11 @@ exports[`StakePoolBuilder queryPoolAPY pagination with startAt 1`] = `
 Array [
   Object {
     "apy": 0,
-    "hashId": "19",
+    "hashId": 19,
   },
   Object {
     "apy": 0,
-    "hashId": "1",
+    "hashId": 1,
   },
 ]
 `;
@@ -845,11 +845,11 @@ exports[`StakePoolBuilder queryPoolAPY sort by APY asc 1`] = `
 Array [
   Object {
     "apy": 0,
-    "hashId": "1",
+    "hashId": 1,
   },
   Object {
     "apy": 0.00186615265931667,
-    "hashId": "14",
+    "hashId": 14,
   },
 ]
 `;
@@ -858,11 +858,11 @@ exports[`StakePoolBuilder queryPoolAPY sort by default sort (APY desc) 1`] = `
 Array [
   Object {
     "apy": 0.00186615265931667,
-    "hashId": "14",
+    "hashId": 14,
   },
   Object {
     "apy": 0,
-    "hashId": "1",
+    "hashId": 1,
   },
 ]
 `;
@@ -1412,68 +1412,68 @@ Array [
 exports[`StakePoolBuilder queryPoolRelays queryPoolRelays 1`] = `
 Array [
   Object {
-    "hashId": "31",
+    "hashId": 31,
     "relay": Object {
       "__typename": "RelayByName",
       "hostname": "www.test2.test",
       "port": null,
     },
-    "updateId": "355",
+    "updateId": 355,
   },
   Object {
-    "hashId": "31",
+    "hashId": 31,
     "relay": Object {
       "__typename": "RelayByNameMultihost",
       "dnsName": "www.test.test",
     },
-    "updateId": "355",
+    "updateId": 355,
   },
   Object {
-    "hashId": "31",
+    "hashId": 31,
     "relay": Object {
       "__typename": "RelayByAddress",
       "ipv4": null,
       "ipv6": "b80d:120:0:a385:2e8a:0:3473:7003",
       "port": 1234,
     },
-    "updateId": "355",
+    "updateId": 355,
   },
   Object {
-    "hashId": "31",
+    "hashId": 31,
     "relay": Object {
       "__typename": "RelayByAddress",
       "ipv4": "192.168.0.1",
       "ipv6": "b80d:120:0:a385:2e8a:0:3473:7003",
       "port": 1234,
     },
-    "updateId": "355",
+    "updateId": 355,
   },
   Object {
-    "hashId": "31",
+    "hashId": 31,
     "relay": Object {
       "__typename": "RelayByAddress",
       "ipv4": "8.8.8.8",
       "ipv6": null,
       "port": 1234,
     },
-    "updateId": "355",
+    "updateId": 355,
   },
   Object {
-    "hashId": "1",
+    "hashId": 1,
     "relay": Object {
       "__typename": "RelayByNameMultihost",
       "dnsName": "relays-new.cardano-testnet.iohkdev.io",
     },
-    "updateId": "1",
+    "updateId": 1,
   },
   Object {
-    "hashId": "19",
+    "hashId": 19,
     "relay": Object {
       "__typename": "RelayByName",
       "hostname": "pool-devtest-a.banderini.net",
       "port": null,
     },
-    "updateId": "20",
+    "updateId": 20,
   },
 ]
 `;

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
@@ -27,8 +27,10 @@ describe('mappers', () => {
     name: 'THE AMSTERDAM NODE',
     ticker: 'AMS'
   };
-  const update_id = 1;
-  const hash_id = 1;
+  const update_id = '1';
+  const hash_id = '1';
+  const hashId = 1;
+
   const poolRetirementModel = {
     hash_id,
     retiring_epoch: 20,
@@ -63,7 +65,7 @@ describe('mappers', () => {
   };
   const poolUpdateModel = {
     id: hash_id,
-    update_id: 1
+    update_id: '1'
   };
   const poolDataModel = {
     fixed_cost: '400000000',
@@ -109,7 +111,7 @@ describe('mappers', () => {
   };
   it('mapPoolRetirement', () => {
     expect(mapPoolRetirement(poolRetirementModel)).toEqual({
-      hashId: poolRetirementModel.hash_id,
+      hashId: Number(poolRetirementModel.hash_id),
       retiringEpoch: poolRetirementModel.retiring_epoch,
       transactionId: Cardano.TransactionId(txHash)
     });
@@ -117,31 +119,31 @@ describe('mappers', () => {
   it('mapPoolRegistration', () => {
     expect(mapPoolRegistration(poolRegistrationModel)).toEqual({
       activeEpochNo: poolRegistrationModel.active_epoch_no,
-      hashId: poolRegistrationModel.hash_id,
+      hashId: Number(poolRegistrationModel.hash_id),
       transactionId: Cardano.TransactionId(txHash)
     });
   });
   it('mapRelay', () => {
     expect(mapRelay(poolRelayByName)).toEqual({
-      hashId: hash_id,
+      hashId: Number(hash_id),
       relay: { __typename: 'RelayByName', hostname: poolRelayByName.hostname, port: poolRelayByName.port },
-      updateId: update_id
+      updateId: Number(update_id)
     });
     expect(mapRelay(poolRelayByNameMultiHost)).toEqual({
-      hashId: hash_id,
+      hashId: Number(hash_id),
       relay: { __typename: 'RelayByNameMultihost', dnsName: poolRelayByNameMultiHost.dns_name },
-      updateId: update_id
+      updateId: Number(update_id)
     });
     expect(mapRelay(poolRelayByAddress)).toEqual({
-      hashId: hash_id,
+      hashId: Number(hash_id),
       relay: { __typename: 'RelayByAddress', ipv4: poolRelayByAddress.ipv4, port: poolRelayByAddress.port },
-      updateId: update_id
+      updateId: Number(update_id)
     });
   });
   it('mapPoolData', () => {
     expect(mapPoolData(poolDataModel)).toEqual({
       cost: BigInt(poolDataModel.fixed_cost),
-      hashId: poolDataModel.hash_id,
+      hashId: Number(poolDataModel.hash_id),
       hexId: Cardano.PoolIdHex(poolHashAsHex),
       id: Cardano.PoolId(poolDataModel.pool_id),
       margin: { denominator: 10_000, numerator: 1 },
@@ -152,24 +154,24 @@ describe('mappers', () => {
       },
       pledge: BigInt(poolDataModel.pledge),
       rewardAccount: Cardano.RewardAccount(poolDataModel.reward_address),
-      updateId: poolDataModel.update_id,
+      updateId: Number(poolDataModel.update_id),
       vrfKeyHash: Cardano.VrfVkHex(vrfKeyHash)
     });
   });
   it('mapPoolUpdate', () => {
     expect(mapPoolUpdate(poolUpdateModel)).toEqual({
-      id: poolUpdateModel.id,
-      updateId: poolUpdateModel.update_id
+      id: Number(poolUpdateModel.id),
+      updateId: Number(poolUpdateModel.update_id)
     });
   });
   it('mapAddressOwner', () => {
     expect(mapAddressOwner(addressOwnerModel)).toEqual({
       address: Cardano.RewardAccount(addressOwnerModel.address),
-      hashId: addressOwnerModel.hash_id
+      hashId: Number(addressOwnerModel.hash_id)
     });
   });
   it('mapEpochReward', () => {
-    expect(mapEpochReward(epochRewardModel, hash_id)).toEqual({
+    expect(mapEpochReward(epochRewardModel, hashId)).toEqual({
       epochReward: {
         activeStake: BigInt(epochRewardModel.active_stake),
         epoch: epochRewardModel.epoch_no,
@@ -178,12 +180,12 @@ describe('mappers', () => {
         operatorFees: BigInt(epochRewardModel.operator_fees),
         totalRewards: BigInt(epochRewardModel.total_rewards)
       },
-      hashId: hash_id
+      hashId
     });
   });
   it('mapPoolMetrics', () => {
     expect(mapPoolMetrics(poolMetricsModel)).toEqual({
-      hashId: poolMetricsModel.pool_hash_id,
+      hashId: Number(poolMetricsModel.pool_hash_id),
       metrics: {
         activeStake: BigInt(poolMetricsModel.active_stake),
         blocksCreated: poolMetricsModel.blocks_created,
@@ -196,7 +198,7 @@ describe('mappers', () => {
   it('mapPoolAPY', () => {
     expect(mapPoolAPY(poolAPYModel)).toEqual({
       apy: poolAPYModel.apy,
-      hashId: poolAPYModel.hash_id
+      hashId
     });
   });
   it('calcNodeMetricsValues', () => {
@@ -231,7 +233,7 @@ describe('mappers', () => {
     const poolRegistrations = [mapPoolRegistration(poolRegistrationModel)];
     const poolRelays = [mapRelay(poolRelayByAddress)];
     const poolRetirements = [mapPoolRetirement(poolRetirementModel)];
-    const poolRewards = [mapEpochReward(epochRewardModel, hash_id)];
+    const poolRewards = [mapEpochReward(epochRewardModel, hashId)];
     const partialMetrics = [mapPoolMetrics(poolMetricsModel)];
     const poolAPYs = [mapPoolAPY(poolAPYModel)];
     const poolMetrics = calcNodeMetricsValues(
@@ -265,7 +267,7 @@ describe('mappers', () => {
 
     it('toStakePoolResults with retiring status', () => {
       expect(
-        toStakePoolResults([poolDataModel.hash_id], fromCache, {
+        toStakePoolResults([hashId], fromCache, {
           lastEpochNo: poolRetirementModel.retiring_epoch - 1,
           nodeMetricsDependencies,
           poolAPYs,
@@ -279,7 +281,7 @@ describe('mappers', () => {
           totalCount
         })
       ).toStrictEqual({
-        poolsToCache: { [poolDataModel.hash_id]: stakePool },
+        poolsToCache: { [hashId]: stakePool },
         results: { pageResults: [stakePool], totalResultCount: totalCount }
       });
     });
@@ -288,7 +290,7 @@ describe('mappers', () => {
       const stakePoolRetired = { ...stakePool, status: Cardano.StakePoolStatus.Retired };
 
       expect(
-        toStakePoolResults([poolDataModel.hash_id], fromCache, {
+        toStakePoolResults([hashId], fromCache, {
           lastEpochNo: poolRetirementModel.retiring_epoch + 1,
           nodeMetricsDependencies,
           poolAPYs,
@@ -323,7 +325,7 @@ describe('mappers', () => {
       };
 
       expect(
-        toStakePoolResults([poolDataModel.hash_id], fromCache, {
+        toStakePoolResults([hashId], fromCache, {
           lastEpochNo: poolRegistrationModel.active_epoch_no - 1,
           nodeMetricsDependencies,
           poolAPYs,
@@ -337,7 +339,7 @@ describe('mappers', () => {
           totalCount
         })
       ).toEqual({
-        poolsToCache: { [poolDataModel.hash_id]: stakePoolActivating },
+        poolsToCache: { [hashId]: stakePoolActivating },
         results: {
           pageResults: [stakePoolActivating],
           totalResultCount: totalCount
@@ -358,7 +360,7 @@ describe('mappers', () => {
       };
 
       expect(
-        toStakePoolResults([poolDataModel.hash_id], fromCache, {
+        toStakePoolResults([hashId], fromCache, {
           lastEpochNo: poolRegistrationModel.active_epoch_no,
           nodeMetricsDependencies,
           poolAPYs,
@@ -372,7 +374,7 @@ describe('mappers', () => {
           totalCount
         })
       ).toEqual({
-        poolsToCache: { [poolDataModel.hash_id]: stakePoolActive },
+        poolsToCache: { [hashId]: stakePoolActive },
         results: {
           pageResults: [stakePoolActive],
           totalResultCount: totalCount
@@ -383,8 +385,8 @@ describe('mappers', () => {
     it('toStakePoolResults with cached pool', () => {
       expect(
         toStakePoolResults(
-          [poolDataModel.hash_id],
-          { [poolDataModel.hash_id]: stakePool },
+          [hashId],
+          { [hashId]: stakePool },
           {
             lastEpochNo: poolRetirementModel.retiring_epoch - 1,
             nodeMetricsDependencies,

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -149,9 +149,9 @@ describe('StakePoolHttpService', () => {
     describe('/search', () => {
       const url = '/search';
       const DB_POLL_QUERIES_COUNT = 1;
-      const cachedSubQueriesCount = 10;
-      const cacheKeysCount = 7;
-      const nonCacheableSubQueriesCount = 2; // queryTotalCount and getLastEpoch
+      const cachedSubQueriesCount = 11;
+      const cacheKeysCount = 8;
+      const nonCacheableSubQueriesCount = 1; // getLastEpoch
       const filerOnePoolOptions: QueryStakePoolsArgs = {
         filters: {
           identifier: {


### PR DESCRIPTION
# Context

Run this twice:

`time curl -d '{"filters":{"pledgeMet":true,"status":["active","activating"]},"pagination":{"startAt":0,"limit":10}}' -H "Content-Type: application/json" -X POST https://testnet-dev-backend.dev.lw.iog.io/stake-pool/search`
2nd run (cache should be primed) takes ~12s
The run this twice:

`time curl -d '{"filters":{"status":["active","activating"]},"pagination":{"startAt":0,"limit":10}}' -H "Content-Type: application/json" -X POST https://testnet-dev-backend.dev.lw.iog.io/stake-pool/search`
2nd run takes ~0.3s

# Proposed Solution
After troubleshooting and reproducing the issue locally with the restored latest `db-sync` snapshot, it's found out that the bottleneck is `#builder.queryTotalCount(query, params)` which initially wasn't cached due to its relative simplicity but it turned out its performance is significantly affected by `pledgeMet` filter option which takes part in the [query builders](https://github.com/input-output-hk/cardano-js-sdk/blob/5910f552755e2a3fda75c48437f8534a913ad6c2/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts#L140-L143) at the beginning.

The proposed solution is to cache the query with the default TTL value.
With the applied fix, the stake pool search total response time with the applied arguments is reduced to a minimum as expected when we have a cache hit.

QA: should be tested in our `https://testnet-dev-backend.dev.lw.iog.io` env once it's merged and deployed.

# Important Changes Introduced
- fix the `hash_id` and `update_id` model value types, their type is `bigint` in the database, so when we query them the values are coming as strings but the return types expose them as numbers. Updated the mappers and tests as we need to cast them as `number` to match the return types.
- cache `queryTotalCount` response to reduce the total response time (explained above in # Proposed Solution)
- fix `orderedResultUpdateIds` [sorting](https://github.com/input-output-hk/cardano-js-sdk/compare/fix/stake-pool-search-with-pledge-met?expand=1#diff-3a938d2c168d4b251612c6efabf201ac70e7585c3c1c2149b3c34e71981e6666R80-R82), while debugging I noticed that the order wasn't correct like `orderedResultHashIds` collection (both exist before caching strategy).The final ordered stake pools response is not affected by this issue at all but would be good to have the right order everywhere, even for the internal computations only.