### PR TITLE
feat(wallet)!: withdraw rewards on every transaction

### DIFF
--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -184,6 +184,7 @@ export interface TxBuilder {
 
   /**
    * Builds a `ValidTxBody` based on partialTxBody.
+   * All positive balance found in reward accounts is included in the transaction withdrawal.
    * Performs multiple validations to make sure the transaction body is correct.
    * In case validations fail, it creates a `TxBodyValidationError` instead of `ValidTxBody`.
    *

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -16,7 +16,6 @@ import { Shutdown } from '@cardano-sdk/util';
 export type InitializeTxProps = {
   outputs?: Set<Cardano.TxOut>;
   certificates?: Cardano.Certificate[];
-  withdrawals?: Cardano.Withdrawal[];
   auxiliaryData?: Cardano.AuxiliaryData;
   options?: {
     validityInterval?: Cardano.ValidityInterval;

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -1,13 +1,40 @@
 import { Cardano } from '@cardano-sdk/core';
-import { SingleAddressWallet, TransactionFailure } from '../../src';
+import { firstValueFrom, of } from 'rxjs';
+import { logger } from '@cardano-sdk/util-dev';
+
+import * as mocks from '../mocks';
+import { RewardAccount, SingleAddressWallet, StakeKeyStatus, TransactionFailure, buildTx } from '../../src';
+import { assertTxIsValid } from '../util';
 import { createWallet } from './util';
-import { firstValueFrom } from 'rxjs';
 
 describe('integration/withdrawal', () => {
   let wallet: SingleAddressWallet;
+  let rewardAccounts: RewardAccount[];
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     ({ wallet } = await createWallet());
+    rewardAccounts = [
+      {
+        address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
+        delegatee: {
+          currentEpoch: undefined,
+          nextEpoch: undefined,
+          nextNextEpoch: undefined
+        },
+        keyStatus: StakeKeyStatus.Registered,
+        rewardBalance: 33_333n
+      },
+      {
+        address: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
+        delegatee: {
+          currentEpoch: undefined,
+          nextEpoch: undefined,
+          nextNextEpoch: undefined
+        },
+        keyStatus: StakeKeyStatus.Unregistered,
+        rewardBalance: 44_444n
+      }
+    ];
   });
 
   it('has balance', async () => {
@@ -15,9 +42,47 @@ describe('integration/withdrawal', () => {
     expect(typeof (await firstValueFrom(wallet.balance.rewardAccounts.rewards$))).toBe('bigint');
   });
 
+  it('does not set withdrawal when reward account has zero balance', async () => {
+    rewardAccounts[0].rewardBalance = 0n;
+    wallet.delegation.rewardAccounts$ = of([rewardAccounts[0]]);
+
+    const txBuilder = buildTx({ logger, observableWallet: wallet });
+    const tx = await txBuilder.addOutput(mocks.utxo[0][1]).build();
+    assertTxIsValid(tx);
+
+    expect(tx.body.withdrawals).toBeUndefined();
+  });
+
+  it(`does not withdraw from reward accounts with zero balance when 
+      there are others with positive balance`, async () => {
+    rewardAccounts[0].rewardBalance = 0n;
+    wallet.delegation.rewardAccounts$ = of(rewardAccounts);
+
+    const txBuilder = buildTx({ logger, observableWallet: wallet });
+    const tx = await txBuilder.addOutput(mocks.utxo[0][1]).build();
+    assertTxIsValid(tx);
+
+    const withdrawWithReward: Cardano.Withdrawal = {
+      quantity: rewardAccounts[1].rewardBalance,
+      stakeAddress: rewardAccounts[1].address
+    };
+    expect(tx.body.withdrawals).toEqual([withdrawWithReward]);
+  });
+
+  it('can withdraw from multiple accounts in the same transaction', async () => {
+    wallet.delegation.rewardAccounts$ = of(rewardAccounts);
+    const txBuilder = buildTx({ logger, observableWallet: wallet });
+    const tx = await txBuilder.addOutput(mocks.utxo[0][1]).build();
+    assertTxIsValid(tx);
+
+    const withdrawals: Cardano.Withdrawal[] = rewardAccounts.map(
+      ({ rewardBalance: quantity, address: stakeAddress }) => ({ quantity, stakeAddress })
+    );
+    expect(tx.body.withdrawals).toEqual(withdrawals);
+  });
+
   it('can submit transaction', async () => {
     const availableRewards = await firstValueFrom(wallet.balance.rewardAccounts.rewards$);
-
     const rewardAccount = (await firstValueFrom(wallet.addresses$))[0].rewardAccount;
     const txInternals = await wallet.initializeTx({
       certificates: [
@@ -26,11 +91,12 @@ describe('integration/withdrawal', () => {
           stakeKeyHash: Cardano.Ed25519KeyHash.fromRewardAccount(rewardAccount)
         }
       ],
-      outputs: new Set(), // In a real transaction you would probably want to have some outputs
-      withdrawals: [{ quantity: availableRewards, stakeAddress: rewardAccount }]
+      outputs: new Set() // In a real transaction you would probably want to have some outputs
     });
     expect(typeof txInternals.body.fee).toBe('bigint');
     const tx = await wallet.finalizeTx({ tx: txInternals });
+
+    expect(tx.body.withdrawals).toEqual([{ quantity: availableRewards, stakeAddress: rewardAccount }]);
 
     const confirmedSubscription = wallet.transactions.outgoing.confirmed$.subscribe((confirmedTx) => {
       if (confirmedTx === tx) {


### PR DESCRIPTION
# Context
ADP-2190 Wallet users shouldn’t have to manually withdraw rewards. 

# Proposed Solution
Update SingleAddressWallet implementation to withdraw rewards on every transaction (if available)

# Important Changes Introduced
removed `withdrawals` property from `InitializeTxProps`