### PR TITLE
feat(wallet): attempt to re-fetch tokenMetadata/nftMetadata if provid…

### DIFF
--- a/packages/wallet/src/services/AssetsTracker.ts
+++ b/packages/wallet/src/services/AssetsTracker.ts
@@ -1,10 +1,13 @@
 import { Asset, Cardano } from '@cardano-sdk/core';
 import { BalanceTracker } from './types';
 import { Logger } from 'ts-log';
-import { Observable, forkJoin, map, mergeMap, of, tap } from 'rxjs';
-import { RetryBackoffConfig } from 'backoff-rxjs';
+import { Observable, Subject, combineLatest, map, mergeMap, of, switchMap, takeUntil, tap } from 'rxjs';
+import { RetryBackoffConfig, intervalBackoff } from 'backoff-rxjs';
 import { TrackedAssetProvider } from './ProviderTracker';
 import { coldObservableProvider } from './util';
+
+const isAssetInfoComplete = (assetInfo: Asset.AssetInfo): boolean =>
+  assetInfo.nftMetadata !== undefined && assetInfo.tokenMetadata !== undefined;
 
 export const createAssetService =
   (assetProvider: TrackedAssetProvider, retryBackoffConfig: RetryBackoffConfig) => (assetId: Cardano.AssetId) =>
@@ -47,16 +50,23 @@ export const createAssetsTracker = (
         // Fetch asset metadata only for assets not already present in assetsMap
         map((assetIds) =>
           assetIds.map((assetId) => {
-            if (assetsMap.has(assetId)) {
-              return of(assetsMap.get(assetId));
+            const assetInfo = assetsMap.get(assetId);
+            if (assetInfo && isAssetInfoComplete(assetInfo)) {
+              return of(assetInfo);
             }
-            logger.debug(`Fetching metadata for asset ${assetId}`);
-            return assetService(assetId);
+            const stopPolling = new Subject<void>();
+            return intervalBackoff(retryBackoffConfig).pipe(
+              // It starts right away, as opposed to rxjs interval which waits the interval before emitting
+              tap((iter) => logger.debug(`Fetch metadata for asset ${assetId}`, iter)),
+              takeUntil(stopPolling),
+              switchMap(() => assetService(assetId)),
+              tap((v) => isAssetInfoComplete(v) && stopPolling.next())
+            );
           })
         ),
         // Wait for all asset metadata fetches to complete
-        mergeMap((assetInfos) => forkJoin(assetInfos)),
-        tap((assetInfos) => logger.debug(`Done fetching metadata for ${assetInfos.length} assets`)),
+        mergeMap((assetInfos) => combineLatest(assetInfos)),
+        tap((assetInfos) => logger.debug(`Got metadata for ${assetInfos.length} assets`)),
         map((assetInfos) => new Map(assetInfos.map((assetInfo) => [assetInfo!.assetId, assetInfo!]))),
         tap((v) => (assetsMap = v))
       )

--- a/packages/wallet/test/mocks/mockAssetProvider.ts
+++ b/packages/wallet/test/mocks/mockAssetProvider.ts
@@ -10,8 +10,10 @@ export const asset = {
     }
   ],
   name: Cardano.AssetName('54534c41'),
+  nftMetadata: null,
   policyId: Cardano.PolicyId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373'),
-  quantity: 1000n
+  quantity: 1000n,
+  tokenMetadata: null
 } as Asset.AssetInfo;
 
 export const mockAssetProvider = () => ({


### PR DESCRIPTION
# Context

AssetInfo tokenMetadata/nftMetadata undefined means that the metadata could not be fetched.
We should still emit the partial AssetInfo, but also refetch refetch the metadata until it is successfully retrieved.

# Proposed Solution
- Enhance `coldObservableProvider` with `pollUntil`, enabling it to retry until the condition is met.
- `AssetsService` will `pollUntil` AssetInfo tokenMetadata and nftMetadata are either null or defined 

# Important Changes Introduced
