### PR TITLE
feat(wallet): tx builder returns inputSelection and hash on build

### DIFF
--- a/packages/wallet/src/TxBuilder/buildTx.ts
+++ b/packages/wallet/src/TxBuilder/buildTx.ts
@@ -175,6 +175,8 @@ export class ObservableWalletTxBuilder implements TxBuilder {
       auxiliaryData: this.auxiliaryData && { ...this.auxiliaryData },
       body: tx.body,
       extraSigners: this.extraSigners && [...this.extraSigners],
+      hash: tx.hash,
+      inputSelection: tx.inputSelection,
       isValid: true,
       sign: () =>
         createSignedTx({

--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -1,7 +1,7 @@
 import { Cardano } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 
-import { InputSelectionError } from '@cardano-sdk/input-selection';
+import { InputSelectionError, SelectionSkeleton } from '@cardano-sdk/input-selection';
 
 import { OutputValidation } from '../types';
 import { SignTransactionOptions, TransactionSigner } from '@cardano-sdk/key-management';
@@ -126,6 +126,8 @@ export interface ValidTxBody {
   readonly auxiliaryData?: Cardano.AuxiliaryData;
   readonly extraSigners?: TransactionSigner[];
   readonly signingOptions?: SignTransactionOptions;
+  readonly inputSelection: SelectionSkeleton;
+  readonly hash: Cardano.TransactionId;
 
   sign(): Promise<SignedTx>;
 }

--- a/packages/wallet/test/integration/buildTx.test.ts
+++ b/packages/wallet/test/integration/buildTx.test.ts
@@ -563,7 +563,9 @@ describe('buildTx', () => {
   it('can be used to build, sign and submit a tx', async () => {
     const tx = await buildTx({ logger, observableWallet }).addOutput(mocks.utxo[0][1]).build();
     if (tx.isValid) {
+      expect(tx.inputSelection).toBeTruthy();
       const signedTx = await tx.sign();
+      expect(signedTx.tx.id).toEqual(tx.hash);
       await signedTx.submit();
     } else {
       expect(tx.errors.length).toBeGreaterThan(0);


### PR DESCRIPTION
# Context

ADP-2246
TxBuilder build method should return the input selection and transaction hash. They are needed by the lace, to be displayed.

# Proposed Solution
Include `inputSelection` and `hash` returned by wallet `initializeTx`,  in the `ValidTx` object returned on `build()`
# Important Changes Introduced
