### PR TITLE
feat: RewardsProvider.rewardsHistory constraints

### DIFF
--- a/packages/cardano-services/src/Program/loadHttpServer.ts
+++ b/packages/cardano-services/src/Program/loadHttpServer.ts
@@ -112,7 +112,14 @@ const serviceMapFactory = (args: ProgramArgs, logger: Logger, dnsResolver: DnsRe
       return new ChainHistoryHttpService({ chainHistoryProvider, logger });
     }, ServiceNames.ChainHistory),
     [ServiceNames.Rewards]: withDb(
-      (db) => new RewardsHttpService({ logger, rewardsProvider: new DbSyncRewardsProvider(db, logger) }),
+      (db) =>
+        new RewardsHttpService({
+          logger,
+          rewardsProvider: new DbSyncRewardsProvider(
+            { paginationPageSizeLimit: args.options!.paginationPageSizeLimit! },
+            { db, logger }
+          )
+        }),
       ServiceNames.Rewards
     ),
     [ServiceNames.NetworkInfo]: withDb(async (db) => {

--- a/packages/cardano-services/src/Rewards/DbSyncRewardProvider/RewardsBuilder.ts
+++ b/packages/cardano-services/src/Rewards/DbSyncRewardProvider/RewardsBuilder.ts
@@ -7,10 +7,12 @@ import { findAccountBalance, findRewardsHistory } from './queries';
 export class RewardsBuilder {
   #db: Pool;
   #logger: Logger;
+
   constructor(db: Pool, logger: Logger) {
     this.#db = db;
     this.#logger = logger;
   }
+
   public async getAccountBalance(rewardAccount: Cardano.RewardAccount) {
     this.#logger.debug('About to run findAccountBalance query');
     const result: QueryResult<AccountBalanceModel> = await this.#db.query(findAccountBalance, [
@@ -18,6 +20,7 @@ export class RewardsBuilder {
     ]);
     return result.rows.length > 0 ? result.rows[0] : undefined;
   }
+
   public async getRewardsHistory(rewardAccounts: Cardano.RewardAccount[], epochs?: Range<Cardano.EpochNo>) {
     const params: (string[] | number)[] = [rewardAccounts.map((rewardAcc) => rewardAcc.toString())];
     this.#logger.debug('About to run findRewardsHistory query');

--- a/packages/cardano-services/test/Asset/AssetHttpService.test.ts
+++ b/packages/cardano-services/test/Asset/AssetHttpService.test.ts
@@ -82,6 +82,7 @@ describe('AssetHttpService', () => {
 
     describe('/get-asset', () => {
       it('returns a 415 coded response if the wrong content type header is used', async () => {
+        expect.assertions(2);
         try {
           await axios.post(
             `${apiUrlBase}/get-asset`,
@@ -96,6 +97,7 @@ describe('AssetHttpService', () => {
       });
 
       it('returns 400 coded response if the request is bad formed', async () => {
+        expect.assertions(2);
         try {
           await axios.post(`${apiUrlBase}/get-asset`, { assetId: [['test']] });
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,11 +108,11 @@ describe('AssetHttpService', () => {
       });
 
       it('returns 404 coded response for not existing existing asset id', async () => {
+        expect.assertions(1);
         try {
-          const res = await axios.post(`${apiUrlBase}/get-asset`, {
+          await axios.post(`${apiUrlBase}/get-asset`, {
             assetId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
           });
-          expect(res.data[0]).toEqual({});
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
           expect(error.response.status).toBe(404);

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -103,6 +103,7 @@ describe('ChainHistoryHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(`${baseUrl}${url}`, { ids: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
             throw new Error('fail');
@@ -132,6 +133,7 @@ describe('ChainHistoryHttpService', () => {
       });
 
       it('returns a 400 coded error if provided block ids are greater than pagination page size limit', async () => {
+        expect.assertions(2);
         const ids: Cardano.BlockId[] = [
           Cardano.BlockId('7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298'),
           Cardano.BlockId('469cc6fbcc186de6b12c392ad0cc84a20c4d4774c1f9c3cfd80745de00856f4b'),
@@ -169,6 +171,7 @@ describe('ChainHistoryHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(`${baseUrl}${url}`, { ids: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
             throw new Error('fail');
@@ -201,6 +204,7 @@ describe('ChainHistoryHttpService', () => {
       });
 
       it('returns a 400 coded error if provided transaction ids are greater than pagination page size limit', async () => {
+        expect.assertions(2);
         const ids: Cardano.TransactionId[] = [
           Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819'),
           Cardano.TransactionId('952dfa431223fd671c5e9e048e016f70fcebd9e41fcb726969415ff692736eeb'),
@@ -311,6 +315,7 @@ describe('ChainHistoryHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(
               `${baseUrl}${url}`,
@@ -408,6 +413,7 @@ describe('ChainHistoryHttpService', () => {
       });
 
       it('returns a 400 coded error if pagination argument is not provided', async () => {
+        expect.assertions(2);
         const addresses: Cardano.Address[] = [
           Cardano.Address(
             'addr_test1qpcnmvyjmxmsm75f747u566gw7ewz4mesdw7yl278uf9r3f5l7d7dpx2ymfwlm3e56flupga8yamjr2kwdt7dw77ktyqqtx2r7'
@@ -423,6 +429,7 @@ describe('ChainHistoryHttpService', () => {
       });
 
       it('returns a 400 coded error if provided transaction addresses are greater than pagination page size limit', async () => {
+        expect.assertions(2);
         const addresses: Cardano.Address[] = [
           Cardano.Address(
             'addr_test1qpcnmvyjmxmsm75f747u566gw7ewz4mesdw7yl278uf9r3f5l7d7dpx2ymfwlm3e56flupga8yamjr2kwdt7dw77ktyqqtx2r7'

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -143,6 +143,7 @@ describe('NetworkInfoHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(
               `${baseUrl}/era-summaries`,
@@ -174,6 +175,7 @@ describe('NetworkInfoHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(`${baseUrl}/stake`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
           } catch (error: any) {
@@ -257,6 +259,7 @@ describe('NetworkInfoHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(
               `${baseUrl}/lovelace-supply`,
@@ -312,6 +315,7 @@ describe('NetworkInfoHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(`${baseUrl}/ledger-tip`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
           } catch (error: any) {
@@ -334,6 +338,7 @@ describe('NetworkInfoHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(
               `${baseUrl}/current-wallet-protocol-parameters`,
@@ -360,6 +365,7 @@ describe('NetworkInfoHttpService', () => {
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
           try {
             await axios.post(
               `${baseUrl}/genesis-parameters`,
@@ -372,6 +378,7 @@ describe('NetworkInfoHttpService', () => {
           }
         });
       });
+
       it('successful request', async () => {
         const response = await provider.genesisParameters();
         expect(response.networkMagic).toBeDefined();

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -153,6 +153,7 @@ describe('TxSubmitHttpService', () => {
       });
 
       it('returns a 415 coded response if the wrong content type header is used', async () => {
+        expect.assertions(3);
         try {
           await axios.post(`${baseUrl}/submit`, bodyTx, {
             headers: { [CONTENT_TYPE]: APPLICATION_CBOR }


### PR DESCRIPTION
# Context

This query currently returns unconstrained results, posing a DOS risk.

# Proposed Solution
Since the return type of [rewardsHistory](https://github.com/input-output-hk/cardano-js-sdk/blob/5910f552755e2a3fda75c48437f8534a913ad6c2/packages/cardano-services/src/Rewards/DbSyncRewardProvider/DbSyncRewardsProvider.ts#L18-L21) is a simple map (not a list with multiple items) : `<Map<Cardano.RewardAccount,EpochRewards[]>` and the relation between the `rewardAccounts` arg and mapped response is 1:1 then we might be better just to apply the `props.rewardAccounts` limitation of `PAGINATION_PAGE_SIZE` without pagination of the response.

# Important Changes Introduced
- apply `rewardAccounts` arg runtime limitation of max page size limit
- extends with missing expect.assertions()
