### PR TITLE
[WIP]test(e2e): added a wait for faucet step in the E2E CI

### DIFF
--- a/.github/workflows/continuous-integration-e2e.yaml
+++ b/.github/workflows/continuous-integration-e2e.yaml
@@ -46,6 +46,7 @@ jobs:
       run: |
         yarn workspace @cardano-sdk/e2e build
         yarn workspace @cardano-sdk/e2e wait-for-network
+        yarn workspace @cardano-sdk/e2e wait-for-faucet
         yarn workspace @cardano-sdk/e2e test:wallet
       env:
         FAUCET_PROVIDER: 'cardano-wallet'

--- a/packages/e2e/local-network/scripts/is-faucet-ready.sh
+++ b/packages/e2e/local-network/scripts/is-faucet-ready.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+root="$(cd "$here/.." && pwd)"
+
+cd "$root"
+
+export PATH=$PWD/bin:$PATH
+
+WALLET_ID="7991322ed68894d0f1fb645a74576c3780ab312c"
+PORT=8090
+FAUCET_WALLET='{"name": "Faucet", "mnemonic_sentence": ["fire", "method", "repair", "aware", "foot", "tray", "accuse", "brother", "popular", "olive", "find", "account", "sick", "rocket", "next"], "passphrase": "passphrase", "address_pool_gap": 20 }'
+
+# Add Faucet wallet
+curl -s http://localhost:"$PORT"/v2/wallets -H 'Content-Type: application/json' -H 'Accept: application/json' -d "$FAUCET_WALLET" > /dev/null
+
+# Get wallet status
+status=$(curl -s http://localhost:"$PORT"/v2/wallets/"$WALLET_ID" -H 'Content-Type: application/json' -H 'Accept: application/json' | jq .state.status)
+epoch=$(curl -s http://localhost:"$PORT"/v2/wallets/"$WALLET_ID" -H 'Content-Type: application/json' -H 'Accept: application/json' | jq .tip.epoch_number)
+totalBalance=$(curl -s http://localhost:"$PORT"/v2/wallets/"$WALLET_ID" -H 'Content-Type: application/json' -H 'Accept: application/json' | jq .balance.total.quantity)
+
+if [[ "$status" == "\"ready\"" && $epoch -gt 4 && $totalBalance -gt 100000000 ]]; then # Faucet will be marked unhealthy if 100 or less tADA remains in the faucet wallet (initial balance is 13.5 billion tADA)
+  exit 0
+fi
+
+exit 9
+

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -42,7 +42,8 @@
     "test:build:verify": "tsc --build ./test && tsc --build ./test/web-extension",
     "test:debug": "DEBUG=true yarn test",
     "generate-mnemonics": "ts-node src/util/mnemonic.ts",
-    "wait-for-network": "ts-node src/util/is-local-network-ready.ts"
+    "wait-for-network": "ts-node src/util/is-local-network-ready.ts",
+    "wait-for-faucet": "ts-node src/util/is-faucet-ready.ts"
   },
   "repository": "https://github.com/input-output-hk/cardano-js-sdk",
   "contributors": [

--- a/packages/e2e/src/FaucetProvider/providers/cardanoWalletFaucetProvider.ts
+++ b/packages/e2e/src/FaucetProvider/providers/cardanoWalletFaucetProvider.ts
@@ -132,6 +132,16 @@ export class CardanoWalletFaucetProvider implements FaucetProvider {
   }
 
   /**
+   * Gets the remaining balance on the faucet.
+   */
+  public async getBalance(): Promise<number> {
+    if (this.#faucetWalletId === undefined) throw new Error('Faucet is not running.');
+
+    const axiosResponse = await this.#walletServer.walletsApi.getWallet(this.#faucetWalletId);
+    return axiosResponse.data.balance.total.quantity;
+  }
+
+  /**
    * Closes the provider.
    */
   public async close(): Promise<void> {
@@ -149,7 +159,8 @@ export class CardanoWalletFaucetProvider implements FaucetProvider {
     return {
       ok:
         networkInfo.sync_progress.status === ApiNetworkInformationSyncProgressStatusEnum.Ready &&
-        this.#faucetWalletId !== ''
+        this.#faucetWalletId !== '' &&
+        (await this.getBalance()) > 100_000_000 // Faucet must have more than 100 tADA to be considered healthy
     };
   }
 

--- a/packages/e2e/src/FaucetProvider/types.ts
+++ b/packages/e2e/src/FaucetProvider/types.ts
@@ -81,6 +81,11 @@ export interface FaucetProvider extends Provider {
   close(): Promise<void>;
 
   /**
+   * Gets the remaining balance on the faucet.
+   */
+  getBalance(): Promise<number>;
+
+  /**
    * Performs a health check on the provider.
    *
    * @returns A promise with the healthcheck reponse.

--- a/packages/e2e/src/util/is-faucet-ready.ts
+++ b/packages/e2e/src/util/is-faucet-ready.ts
@@ -1,0 +1,55 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import * as Process from 'process';
+import { faucetProviderFactory, getLogger } from '../factories';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Waits until the faucet is ready.
+ */
+(async () => {
+  if (Process.env.FAUCET_PROVIDER === undefined) {
+    console.error('The FAUCET_PROVIDER env variable must be defined');
+    return -1;
+  }
+
+  if (Process.env.FAUCET_PROVIDER_PARAMS === undefined) {
+    console.error('The FAUCET_PROVIDER_PARAMS env variable must be defined');
+    return -1;
+  }
+
+  const logSeverity = Process.env.LOGGER_MIN_SEVERITY ? Process.env.LOGGER_MIN_SEVERITY : 'debug';
+
+  const faucetProvider = await faucetProviderFactory.create(
+    Process.env.FAUCET_PROVIDER,
+    Process.env.FAUCET_PROVIDER_PARAMS,
+    getLogger(logSeverity)
+  );
+
+  await faucetProvider.start();
+
+  const start = Date.now() / 1000;
+  const waitTime = Process.env.LOCAL_NETWORK_READY_WAIT_TIME ? Process.env.LOCAL_NETWORK_READY_WAIT_TIME : 1200;
+  let isReady = false;
+  let currentElapsed = 0;
+
+  while (!isReady && currentElapsed < waitTime) {
+    try {
+      console.log('Waiting for faucet...');
+      isReady = (await faucetProvider.healthCheck()).ok;
+    } catch {
+      // continue
+    } finally {
+      currentElapsed = Date.now() / 1000 - start;
+      await sleep(5000);
+    }
+  }
+
+  if (currentElapsed > waitTime) {
+    console.error('Wait time expired. The faucet was not ready on time.');
+    return -1;
+  }
+
+  console.log('Faucet ready!');
+})();


### PR DESCRIPTION
# Context

The faucet is sometimes failing to transfer funds to the wallets that request it during CI e2e tests. This maybe due to the fact that the faucet uses cardano-wallet and this service is the last one started. We must wait until the cardano-wallet service is fully operational before running the e2e tests.

# Proposed Solution

- The healthcheck of the faucet now checks whether the faucet has any balance on it.
- There is a new script that checks whether the faucet is healthy before attempting to run the e2e tests.

I also added a script bash script that checks for balance and current epoch, however since the carano-wallet image is pretty bare bones we dont have enough tools to execute the scripts as its healthcheck (no grep, cut, jq, apt-get etc). 
