### PR TITLE
feat(cardano-services): make search stake pool case insensitive

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -662,6 +662,8 @@ LEFT JOIN pool_offline_data pod
 WHERE pu.id = ANY($1)
 `;
 
+const toCaseInsensitiveParam = (_array: string[]) => `${_array.join('|')}`;
+
 const toSimilarToString = (_array: string[]) => `%(${_array.join('|')})%`;
 
 export const getIdentifierWhereClause = (
@@ -681,13 +683,13 @@ export const getIdentifierWhereClause = (
   const whereConditions = [];
   const params = [];
   if (names.length > 0) {
-    params.push(toSimilarToString(names));
+    params.push(toCaseInsensitiveParam(names));
     // eslint-disable-next-line quotes
-    whereConditions.push(`(pod."json" ->>'name')::varchar SIMILAR TO $1`);
+    whereConditions.push(`(pod."json" ->>'name')::varchar ~* $1`);
   }
   if (tickers.length > 0) {
-    params.push(toSimilarToString(tickers));
-    whereConditions.push(`pod.ticker_name SIMILAR TO $${params.length}`);
+    params.push(toCaseInsensitiveParam(tickers));
+    whereConditions.push(`pod.ticker_name ~* $${params.length}`);
   }
   if (ids.length > 0) {
     params.push(toSimilarToString(ids));

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`StakePoolBuilder buildAndQuery buildAndQuery, queryPoolHashes & queryTotalCount 1`] = `
 Object {
   "params": Array [
-    "%(CL)%",
-    "%(CLIO)%",
+    "CL",
+    "CLIO",
     "%(pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70)%",
   ],
   "query": "WITH 
@@ -131,7 +131,7 @@ Object {
            WHERE  
     ((COALESCE(o_balance.total_amount,0) +
     COALESCE (r_balance.total_amount, 0)) 
-     >= ph.pledge) AND ((pod.\\"json\\" ->>'name')::varchar SIMILAR TO $1 and pod.ticker_name SIMILAR TO $2 and ph.view SIMILAR TO $3) AND ((COALESCE(pr.retiring_epoch,0) > (SELECT \\"no\\" FROM current_epoch) 
+     >= ph.pledge) AND ((pod.\\"json\\" ->>'name')::varchar ~* $1 and pod.ticker_name ~* $2 and ph.view SIMILAR TO $3) AND ((COALESCE(pr.retiring_epoch,0) > (SELECT \\"no\\" FROM current_epoch) 
           AND COALESCE(pr.retiring_epoch,0) > ph.active_epoch_no) OR (COALESCE(pr.retiring_epoch,0) <= (SELECT \\"no\\" FROM current_epoch) 
           AND COALESCE(pr.retiring_epoch,0) > ph.active_epoch_no) OR (ph.active_epoch_no > (SELECT \\"no\\" FROM current_epoch) 
           AND COALESCE(pr.retiring_epoch,0) <= ph.active_epoch_no) OR (ph.active_epoch_no <= (SELECT \\"no\\" FROM current_epoch) 
@@ -144,8 +144,8 @@ exports[`StakePoolBuilder buildAndQuery buildAndQuery, queryPoolHashes & queryTo
 exports[`StakePoolBuilder buildOrQuery buildOrQuery, queryPoolHashes & queryTotalCount 1`] = `
 Object {
   "params": Array [
-    "%(CL)%",
-    "%(CLIO)%",
+    "CL",
+    "CLIO",
     "%(pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70)%",
   ],
   "query": "
@@ -175,7 +175,7 @@ Object {
     LEFT JOIN pool_offline_data pod 
       ON pod.pool_id = ph.id
     
-    WHERE ((pod.\\"json\\" ->>'name')::varchar SIMILAR TO $1 and pod.ticker_name SIMILAR TO $2 and ph.view SIMILAR TO $3)
+    WHERE ((pod.\\"json\\" ->>'name')::varchar ~* $1 and pod.ticker_name ~* $2 and ph.view SIMILAR TO $3)
     ), pools_by_status AS (
     
     SELECT
@@ -320,8 +320,8 @@ Object {
     "name": "pools_by_identifier",
   },
   "params": Array [
-    "%(CL)%",
-    "%(CLIO)%",
+    "CL",
+    "CLIO",
     "%(pool1jcwn98a6rqr7a7yakanm5sz6asx9gfjsr343mus0tsye23wmg70)%",
   ],
   "query": "
@@ -344,7 +344,7 @@ Object {
     LEFT JOIN pool_offline_data pod 
       ON pod.pool_id = ph.id
     
-    WHERE ((pod.\\"json\\" ->>'name')::varchar SIMILAR TO $1 and pod.ticker_name SIMILAR TO $2 and ph.view SIMILAR TO $3)
+    WHERE ((pod.\\"json\\" ->>'name')::varchar ~* $1 and pod.ticker_name ~* $2 and ph.view SIMILAR TO $3)
     ",
 }
 `;

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -365,6 +365,23 @@ describe('StakePoolHttpService', () => {
           expect(responseWithOrCondition).toEqual(responseWithAndConditionCached);
           expect(responseWithAndCondition).toEqual(responseWithAndConditionCached);
         });
+        it('is case insensitive', async () => {
+          const values = [{ name: 'banderini', ticker: 'TEST' }];
+          const insensitiveValues = [{ name: 'bAnDeRiNi', ticker: 'TeSt' }];
+          const req: QueryStakePoolsArgs = {
+            filters: {
+              identifier: { values }
+            }
+          };
+          const reqWithInsensitiveValues: QueryStakePoolsArgs = {
+            filters: {
+              identifier: { values: insensitiveValues }
+            }
+          };
+          const response = await provider.queryStakePools(req);
+          const responseWithInsensitiveValues = await provider.queryStakePools(reqWithInsensitiveValues);
+          expect(response).toEqual(responseWithInsensitiveValues);
+        });
         it('no given condition equals to OR condition', async () => {
           const req: QueryStakePoolsArgs = {
             filters: {


### PR DESCRIPTION
# Context

Make stake pool search by ticker and name case insensitive

# Description

Replace `SIMILAR TO` sentence by `~*` POSIX regular expression.
Ref: https://stackoverflow.com/questions/7005302/how-to-make-case-insensitive-query-in-postgresql
