### PR TITLE
feat!: StakePoolProvider query constraints

### DIFF
--- a/packages/cardano-services-client/test/StakePoolProvider/stakePoolHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/StakePoolProvider/stakePoolHttpProvider.test.ts
@@ -21,7 +21,7 @@ describe('stakePoolHttpProvider', () => {
   test('queryStakePools doesnt throw', async () => {
     axiosMock.onPost().replyOnce(200, []);
     const provider = stakePoolHttpProvider(config);
-    await expect(provider.queryStakePools()).resolves.toEqual([]);
+    await expect(provider.queryStakePools({ pagination: { limit: 25, startAt: 1 } })).resolves.toEqual([]);
   });
 
   test('stakePoolStats doesnt throw', async () => {

--- a/packages/cardano-services/src/Program/loadHttpServer.ts
+++ b/packages/cardano-services/src/Program/loadHttpServer.ts
@@ -97,13 +97,16 @@ const serviceMapFactory = (args: ProgramArgs, logger: Logger, dnsResolver: DnsRe
     }, ServiceNames.Asset),
     [ServiceNames.StakePool]: withDb(async (db) => {
       const cardanoNode = await getOgmiosCardanoNode(dnsResolver, logger, args.options);
-      const stakePoolProvider = new DbSyncStakePoolProvider({
-        cache: new InMemoryCache(args.options!.dbCacheTtl!),
-        cardanoNode,
-        db,
-        epochMonitor: getEpochMonitor(db),
-        logger
-      });
+      const stakePoolProvider = new DbSyncStakePoolProvider(
+        { paginationPageSizeLimit: args.options!.paginationPageSizeLimit! },
+        {
+          cache: new InMemoryCache(args.options!.dbCacheTtl!),
+          cardanoNode,
+          db,
+          epochMonitor: getEpochMonitor(db),
+          logger
+        }
+      );
       return new StakePoolHttpService({ logger, stakePoolProvider });
     }, ServiceNames.StakePool),
     [ServiceNames.Utxo]: withDb(

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
@@ -19,6 +19,7 @@ import {
   PoolRegistrationModel,
   PoolRetirementModel,
   PoolUpdateModel,
+  QueryPoolsApyArgs,
   RelayModel,
   StakePoolStatsModel,
   SubQuery,
@@ -99,7 +100,7 @@ export class StakePoolBuilder {
       })
     );
   }
-  public async queryPoolAPY(hashesIds: number[], options?: QueryStakePoolsArgs): Promise<PoolAPY[]> {
+  public async queryPoolAPY(hashesIds: number[], options?: QueryPoolsApyArgs): Promise<PoolAPY[]> {
     this.#logger.debug('About to query pools APY');
     const defaultSort: OrderByOptions[] = [{ field: 'apy', order: 'desc' }];
     const queryWithSortAndPagination = withPagination(

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, Paginated } from '@cardano-sdk/core';
+import { Cardano, Paginated, QueryStakePoolsArgs } from '@cardano-sdk/core';
 export interface PoolUpdateModel {
   id: string; // pool hash id
   update_id: string;
@@ -185,3 +185,5 @@ export type StakePoolResults = {
   results: Paginated<Cardano.StakePool>;
   poolsToCache: PoolsToCache;
 };
+
+export type QueryPoolsApyArgs = Partial<QueryStakePoolsArgs>;

--- a/packages/cardano-services/src/StakePool/openApi.json
+++ b/packages/cardano-services/src/StakePool/openApi.json
@@ -46,7 +46,14 @@
             }
           },
           "400": {
-            "description": "invalid request"
+            "description": "invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           }
         }
       }
@@ -56,14 +63,22 @@
         "summary": "stake pool stats",
         "operationId": "stakePoolStats",
         "requestBody": {
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StakePoolStats_body" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StakePoolStats_body"
+              }
+            }
+          }
         },
         "responses": {
           "200": {
             "description": "Stake pool stats fetched",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StakePoolStats" }
+                "schema": {
+                  "$ref": "#/components/schemas/StakePoolStats"
+                }
               }
             }
           },
