### PR TITLE
fix(core): coreToCsl converts datum in txOut function

### DIFF
--- a/packages/core/src/CSL/coreToCsl/coreToCsl.ts
+++ b/packages/core/src/CSL/coreToCsl/coreToCsl.ts
@@ -9,6 +9,7 @@ import {
   BootstrapWitness,
   BootstrapWitnesses,
   Certificates,
+  DataHash,
   Ed25519KeyHash,
   Ed25519KeyHashes,
   Ed25519Signature,
@@ -94,8 +95,15 @@ export const value = ({ coins, assets }: Cardano.Value): Value => {
 export const txIn = (core: Cardano.NewTxIn): TransactionInput =>
   TransactionInput.new(TransactionHash.from_bytes(Buffer.from(core.txId, 'hex')), core.index);
 
-export const txOut = (core: Cardano.TxOut): TransactionOutput =>
-  TransactionOutput.new(parseCslAddress(core.address.toString())!, value(core.value));
+export const txOut = (core: Cardano.TxOut): TransactionOutput => {
+  const cslTxOut = TransactionOutput.new(parseCslAddress(core.address.toString())!, value(core.value));
+
+  if (core.datum !== undefined) {
+    cslTxOut.set_data_hash(DataHash.from_bytes(Buffer.from(core.datum.toString(), 'hex')));
+  }
+
+  return cslTxOut;
+};
 
 export const utxo = (core: Cardano.Utxo[]): TransactionUnspentOutput[] =>
   core.map((item) => TransactionUnspentOutput.new(txIn(item[0]), txOut(item[1])));

--- a/packages/core/test/CSL/coreToCsl.test.ts
+++ b/packages/core/test/CSL/coreToCsl.test.ts
@@ -2,7 +2,18 @@
 import { Asset, CSL, Cardano, SerializationFailure, coreToCsl } from '../../src';
 import { BigNum } from '@emurgo/cardano-serialization-lib-nodejs';
 import { Ed25519KeyHash, NativeScript, NativeScriptKind, ScriptType } from '../../src/Cardano';
-import { signature, tx, txBody, txIn, txInWithAddress, txOut, valueCoinOnly, valueWithAssets, vkey } from './testData';
+import {
+  signature,
+  tx,
+  txBody,
+  txIn,
+  txInWithAddress,
+  txOut,
+  txOutWithDatum,
+  valueCoinOnly,
+  valueWithAssets,
+  vkey
+} from './testData';
 
 const txOutByron = {
   ...txOut,
@@ -15,9 +26,16 @@ describe('coreToCsl', () => {
   it('txIn', () => {
     expect(coreToCsl.txIn(txIn)).toBeInstanceOf(CSL.TransactionInput);
   });
-  it('txOut', () => {
-    expect(coreToCsl.txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
-    expect(coreToCsl.txOut(txOutByron)).toBeInstanceOf(CSL.TransactionOutput);
+  describe('txOut', () => {
+    it('converts to CSL.TransactionOutput', () => {
+      expect(coreToCsl.txOut(txOut)).toBeInstanceOf(CSL.TransactionOutput);
+      expect(coreToCsl.txOut(txOutByron)).toBeInstanceOf(CSL.TransactionOutput);
+    });
+    it('converts datum to CSL.DataHash', () => {
+      const cslTxOut = coreToCsl.txOut(txOutWithDatum);
+      expect(cslTxOut.data_hash()).toBeInstanceOf(CSL.DataHash);
+      expect(Buffer.from(cslTxOut.data_hash()!.to_bytes()).toString('hex')).toBe(txOutWithDatum.datum?.toString());
+    });
   });
   it('utxo', () => {
     expect(coreToCsl.utxo([[txInWithAddress, txOut]])[0]).toBeInstanceOf(CSL.TransactionUnspentOutput);

--- a/packages/core/test/CSL/testData.ts
+++ b/packages/core/test/CSL/testData.ts
@@ -67,6 +67,14 @@ export const txOut: Cardano.TxOut = {
   value: valueWithAssets
 };
 
+export const txOutWithDatum: Cardano.TxOut = {
+  address: Cardano.Address(
+    'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+  ),
+  datum: Cardano.Hash32ByteBase16('4c94610a582b748b8db506abb45ccd48d0d4934942daa87d191645b947a547a7'),
+  value: valueWithAssets
+};
+
 export const txBody: Cardano.NewTxBodyAlonzo = {
   certificates: [
     {


### PR DESCRIPTION
# Context

I commit another change because I found that coreToCsl.txOut doesn't include the datum hash when the attibute _TxOut.datum?_ is defined. 

# Proposed Solution

I added an if statement in the function to convert the 32 bytes hex strting to a DataHash:

``` javascript
export const txOut = (core: Cardano.TxOut): TransactionOutput => {
  const cslTxOut = TransactionOutput.new(parseCslAddress(core.address.toString())!, value(core.value));

  if (core.datum !== undefined) {
    cslTxOut.set_data_hash(DataHash.from_bytes(Buffer.from(core.datum.toString(), 'hex')));
  }

  return cslTxOut;
};
```
I also added as test data _txOutWithDatum_ and the following unit test, which failed with the old implementation:

``` javascript
    it('converts datum to CSL.DataHash', () => {
      const cslTxOut = coreToCsl.txOut(txOutWithDatum);
      expect(cslTxOut.data_hash()).toBeInstanceOf(CSL.DataHash);
      expect(Buffer.from(cslTxOut.data_hash()!.to_bytes()).toString('hex')).toBe(txOutWithDatum.datum?.toString());
    });
```

# Important Changes Introduced

None.
