### PR TITLE
perf(cardano-services): order by block.id in ledger tip queries

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -59,7 +59,7 @@ export const findTip = `
 		hash,
 		slot_no
 	FROM block
-	ORDER BY block.block_no DESC NULLS LAST
+	ORDER BY block.id DESC
 	LIMIT 1`;
 
 export const findBlocksByHashes = `
@@ -83,7 +83,7 @@ export const findBlocksByHashes = `
 	LEFT JOIN block AS prev_blk ON block.previous_id = prev_blk.id
 	LEFT JOIN pool_hash AS pool ON pool.id = leader.pool_hash_id
 	WHERE block.hash = ANY($1)
-	ORDER BY block.block_no ASC NULLS LAST`;
+	ORDER BY block.id ASC`;
 
 export const findBlocksOutputByHashes = `
 	SELECT
@@ -94,7 +94,7 @@ export const findBlocksOutputByHashes = `
 	JOIN block ON block.id = tx.block_id
 	WHERE block.hash = ANY($1)
 	GROUP BY block.hash, block.id
-	ORDER BY block.block_no ASC NULLS LAST`;
+	ORDER BY block.id ASC`;
 
 export const findMultiAssetByTxOut = `
 	SELECT 

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -49,7 +49,7 @@ export const findLatestCompleteEpoch = `
 export const findLedgerTip = `
     SELECT block_no, slot_no, hash
     FROM block
-    ORDER BY block_no DESC NULLS LAST
+    ORDER BY id DESC
     LIMIT 1;
 `;
 


### PR DESCRIPTION
# Context
We're ordering SQL queries by an unindexed column, `block_no`, so queries on mainnet sized databases are taking ~10 seconds

# Proposed Solution
Order by the naturally indexed `id` column.