@@ -77,10 +92,17 @@
   "components": {
     "schemas": {
       "Undefined": {
-        "required": ["__type"],
+        "required": [
+          "__type"
+        ],
         "type": "object",
         "properties": {
-          "__type": { "type": "string", "enum": ["undefined"] }
+          "__type": {
+            "type": "string",
+            "enum": [
+              "undefined"
+            ]
+          }
         }
       },
       "StakePoolStats": {
@@ -89,9 +111,15 @@
           "qty": {
             "type": "object",
             "properties": {
-              "active": { "type": "number" },
-              "retired": { "type": "number" },
-              "retiring": { "type": "number" }
+              "active": {
+                "type": "number"
+              },
+              "retired": {
+                "type": "number"
+              },
+              "retiring": {
+                "type": "number"
+              }
             }
           }
         }
@@ -100,6 +128,9 @@
         "type": "object"
       },
       "SearchStakePoolRequest": {
+        "required": [
+          "pagination"
+        ],
         "type": "object",
         "properties": {
           "filters": {
@@ -115,11 +146,17 @@
         }
       },
       "IdentifierFilter": {
+        "required": [
+          "values"
+        ],
         "type": "object",
         "properties": {
           "_condition": {
             "type": "string",
-            "enum": ["and", "or"]
+            "enum": [
+              "and",
+              "or"
+            ]
           },
           "values": {
             "type": "array",
@@ -130,7 +167,15 @@
         }
       },
       "SearchStakePool": {
-        "required": ["cost", "id", "margin", "owners", "pledge", "relays", "vrf"],
+        "required": [
+          "cost",
+          "id",
+          "margin",
+          "owners",
+          "pledge",
+          "relays",
+          "vrf"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -233,13 +278,37 @@
         "type": "object",
         "properties": {
           "ipv4": {
-            "anyOf": [{ "$ref": "#/components/schemas/Undefined" }, { "type": "string", "nullable": true }]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Undefined"
+              },
+              {
+                "type": "string",
+                "nullable": true
+              }
+            ]
           },
           "ipv6": {
-            "anyOf": [{ "$ref": "#/components/schemas/Undefined" }, { "type": "string", "nullable": true }]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Undefined"
+              },
+              {
+                "type": "string",
+                "nullable": true
+              }
+            ]
           },
           "port": {
-            "anyOf": [{ "$ref": "#/components/schemas/Undefined" }, { "type": "number", "nullable": true }]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Undefined"
+              },
+              {
+                "type": "number",
+                "nullable": true
+              }
+            ]
           },
           "dnsName": {
             "type": "string"
@@ -280,10 +349,18 @@
       },
       "StakePoolStatus": {
         "type": "string",
-        "enum": ["active", "activating", "retired", "retiring"]
+        "enum": [
+          "active",
+          "activating",
+          "retired",
+          "retiring"
+        ]
       },
       "Fraction": {
-        "required": ["denominator", "numerator"],
+        "required": [
+          "denominator",
+          "numerator"
+        ],
         "type": "object",
         "properties": {
           "numerator": {
@@ -306,7 +383,10 @@
         }
       },
       "BigInt": {
-        "required": ["value", "__type"],
+        "required": [
+          "value",
+          "__type"
+        ],
         "type": "object",
         "properties": {
           "value": {
@@ -314,7 +394,9 @@
           },
           "__type": {
             "type": "string",
-            "enum": ["bigint"]
+            "enum": [
+              "bigint"
+            ]
           }
         }
       },
@@ -323,7 +405,10 @@
         "properties": {
           "_condition": {
             "type": "string",
-            "enum": ["and", "or"]
+            "enum": [
+              "and",
+              "or"
+            ]
           },
           "identifier": {
             "$ref": "#/components/schemas/IdentifierFilter"
@@ -340,7 +425,10 @@
         }
       },
       "SearchStakePoolRequest_pagination": {
-        "required": ["limit", "startAt"],
+        "required": [
+          "limit",
+          "startAt"
+        ],
         "type": "object",
         "properties": {
           "startAt": {
@@ -449,7 +537,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "retired", "offline", "experimental", "private"]
+            "enum": [
+              "active",
+              "retired",
+              "offline",
+              "experimental",
+              "private"
+            ]
           },
           "contact": {
             "$ref": "#/components/schemas/ExtendedMetadataFields_pool_contact"

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -29,7 +29,6 @@ import {
   loadSecret
 } from './Program';
 import { Command, Option } from 'commander';
-
 import { DB_CACHE_TTL_DEFAULT } from './InMemoryCache';
 import { DEFAULT_TOKEN_METADATA_CACHE_TTL, DEFAULT_TOKEN_METADATA_SERVER_URL } from './Asset';
 import { EPOCH_POLL_INTERVAL_DEFAULT } from './util';

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -139,17 +139,13 @@ describe('NetworkInfoHttpService', () => {
     describe('/era-summaries', () => {
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/era-summaries`, { args: [] })).status).toEqual(200);
+          expect((await axios.post(`${baseUrl}/era-summaries`, {})).status).toEqual(200);
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
           expect.assertions(2);
           try {
-            await axios.post(
-              `${baseUrl}/era-summaries`,
-              { args: [] },
-              { headers: { 'Content-Type': APPLICATION_CBOR } }
-            );
+            await axios.post(`${baseUrl}/era-summaries`, {}, { headers: { 'Content-Type': APPLICATION_CBOR } });
           } catch (error: any) {
             expect(error.response.status).toBe(415);
             expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
@@ -171,13 +167,13 @@ describe('NetworkInfoHttpService', () => {
 
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/stake`, { args: [] })).status).toEqual(200);
+          expect((await axios.post(`${baseUrl}/stake`, {})).status).toEqual(200);
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
           expect.assertions(2);
           try {
-            await axios.post(`${baseUrl}/stake`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+            await axios.post(`${baseUrl}/stake`, {}, { headers: { 'Content-Type': APPLICATION_CBOR } });
           } catch (error: any) {
             expect(error.response.status).toBe(415);
             expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
@@ -255,17 +251,13 @@ describe('NetworkInfoHttpService', () => {
 
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/lovelace-supply`, { args: [] })).status).toEqual(200);
+          expect((await axios.post(`${baseUrl}/lovelace-supply`, {})).status).toEqual(200);
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
           expect.assertions(2);
           try {
-            await axios.post(
-              `${baseUrl}/lovelace-supply`,
-              { args: [] },
-              { headers: { 'Content-Type': APPLICATION_CBOR } }
-            );
+            await axios.post(`${baseUrl}/lovelace-supply`, {}, { headers: { 'Content-Type': APPLICATION_CBOR } });
           } catch (error: any) {
             expect(error.response.status).toBe(415);
             expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
@@ -311,13 +303,13 @@ describe('NetworkInfoHttpService', () => {
     describe('/ledger-tip', () => {
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/ledger-tip`, { args: [] })).status).toEqual(200);
+          expect((await axios.post(`${baseUrl}/ledger-tip`, {})).status).toEqual(200);
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
           expect.assertions(2);
           try {
-            await axios.post(`${baseUrl}/ledger-tip`, { args: [] }, { headers: { 'Content-Type': APPLICATION_CBOR } });
+            await axios.post(`${baseUrl}/ledger-tip`, {}, { headers: { 'Content-Type': APPLICATION_CBOR } });
           } catch (error: any) {
             expect(error.response.status).toBe(415);
             expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
@@ -334,7 +326,7 @@ describe('NetworkInfoHttpService', () => {
     describe('/current-wallet-protocol-parameters', () => {
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/current-wallet-protocol-parameters`, { args: [] })).status).toEqual(200);
+          expect((await axios.post(`${baseUrl}/current-wallet-protocol-parameters`, {})).status).toEqual(200);
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
@@ -342,7 +334,7 @@ describe('NetworkInfoHttpService', () => {
           try {
             await axios.post(
               `${baseUrl}/current-wallet-protocol-parameters`,
-              { args: [] },
+              {},
               { headers: { 'Content-Type': APPLICATION_CBOR } }
             );
           } catch (error: any) {
@@ -361,17 +353,13 @@ describe('NetworkInfoHttpService', () => {
     describe('/genesis-parameters', () => {
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/genesis-parameters`, { args: [] })).status).toEqual(200);
+          expect((await axios.post(`${baseUrl}/genesis-parameters`, {})).status).toEqual(200);
         });
 
         it('returns a 415 coded response if the wrong content type header is used', async () => {
           expect.assertions(2);
           try {
-            await axios.post(
-              `${baseUrl}/genesis-parameters`,
-              { args: [] },
-              { headers: { 'Content-Type': APPLICATION_CBOR } }
-            );
+            await axios.post(`${baseUrl}/genesis-parameters`, {}, { headers: { 'Content-Type': APPLICATION_CBOR } });
           } catch (error: any) {
             expect(error.response.status).toBe(415);
             expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
@@ -1,13 +1,14 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Cardano, QueryStakePoolsArgs } from '@cardano-sdk/core';
+import { PAGINATION_PAGE_SIZE_LIMIT_DEFAULT, StakePoolBuilder } from '../../../src';
 import { Pool } from 'pg';
-import { StakePoolBuilder } from '../../../src';
 import { dummyLogger as logger } from 'ts-log';
 
 describe('StakePoolBuilder', () => {
   const dbConnection = new Pool({ connectionString: process.env.POSTGRES_CONNECTION_STRING });
   const builder = new StakePoolBuilder(dbConnection, logger);
+  const pagination = { limit: PAGINATION_PAGE_SIZE_LIMIT_DEFAULT, startAt: 0 };
 
   afterAll(async () => {
     await dbConnection.end();
@@ -74,7 +75,10 @@ describe('StakePoolBuilder', () => {
       });
       it('by saturation', async () => {
         const metrics = (
-          await builder.queryPoolMetrics([1, 31, 19], totalAda, { sort: { field: 'saturation', order: 'asc' } })
+          await builder.queryPoolMetrics([1, 31, 19], totalAda, {
+            pagination,
+            sort: { field: 'saturation', order: 'asc' }
+          })
         ).map((m) => m.metrics);
         expect(metrics).toHaveLength(3);
         expect(metrics).toMatchSnapshot();
@@ -108,32 +112,32 @@ describe('StakePoolBuilder', () => {
         expect(pools).toMatchSnapshot();
       });
       it('by name desc', async () => {
-        const pools = (await builder.queryPoolData([14, 15, 20], { sort: { field: 'name', order: 'desc' } })).map(
-          (qR) => {
-            const { hashId: _1, updateId: _2, ...poolData } = qR;
-            return poolData;
-          }
-        );
+        const pools = (
+          await builder.queryPoolData([14, 15, 20], { pagination, sort: { field: 'name', order: 'desc' } })
+        ).map((qR) => {
+          const { hashId: _1, updateId: _2, ...poolData } = qR;
+          return poolData;
+        });
         expect(pools).toHaveLength(3);
         expect(pools).toMatchSnapshot();
       });
       it('by real-world cost considering fixed cost and margin when specifying sort by cost desc', async () => {
-        const pools = (await builder.queryPoolData([14, 15, 20], { sort: { field: 'cost', order: 'desc' } })).map(
-          (qR) => {
-            const { hashId: _1, updateId: _2, ...poolData } = qR;
-            return poolData;
-          }
-        );
+        const pools = (
+          await builder.queryPoolData([14, 15, 20], { pagination, sort: { field: 'cost', order: 'desc' } })
+        ).map((qR) => {
+          const { hashId: _1, updateId: _2, ...poolData } = qR;
+          return poolData;
+        });
         expect(pools).toHaveLength(3);
         expect(pools).toMatchSnapshot();
       });
       it('by real-world cost considering fixed cost and margin when specifying sort by cost asc', async () => {
-        const pools = (await builder.queryPoolData([14, 15, 20], { sort: { field: 'cost', order: 'asc' } })).map(
-          (qR) => {
-            const { hashId: _1, updateId: _2, ...poolData } = qR;
-            return poolData;
-          }
-        );
+        const pools = (
+          await builder.queryPoolData([14, 15, 20], { pagination, sort: { field: 'cost', order: 'asc' } })
+        ).map((qR) => {
+          const { hashId: _1, updateId: _2, ...poolData } = qR;
+          return poolData;
+        });
         expect(pools).toHaveLength(3);
         expect(pools).toMatchSnapshot();
       });

--- a/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
+++ b/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
@@ -49,7 +49,7 @@ export interface QueryStakePoolsArgs {
   /**
    * Will return all stake pools matching the query if not specified
    */
-  pagination?: PaginationArgs;
+  pagination: PaginationArgs;
 }
 
 export interface StakePoolStats {
@@ -66,7 +66,7 @@ export interface StakePoolProvider extends Provider {
    * @returns Stake pools
    * @throws ProviderError
    */
-  queryStakePools: (args?: QueryStakePoolsArgs) => Promise<Paginated<Cardano.StakePool>>;
+  queryStakePools: (args: QueryStakePoolsArgs) => Promise<Paginated<Cardano.StakePool>>;
   /**
    * @returns {StakePoolStats} Stake pool stats
    */

--- a/packages/util-dev/test/createStubStakePoolProvider.test.ts
+++ b/packages/util-dev/test/createStubStakePoolProvider.test.ts
@@ -14,7 +14,8 @@ describe('createStubStakePoolProvider', () => {
     });
     it('matches by id', async () => {
       const stakePools = await provider.queryStakePools({
-        filters: { identifier: { values: [{ id: 'd-to-matc' as unknown as Cardano.PoolId }] } }
+        filters: { identifier: { values: [{ id: 'd-to-matc' as unknown as Cardano.PoolId }] } },
+        pagination: { limit: 25, startAt: 0 }
       });
       expect(stakePools.pageResults).toHaveLength(1);
       expect(stakePools.totalResultCount).toEqual(1);
@@ -23,7 +24,8 @@ describe('createStubStakePoolProvider', () => {
 
     it('matches by name', async () => {
       const stakePools = await provider.queryStakePools({
-        filters: { identifier: { values: [{ name: 'ool1' }] } }
+        filters: { identifier: { values: [{ name: 'ool1' }] } },
+        pagination: { limit: 25, startAt: 0 }
       });
       expect(stakePools.pageResults).toHaveLength(1);
       expect(stakePools.totalResultCount).toEqual(1);
@@ -32,7 +34,8 @@ describe('createStubStakePoolProvider', () => {
 
     it('matches by ticker', async () => {
       const stakePools = await provider.queryStakePools({
-        filters: { identifier: { values: [{ ticker: 'TIC' }] } }
+        filters: { identifier: { values: [{ ticker: 'TIC' }] } },
+        pagination: { limit: 25, startAt: 0 }
       });
       expect(stakePools.pageResults).toHaveLength(1);
       expect(stakePools.totalResultCount).toEqual(1);

--- a/packages/wallet/test/mocks/mockChainHistoryProvider.ts
+++ b/packages/wallet/test/mocks/mockChainHistoryProvider.ts
@@ -4,7 +4,7 @@ import { currentEpoch, ledgerTip, stakeKeyHash } from './mockData';
 import { somePartialStakePools } from '@cardano-sdk/util-dev';
 import delay from 'delay';
 
-const getRandomTxId = () =>
+export const getRandomTxId = () =>
   Array.from({ length: 64 })
     .map(() => Math.floor(Math.random() * 16).toString(16))
     .join('');

--- a/packages/wallet/test/mocks/mockRewardsProvider.ts
+++ b/packages/wallet/test/mocks/mockRewardsProvider.ts
@@ -1,3 +1,5 @@
+import { Cardano, Paginated, StakePoolProvider } from '@cardano-sdk/core';
+import { getRandomTxId } from './mockChainHistoryProvider';
 import { rewardAccountBalance, rewardAccountBalance2, rewardsHistory, rewardsHistory2 } from './mockData';
 import delay from 'delay';
 
@@ -16,5 +18,80 @@ export const mockRewardsProvider2 = (delayMs: number) => {
     rewardsHistory: delayedJestFn(rewardsHistory2)
   };
 };
+
+export const generateStakePools = (qty: number): Cardano.StakePool[] =>
+  [...Array.from({ length: qty }).keys()].map(() => ({
+    cost: 340_000_000n,
+    epochRewards: [
+      {
+        activeStake: 2_986_376_991n,
+        epoch: 205,
+        epochLength: 431_850_000,
+        memberROI: 0,
+        operatorFees: 0n,
+        totalRewards: 0n
+      }
+    ],
+    hexId: Cardano.PoolIdHex('5d99282bbb4840380bb98c075498ed1983aee18a4a0925b9b44d93f1'),
+    id: Cardano.PoolId('pool1tkvjs2amfpqrszae3sr4fx8drxp6acv2fgyjtwd5fkflzguqp96'),
+    margin: {
+      denominator: 1000,
+      numerator: 27
+    },
+    metadata: {
+      description: 'Pool a of the banderini devtest staking pools',
+      homepage: 'http://www.banderini.net',
+      name: 'banderini-devtest-a',
+      ticker: 'BANDA'
+    },
+    metadataJson: {
+      hash: Cardano.util.Hash32ByteBase16(getRandomTxId()),
+      url: 'https://git.io/JJ7wm'
+    },
+    metrics: {
+      apy: 0,
+      blocksCreated: 0,
+      delegators: 1,
+      livePledge: 495_463_149n,
+      saturation: 0.000_035_552_103_558_591_88,
+      size: {
+        active: 1,
+        live: 0
+      },
+      stake: {
+        active: 2_986_376_991n,
+        live: 0n
+      }
+    },
+    owners: [],
+    pledge: 100_000_000n,
+    relays: [],
+    rewardAccount: Cardano.RewardAccount('stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt'),
+    status: Cardano.StakePoolStatus.Active,
+    transactions: {
+      registration: [Cardano.TransactionId(getRandomTxId())],
+      retirement: []
+    },
+    vrf: Cardano.VrfVkHex(getRandomTxId())
+  }));
+
+export const stakePoolsPaginated: Paginated<Cardano.StakePool> = {
+  pageResults: generateStakePools(10),
+  totalResultCount: 1
+};
+
+const stakePoolStatsMock = {
+  qty: {
+    active: 5,
+    retired: 5,
+    retiring: 5
+  }
+};
+
+export const mockStakePoolsProvider = (): StakePoolProvider => ({
+  healthCheck: jest.fn().mockResolvedValue({ ok: true }),
+  queryStakePools: jest.fn().mockResolvedValue(stakePoolsPaginated),
+  stakePoolStats: jest.fn().mockResolvedValue(stakePoolStatsMock)
+});
 
 export type RewardsProviderStub = ReturnType<typeof mockRewardsProvider>;

--- a/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
@@ -39,7 +39,7 @@ describe('RewardsHistory', () => {
   });
 
   describe('createRewardsHistoryTracker', () => {
-    it('queries and maps reward history starting from first delgation epoch+3', () => {
+    it('queries and maps reward history starting from first delegation epoch+3', () => {
       createTestScheduler().run(({ cold, expectObservable, flush }) => {
         const accountRewardsHistory = rewardsHistory.get(rewardAccount)!;
         const epoch = accountRewardsHistory[0].epoch;

--- a/packages/wallet/test/services/ProviderTracker/TrackedStakePoolProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedStakePoolProvider.test.ts
@@ -48,7 +48,7 @@ describe('TrackedStakePoolProvider', () => {
     test(
       'queryStakePools',
       testFunctionStats(
-        (provider) => provider.queryStakePools({}),
+        (provider) => provider.queryStakePools({ pagination: { limit: 25, startAt: 0 } }),
         (stats) => stats.queryStakePools$
       )
     );


### PR DESCRIPTION
# Context
Currently the `StakePoolProvider.queryStakePools` query _“Will return all stake pools matching the query if not specified”_. As this interface has been faithfully implemented by the DbSyncStakePoolProvider, the server will run out of memory if queried without pagination.

**Acceptance Criteria**
Type updated to require pagination.
The HTTP response must be paginated and arguments must be passed and enforced at runtime. Interpret the error as a 400 code response in the HTTP service.
Make pagination a configurable option, defaulting to 25. as `PAGINATION_PAGE_SIZE_LIMIT`
StakePoolQueryOptions.identifier should be limited to `PAGINATION_PAGE_SIZE_LIMIT`

# Proposed Solution

# Important Changes Introduced
- enforce `pagination` as required argument
- add pagination page size limit constraints in the provider
- interpret the error as a 400 code response
- update OpenApi schema
- in wallet fetch all stake pools page by page
- remove obsolete `args:[]` usage in providers' tests
