### PR TITLE
fix(wallet): await for updated rewards after tx confirmation

### DIFF
--- a/packages/cardano-services/src/Rewards/DbSyncRewardProvider/queries.ts
+++ b/packages/cardano-services/src/Rewards/DbSyncRewardProvider/queries.ts
@@ -1,4 +1,13 @@
 export const findAccountBalance = `
+    WITH current_epoch AS (
+        SELECT
+            e."no" AS epoch_no,
+            optimal_pool_count
+        FROM epoch e
+        JOIN epoch_param ep ON
+            ep.epoch_no = e."no"
+        ORDER BY e.no DESC LIMIT 1
+    )
     SELECT 
     (
         SELECT COALESCE(SUM(r.amount),0) 
@@ -6,6 +15,7 @@ export const findAccountBalance = `
         JOIN stake_address ON 
             stake_address.id = r.addr_id
         WHERE stake_address.view = $1
+        AND r.spendable_epoch <= (SELECT epoch_no FROM current_epoch)
     ) - (
         SELECT COALESCE(SUM(w.amount),0) 
         FROM withdrawal w

--- a/packages/wallet/src/SingleAddressWallet/index.ts
+++ b/packages/wallet/src/SingleAddressWallet/index.ts
@@ -1,0 +1,1 @@
+export * from './SingleAddressWallet';

--- a/packages/wallet/src/SingleAddressWallet/prepareTx.ts
+++ b/packages/wallet/src/SingleAddressWallet/prepareTx.ts
@@ -1,0 +1,79 @@
+import { Cardano, coreToCsl } from '@cardano-sdk/core';
+import { FinalizeTxProps, InitializeTxProps, ObservableWallet } from '../types';
+import { Logger } from 'ts-log';
+import { Observable, combineLatest, firstValueFrom, lastValueFrom, map, take } from 'rxjs';
+import { createTransactionInternals, ensureValidityInterval } from '../Transaction';
+import { defaultSelectionConstraints } from '@cardano-sdk/input-selection';
+
+export interface PrepareTxDependencies {
+  wallet: Pick<ObservableWallet, 'tip$' | 'protocolParameters$' | 'addresses$'> & {
+    delegation: Pick<ObservableWallet['delegation'], 'rewardAccounts$'>;
+    utxo: Pick<ObservableWallet['utxo'], 'available$'>;
+  };
+  signer: {
+    stubFinalizeTx(props: FinalizeTxProps): Observable<Cardano.NewTxAlonzo>;
+  };
+  logger: Logger;
+}
+
+export const createTxPreparer =
+  ({ wallet, signer, logger }: PrepareTxDependencies) =>
+  (props: InitializeTxProps) => {
+    const withdrawals$: Observable<Cardano.Withdrawal[] | undefined> = wallet.delegation.rewardAccounts$.pipe(
+      map((accounts) => accounts.filter((account) => account.rewardBalance)),
+      map((accounts) =>
+        accounts.map((account) => ({ quantity: account.rewardBalance, stakeAddress: account.address }))
+      ),
+      map((withdrawals) => (withdrawals.length > 0 ? withdrawals : undefined))
+    );
+    return lastValueFrom(
+      combineLatest([
+        wallet.tip$,
+        wallet.utxo.available$,
+        wallet.protocolParameters$,
+        wallet.addresses$,
+        withdrawals$
+      ]).pipe(
+        take(1),
+        map(([tip, utxo, protocolParameters, [{ address: changeAddress }], withdrawals]) => {
+          const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
+          const constraints = defaultSelectionConstraints({
+            buildTx: async (inputSelection) => {
+              logger.debug('Building TX for selection constraints', inputSelection);
+              if (withdrawals?.length) {
+                logger.debug('Adding rewards withdrawal in the transaction', withdrawals);
+              }
+              const txInternals = await createTransactionInternals({
+                auxiliaryData: props.auxiliaryData,
+                certificates: props.certificates,
+                changeAddress,
+                collaterals: props.collaterals,
+                inputSelection,
+                mint: props.mint,
+                requiredExtraSignatures: props.requiredExtraSignatures,
+                scriptIntegrityHash: props.scriptIntegrityHash,
+                validityInterval,
+                withdrawals
+              });
+              return coreToCsl.tx(
+                await firstValueFrom(
+                  signer.stubFinalizeTx({
+                    auxiliaryData: props.auxiliaryData,
+                    extraSigners: props.extraSigners,
+                    scripts: props.scripts,
+                    signingOptions: props.signingOptions,
+                    tx: txInternals
+                  })
+                )
+              );
+            },
+            protocolParameters
+          });
+          const implicitCoin = Cardano.util.computeImplicitCoin(protocolParameters, props);
+          return { changeAddress, constraints, implicitCoin, utxo, validityInterval, withdrawals };
+        })
+      )
+    );
+  };
+
+export type PrepareTx = ReturnType<typeof createTxPreparer>;

--- a/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
@@ -2,8 +2,23 @@
 import { BigIntMath, deepEquals, isNotNil } from '@cardano-sdk/util';
 import { Cardano, RewardsProvider } from '@cardano-sdk/core';
 import { ConfirmedTx, Delegatee, RewardAccount, StakeKeyStatus, TxInFlight } from '../types';
+import {
+  EMPTY,
+  Observable,
+  combineLatest,
+  concat,
+  distinctUntilChanged,
+  filter,
+  map,
+  merge,
+  mergeMap,
+  of,
+  pairwise,
+  startWith,
+  switchMap,
+  tap
+} from 'rxjs';
 import { KeyValueStore } from '../../persistence';
-import { Observable, combineLatest, concat, distinctUntilChanged, filter, map, merge, of, switchMap, tap } from 'rxjs';
 import {
   RegAndDeregCertificateTypes,
   includesAnyCertificate,
@@ -50,7 +65,7 @@ export const createQueryStakePoolsProvider =
 export type ObservableStakePoolProvider = ReturnType<typeof createQueryStakePoolsProvider>;
 
 const getWithdrawalQuantity = (
-  { body: { withdrawals } }: Cardano.NewTxAlonzo,
+  withdrawals: Cardano.TxBodyAlonzo['withdrawals'],
   rewardAccount?: Cardano.RewardAccount
 ): Cardano.Lovelace =>
   BigIntMath.sum(
@@ -66,7 +81,7 @@ export const fetchRewardsTrigger$ = (
     // Reload every epoch and after every tx that has withdrawals for this reward account
     epoch$,
     txConfirmed$.pipe(
-      map(({ tx }) => getWithdrawalQuantity(tx, rewardAccount)),
+      map(({ tx }) => getWithdrawalQuantity(tx.body.withdrawals, rewardAccount)),
       filter((withdrawalQty) => withdrawalQty > 0n)
     )
   );
@@ -78,15 +93,15 @@ export const createRewardsProvider =
     rewardsProvider: RewardsProvider,
     retryBackoffConfig: RetryBackoffConfig
   ) =>
-  (rewardAccounts: Cardano.RewardAccount[]): Observable<Cardano.Lovelace[]> =>
+  (rewardAccounts: Cardano.RewardAccount[], equals = isEqual): Observable<Cardano.Lovelace[]> =>
     combineLatest(
       rewardAccounts.map((rewardAccount) =>
         coldObservableProvider({
-          equals: isEqual,
+          equals,
           provider: () => rewardsProvider.rewardAccountBalance({ rewardAccount }),
           retryBackoffConfig,
           trigger$: fetchRewardsTrigger$(epoch$, txConfirmed$, rewardAccount)
-        }).pipe(distinctUntilChanged())
+        })
       )
     );
 export type ObservableRewardsProvider = ReturnType<typeof createRewardsProvider>;
