### PR TITLE
fix(cardano-services): fixed an issue that was causing pool saturation to be always 0

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -159,7 +159,7 @@ export class DbSyncStakePoolProvider extends DbSyncProvider implements StakePool
 
     // Get last epoch data
     const lastEpoch = await this.#builder.getLastEpochWithData();
-    const { poolOptimalCount, no: lastEpochNo } = lastEpoch;
+    const { optimalPoolCount, no: lastEpochNo } = lastEpoch;
 
     // Get stake pools data cached
     const { orderedResultHashIds, orderedResultUpdateIds, orderedResult, poolDatas, hashesIds, sortType } =
@@ -214,7 +214,7 @@ export class DbSyncStakePoolProvider extends DbSyncProvider implements StakePool
     const { results, poolsToCache } = toStakePoolResults(orderedResultHashIds, fromCache, {
       lastEpochNo,
       nodeMetricsDependencies: {
-        poolOptimalCount,
+        optimalPoolCount,
         stakeDistribution,
         totalAdaAmount: BigInt(totalAdaAmount)
       },

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
@@ -45,7 +45,7 @@ const getPoolStatus = (
 interface NodeMetricsDependencies {
   stakeDistribution: StakeDistribution;
   totalAdaAmount: Cardano.Lovelace;
-  poolOptimalCount?: number;
+  optimalPoolCount?: number;
 }
 
 interface ToCoreStakePoolInput {
@@ -69,7 +69,7 @@ interface ToCoreStakePoolInput {
 export const calcNodeMetricsValues = (
   poolId: Cardano.PoolId,
   metrics: PoolMetrics['metrics'],
-  { totalAdaAmount, stakeDistribution, poolOptimalCount = 0 }: NodeMetricsDependencies,
+  { totalAdaAmount, stakeDistribution, optimalPoolCount = 0 }: NodeMetricsDependencies,
   apy: number
 ): Cardano.StakePoolMetrics => {
   const { activeStake, ...rest } = metrics;
@@ -89,7 +89,7 @@ export const calcNodeMetricsValues = (
   };
   stakePoolMetrics.size = size;
   stakePoolMetrics.stake = stake;
-  stakePoolMetrics.saturation = Number(divideBigIntToFloat(totalStake * BigInt(poolOptimalCount), totalAdaAmount));
+  stakePoolMetrics.saturation = Number(divideBigIntToFloat(totalStake * BigInt(optimalPoolCount), totalAdaAmount));
   return stakePoolMetrics;
 };
 
@@ -224,9 +224,9 @@ export const mapRelay = (relayModel: RelayModel): PoolRelay => {
   return { hashId: Number(relayModel.hash_id), relay, updateId: Number(relayModel.update_id) };
 };
 
-export const mapEpoch = ({ no, pool_optimal_count }: EpochModel): Epoch => ({
+export const mapEpoch = ({ no, optimal_pool_count }: EpochModel): Epoch => ({
   no,
-  poolOptimalCount: pool_optimal_count
+  optimalPoolCount: optimal_pool_count
 });
 
 export const mapEpochReward = (epochRewardModel: EpochRewardModel, hashId: number): EpochReward => ({
@@ -265,7 +265,7 @@ export const mapPoolMetrics = (poolMetricsModel: PoolMetricsModel): PoolMetrics 
     blocksCreated: poolMetricsModel.blocks_created,
     delegators: poolMetricsModel.delegators,
     livePledge: BigInt(poolMetricsModel.live_pledge),
-    saturation: poolMetricsModel.saturation
+    saturation: Number.parseFloat(poolMetricsModel.saturation)
   }
 });
 

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
@@ -54,12 +54,12 @@ export interface RelayModel {
 
 export interface Epoch {
   no: number;
-  poolOptimalCount?: number;
+  optimalPoolCount?: number;
 }
 
 export interface EpochModel {
   no: number;
-  pool_optimal_count?: number;
+  optimal_pool_count?: number;
 }
 
 export interface EpochReward {
@@ -130,7 +130,7 @@ export interface PoolMetricsModel {
   active_stake: string;
   live_stake: string;
   live_pledge: string;
-  saturation: number;
+  saturation: string;
   active_stake_percentage: number;
   live_stake_percentage: number;
   pool_hash_id: string;

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -1320,14 +1320,14 @@ Array [
     "blocksCreated": "0",
     "delegators": "1",
     "livePledge": 999999828559n,
-    "saturation": "0.01189867476975633141",
+    "saturation": 0.011898674769756331,
   },
   Object {
     "activeStake": 2986376991n,
     "blocksCreated": "0",
     "delegators": "1",
     "livePledge": 495463149n,
-    "saturation": "0.000041429290528821850262",
+    "saturation": 0.00004142929052882185,
   },
 ]
 `;
@@ -1339,14 +1339,14 @@ Array [
     "blocksCreated": "0",
     "delegators": "1",
     "livePledge": 495463149n,
-    "saturation": "0.000041429290528821850262",
+    "saturation": 0.00004142929052882185,
   },
   Object {
     "activeStake": 1614945000n,
     "blocksCreated": "0",
     "delegators": "0",
     "livePledge": 497325000n,
-    "saturation": "0.000019215708620404440214",
+    "saturation": 0.00001921570862040444,
   },
 ]
 `;
@@ -1358,21 +1358,21 @@ Array [
     "blocksCreated": "0",
     "delegators": "1",
     "livePledge": 999999828559n,
-    "saturation": "0.01189867476975633141",
+    "saturation": 0.011898674769756331,
   },
   Object {
     "activeStake": 2986376991n,
     "blocksCreated": "0",
     "delegators": "1",
     "livePledge": 495463149n,
-    "saturation": "0.000041429290528821850262",
+    "saturation": 0.00004142929052882185,
   },
   Object {
     "activeStake": 1614945000n,
     "blocksCreated": "0",
     "delegators": "0",
     "livePledge": 497325000n,
-    "saturation": "0.000019215708620404440214",
+    "saturation": 0.00001921570862040444,
   },
 ]
 `;
@@ -1384,21 +1384,21 @@ Array [
     "blocksCreated": "0",
     "delegators": "0",
     "livePledge": 497325000n,
-    "saturation": "0.000019215708620404440214",
+    "saturation": 0.00001921570862040444,
   },
   Object {
     "activeStake": 2986376991n,
     "blocksCreated": "0",
     "delegators": "1",
     "livePledge": 495463149n,
-    "saturation": "0.000041429290528821850262",
+    "saturation": 0.00004142929052882185,
   },
   Object {
     "activeStake": 0n,
     "blocksCreated": "0",
     "delegators": "1",
     "livePledge": 999999828559n,
-    "saturation": "0.01189867476975633141",
+    "saturation": 0.011898674769756331,
   },
 ]
 `;

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
@@ -1,7 +1,9 @@
 import { Cardano, StakePoolStats } from '@cardano-sdk/core';
 import {
+  Epoch,
   calcNodeMetricsValues,
   mapAddressOwner,
+  mapEpoch,
   mapEpochReward,
   mapPoolAPY,
   mapPoolData,
@@ -98,14 +100,14 @@ describe('mappers', () => {
     live_stake: '100000000',
     live_stake_percentage: 0.5,
     pool_hash_id: hash_id,
-    saturation: 0.000_000_8
+    saturation: '0.000_000_8'
   };
   const poolAPYModel = {
     apy: 0.015,
     hash_id
   };
   const nodeMetricsDependencies = {
-    poolOptimalCount: 10,
+    optimalPoolCount: 10,
     stakeDistribution: mockStakeDistribution,
     totalAdaAmount: BigInt('42000004107749657')
   };
@@ -191,7 +193,7 @@ describe('mappers', () => {
         blocksCreated: poolMetricsModel.blocks_created,
         delegators: poolMetricsModel.delegators,
         livePledge: BigInt(poolMetricsModel.live_pledge),
-        saturation: poolMetricsModel.saturation
+        saturation: Number.parseFloat(poolMetricsModel.saturation)
       }
     });
   });
@@ -411,6 +413,13 @@ describe('mappers', () => {
   it('mapPoolStats', () => {
     expect(mapPoolStats({ active: '20', retired: '0', retiring: '1' })).toEqual<StakePoolStats>({
       qty: { active: 20, retired: 0, retiring: 1 }
+    });
+  });
+
+  it('maps getLastEpochWithData query result to Epoch', () => {
+    expect(mapEpoch({ no: 44, optimal_pool_count: 500 })).toEqual<Epoch>({
+      no: 44,
+      optimalPoolCount: 500
     });
   });
 });

--- a/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
@@ -36,7 +36,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -110,7 +110,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -183,7 +183,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -247,7 +247,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -313,7 +313,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -378,7 +378,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -451,7 +451,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -515,7 +515,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -649,7 +649,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -714,7 +714,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -777,7 +777,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -842,7 +842,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -960,7 +960,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1062,7 +1062,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1126,7 +1126,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1192,7 +1192,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1257,7 +1257,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -1322,7 +1322,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1395,7 +1395,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -1460,7 +1460,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1540,7 +1540,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1604,7 +1604,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1670,7 +1670,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1735,7 +1735,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -1800,7 +1800,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -1939,7 +1939,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2003,7 +2003,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2069,7 +2069,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2134,7 +2134,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -2199,7 +2199,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2272,7 +2272,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2336,7 +2336,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2470,7 +2470,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2533,7 +2533,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -2598,7 +2598,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2716,7 +2716,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2818,7 +2818,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -2882,7 +2882,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3016,7 +3016,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -3081,7 +3081,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3213,7 +3213,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3277,7 +3277,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3358,7 +3358,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3422,7 +3422,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3556,7 +3556,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3621,7 +3621,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -3686,7 +3686,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3884,7 +3884,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -3948,7 +3948,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4082,7 +4082,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -4147,7 +4147,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4279,7 +4279,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4343,7 +4343,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4409,7 +4409,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -4474,7 +4474,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4547,7 +4547,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4611,7 +4611,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4745,7 +4745,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4810,7 +4810,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -4873,7 +4873,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -4938,7 +4938,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5056,7 +5056,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5217,7 +5217,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5281,7 +5281,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5347,7 +5347,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -5412,7 +5412,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5485,7 +5485,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5549,7 +5549,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5615,7 +5615,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -5680,7 +5680,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5753,7 +5753,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5817,7 +5817,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -5951,7 +5951,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6014,7 +6014,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -6079,7 +6079,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6197,7 +6197,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6299,7 +6299,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6363,7 +6363,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6429,7 +6429,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6494,7 +6494,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -6559,7 +6559,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6698,7 +6698,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6762,7 +6762,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6828,7 +6828,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -6893,7 +6893,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -6966,7 +6966,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7031,7 +7031,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -7096,7 +7096,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7176,7 +7176,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7240,7 +7240,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7374,7 +7374,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7437,7 +7437,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -7502,7 +7502,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7620,7 +7620,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7715,7 +7715,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -7972,7 +7972,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8037,7 +8037,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -8102,7 +8102,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8160,7 +8160,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8315,7 +8315,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8380,7 +8380,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8443,7 +8443,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8517,7 +8517,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8701,7 +8701,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8766,7 +8766,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -8831,7 +8831,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -8889,7 +8889,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9044,7 +9044,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9109,7 +9109,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9180,7 +9180,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9245,7 +9245,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -9310,7 +9310,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9384,7 +9384,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9576,7 +9576,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9641,7 +9641,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -9706,7 +9706,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9778,7 +9778,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9909,7 +9909,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -9973,7 +9973,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10092,7 +10092,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10179,7 +10179,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10244,7 +10244,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10368,7 +10368,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -10441,7 +10441,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -10565,7 +10565,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10630,7 +10630,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10689,7 +10689,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10835,7 +10835,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10901,7 +10901,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -10965,7 +10965,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11104,7 +11104,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11170,7 +11170,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11235,7 +11235,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -11308,7 +11308,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -11432,7 +11432,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11505,7 +11505,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11564,7 +11564,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11718,7 +11718,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11782,7 +11782,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11916,7 +11916,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -11981,7 +11981,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12044,7 +12044,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -12109,7 +12109,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12227,7 +12227,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12381,7 +12381,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12445,7 +12445,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12587,7 +12587,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12652,7 +12652,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12715,7 +12715,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -12788,7 +12788,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12854,7 +12854,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -12919,7 +12919,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -12992,7 +12992,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13056,7 +13056,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13190,7 +13190,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13255,7 +13255,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13326,7 +13326,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -13391,7 +13391,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13509,7 +13509,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13663,7 +13663,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13728,7 +13728,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -13793,7 +13793,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13856,7 +13856,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -13989,7 +13989,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14055,7 +14055,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14172,7 +14172,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14326,7 +14326,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14390,7 +14390,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14524,7 +14524,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14589,7 +14589,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14652,7 +14652,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -14717,7 +14717,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14835,7 +14835,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -14989,7 +14989,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15054,7 +15054,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -15119,7 +15119,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15320,7 +15320,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -15379,7 +15379,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15466,7 +15466,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15531,7 +15531,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15595,7 +15595,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15658,7 +15658,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15782,7 +15782,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15856,7 +15856,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -15981,7 +15981,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 2080157396n,
-        "saturation": 0,
+        "saturation": 0.003832479766253156,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -16046,7 +16046,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 1099603790n,
-        "saturation": 0,
+        "saturation": 0.0001193079607122087,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -16109,7 +16109,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -16173,7 +16173,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -16232,7 +16232,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -16319,7 +16319,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -16519,7 +16519,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -16584,7 +16584,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -16649,7 +16649,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
-        "saturation": 0,
+        "saturation": 0.5970642370170973,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -16850,7 +16850,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 199806239n,
-        "saturation": 0,
+        "saturation": 0.00018561353404871592,
         "size": Object {
           "active": 0.08565983586872336,
           "live": 0.9143401641312766,
@@ -16917,7 +16917,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "0",
         "livePledge": 497325000n,
-        "saturation": 0,
+        "saturation": 0.00001922553383396,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -17004,7 +17004,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 487464117n,
-        "saturation": 0,
+        "saturation": 0.00002975837301809651,
         "size": Object {
           "active": 1,
           "live": 0,
@@ -17069,7 +17069,7 @@ Object {
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 495463149n,
-        "saturation": 0,
+        "saturation": 0.00003555210355859188,
         "size": Object {
           "active": 1,
           "live": 0,


### PR DESCRIPTION
# Context

Currently pool saturation is being returned as 0. This happens due to a small bug in a `mapEpoch` in the service which maps the dbSync result to a domain type. The query returns `optimal_pool_count`  but the mapping function was expecting it as `pool_optimal_count`.

# Proposed Solution

Fix the mapping function to expect the right field name.

# Important Changes Introduced

- Small bug was fixed in the pool saturation calculation.
- A new unit test to verify the proper function of the mapping function was added.