### PR TITLE
docs: update README workflow badges

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,7 +21,7 @@ jobs:
         ref: nightly
         submodules: true
 
-    - name: Merge in master
+    - name: ⏬ Merge in master
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
@@ -34,19 +34,20 @@ jobs:
         node-version: 14.17
         registry-url: 'https://registry.npmjs.org'
 
-    - name: Install dependencies
+    - name: 💽 Install dependencies
       run: |
         yarn install --immutable --inline-builds --mode=skip-build
         git checkout yarn-project.nix
 
-    - name: Check if any packages changed
+    - name: 📝 Count changed packages
+      uses: sergeysova/jq-action@v2
       id: precondition
       run: |
-        CHANGED=$(yarn run lerna changed --json | node -e "console.log(JSON.parse(require('fs').readFileSync(0).toString()).length)")
+        CHANGED=$(yarn run lerna changed --json | jq -ne 'input? // 0 | length')
         echo "$CHANGED packages changed"
         echo "::set-output name=changed::$(($CHANGED))"
 
-    - name: Publish
+    - name: 📤 Publish
       if: steps.precondition.outputs.changed > 0
       run: |
         yarn build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
   <img width="200" src=".github/images/cardano-logo.png"/>
 </p>
 
-[![CI][img_src_ci]][workflow_ci]
+[![PostIntegration][img_src_post-integration]][workflow_post-integration]
+[![Nightly][img_src_nightly]][workflow_nightly]
+[![Release][img_src_release]][workflow_release]
 
 <hr/>
 
@@ -116,6 +118,10 @@ yarn docs
   <a href="https://input-output-hk.github.io/cardano-js-sdk">:book: Documentation</a>
 </p>
 
-[img_src_ci]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/continuous-integration.yaml/badge.svg
-[workflow_ci]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/continuous-integration.yaml
+[img_src_post-integration]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/post_integration.yml/badge.svg
+[workflow_post-integration]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/post_integration.yml
+[img_src_nightly]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/nightly.yaml/badge.svg
+[workflow_nightly]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/nightly.yaml
+[img_src_release]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/release.yaml/badge.svg
+[workflow_release]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/release.yaml
 [let us know!]: https://github.com/input-output-hk/cardano-graphql/discussions/new


### PR DESCRIPTION
# Context
The CI badge on the homepage is misleading, as it's reflecting the pre-merge state which is often not passing. It's better to show the _post-integration_ workflow run. There are also now two more workflows of interest, _nightly_ and _release_ that we could use some more oversight of.

# Proposed Solution
- replace CI with Post-integration
- Add Nightly and Release
See rendered MD here: https://github.com/input-output-hk/cardano-js-sdk/blob/12171b8265fcda1ac6606deabad0874ada3f5558/README.md