@@ -217,28 +232,53 @@ export const addressRewards = (
   transactionsInFlight$: Observable<TxInFlight[]>,
   rewardsProvider: ObservableRewardsProvider,
   balancesStore: KeyValueStore<Cardano.RewardAccount, Cardano.Lovelace>
-): Observable<Cardano.Lovelace[]> =>
-  combineLatest([
-    concat(
-      balancesStore.getValues(rewardAccounts),
-      rewardsProvider(rewardAccounts).pipe(
-        tap((balances) => {
-          for (const [i, rewardAccount] of rewardAccounts.entries()) {
-            balancesStore.setValue(rewardAccount, balances[i]);
-          }
-        })
-      )
-    ),
-    transactionsInFlight$
-  ]).pipe(
-    map(([totalRewards, transactionsInFlight]) =>
-      totalRewards.map(
-        (total, i) =>
-          total - transactionsInFlight.reduce((sum, { tx }) => sum + getWithdrawalQuantity(tx, rewardAccounts[i]), 0n)
-      )
+): Observable<Cardano.Lovelace[]> => {
+  // Allow identical rewards$ emits to fix corner case.
+  // Epoch change can trigger rewards fetch before tx is detected as confirmed:
+  // rewards$:             'a-b---b' b:{a-tx.rewards} <-- allow 'b' to emitted twice
+  // withdrawalsInFlight$: 'x---y--' x:[tx], y:[]
+  // combineLatest:        'm-n---p' m:{a-tx.rewards}, n:{b-tx.rewards}, p:{b}
+  const rewards$ = concat(
+    balancesStore.getValues(rewardAccounts),
+    rewardsProvider(rewardAccounts, () => false /* allow identical emits */).pipe(
+      tap((balances) => {
+        for (const [i, rewardAccount] of rewardAccounts.entries()) {
+          balancesStore.setValue(rewardAccount, balances[i]);
+        }
+      })
+    )
+  );
+  const withdrawalsInFlight$ = transactionsInFlight$.pipe(
+    map((txs) =>
+      txs
+        .flatMap(
+          ({
+            tx: {
+              body: { withdrawals }
+            }
+          }) => withdrawals
+        )
+        .filter(isNotNil)
     ),
     distinctUntilChanged(deepEquals)
   );
+  return combineLatest([rewards$, withdrawalsInFlight$]).pipe(
+    startWith([[] as bigint[], [] as Cardano.Withdrawal[]] as const),
+    pairwise(),
+    mergeMap(([[_, prevWithdrawalsInFlight], [totalRewards, withdrawalsInFlight]]) => {
+      // Either rewards$ or withdrawalsInFlight$ can change.
+      // If the change was on withdrawalsInFlight$ AND it's size is smaller (which means a withdrawal tx was confirmed),
+      // then we expect rewards$ to also emit, as it's balance must change after such transaction.
+      // This is coupled with implementation of `rewardsProvider` observable, as it assumes that
+      // rewards re-fetch is triggered by transaction confirmation, therefore must happen AFTER it.
+      if (prevWithdrawalsInFlight.length > withdrawalsInFlight.length) {
+        return EMPTY;
+      }
+      return of(totalRewards.map((total, i) => total - getWithdrawalQuantity(withdrawalsInFlight, rewardAccounts[i])));
+    }),
+    distinctUntilChanged(deepEquals)
+  );
+};
 
 export const toRewardAccounts =
   (addresses: Cardano.RewardAccount[]) =>


### PR DESCRIPTION
# Context

Rewards are computed by subtracting in-flight tx withdrawals. Once tx is confirmed, it triggers a re-fetch of rewards balance from the provider. During this re-fetch, the tx is no longer 'in-flight', so there was a brief period of time when rewards balance is incorrect.

# Proposed Solution

See inline comment in the commit

## Follow-up work

ADP-2275 (see inline comment in [this wip commit](https://github.com/input-output-hk/cardano-js-sdk/commit/131a18ee33148ab55bdb456c0ba5ca7c5d6b49af#diff-a24ba91fcdc49ed6949e92d1ceeef8b221721a0c810cb4f1c54b758a9d243a84R279-R295)).

f50ce5dc84a76a0a5db7426906f13458f1df869f isn't really needed for this PR and is just some preparation work for that parked commit, but I think it's better to merge it now to have less git conflicts later.