### PR TITLE
fix: rollback ProtocolParametersRequiredByWallet type

### DIFF
--- a/packages/blockfrost/src/BlockfrostToCore.ts
+++ b/packages/blockfrost/src/BlockfrostToCore.ts
@@ -27,36 +27,15 @@ export const BlockfrostToCore = {
     blockfrost: Responses['epoch_param_content']
   ): ProtocolParametersRequiredByWallet => ({
     coinsPerUtxoByte: Number(blockfrost.coins_per_utxo_word),
-    collateralPercentage: Number(blockfrost.collateral_percent),
-    decentralizationParameter: String(blockfrost.decentralisation_param),
-    desiredNumberOfPools: blockfrost.n_opt,
-    maxBlockBodySize: blockfrost.max_block_size,
-    maxBlockHeaderSize: blockfrost.max_block_header_size,
     maxCollateralInputs: Number(blockfrost.max_collateral_inputs),
-    maxExecutionUnitsPerBlock: {
-      memory: Number(blockfrost.max_block_ex_mem),
-      steps: Number(blockfrost.max_block_ex_mem)
-    },
-    maxExecutionUnitsPerTransaction: {
-      memory: Number(blockfrost.max_tx_ex_mem),
-      steps: Number(blockfrost.max_tx_ex_steps)
-    },
     maxTxSize: Number(blockfrost.max_tx_size),
     maxValueSize: Number(blockfrost.max_val_size),
     minFeeCoefficient: blockfrost.min_fee_a,
     minFeeConstant: blockfrost.min_fee_b,
     minPoolCost: Number(blockfrost.min_pool_cost),
-    monetaryExpansion: String(blockfrost.rho),
     poolDeposit: Number(blockfrost.pool_deposit),
-    poolInfluence: String(blockfrost.a0),
-    poolRetirementEpochBound: blockfrost.e_max,
-    prices: {
-      memory: Number(blockfrost.price_mem),
-      steps: Number(blockfrost.price_step)
-    },
     protocolVersion: { major: blockfrost.protocol_major_ver, minor: blockfrost.protocol_minor_ver },
-    stakeKeyDeposit: Number(blockfrost.key_deposit),
-    treasuryExpansion: String(blockfrost.tau)
+    stakeKeyDeposit: Number(blockfrost.key_deposit)
   }),
 
   inputFromUtxo: (address: string, utxo: BlockfrostUtxo): BlockfrostInput => ({

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -42,57 +42,21 @@ export const toWalletProtocolParams = ({
   protocol_major,
   protocol_minor,
   min_fee_a,
-  min_fee_b,
-  max_block_size,
-  max_bh_size,
-  optimal_pool_count,
-  influence,
-  monetary_expand_rate,
-  treasury_growth_rate,
-  decentralisation,
-  collateral_percent,
-  price_mem,
-  price_step,
-  max_tx_ex_mem,
-  max_tx_ex_steps,
-  max_block_ex_mem,
-  max_block_ex_steps,
-  max_epoch
+  min_fee_b
 }: WalletProtocolParamsModel): ProtocolParametersRequiredByWallet => ({
   coinsPerUtxoByte: Number(coins_per_utxo_size),
-  collateralPercentage: collateral_percent,
-  decentralizationParameter: String(decentralisation),
-  desiredNumberOfPools: optimal_pool_count,
-  maxBlockBodySize: max_block_size,
-  maxBlockHeaderSize: max_bh_size,
   maxCollateralInputs: max_collateral_inputs,
-  maxExecutionUnitsPerBlock: {
-    memory: Number(max_block_ex_mem),
-    steps: Number(max_block_ex_steps)
-  },
-  maxExecutionUnitsPerTransaction: {
-    memory: Number(max_tx_ex_mem),
-    steps: Number(max_tx_ex_steps)
-  },
   maxTxSize: max_tx_size,
   maxValueSize: Number(max_val_size),
   minFeeCoefficient: min_fee_a,
   minFeeConstant: min_fee_b,
   minPoolCost: Number(min_pool_cost),
-  monetaryExpansion: String(monetary_expand_rate),
   poolDeposit: Number(pool_deposit),
-  poolInfluence: String(influence),
-  poolRetirementEpochBound: max_epoch,
-  prices: {
-    memory: price_mem,
-    steps: price_step
-  },
   protocolVersion: {
     major: protocol_major,
     minor: protocol_minor
   },
-  stakeKeyDeposit: Number(key_deposit),
-  treasuryExpansion: String(treasury_growth_rate)
+  stakeKeyDeposit: Number(key_deposit)
 });
 
 export const toGenesisParams = (genesis: GenesisData): Cardano.CompactGenesis => ({

--- a/packages/core/src/Provider/NetworkInfoProvider/types.ts
+++ b/packages/core/src/Provider/NetworkInfoProvider/types.ts
@@ -1,6 +1,18 @@
 import { Cardano, EraSummary, Provider } from '../..';
 
-export type ProtocolParametersRequiredByWallet = Omit<Cardano.ProtocolParameters, 'costModels'>;
+export type ProtocolParametersRequiredByWallet = Pick<
+  Cardano.ProtocolParameters,
+  | 'coinsPerUtxoByte'
+  | 'maxTxSize'
+  | 'maxValueSize'
+  | 'stakeKeyDeposit'
+  | 'maxCollateralInputs'
+  | 'minFeeCoefficient'
+  | 'minFeeConstant'
+  | 'minPoolCost'
+  | 'poolDeposit'
+  | 'protocolVersion'
+>;
 
 export type SupplySummary = {
   circulating: Cardano.Lovelace;


### PR DESCRIPTION
# Context

#416 introduced an unnecessary breaking change: add more properties to `ProtocolParametersRequiredByWallet`

# Proposed Solution

Rollback the change to `ProtocolParametersRequiredByWallet`
