### PR TITLE
Fix/Ogmios WebSocket close logging

### DIFF
--- a/packages/ogmios/src/util.ts
+++ b/packages/ogmios/src/util.ts
@@ -1,7 +1,13 @@
-import { ConnectionConfig } from '@cardano-ogmios/client';
+import {
+  ConnectionConfig,
+  InteractionContext,
+  InteractionType,
+  createInteractionContext
+} from '@cardano-ogmios/client';
+import { Logger } from 'ts-log';
 
 /**
- * Converts an Ogmios connection URL to a Ogmios ConnectionConfig Object
+ * Converts an Ogmios connection URL to an Ogmios ConnectionConfig Object
  *
  * @param {URL} connectionURL Ogmios connection URL
  * @returns {ConnectionConfig} the ConnectionConfig Object
@@ -11,3 +17,36 @@ export const urlToConnectionConfig = (connectionURL?: URL): ConnectionConfig => 
   port: connectionURL ? Number.parseInt(connectionURL.port) : undefined,
   tls: connectionURL?.protocol === 'wss'
 });
+
+type CreateInteractionContextOptions = {
+  connection?: ConnectionConfig;
+  interactionType?: InteractionType;
+};
+
+/**
+ * Creates an Ogmios InteractionContext with close logic
+ *
+ * @param {Logger} logger Logger instance
+ * @param {CreateInteractionContextOptions} options Options passed to the createInteractionContext function
+ * @param {Function} onUnexpectedClose Optional callback to trigger an action when an unexpected close event occurs
+ * @returns {Promise<InteractionContext>} Promise resolving an Ogmios InteractionContext
+ */
+export const createInteractionContextWithLogger = (
+  logger: Logger,
+  options?: CreateInteractionContextOptions,
+  onUnexpectedClose?: () => Promise<void>
+): Promise<InteractionContext> =>
+  createInteractionContext(
+    (error) => {
+      logger.error({ error }, error.message);
+    },
+    async (code, reason) => {
+      if (code === 1000) {
+        logger.info({ code }, reason);
+      } else {
+        logger.error({ code }, 'Connection closed');
+        await onUnexpectedClose?.();
+      }
+    },
+    options
+  );

--- a/packages/ogmios/test/util.test.ts
+++ b/packages/ogmios/test/util.test.ts
@@ -1,0 +1,84 @@
+import { InteractionContext } from '@cardano-ogmios/client';
+import { Logger } from 'ts-log';
+import { createInteractionContextWithLogger } from '../src';
+import { createLogger } from '@cardano-sdk/util-dev';
+import { createMockOgmiosServer, listenPromise, serverClosePromise } from './mocks/mockOgmiosServer';
+import { getRandomPort } from 'get-port-please';
+import WebSocket from 'ws';
+import http from 'http';
+
+const closeWithCode = (socket: WebSocket, code: number) =>
+  new Promise((resolve, reject) => {
+    socket.on('error', reject);
+    socket.on('close', resolve);
+    socket.close(code);
+  });
+
+describe('util', () => {
+  describe('createInteractionContextWithLogger', () => {
+    let interactionContext: InteractionContext;
+    let logger: Logger;
+    let mockServer: http.Server;
+    let port: number;
+
+    beforeEach(async () => {
+      logger = createLogger({ record: true });
+      port = await getRandomPort();
+      mockServer = createMockOgmiosServer({
+        healthCheck: { response: { networkSynchronization: 0.999, success: true } },
+        submitTx: { response: { success: true } }
+      });
+      await listenPromise(mockServer, port);
+    });
+
+    afterEach(async () => {
+      if (mockServer !== undefined) {
+        await serverClosePromise(mockServer);
+      }
+    });
+
+    it('will use Ogmios defaults if no configuration is passed', async () => {
+      await expect(async () => await createInteractionContextWithLogger(logger)).rejects.toThrowError('ECONNREFUSED');
+    });
+
+    describe('logging', () => {
+      beforeEach(async () => {
+        interactionContext = await createInteractionContextWithLogger(logger, { connection: { port } });
+        expect(interactionContext.socket.readyState).toEqual(interactionContext.socket.OPEN);
+      });
+
+      it('logs an info message if the WebSocket is closed normally', async () => {
+        await closeWithCode(interactionContext.socket, 1000);
+        expect(logger.messages).toEqual([{ level: 'info', message: [{ code: 1000 }, ''] }]);
+      });
+
+      it('logs an error if the WebSocket is closed due to the server going down', async () => {
+        await closeWithCode(interactionContext.socket, 1001);
+        expect(logger.messages).toEqual([{ level: 'error', message: [{ code: 1001 }, 'Connection closed'] }]);
+      });
+    });
+
+    describe('onUnexpectedClose callback', () => {
+      let onUnexpectedClose: jest.Mock;
+      beforeEach(async () => {
+        onUnexpectedClose = jest.fn();
+        interactionContext = await createInteractionContextWithLogger(
+          logger,
+          { connection: { port } },
+          onUnexpectedClose
+        );
+        expect(interactionContext.socket.readyState).toEqual(interactionContext.socket.OPEN);
+      });
+
+      it('does not invoke the function if the close is normal', async () => {
+        await closeWithCode(interactionContext.socket, 1000);
+        expect(onUnexpectedClose).not.toHaveBeenCalled();
+      });
+
+      it('logs an error if the WebSocket is closed due to the server going down', async () => {
+        await closeWithCode(interactionContext.socket, 1001);
+        expect(onUnexpectedClose).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Context
Currently, we're logging the whole WebSocket object as an `info` message on any close event, which is cumbersome and invalid given a particular closure is actually an error. There's also some uncertainty about reconnection behaviour, however this PR is scoped just to address the logging issue.

https://www.rfc-editor.org/rfc/rfc6455#section-7.4.1

# Proposed Solution
- Add a util to `createInteractionContextWithLogger`, that includes the capability to later include a reconnect handler. 
- Refactor the invalid implementations, without introducing restart logic, which will be considered in a later PR