### PR TITLE
fix: re-submit recoverable transactions

### DIFF
--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -32,7 +32,7 @@ const waitForTx = async (wallet: ObservableWallet, hash: Cardano.TransactionId) 
     combineLatest([
       wallet.transactions.history$.pipe(filter((txs) => txs.some(({ id }) => id === hash))),
       // test that confirmed$ works
-      wallet.transactions.outgoing.confirmed$.pipe(filter(({ id }) => id === hash))
+      wallet.transactions.outgoing.confirmed$.pipe(filter(({ tx: { id } }) => id === hash))
     ]),
     'Tx not confirmed for too long',
     TX_TIMEOUT

--- a/packages/wallet/src/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet.ts
@@ -318,13 +318,11 @@ export class SingleAddressWallet implements ObservableWallet {
     });
 
     this.#resubmitSubscription = createTransactionReemitter({
-      confirmed$: this.transactions.outgoing.confirmed$,
       genesisParameters$: this.genesisParameters$,
       logger: contextLogger(this.#logger, 'transactionsReemitter'),
-      rollback$: this.transactions.rollback$,
       store: stores.volatileTransactions,
-      submitting$: this.transactions.outgoing.submitting$,
-      tipSlot$: this.tip$.pipe(map((tip) => tip.slot))
+      tipSlot$: this.tip$.pipe(map((tip) => tip.slot)),
+      transactions: this.transactions
     })
       .pipe(
         mergeMap((transaction) => from(this.submitTx(transaction))),

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -1,11 +1,11 @@
 import { Assets } from '../../types';
 import { Cardano, EpochRewards, EraSummary, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { ConfirmedTx, TxInFlight } from '../../services';
 import { EMPTY, combineLatest, map } from 'rxjs';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { InMemoryCollectionStore } from './InMemoryCollectionStore';
 import { InMemoryDocumentStore } from './InMemoryDocumentStore';
 import { InMemoryKeyValueStore } from './InMemoryKeyValueStore';
-import { NewTxAlonzoWithSlot } from '../../services';
 import { WalletStores } from '../types';
 
 export class InMemoryTipStore extends InMemoryDocumentStore<Cardano.Tip> {}
@@ -15,8 +15,8 @@ export class InMemoryEraSummariesStore extends InMemoryDocumentStore<EraSummary[
 
 export class InMemoryAssetsStore extends InMemoryDocumentStore<Assets> {}
 export class InMemoryAddressesStore extends InMemoryDocumentStore<GroupedAddress[]> {}
-export class InMemoryInFlightTransactionsStore extends InMemoryDocumentStore<Cardano.NewTxAlonzo[]> {}
-export class InMemoryVolatileTransactionsStore extends InMemoryDocumentStore<NewTxAlonzoWithSlot[]> {}
+export class InMemoryInFlightTransactionsStore extends InMemoryDocumentStore<TxInFlight[]> {}
+export class InMemoryVolatileTransactionsStore extends InMemoryDocumentStore<ConfirmedTx[]> {}
 
 export class InMemoryTransactionsStore extends InMemoryCollectionStore<Cardano.TxAlonzo> {}
 export class InMemoryUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -1,9 +1,9 @@
 import { Assets } from '../../types';
 import { Cardano, EpochRewards, EraSummary, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { ConfirmedTx, TxInFlight } from '../../services';
 import { CreatePouchDbStoresDependencies } from './types';
 import { EMPTY, combineLatest, map } from 'rxjs';
 import { GroupedAddress } from '@cardano-sdk/key-management';
-import { NewTxAlonzoWithSlot } from '../../services';
 import { PouchDbCollectionStore } from './PouchDbCollectionStore';
 import { PouchDbDocumentStore } from './PouchDbDocumentStore';
 import { PouchDbKeyValueStore } from './PouchDbKeyValueStore';
@@ -16,8 +16,8 @@ export class PouchDbEraSummariesStore extends PouchDbDocumentStore<EraSummary[]>
 
 export class PouchDbAssetsStore extends PouchDbDocumentStore<Assets> {}
 export class PouchDbAddressesStore extends PouchDbDocumentStore<GroupedAddress[]> {}
-export class PouchDbInFlightTransactionsStore extends PouchDbDocumentStore<Cardano.NewTxAlonzo[]> {}
-export class PouchDbVolatileTransactionsStore extends PouchDbDocumentStore<NewTxAlonzoWithSlot[]> {}
+export class PouchDbInFlightTransactionsStore extends PouchDbDocumentStore<TxInFlight[]> {}
+export class PouchDbVolatileTransactionsStore extends PouchDbDocumentStore<ConfirmedTx[]> {}
 
 export class PouchDbTransactionsStore extends PouchDbCollectionStore<Cardano.TxAlonzo> {}
 export class PouchDbUtxoStore extends PouchDbCollectionStore<Cardano.Utxo> {}
@@ -59,7 +59,7 @@ export const createPouchDbWalletStores = (
     destroyed: false,
     eraSummaries: new PouchDbEraSummariesStore(docsDbName, 'EraSummaries', logger),
     genesisParameters: new PouchDbGenesisParametersStore(docsDbName, 'genesisParameters', logger),
-    inFlightTransactions: new PouchDbInFlightTransactionsStore(docsDbName, 'newTransactions', logger),
+    inFlightTransactions: new PouchDbInFlightTransactionsStore(docsDbName, 'transactionsInFlight', logger),
     protocolParameters: new PouchDbProtocolParametersStore(docsDbName, 'protocolParameters', logger),
     rewardsBalances: new PouchDbRewardsBalancesStore(`${baseDbName}RewardsBalances`, logger),
     rewardsHistory: new PouchDbRewardsHistoryStore(`${baseDbName}RewardsHistory`, logger),

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -7,8 +7,8 @@ import {
   StakeSummary,
   SupplySummary
 } from '@cardano-sdk/core';
+import { ConfirmedTx, TxInFlight } from '../services';
 import { GroupedAddress } from '@cardano-sdk/key-management';
-import { NewTxAlonzoWithSlot } from '../services';
 import { Observable } from 'rxjs';
 
 export interface Destroyable {
@@ -81,8 +81,8 @@ export interface WalletStores extends Destroyable {
   utxo: CollectionStore<Cardano.Utxo>;
   unspendableUtxo: CollectionStore<Cardano.Utxo>;
   transactions: OrderedCollectionStore<Cardano.TxAlonzo>;
-  inFlightTransactions: DocumentStore<Cardano.NewTxAlonzo[]>;
-  volatileTransactions: DocumentStore<NewTxAlonzoWithSlot[]>;
+  inFlightTransactions: DocumentStore<TxInFlight[]>;
+  volatileTransactions: DocumentStore<ConfirmedTx[]>;
   rewardsHistory: KeyValueStore<Cardano.RewardAccount, EpochRewards[]>;
   rewardsBalances: KeyValueStore<Cardano.RewardAccount, Cardano.Lovelace>;
   stakePools: KeyValueStore<Cardano.PoolId, Cardano.StakePool>;

--- a/packages/wallet/src/services/SmartTxSubmitProvider.ts
+++ b/packages/wallet/src/services/SmartTxSubmitProvider.ts
@@ -1,0 +1,90 @@
+import {
+  Cardano,
+  HealthCheckResponse,
+  ProviderError,
+  ProviderFailure,
+  SubmitTxArgs,
+  TxSubmitProvider,
+  cslUtil
+} from '@cardano-sdk/core';
+import { ConnectionStatus, ConnectionStatusTracker } from './util';
+import { Observable, combineLatest, filter, firstValueFrom, from, mergeMap, take, tap } from 'rxjs';
+import { RetryBackoffConfig, retryBackoff } from 'backoff-rxjs';
+
+export interface RetryingTxSubmitProviderProps {
+  retryBackoffConfig: RetryBackoffConfig;
+}
+
+export type TipSlot = Pick<Cardano.Tip, 'slot'>;
+
+export interface RetryingTxSubmitProviderDependencies {
+  txSubmitProvider: TxSubmitProvider;
+  tip$: Observable<TipSlot>;
+  connectionStatus$: ConnectionStatusTracker;
+}
+
+/**
+ * Wraps a `TxSubmitProvider` to enchance it's `submitTx` with the following functionality:
+ * - Immediately rejects if network tip is already >= `ValidityInterval.invalidHereafter`
+ * - Awaits for the following conditions before submitting:
+ *   - Network tip is ahead of tx body `ValidityInterval.invalidBefore`.
+ *   - Connection status is 'up'.
+ * - Re-submits transactions that failed to submit due to connection or recoverable provider issue.
+ */
+export class SmartTxSubmitProvider implements TxSubmitProvider {
+  readonly #txSubmitProvider: TxSubmitProvider;
+  readonly #tip$: Observable<TipSlot>;
+  readonly #retryBackoffConfig: RetryBackoffConfig;
+  readonly #connectionStatus$: ConnectionStatusTracker;
+
+  constructor(
+    { retryBackoffConfig }: RetryingTxSubmitProviderProps,
+    { connectionStatus$, tip$, txSubmitProvider }: RetryingTxSubmitProviderDependencies
+  ) {
+    this.#txSubmitProvider = txSubmitProvider;
+    this.#tip$ = tip$;
+    this.#connectionStatus$ = connectionStatus$;
+    this.#retryBackoffConfig = retryBackoffConfig;
+  }
+
+  submitTx(args: SubmitTxArgs): Promise<void> {
+    const {
+      body: {
+        validityInterval: { invalidBefore, invalidHereafter }
+      }
+    } = cslUtil.deserializeTx(args.signedTransaction);
+    const onlineAndWithinValidityInterval$ = combineLatest([this.#connectionStatus$, this.#tip$]).pipe(
+      tap(([_, { slot }]) => {
+        if (slot >= (invalidHereafter || Number.POSITIVE_INFINITY))
+          throw new ProviderError(
+            ProviderFailure.BadRequest,
+            new Cardano.TxSubmissionErrors.OutsideOfValidityIntervalError({
+              outsideOfValidityInterval: {
+                currentSlot: slot,
+                interval: { invalidBefore: invalidBefore || null, invalidHereafter: invalidHereafter || null }
+              }
+            })
+          );
+      }),
+      filter(
+        ([connectionStatus, { slot }]) => connectionStatus === ConnectionStatus.up && slot >= (invalidBefore || 0)
+      ),
+      take(1)
+    );
+    return firstValueFrom(
+      onlineAndWithinValidityInterval$.pipe(
+        mergeMap(() => from(this.#txSubmitProvider.submitTx(args))),
+        retryBackoff({
+          ...this.#retryBackoffConfig,
+          shouldRetry: (error) =>
+            error instanceof ProviderError &&
+            [ProviderFailure.Unhealthy, ProviderFailure.ConnectionFailure].includes(error.reason)
+        })
+      )
+    );
+  }
+
+  healthCheck(): Promise<HealthCheckResponse> {
+    return this.#txSubmitProvider.healthCheck();
+  }
+}

--- a/packages/wallet/src/services/TransactionReemitter.ts
+++ b/packages/wallet/src/services/TransactionReemitter.ts
@@ -4,7 +4,7 @@ import { Observable, filter, from, map, merge, mergeMap, scan, tap, withLatestFr
 
 import { CustomError } from 'ts-custom-error';
 import { DocumentStore } from '../persistence';
-import { NewTxAlonzoWithSlot } from './types';
+import { NewTxAlonzoWithSlot, TransactionsTracker } from './types';
 
 export enum TransactionReemitErrorCode {
   invalidHereafter = 'invalidHereafter',
@@ -19,9 +19,9 @@ class TransactionReemitError extends CustomError {
 }
 
 interface TransactionReemitterProps {
-  rollback$: Observable<Cardano.TxAlonzo>;
-  confirmed$: Observable<NewTxAlonzoWithSlot>;
-  submitting$: Observable<Cardano.NewTxAlonzo>;
+  transactions: Pick<TransactionsTracker, 'rollback$'> & {
+    outgoing: Pick<TransactionsTracker['outgoing'], 'confirmed$' | 'submitting$'>;
+  };
   store: DocumentStore<NewTxAlonzoWithSlot[]>;
   tipSlot$: Observable<Cardano.Slot>;
   genesisParameters$: Observable<Pick<Cardano.CompactGenesis, 'securityParameter' | 'activeSlotsCoefficient'>>;
@@ -35,9 +35,10 @@ enum txSource {
 }
 
 export const createTransactionReemitter = ({
-  rollback$,
-  confirmed$,
-  submitting$,
+  transactions: {
+    rollback$,
+    outgoing: { confirmed$, submitting$ }
+  },
   store,
   tipSlot$,
   genesisParameters$,

--- a/packages/wallet/src/services/index.ts
+++ b/packages/wallet/src/services/index.ts
@@ -11,3 +11,4 @@ export * from './EpochTracker';
 export * from './TipTracker';
 export * from './TransactionReemitter';
 export * from './SupplyDistributionTracker';
+export * from './SmartTxSubmitProvider';

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -51,17 +51,18 @@ export interface FailedTx {
   error?: Cardano.TxSubmissionError;
 }
 
-export type NewTxAlonzoWithSlot = Cardano.NewTxAlonzo & { slot: Cardano.PartialBlockHeader['slot'] };
+export type ConfirmedTx = { tx: Cardano.NewTxAlonzo; confirmedAt: Cardano.PartialBlockHeader['slot'] };
+export type TxInFlight = { tx: Cardano.NewTxAlonzo; submittedAt?: Cardano.PartialBlockHeader['slot'] };
 
 export interface TransactionsTracker {
   readonly history$: Observable<Cardano.TxAlonzo[]>;
   readonly rollback$: Observable<Cardano.TxAlonzo>;
   readonly outgoing: {
-    readonly inFlight$: Observable<Cardano.NewTxAlonzo[]>;
+    readonly inFlight$: Observable<TxInFlight[]>;
     readonly submitting$: Observable<Cardano.NewTxAlonzo>;
     readonly pending$: Observable<Cardano.NewTxAlonzo>;
     readonly failed$: Observable<FailedTx>;
-    readonly confirmed$: Observable<NewTxAlonzoWithSlot>;
+    readonly confirmed$: Observable<ConfirmedTx>;
   };
 }
 

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -274,8 +274,9 @@ describe('SingleAddressWallet load', () => {
 
     // Auto interval tip$ trigger
     // Don't need to add ONCE_SETTLED_FETCH_AFTER + 1
-    // because it's already awaited in a delay above
-    await delay(AUTO_TRIGGER_AFTER);
+    // because it's already awaited in a delay above.
+    // Failed once without "+ 1"
+    await delay(AUTO_TRIGGER_AFTER + 1);
     expect(networkInfoProvider.ledgerTip).toHaveBeenCalledTimes(3);
 
     // Auto interval tip$ trigger no longer works once offline

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -97,8 +97,7 @@ const txBody: Cardano.NewTxBodyAlonzo = {
   ],
   outputs: [txOut],
   validityInterval: {
-    invalidBefore: 100,
-    invalidHereafter: 1000
+    invalidHereafter: mocks.ledgerTip.slot + 10
   }
 };
 

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -147,8 +147,8 @@ describe('SingleAddressWallet rollback', () => {
 
     stores.volatileTransactions.set([
       {
-        ...tx,
-        slot: rollBackTx.blockHeader.slot
+        confirmedAt: rollBackTx.blockHeader.slot,
+        tx
       }
     ]);
 

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -98,7 +98,7 @@ describe('integration/withdrawal', () => {
 
     expect(tx.body.withdrawals).toEqual([{ quantity: availableRewards, stakeAddress: rewardAccount }]);
 
-    const confirmedSubscription = wallet.transactions.outgoing.confirmed$.subscribe((confirmedTx) => {
+    const confirmedSubscription = wallet.transactions.outgoing.confirmed$.subscribe(({ tx: confirmedTx }) => {
       if (confirmedTx === tx) {
         // Transaction successful
       }

--- a/packages/wallet/test/mocks/mockTxSubmitProvider.ts
+++ b/packages/wallet/test/mocks/mockTxSubmitProvider.ts
@@ -5,7 +5,7 @@ import { TxSubmitProvider } from '@cardano-sdk/core';
  *
  * returns TxSubmitProvider-compatible object
  */
-export const mockTxSubmitProvider = (): TxSubmitProvider => ({
+export const mockTxSubmitProvider = (): jest.Mocked<TxSubmitProvider> => ({
   healthCheck: jest.fn().mockResolvedValue(true),
   submitTx: jest.fn().mockResolvedValue(void 0)
 });

--- a/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
+++ b/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
@@ -1,0 +1,140 @@
+import { BehaviorSubject, EMPTY, of } from 'rxjs';
+import { Cardano, ProviderError, ProviderFailure, TxSubmitProvider, coreToCsl, util } from '@cardano-sdk/core';
+import { ConnectionStatus, SmartTxSubmitProvider, TipSlot } from '../../src';
+import { RetryBackoffConfig } from 'backoff-rxjs';
+import { flushPromises } from '@cardano-sdk/util-dev';
+import { mockTxSubmitProvider } from '../mocks';
+
+describe('SmartTxSubmitProvider', () => {
+  let underlyingProvider: jest.Mocked<TxSubmitProvider>;
+  let provider: SmartTxSubmitProvider;
+  const retryBackoffConfig: RetryBackoffConfig = { initialInterval: 1 };
+
+  beforeEach(() => (underlyingProvider = mockTxSubmitProvider()));
+
+  describe('healthCheck', () => {
+    it('calls underlying provider', () => {
+      provider = new SmartTxSubmitProvider(
+        { retryBackoffConfig },
+        { connectionStatus$: EMPTY, tip$: EMPTY, txSubmitProvider: underlyingProvider }
+      );
+      expect(provider.healthCheck()).toEqual(underlyingProvider.healthCheck());
+      expect(underlyingProvider.healthCheck).toBeCalledTimes(2);
+    });
+  });
+
+  describe('submitTx', () => {
+    const txWithoutValidityInterval: Cardano.NewTxAlonzo = {
+      body: {
+        fee: 0n,
+        inputs: [],
+        outputs: [],
+        validityInterval: {}
+      },
+      id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
+      witness: { signatures: new Map() }
+    };
+    const validityInterval = { invalidBefore: 5, invalidHereafter: 10 };
+    const txWithoutValidityIntervalHex = util.bytesToHex(coreToCsl.tx(txWithoutValidityInterval).to_bytes());
+    const txWithValidityIntervalHex = util.bytesToHex(
+      coreToCsl
+        .tx({
+          ...txWithoutValidityInterval,
+          body: {
+            ...txWithoutValidityInterval.body,
+            validityInterval
+          }
+        })
+        .to_bytes()
+    );
+
+    describe('all preconditions are met', () => {
+      beforeEach(() => {
+        provider = new SmartTxSubmitProvider(
+          { retryBackoffConfig },
+          {
+            connectionStatus$: of(ConnectionStatus.up),
+            tip$: of({ slot: validityInterval.invalidBefore }),
+            txSubmitProvider: underlyingProvider
+          }
+        );
+      });
+
+      it('calls underlying provider when online and tx has no validity interval', async () => {
+        await provider.submitTx({ signedTransaction: txWithoutValidityIntervalHex });
+        expect(underlyingProvider.submitTx).toBeCalledTimes(1);
+      });
+
+      it('calls underlying provider when online and within validity interval', async () => {
+        await provider.submitTx({ signedTransaction: txWithValidityIntervalHex });
+        expect(underlyingProvider.submitTx).toBeCalledTimes(1);
+      });
+
+      it('re-submits transactions that failed to submit due to a recoverable provider failure', async () => {
+        underlyingProvider.submitTx
+          .mockRejectedValueOnce(new ProviderError(ProviderFailure.ConnectionFailure))
+          .mockRejectedValueOnce(new ProviderError(ProviderFailure.Unhealthy));
+        await provider.submitTx({ signedTransaction: txWithValidityIntervalHex });
+        expect(underlyingProvider.submitTx).toBeCalledTimes(3);
+      });
+
+      it('rejects with any non-recoverable provider error', async () => {
+        const error = new ProviderError(ProviderFailure.BadRequest);
+        underlyingProvider.submitTx.mockRejectedValueOnce(error);
+        await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(error);
+        expect(underlyingProvider.submitTx).toBeCalledTimes(1);
+      });
+    });
+
+    it('immediately rejects if network tip is already >= `ValidityInterval.invalidHereafter`', async () => {
+      provider = new SmartTxSubmitProvider(
+        { retryBackoffConfig },
+        {
+          connectionStatus$: of(ConnectionStatus.up),
+          tip$: of({ slot: validityInterval.invalidHereafter }),
+          txSubmitProvider: underlyingProvider
+        }
+      );
+      await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(
+        ProviderFailure.BadRequest
+      );
+      expect(underlyingProvider.submitTx).toBeCalledTimes(0);
+    });
+
+    it('awaits for network tip to be ahead of tx body `ValidityInterval.invalidBefore` before submitting', async () => {
+      const tip$ = new BehaviorSubject<TipSlot>({ slot: validityInterval.invalidBefore - 1 });
+      provider = new SmartTxSubmitProvider(
+        { retryBackoffConfig },
+        {
+          connectionStatus$: of(ConnectionStatus.up),
+          tip$,
+          txSubmitProvider: underlyingProvider
+        }
+      );
+      const submitted = provider.submitTx({ signedTransaction: txWithValidityIntervalHex });
+      await flushPromises();
+      expect(underlyingProvider.submitTx).not.toBeCalled();
+      tip$.next({ slot: validityInterval.invalidBefore });
+      await submitted;
+      expect(underlyingProvider.submitTx).toBeCalledTimes(1);
+    });
+
+    it('awaits for connection status to be "up" before submitting', async () => {
+      const connectionStatus$ = new BehaviorSubject<ConnectionStatus>(ConnectionStatus.down);
+      provider = new SmartTxSubmitProvider(
+        { retryBackoffConfig },
+        {
+          connectionStatus$,
+          tip$: of({ slot: validityInterval.invalidBefore }),
+          txSubmitProvider: underlyingProvider
+        }
+      );
+      const submitted = provider.submitTx({ signedTransaction: txWithValidityIntervalHex });
+      await flushPromises();
+      expect(underlyingProvider.submitTx).not.toBeCalled();
+      connectionStatus$.next(ConnectionStatus.up);
+      await submitted;
+      expect(underlyingProvider.submitTx).toBeCalledTimes(1);
+    });
+  });
+});

--- a/packages/wallet/test/services/TransactionReemitter.test.ts
+++ b/packages/wallet/test/services/TransactionReemitter.test.ts
@@ -48,13 +48,17 @@ describe('TransactionReemiter', () => {
       const rollback$ = cold<Cardano.TxAlonzo>('-|');
       const submitting$ = cold<NewTxAlonzoWithSlot>('-|');
       const transactionReemiter = createTransactionReemitter({
-        confirmed$,
         genesisParameters$,
         logger,
-        rollback$,
         store,
-        submitting$,
-        tipSlot$
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            submitting$
+          },
+          rollback$
+        }
       });
       expectObservable(transactionReemiter).toBe('-|');
     });
@@ -72,13 +76,17 @@ describe('TransactionReemiter', () => {
       const rollback$ = cold<Cardano.TxAlonzo>('----|');
       const submitting$ = cold<NewTxAlonzoWithSlot>('----|');
       const transactionReemiter = createTransactionReemitter({
-        confirmed$,
         genesisParameters$,
         logger,
-        rollback$,
         store,
-        submitting$,
-        tipSlot$
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            submitting$
+          },
+          rollback$
+        }
       });
       expectObservable(transactionReemiter).toBe('----|');
     });
@@ -96,13 +104,17 @@ describe('TransactionReemiter', () => {
       const rollback$ = cold<Cardano.TxAlonzo>('--|');
       const submitting$ = cold<NewTxAlonzoWithSlot>('-b|', { b: volatileTransactions[0] });
       const transactionReemiter = createTransactionReemitter({
-        confirmed$,
         genesisParameters$,
         logger,
-        rollback$,
         store,
-        submitting$,
-        tipSlot$
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            submitting$
+          },
+          rollback$
+        }
       });
       expectObservable(transactionReemiter).toBe('--|');
     });
@@ -125,13 +137,17 @@ describe('TransactionReemiter', () => {
       const rollback$ = cold<Cardano.TxAlonzo>('---|');
       const submitting$ = cold<NewTxAlonzoWithSlot>('---|');
       const transactionReemiter = createTransactionReemitter({
-        confirmed$,
         genesisParameters$,
         logger,
-        rollback$,
         store,
-        submitting$,
-        tipSlot$
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            submitting$
+          },
+          rollback$
+        }
       });
       expectObservable(transactionReemiter).toBe('---|');
     });
@@ -164,13 +180,17 @@ describe('TransactionReemiter', () => {
       const rollback$ = cold<Cardano.TxAlonzo>('--a--c--d|', { a: rollbackA, c: rollbackC, d: rollbackD });
       const submitting$ = cold<NewTxAlonzoWithSlot>('---------|');
       const transactionReemiter = createTransactionReemitter({
-        confirmed$,
         genesisParameters$,
         logger,
-        rollback$,
         store,
-        submitting$,
-        tipSlot$
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            submitting$
+          },
+          rollback$
+        }
       });
       expectObservable(transactionReemiter).toBe('--a-----d|', { a: volatileA, d: volatileD });
     });
@@ -195,13 +215,17 @@ describe('TransactionReemiter', () => {
       const rollback$ = cold<Cardano.TxAlonzo>('--c|', { c: rollbackC });
       const submitting$ = cold<NewTxAlonzoWithSlot>('---|');
       const transactionReemiter = createTransactionReemitter({
-        confirmed$,
         genesisParameters$,
         logger,
-        rollback$,
         store,
-        submitting$,
-        tipSlot$
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            submitting$
+          },
+          rollback$
+        }
       });
       expectObservable(transactionReemiter).toBe('---|');
     });

--- a/packages/wallet/test/services/TransactionReemitter.test.ts
+++ b/packages/wallet/test/services/TransactionReemitter.test.ts
@@ -1,60 +1,84 @@
 import { Cardano } from '@cardano-sdk/core';
-import { InMemoryVolatileTransactionsStore, WalletStores } from '../../src/persistence';
+import {
+  ConfirmedTx,
+  TransactionReemitErrorCode,
+  TransactionReemitterProps,
+  TxInFlight,
+  createTransactionReemitter
+} from '../../src';
+import { InMemoryInFlightTransactionsStore, InMemoryVolatileTransactionsStore } from '../../src/persistence';
 import { Logger, dummyLogger } from 'ts-log';
-import { NewTxAlonzoWithSlot, TransactionReemitErrorCode, createTransactionReemitter } from '../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 import { genesisParameters } from '../mocks';
 
 describe('TransactionReemiter', () => {
-  let store: WalletStores['volatileTransactions'];
-  let volatileTransactions: NewTxAlonzoWithSlot[];
+  const maxInterval = 2000;
+  let stores: TransactionReemitterProps['stores'];
+  let volatileTransactions: ConfirmedTx[];
   let logger: Logger;
 
   beforeEach(() => {
     logger = dummyLogger;
-    store = new InMemoryVolatileTransactionsStore();
-    store.set = jest.fn();
+    stores = {
+      inFlightTransactions: new InMemoryInFlightTransactionsStore(),
+      volatileTransactions: new InMemoryVolatileTransactionsStore()
+    };
+    stores.volatileTransactions.set = jest.fn();
+    stores.inFlightTransactions.set = jest.fn();
     volatileTransactions = [
       {
-        body: { validityInterval: { invalidHereafter: 1000 } },
-        id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
-        slot: 100
+        confirmedAt: 100,
+        tx: {
+          body: { validityInterval: { invalidHereafter: 1000 } },
+          id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
+        }
       },
       {
-        body: { validityInterval: { invalidHereafter: 1000 } },
-        id: Cardano.TransactionId('7804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
-        slot: 200
+        confirmedAt: 200,
+        tx: {
+          body: { validityInterval: { invalidHereafter: 1000 } },
+          id: Cardano.TransactionId('7804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
+        }
       },
       {
-        body: { validityInterval: { invalidHereafter: 1000 } },
-        id: Cardano.TransactionId('8804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
-        slot: 300
+        confirmedAt: 300,
+        tx: {
+          body: { validityInterval: { invalidHereafter: 1000 } },
+          id: Cardano.TransactionId('8804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
+          slot: 300
+        }
       },
       {
-        body: { validityInterval: { invalidHereafter: 1000 } },
-        id: Cardano.TransactionId('9904edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
-        slot: 400
+        confirmedAt: 400,
+        tx: {
+          body: { validityInterval: { invalidHereafter: 1000 } },
+          id: Cardano.TransactionId('9904edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
+          slot: 400
+        }
       }
-    ] as NewTxAlonzoWithSlot[];
+    ] as ConfirmedTx[];
   });
 
   it('Stored volatile transactions are fetched on init', () => {
     const storeTransaction = volatileTransactions[0];
     createTestScheduler().run(({ hot, cold, expectObservable }) => {
-      store.get = jest.fn(() => cold('a|', { a: [storeTransaction] }));
+      stores.volatileTransactions.get = jest.fn(() => cold('a|', { a: [storeTransaction] }));
       const tipSlot$ = hot<Cardano.Slot>('-|');
       const genesisParameters$ = cold<Cardano.CompactGenesis>('-|');
-      const confirmed$ = cold<NewTxAlonzoWithSlot>('-|');
+      const confirmed$ = cold<ConfirmedTx>('-|');
       const rollback$ = cold<Cardano.TxAlonzo>('-|');
-      const submitting$ = cold<NewTxAlonzoWithSlot>('-|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
         logger,
-        store,
+        maxInterval,
+        stores,
         tipSlot$,
         transactions: {
           outgoing: {
             confirmed$,
+            inFlight$,
             submitting$
           },
           rollback$
@@ -62,27 +86,30 @@ describe('TransactionReemiter', () => {
       });
       expectObservable(transactionReemiter).toBe('-|');
     });
-    expect(store.get).toHaveBeenCalledTimes(1);
-    expect(store.set).not.toHaveBeenCalledTimes(1); // already in store
+    expect(stores.volatileTransactions.get).toHaveBeenCalledTimes(1);
+    expect(stores.volatileTransactions.set).not.toHaveBeenCalledTimes(1); // already in store
   });
 
   it('Merges stored transacions with confirmed transactions and adds them all to store', () => {
     const storeTransaction = volatileTransactions[0];
     createTestScheduler().run(({ hot, cold, expectObservable }) => {
-      store.get = jest.fn(() => cold('a|', { a: [storeTransaction] }));
+      stores.volatileTransactions.get = jest.fn(() => cold('a|', { a: [storeTransaction] }));
       const tipSlot$ = hot<Cardano.Slot>('----|');
       const genesisParameters$ = cold<Cardano.CompactGenesis>('a---|', { a: genesisParameters });
-      const confirmed$ = cold<NewTxAlonzoWithSlot>('-b-c|', { b: volatileTransactions[1], c: volatileTransactions[2] });
+      const confirmed$ = cold<ConfirmedTx>('-b-c|', { b: volatileTransactions[1], c: volatileTransactions[2] });
       const rollback$ = cold<Cardano.TxAlonzo>('----|');
-      const submitting$ = cold<NewTxAlonzoWithSlot>('----|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('----|');
+      const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
         logger,
-        store,
+        maxInterval,
+        stores,
         tipSlot$,
         transactions: {
           outgoing: {
             confirmed$,
+            inFlight$,
             submitting$
           },
           rollback$
@@ -90,27 +117,30 @@ describe('TransactionReemiter', () => {
       });
       expectObservable(transactionReemiter).toBe('----|');
     });
-    expect(store.set).toHaveBeenCalledTimes(2);
-    expect(store.set).toHaveBeenLastCalledWith(volatileTransactions.slice(0, 3));
+    expect(stores.volatileTransactions.set).toHaveBeenCalledTimes(2);
+    expect(stores.volatileTransactions.set).toHaveBeenLastCalledWith(volatileTransactions.slice(0, 3));
   });
 
   it('Removes transaction from volatiles if it is reported as submitting', () => {
     const storeTransaction = volatileTransactions;
     createTestScheduler().run(({ hot, cold, expectObservable }) => {
-      store.get = jest.fn(() => cold('a|', { a: storeTransaction }));
+      stores.volatileTransactions.get = jest.fn(() => cold('a|', { a: storeTransaction }));
       const tipSlot$ = hot<Cardano.Slot>('--|');
       const genesisParameters$ = cold<Cardano.CompactGenesis>('a-|', { a: genesisParameters });
-      const confirmed$ = cold<NewTxAlonzoWithSlot>('--|');
+      const confirmed$ = cold<ConfirmedTx>('--|');
       const rollback$ = cold<Cardano.TxAlonzo>('--|');
-      const submitting$ = cold<NewTxAlonzoWithSlot>('-b|', { b: volatileTransactions[0] });
+      const submitting$ = cold<Cardano.NewTxAlonzo>('-b|', { b: volatileTransactions[0].tx });
+      const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
         logger,
-        store,
+        maxInterval,
+        stores,
         tipSlot$,
         transactions: {
           outgoing: {
             confirmed$,
+            inFlight$,
             submitting$
           },
           rollback$
@@ -118,8 +148,8 @@ describe('TransactionReemiter', () => {
       });
       expectObservable(transactionReemiter).toBe('--|');
     });
-    expect(store.set).toHaveBeenCalledTimes(1);
-    expect(store.set).toHaveBeenLastCalledWith(volatileTransactions.slice(1));
+    expect(stores.volatileTransactions.set).toHaveBeenCalledTimes(1);
+    expect(stores.volatileTransactions.set).toHaveBeenLastCalledWith(volatileTransactions.slice(1));
   });
 
   it('Uses stability window to remove transactions no longer volatile', () => {
@@ -129,21 +159,24 @@ describe('TransactionReemiter', () => {
       const genesisParameters$ = cold<Cardano.CompactGenesis>('a--|', {
         a: { ...genesisParameters, activeSlotsCoefficient: 33 }
       });
-      const confirmed$ = cold<NewTxAlonzoWithSlot>('abc|', {
+      const confirmed$ = cold<ConfirmedTx>('abc|', {
         a: volatileSlot100,
         b: volatileSlot200,
         c: volatileSlot300
       });
       const rollback$ = cold<Cardano.TxAlonzo>('---|');
-      const submitting$ = cold<NewTxAlonzoWithSlot>('---|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('---|');
+      const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
         logger,
-        store,
+        maxInterval,
+        stores,
         tipSlot$,
         transactions: {
           outgoing: {
             confirmed$,
+            inFlight$,
             submitting$
           },
           rollback$
@@ -151,19 +184,19 @@ describe('TransactionReemiter', () => {
       });
       expectObservable(transactionReemiter).toBe('---|');
     });
-    expect(store.set).toHaveBeenCalledTimes(3);
-    expect(store.set).toHaveBeenLastCalledWith(volatileTransactions.slice(1, 3));
+    expect(stores.volatileTransactions.set).toHaveBeenCalledTimes(3);
+    expect(stores.volatileTransactions.set).toHaveBeenLastCalledWith(volatileTransactions.slice(1, 3));
   });
 
   it('Emits transactions that were rolled back and still valid', () => {
     const LAST_TIP_SLOT = 400;
     const [volatileA, volatileB, volatileC, volatileD] = volatileTransactions;
-    const rollbackA: Cardano.TxAlonzo = { body: volatileA.body, id: volatileA.id } as Cardano.TxAlonzo;
+    const rollbackA: Cardano.TxAlonzo = { body: volatileA.tx.body, id: volatileA.tx.id } as Cardano.TxAlonzo;
     const rollbackC: Cardano.TxAlonzo = {
       body: { validityInterval: { invalidHereafter: LAST_TIP_SLOT - 1 } },
-      id: volatileC.id
+      id: volatileC.tx.id
     } as Cardano.TxAlonzo;
-    const rollbackD: Cardano.TxAlonzo = { body: volatileD.body, id: volatileD.id } as Cardano.TxAlonzo;
+    const rollbackD: Cardano.TxAlonzo = { body: volatileD.tx.body, id: volatileD.tx.id } as Cardano.TxAlonzo;
 
     // eslint-disable-next-line @typescript-eslint/no-shadow
     logger.error = jest.fn();
@@ -171,28 +204,31 @@ describe('TransactionReemiter', () => {
     createTestScheduler().run(({ hot, cold, expectObservable }) => {
       const tipSlot$ = hot<Cardano.Slot>('x--------|', { x: LAST_TIP_SLOT });
       const genesisParameters$ = cold<Cardano.CompactGenesis>('a--------|', { a: genesisParameters });
-      const confirmed$ = cold<NewTxAlonzoWithSlot>('a-b-c-d--|', {
+      const confirmed$ = cold<ConfirmedTx>('a-b-c-d--|', {
         a: volatileA,
         b: volatileB,
         c: volatileC,
         d: volatileD
       });
       const rollback$ = cold<Cardano.TxAlonzo>('--a--c--d|', { a: rollbackA, c: rollbackC, d: rollbackD });
-      const submitting$ = cold<NewTxAlonzoWithSlot>('---------|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('---------|');
+      const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
         logger,
-        store,
+        maxInterval,
+        stores,
         tipSlot$,
         transactions: {
           outgoing: {
             confirmed$,
+            inFlight$,
             submitting$
           },
           rollback$
         }
       });
-      expectObservable(transactionReemiter).toBe('--a-----d|', { a: volatileA, d: volatileD });
+      expectObservable(transactionReemiter).toBe('--a-----d|', { a: volatileA.tx, d: volatileD.tx });
     });
 
     expect(logger.error).toHaveBeenCalledWith(expect.anything(), TransactionReemitErrorCode.invalidHereafter);
@@ -200,7 +236,7 @@ describe('TransactionReemiter', () => {
 
   it('Logs error message for rolledback transactions not found in volatiles', () => {
     const [volatileA, volatileB, volatileC] = volatileTransactions;
-    const rollbackC: Cardano.TxAlonzo = { body: volatileC.body, id: volatileC.id } as Cardano.TxAlonzo;
+    const rollbackC: Cardano.TxAlonzo = { body: volatileC.tx.body, id: volatileC.tx.id } as Cardano.TxAlonzo;
     // eslint-disable-next-line @typescript-eslint/no-shadow
     const logger = dummyLogger;
     logger.error = jest.fn();
@@ -208,20 +244,23 @@ describe('TransactionReemiter', () => {
     createTestScheduler().run(({ hot, cold, expectObservable }) => {
       const tipSlot$ = hot<Cardano.Slot>('x--|', { x: 300 });
       const genesisParameters$ = cold<Cardano.CompactGenesis>('a--|', { a: genesisParameters });
-      const confirmed$ = cold<NewTxAlonzoWithSlot>('ab-|', {
+      const confirmed$ = cold<ConfirmedTx>('ab-|', {
         a: volatileA,
         b: volatileB
       });
       const rollback$ = cold<Cardano.TxAlonzo>('--c|', { c: rollbackC });
-      const submitting$ = cold<NewTxAlonzoWithSlot>('---|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('---|');
+      const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
         logger,
-        store,
+        maxInterval,
+        stores,
         tipSlot$,
         transactions: {
           outgoing: {
             confirmed$,
+            inFlight$,
             submitting$
           },
           rollback$
@@ -230,5 +269,119 @@ describe('TransactionReemiter', () => {
       expectObservable(transactionReemiter).toBe('---|');
     });
     expect(logger.error).toHaveBeenCalledWith(expect.anything(), TransactionReemitErrorCode.notFound);
+  });
+
+  it('Emits unconfirmed submission transactions from stores.inFlightTransactions', () => {
+    createTestScheduler().run(({ hot, cold, expectObservable }) => {
+      stores.inFlightTransactions.get = jest.fn(() =>
+        cold<TxInFlight[]>('a|', {
+          a: [
+            {
+              tx: volatileTransactions[0].tx
+            },
+            {
+              submittedAt: 123,
+              tx: volatileTransactions[1].tx
+            }
+          ]
+        })
+      );
+      const tipSlot$ = hot<Cardano.Slot>('-|');
+      const genesisParameters$ = cold<Cardano.CompactGenesis>('-|');
+      const confirmed$ = cold<ConfirmedTx>('-|');
+      const rollback$ = cold<Cardano.TxAlonzo>('-|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const inFlight$ = cold<TxInFlight[]>('-|');
+      const transactionReemiter = createTransactionReemitter({
+        genesisParameters$,
+        logger,
+        maxInterval,
+        stores,
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            inFlight$,
+            submitting$
+          },
+          rollback$
+        }
+      });
+      expectObservable(transactionReemiter).toBe('a|', { a: volatileTransactions[0].tx });
+    });
+    expect(stores.inFlightTransactions.get).toHaveBeenCalledTimes(1);
+  });
+
+  // eslint-disable-next-line max-len
+  it('Emits inFlight transactions that were unconfirmed for longer than maxInterval since submittedAt', () => {
+    createTestScheduler().run(({ hot, cold, expectObservable }) => {
+      const tip = 123;
+      const tipSlot$ = hot<Cardano.Slot>('-a|', { a: tip });
+      const genesisParameters$ = hot('a|', { a: genesisParameters });
+      const confirmed$ = cold<ConfirmedTx>('-|');
+      const rollback$ = cold<Cardano.TxAlonzo>('-|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const inFlight$ = cold<TxInFlight[]>('a|', {
+        a: [
+          { submittedAt: tip - 1, tx: volatileTransactions[0].tx },
+          {
+            submittedAt: tip - maxInterval / 1000 - 1,
+            tx: volatileTransactions[1].tx
+          }
+        ]
+      });
+      const transactionReemiter = createTransactionReemitter({
+        genesisParameters$,
+        logger,
+        maxInterval,
+        stores,
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            inFlight$,
+            submitting$
+          },
+          rollback$
+        }
+      });
+      expectObservable(transactionReemiter).toBe('-a|', { a: volatileTransactions[1].tx });
+    });
+  });
+
+  it('Does not re-emit already emitted transactions due to new genesisParameters$', () => {
+    createTestScheduler().run(({ hot, cold, expectObservable }) => {
+      const tip = 123;
+      const tipSlot$ = hot<Cardano.Slot>('-a--|', { a: tip });
+      const genesisParameters$ = cold('a-b|', { a: genesisParameters, b: genesisParameters });
+      const confirmed$ = cold<ConfirmedTx>('-|');
+      const rollback$ = cold<Cardano.TxAlonzo>('-|');
+      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const inFlight$ = cold<TxInFlight[]>('a|', {
+        a: [
+          { submittedAt: tip - 1, tx: volatileTransactions[0].tx },
+          {
+            submittedAt: tip - maxInterval / 1000 - 1,
+            tx: volatileTransactions[1].tx
+          }
+        ]
+      });
+      const transactionReemiter = createTransactionReemitter({
+        genesisParameters$,
+        logger,
+        maxInterval,
+        stores,
+        tipSlot$,
+        transactions: {
+          outgoing: {
+            confirmed$,
+            inFlight$,
+            submitting$
+          },
+          rollback$
+        }
+      });
+      expectObservable(transactionReemiter).toBe('-a--|', { a: volatileTransactions[1].tx });
+    });
   });
 });

--- a/packages/wallet/test/services/UtxoTracker.test.ts
+++ b/packages/wallet/test/services/UtxoTracker.test.ts
@@ -68,8 +68,8 @@ describe('createUtxoTracker', () => {
       } as unknown as Cardano.NewTxAlonzo;
       const transactionsInFlight$ = cold('-a-b-c|', {
         a: [],
-        b: [inFlightTx1],
-        c: [inFlightTx1, inFlightTx2]
+        b: [{ tx: inFlightTx1 }],
+        c: [{ tx: inFlightTx1 }, { tx: inFlightTx2 }]
       });
       const utxoTracker = createUtxoTracker(
         {


### PR DESCRIPTION
# Context

Transactions should be resubmitted (TransactionReemiter) when:

- Resubmit on certain errors (probably with some timeout and maybe considering online status as well): ProviderFailure.{~~Unknown~~,Unhealthy,ConnectionFailure}
- Previously submitted transaction didn't get into history$ for too long (e.g. due to timing of rollback - when tx was submitted successfully but never got to history$)

# Proposed Solution

See notes in the commits
