### PR TITLE
feat!: Support the complete set of protocol parameters by cardano services

### DIFF
--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -5,12 +5,12 @@ import { NetworkInfoProvider } from '@cardano-sdk/core';
  * The NetworkInfoProvider endpoint paths.
  */
 const paths: HttpProviderConfigPaths<NetworkInfoProvider> = {
-  currentWalletProtocolParameters: '/current-wallet-protocol-parameters',
   eraSummaries: '/era-summaries',
   genesisParameters: '/genesis-parameters',
   healthCheck: '/health',
   ledgerTip: '/ledger-tip',
   lovelaceSupply: '/lovelace-supply',
+  protocolParameters: '/protocol-parameters',
   stake: '/stake'
 };
 

--- a/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
@@ -50,9 +50,9 @@ describe('networkInfoHttpProvider', () => {
     await expect(provider.genesisParameters()).resolves.toEqual({});
   });
 
-  test('currentWalletProtocolParameters does not throw', async () => {
+  test('protocolParameters does not throw', async () => {
     axiosMock.onPost().replyOnce(200, {});
     const provider = networkInfoHttpProvider(config);
-    await expect(provider.currentWalletProtocolParameters()).resolves.toEqual({});
+    await expect(provider.protocolParameters()).resolves.toEqual({});
   });
 });

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
@@ -4,7 +4,6 @@ import {
   CardanoNodeUtil,
   EraSummary,
   NetworkInfoProvider,
-  ProtocolParametersRequiredByWallet,
   StakeSummary,
   SupplySummary
 } from '@cardano-sdk/core';
@@ -17,7 +16,7 @@ import { NetworkInfoBuilder } from './NetworkInfoBuilder';
 import { NetworkInfoCacheKey } from '.';
 import { Pool } from 'pg';
 import { RunnableModule } from '@cardano-sdk/util';
-import { loadGenesisData, toGenesisParams, toLedgerTip, toSupply, toWalletProtocolParams } from './mappers';
+import { loadGenesisData, toGenesisParams, toLedgerTip, toProtocolParams, toSupply } from './mappers';
 
 export interface NetworkInfoProviderProps {
   cardanoNodeConfigPath: string;
@@ -54,9 +53,9 @@ export class DbSyncNetworkInfoProvider extends DbSyncProvider(RunnableModule) im
     return toLedgerTip(tip);
   }
 
-  public async currentWalletProtocolParameters(): Promise<ProtocolParametersRequiredByWallet> {
-    const currentProtocolParams = await this.#builder.queryCurrentWalletProtocolParams();
-    return toWalletProtocolParams(currentProtocolParams);
+  public async protocolParameters(): Promise<Cardano.ProtocolParameters> {
+    const currentProtocolParams = await this.#builder.queryProtocolParams();
+    return toProtocolParams(currentProtocolParams);
   }
 
   public async genesisParameters(): Promise<Cardano.CompactGenesis> {

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
@@ -3,8 +3,8 @@ import {
   CirculatingSupplyModel,
   EpochModel,
   LedgerTipModel,
-  TotalSupplyModel,
-  WalletProtocolParamsModel
+  ProtocolParamsModel,
+  TotalSupplyModel
 } from './types';
 import { Cardano } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
@@ -49,11 +49,9 @@ export class NetworkInfoBuilder {
     return result.rows[0];
   }
 
-  public async queryCurrentWalletProtocolParams() {
-    this.#logger.debug('About to query current wallet protocol params');
-    const result: QueryResult<WalletProtocolParamsModel> = await this.#db.query(
-      Queries.findCurrentWalletProtocolParams
-    );
+  public async queryProtocolParams() {
+    this.#logger.debug('About to query protocol params');
+    const result: QueryResult<ProtocolParamsModel> = await this.#db.query(Queries.findProtocolParams);
     return result.rows[0];
   }
 }

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -1,11 +1,5 @@
-import {
-  Cardano,
-  ProtocolParametersRequiredByWallet,
-  ProviderError,
-  ProviderFailure,
-  SupplySummary
-} from '@cardano-sdk/core';
-import { GenesisData, LedgerTipModel, WalletProtocolParamsModel } from './types';
+import { Cardano, ProviderError, ProviderFailure, SupplySummary } from '@cardano-sdk/core';
+import { CostModelsParamModel, GenesisData, LedgerTipModel, ProtocolParamsModel } from './types';
 import JSONbig from 'json-bigint';
 import fs from 'fs';
 import path from 'path';
@@ -31,7 +25,14 @@ export const toLedgerTip = ({ block_no, slot_no, hash }: LedgerTipModel): Cardan
   slot: Number(slot_no)
 });
 
-export const toWalletProtocolParams = ({
+export const mapCostModels = (costs: CostModelsParamModel | null) => {
+  const models: Cardano.CostModels = [];
+  if (costs?.PlutusV1) models[Cardano.PlutusLanguageVersion.V1] = costs.PlutusV1;
+  if (costs?.PlutusV2) models[Cardano.PlutusLanguageVersion.V2] = costs.PlutusV2;
+  return models;
+};
+
+export const toProtocolParams = ({
   coins_per_utxo_size,
   max_tx_size,
   max_val_size,
@@ -42,21 +43,59 @@ export const toWalletProtocolParams = ({
   protocol_major,
   protocol_minor,
   min_fee_a,
-  min_fee_b
-}: WalletProtocolParamsModel): ProtocolParametersRequiredByWallet => ({
+  min_fee_b,
+  max_block_size,
+  max_bh_size,
+  optimal_pool_count,
+  influence,
+  monetary_expand_rate,
+  treasury_growth_rate,
+  decentralisation,
+  collateral_percent,
+  price_mem,
+  price_step,
+  max_tx_ex_mem,
+  max_tx_ex_steps,
+  max_block_ex_mem,
+  max_block_ex_steps,
+  max_epoch,
+  costs
+}: ProtocolParamsModel): Cardano.ProtocolParameters => ({
   coinsPerUtxoByte: Number(coins_per_utxo_size),
+  collateralPercentage: collateral_percent,
+  costModels: mapCostModels(costs),
+  decentralizationParameter: String(decentralisation),
+  desiredNumberOfPools: optimal_pool_count,
+  maxBlockBodySize: max_block_size,
+  maxBlockHeaderSize: max_bh_size,
   maxCollateralInputs: max_collateral_inputs,
+  maxExecutionUnitsPerBlock: {
+    memory: Number(max_block_ex_mem),
+    steps: Number(max_block_ex_steps)
+  },
+  maxExecutionUnitsPerTransaction: {
+    memory: Number(max_tx_ex_mem),
+    steps: Number(max_tx_ex_steps)
+  },
   maxTxSize: max_tx_size,
   maxValueSize: Number(max_val_size),
   minFeeCoefficient: min_fee_a,
   minFeeConstant: min_fee_b,
   minPoolCost: Number(min_pool_cost),
+  monetaryExpansion: String(monetary_expand_rate),
   poolDeposit: Number(pool_deposit),
+  poolInfluence: String(influence),
+  poolRetirementEpochBound: max_epoch,
+  prices: {
+    memory: price_mem,
+    steps: price_step
+  },
   protocolVersion: {
     major: protocol_major,
     minor: protocol_minor
   },
-  stakeKeyDeposit: Number(key_deposit)
+  stakeKeyDeposit: Number(key_deposit),
+  treasuryExpansion: String(treasury_growth_rate)
 });
 
 export const toGenesisParams = (genesis: GenesisData): Cardano.CompactGenesis => ({

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -53,7 +53,7 @@ export const findLedgerTip = `
     LIMIT 1;
 `;
 
-export const findCurrentWalletProtocolParams = `
+export const findProtocolParams = `
     SELECT 
     min_fee_a, 
     min_fee_b, 
@@ -80,8 +80,11 @@ export const findCurrentWalletProtocolParams = `
     max_tx_ex_steps,
     max_block_ex_mem,
     max_block_ex_steps,
-    max_epoch
-    FROM public.epoch_param
+    max_epoch,
+    cost_model.costs
+    FROM epoch_param
+    LEFT JOIN cost_model
+        ON cost_model.id = epoch_param.cost_model_id
     ORDER BY epoch_no DESC NULLS LAST
     LIMIT 1;
 `;
@@ -89,9 +92,9 @@ export const findCurrentWalletProtocolParams = `
 const Queries = {
   findActiveStake,
   findCirculatingSupply,
-  findCurrentWalletProtocolParams,
   findLatestCompleteEpoch,
   findLedgerTip,
+  findProtocolParams,
   findTotalSupply
 };
 

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
@@ -26,7 +26,12 @@ export interface LedgerTipModel {
   hash: Buffer;
 }
 
-export interface WalletProtocolParamsModel {
+export interface CostModelsParamModel {
+  PlutusV1?: Cardano.CostModel;
+  PlutusV2?: Cardano.CostModel;
+}
+
+export interface ProtocolParamsModel {
   coins_per_utxo_size: string;
   max_tx_size: number;
   max_val_size: string;
@@ -53,6 +58,7 @@ export interface WalletProtocolParamsModel {
   max_block_ex_mem: string;
   max_block_ex_steps: string;
   max_epoch: number;
+  costs: CostModelsParamModel | null;
 }
 
 export interface GenesisData {

--- a/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
+++ b/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
@@ -52,8 +52,15 @@ export class NetworkInfoHttpService extends HttpService {
       providerHandler(networkInfoProvider.ledgerTip.bind(networkInfoProvider))(HttpService.routeHandler(logger), logger)
     );
     router.post(
+      '/protocol-parameters',
+      providerHandler(networkInfoProvider.protocolParameters.bind(networkInfoProvider))(
+        HttpService.routeHandler(logger),
+        logger
+      )
+    );
+    router.post(
       '/current-wallet-protocol-parameters',
-      providerHandler(networkInfoProvider.currentWalletProtocolParameters.bind(networkInfoProvider))(
+      providerHandler(networkInfoProvider.protocolParameters.bind(networkInfoProvider))(
         HttpService.routeHandler(logger),
         logger
       )

--- a/packages/cardano-services/src/NetworkInfo/openApi.json
+++ b/packages/cardano-services/src/NetworkInfo/openApi.json
@@ -120,6 +120,33 @@
         }
       }
     },
+    "/network-info/protocol-parameters": {
+      "post": {
+        "summary": "fetch protocol params",
+        "description": "Fetch Protocol Params",
+        "operationId": "protocolParams",
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "protocol params fetched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProtocolParametersResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid request"
+          }
+        }
+      }
+    },
     "/network-info/current-wallet-protocol-parameters": {
       "post": {
         "summary": "fetch current wallet protocol params",
@@ -136,7 +163,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CurrentWalletProtocolParametersResponse"
+                  "$ref": "#/components/schemas/ProtocolParametersResponse"
                 }
               }
             }
@@ -308,7 +335,7 @@
           }
         }
       },
-      "CurrentWalletProtocolParametersResponse": {
+      "ProtocolParametersResponse": {
         "type": "object",
         "required": [
           "minFeeCoefficient",

--- a/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.test.ts
@@ -55,9 +55,9 @@ describe('NetworkInfoBuilder', () => {
     });
   });
 
-  describe('queryCurrentWalletProtocolParams', () => {
+  describe('queryProtocolParams', () => {
     test('query wallet protocol params from current epoch', async () => {
-      const result = await builder.queryCurrentWalletProtocolParams();
+      const result = await builder.queryProtocolParams();
       expect(result).toMatchSnapshot();
     });
   });

--- a/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
+++ b/packages/cardano-services/test/NetworkInfo/DbSyncNetworkInfoProvider/__snapshots__/NetworkInfoBuilder.test.ts.snap
@@ -4,10 +4,27 @@ exports[`NetworkInfoBuilder queryActiveStake query active stake 1`] = `"15039823
 
 exports[`NetworkInfoBuilder queryCirculatingSupply query circulating supply 1`] = `"42022749185221758"`;
 
-exports[`NetworkInfoBuilder queryCurrentWalletProtocolParams query wallet protocol params from current epoch 1`] = `
+exports[`NetworkInfoBuilder queryLatestEpoch query latest epoch 1`] = `205`;
+
+exports[`NetworkInfoBuilder queryLedgerTip query ledger tip 1`] = `
+Object {
+  "block_no": 3556390,
+  "hash": "332340bfcf47951b4bc8eca51c4e9190d29e2fd6dae30be231ebcdadb2d8c399",
+  "slot_no": "58336266",
+}
+`;
+
+exports[`NetworkInfoBuilder queryProtocolParams query wallet protocol params from current epoch 1`] = `
 Object {
   "coins_per_utxo_size": "34482",
   "collateral_percent": 150,
+  "costs": Object {
+    "PlutusV1": Object {
+      "bData-cpu-arguments": 150000,
+      "equalsString-memory-arguments": 1,
+      "iData-cpu-arguments": 150000,
+    },
+  },
   "decentralisation": 0,
   "influence": 0.3,
   "key_deposit": "2000000",
@@ -32,16 +49,6 @@ Object {
   "protocol_major": 6,
   "protocol_minor": 0,
   "treasury_growth_rate": 0.2,
-}
-`;
-
-exports[`NetworkInfoBuilder queryLatestEpoch query latest epoch 1`] = `205`;
-
-exports[`NetworkInfoBuilder queryLedgerTip query ledger tip 1`] = `
-Object {
-  "block_no": 3556390,
-  "hash": "332340bfcf47951b4bc8eca51c4e9190d29e2fd6dae30be231ebcdadb2d8c399",
-  "slot_no": "58336266",
 }
 `;
 

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -54,12 +54,12 @@ describe('NetworkInfoHttpService', () => {
         healthCheckResponseMock({ blockNo: lastBlockNoInDb })
       ) as unknown as OgmiosCardanoNode;
       networkInfoProvider = {
-        currentWalletProtocolParameters: jest.fn(),
         eraSummaries: jest.fn(),
         genesisParameters: jest.fn(),
         healthCheck: jest.fn(() => Promise.resolve({ ok: false })),
         ledgerTip: jest.fn(),
         lovelaceSupply: jest.fn(),
+        protocolParameters: jest.fn(),
         stake: jest.fn()
       } as unknown as DbSyncNetworkInfoProvider;
     });
@@ -327,6 +327,29 @@ describe('NetworkInfoHttpService', () => {
       });
     });
 
+    describe('/protocol-parameters', () => {
+      describe('with Http Server', () => {
+        it('returns a 200 coded response with a well formed HTTP request', async () => {
+          expect((await axios.post(`${baseUrl}/protocol-parameters`, {})).status).toEqual(200);
+        });
+
+        it('returns a 415 coded response if the wrong content type header is used', async () => {
+          expect.assertions(2);
+          try {
+            await axios.post(`${baseUrl}/protocol-parameters`, {}, { headers: { 'Content-Type': APPLICATION_CBOR } });
+          } catch (error: any) {
+            expect(error.response.status).toBe(415);
+            expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
+          }
+        });
+      });
+
+      it('successful request', async () => {
+        const response = await provider.protocolParameters();
+        expect(response.maxTxSize).toBeDefined();
+      });
+    });
+
     describe('/current-wallet-protocol-parameters', () => {
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {
@@ -346,11 +369,6 @@ describe('NetworkInfoHttpService', () => {
             expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
           }
         });
-      });
-
-      it('successful request', async () => {
-        const response = await provider.currentWalletProtocolParameters();
-        expect(response.maxTxSize).toBeDefined();
       });
     });
 

--- a/packages/core/src/Cardano/types/ProtocolParameters.ts
+++ b/packages/core/src/Cardano/types/ProtocolParameters.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { Slot } from './Block';
 
 /* eslint-disable no-use-before-define */

--- a/packages/core/src/Cardano/util/computeImplicitCoin.ts
+++ b/packages/core/src/Cardano/util/computeImplicitCoin.ts
@@ -1,6 +1,6 @@
 import { BigIntMath } from '@cardano-sdk/util';
+import { Cardano } from '../..';
 import { CertificateType, Lovelace, TxBodyAlonzo } from '../types';
-import { ProtocolParametersRequiredByWallet } from '../../Provider';
 
 /**
  * Implicit coin quantities used in the transaction
@@ -20,7 +20,7 @@ export interface ImplicitCoin {
  * Implementation is the same as in CSL.get_implicit_input() and CSL.get_deposit().
  */
 export const computeImplicitCoin = (
-  { stakeKeyDeposit, poolDeposit }: Pick<ProtocolParametersRequiredByWallet, 'stakeKeyDeposit' | 'poolDeposit'>,
+  { stakeKeyDeposit, poolDeposit }: Pick<Cardano.ProtocolParameters, 'stakeKeyDeposit' | 'poolDeposit'>,
   { certificates, withdrawals }: Pick<TxBodyAlonzo, 'certificates' | 'withdrawals'>
 ): ImplicitCoin => {
   const stakeKeyDepositBigint = stakeKeyDeposit && BigInt(stakeKeyDeposit);

--- a/packages/core/src/Provider/NetworkInfoProvider/types.ts
+++ b/packages/core/src/Provider/NetworkInfoProvider/types.ts
@@ -1,19 +1,5 @@
 import { Cardano, EraSummary, Provider } from '../..';
 
-export type ProtocolParametersRequiredByWallet = Pick<
-  Cardano.ProtocolParameters,
-  | 'coinsPerUtxoByte'
-  | 'maxTxSize'
-  | 'maxValueSize'
-  | 'stakeKeyDeposit'
-  | 'maxCollateralInputs'
-  | 'minFeeCoefficient'
-  | 'minFeeConstant'
-  | 'minPoolCost'
-  | 'poolDeposit'
-  | 'protocolVersion'
->;
-
 export type SupplySummary = {
   circulating: Cardano.Lovelace;
   total: Cardano.Lovelace;
@@ -26,7 +12,7 @@ export type StakeSummary = {
 
 export interface NetworkInfoProvider extends Provider {
   ledgerTip(): Promise<Cardano.Tip>;
-  currentWalletProtocolParameters(): Promise<ProtocolParametersRequiredByWallet>;
+  protocolParameters(): Promise<Cardano.ProtocolParameters>;
   genesisParameters(): Promise<Cardano.CompactGenesis>;
   lovelaceSupply(): Promise<SupplySummary>;
   stake(): Promise<StakeSummary>;

--- a/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
+++ b/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
@@ -1,8 +1,8 @@
-import { Cardano, ProtocolParametersRequiredByWallet } from '../../../src';
+import { Cardano } from '../../../src';
 
 describe('Cardano.util.computeImplicitCoin', () => {
   it('sums registrations for deposit, withdrawals and deregistrations for input', async () => {
-    const protocolParameters = { poolDeposit: 3, stakeKeyDeposit: 2 } as ProtocolParametersRequiredByWallet;
+    const protocolParameters = { poolDeposit: 3, stakeKeyDeposit: 2 } as Cardano.ProtocolParameters;
     const rewardAccount = Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27');
     const stakeKeyHash = Cardano.Ed25519KeyHash.fromRewardAccount(rewardAccount);
     const certificates: Cardano.Certificate[] = [

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -13,7 +13,6 @@ import {
   ChainHistoryProvider,
   EpochInfo,
   EraSummary,
-  ProtocolParametersRequiredByWallet,
   ProviderError,
   RewardsProvider,
   StakePoolProvider,
@@ -159,7 +158,7 @@ export class SingleAddressWallet implements ObservableWallet {
   readonly tip$: BehaviorObservable<Cardano.Tip>;
   readonly eraSummaries$: TrackerSubject<EraSummary[]>;
   readonly addresses$: TrackerSubject<GroupedAddress[]>;
-  readonly protocolParameters$: TrackerSubject<ProtocolParametersRequiredByWallet>;
+  readonly protocolParameters$: TrackerSubject<Cardano.ProtocolParameters>;
   readonly genesisParameters$: TrackerSubject<Cardano.CompactGenesis>;
   readonly assets$: TrackerSubject<Assets>;
   readonly syncStatus: SyncStatus;
@@ -301,7 +300,7 @@ export class SingleAddressWallet implements ObservableWallet {
       coldObservableProvider({
         cancel$,
         equals: isEqual,
-        provider: this.networkInfoProvider.currentWalletProtocolParameters,
+        provider: this.networkInfoProvider.protocolParameters,
         retryBackoffConfig,
         trigger$: epoch$
       }),

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -1,5 +1,5 @@
 import { Assets } from '../../types';
-import { Cardano, EpochRewards, EraSummary, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { Cardano, EpochRewards, EraSummary } from '@cardano-sdk/core';
 import { ConfirmedTx, TxInFlight } from '../../services';
 import { EMPTY, combineLatest, map } from 'rxjs';
 import { GroupedAddress } from '@cardano-sdk/key-management';
@@ -9,7 +9,7 @@ import { InMemoryKeyValueStore } from './InMemoryKeyValueStore';
 import { WalletStores } from '../types';
 
 export class InMemoryTipStore extends InMemoryDocumentStore<Cardano.Tip> {}
-export class InMemoryProtocolParametersStore extends InMemoryDocumentStore<ProtocolParametersRequiredByWallet> {}
+export class InMemoryProtocolParametersStore extends InMemoryDocumentStore<Cardano.ProtocolParameters> {}
 export class InMemoryGenesisParametersStore extends InMemoryDocumentStore<Cardano.CompactGenesis> {}
 export class InMemoryEraSummariesStore extends InMemoryDocumentStore<EraSummary[]> {}
 

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -1,5 +1,5 @@
 import { Assets } from '../../types';
-import { Cardano, EpochRewards, EraSummary, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { Cardano, EpochRewards, EraSummary } from '@cardano-sdk/core';
 import { ConfirmedTx, TxInFlight } from '../../services';
 import { CreatePouchDbStoresDependencies } from './types';
 import { EMPTY, combineLatest, map } from 'rxjs';
@@ -10,7 +10,7 @@ import { PouchDbKeyValueStore } from './PouchDbKeyValueStore';
 import { WalletStores } from '../types';
 
 export class PouchDbTipStore extends PouchDbDocumentStore<Cardano.Tip> {}
-export class PouchDbProtocolParametersStore extends PouchDbDocumentStore<ProtocolParametersRequiredByWallet> {}
+export class PouchDbProtocolParametersStore extends PouchDbDocumentStore<Cardano.ProtocolParameters> {}
 export class PouchDbGenesisParametersStore extends PouchDbDocumentStore<Cardano.CompactGenesis> {}
 export class PouchDbEraSummariesStore extends PouchDbDocumentStore<EraSummary[]> {}
 

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -1,12 +1,5 @@
 import { Assets } from '../types';
-import {
-  Cardano,
-  EpochRewards,
-  EraSummary,
-  ProtocolParametersRequiredByWallet,
-  StakeSummary,
-  SupplySummary
-} from '@cardano-sdk/core';
+import { Cardano, EpochRewards, EraSummary, StakeSummary, SupplySummary } from '@cardano-sdk/core';
 import { ConfirmedTx, TxInFlight } from '../services';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { Observable } from 'rxjs';
@@ -86,7 +79,7 @@ export interface WalletStores extends Destroyable {
   rewardsHistory: KeyValueStore<Cardano.RewardAccount, EpochRewards[]>;
   rewardsBalances: KeyValueStore<Cardano.RewardAccount, Cardano.Lovelace>;
   stakePools: KeyValueStore<Cardano.PoolId, Cardano.StakePool>;
-  protocolParameters: DocumentStore<ProtocolParametersRequiredByWallet>;
+  protocolParameters: DocumentStore<Cardano.ProtocolParameters>;
   genesisParameters: DocumentStore<Cardano.CompactGenesis>;
   eraSummaries: DocumentStore<EraSummary[]>;
   assets: DocumentStore<Assets>;

--- a/packages/wallet/src/services/BalanceTracker.ts
+++ b/packages/wallet/src/services/BalanceTracker.ts
@@ -1,5 +1,5 @@
 import { BalanceTracker, DelegationTracker, StakeKeyStatus, TransactionalObservables } from './types';
-import { Cardano, ProtocolParametersRequiredByWallet, coalesceValueQuantities } from '@cardano-sdk/core';
+import { Cardano, coalesceValueQuantities } from '@cardano-sdk/core';
 
 import { Observable, combineLatest, distinctUntilChanged, map } from 'rxjs';
 
@@ -8,7 +8,7 @@ const mapUtxoValue = map<Cardano.Utxo[], Cardano.Value>((utxo) =>
 );
 
 const computeDepositCoin = (
-  protocolParameters$: Observable<ProtocolParametersRequiredByWallet>,
+  protocolParameters$: Observable<Cardano.ProtocolParameters>,
   numDeposits$: Observable<number>
 ) =>
   combineLatest([numDeposits$, protocolParameters$]).pipe(
@@ -22,7 +22,7 @@ const numRewardAccountsWithKeyStatus = (delegationTracker: DelegationTracker, ke
   );
 
 export const createBalanceTracker = (
-  protocolParameters$: Observable<ProtocolParametersRequiredByWallet>,
+  protocolParameters$: Observable<Cardano.ProtocolParameters>,
   utxoTracker: TransactionalObservables<Cardano.Utxo[]>,
   delegationTracker: DelegationTracker
 ): BalanceTracker => ({

--- a/packages/wallet/src/services/ProviderTracker/ProviderStatusTracker.ts
+++ b/packages/wallet/src/services/ProviderTracker/ProviderStatusTracker.ts
@@ -51,7 +51,7 @@ const getDefaultProviderSyncRelevantStats = ({
 }: ProviderStatusTrackerDependencies): Observable<ProviderFnStats[]> =>
   combineLatest([
     networkInfoProvider.stats.ledgerTip$,
-    networkInfoProvider.stats.currentWalletProtocolParameters$,
+    networkInfoProvider.stats.protocolParameters$,
     networkInfoProvider.stats.genesisParameters$,
     networkInfoProvider.stats.eraSummaries$,
     assetProvider.stats.getAsset$,

--- a/packages/wallet/src/services/ProviderTracker/TrackedWalletNetworkInfoProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedWalletNetworkInfoProvider.ts
@@ -5,20 +5,20 @@ import { WalletNetworkInfoProvider } from '../../types';
 
 export class WalletNetworkInfoProviderStats {
   readonly eraSummaries$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
-  readonly currentWalletProtocolParameters$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
+  readonly protocolParameters$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly genesisParameters$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
   readonly ledgerTip$ = new BehaviorSubject<ProviderFnStats>(CLEAN_FN_STATS);
 
   shutdown() {
     this.eraSummaries$.complete();
-    this.currentWalletProtocolParameters$.complete();
+    this.protocolParameters$.complete();
     this.genesisParameters$.complete();
     this.ledgerTip$.complete();
   }
 
   reset() {
     this.eraSummaries$.next(CLEAN_FN_STATS);
-    this.currentWalletProtocolParameters$.next(CLEAN_FN_STATS);
+    this.protocolParameters$.next(CLEAN_FN_STATS);
     this.genesisParameters$.next(CLEAN_FN_STATS);
     this.ledgerTip$.next(CLEAN_FN_STATS);
   }
@@ -31,7 +31,7 @@ export class TrackedWalletNetworkInfoProvider extends ProviderTracker implements
   readonly stats = new WalletNetworkInfoProviderStats();
   readonly eraSummaries: WalletNetworkInfoProvider['eraSummaries'];
   readonly ledgerTip: WalletNetworkInfoProvider['ledgerTip'];
-  readonly currentWalletProtocolParameters: WalletNetworkInfoProvider['currentWalletProtocolParameters'];
+  readonly protocolParameters: WalletNetworkInfoProvider['protocolParameters'];
   readonly genesisParameters: WalletNetworkInfoProvider['genesisParameters'];
 
   constructor(networkInfoProvider: WalletNetworkInfoProvider) {
@@ -40,11 +40,8 @@ export class TrackedWalletNetworkInfoProvider extends ProviderTracker implements
 
     this.eraSummaries = () => this.trackedCall(networkInfoProvider.eraSummaries, this.stats.eraSummaries$);
     this.ledgerTip = () => this.trackedCall(networkInfoProvider.ledgerTip, this.stats.ledgerTip$);
-    this.currentWalletProtocolParameters = () =>
-      this.trackedCall(
-        networkInfoProvider.currentWalletProtocolParameters,
-        this.stats.currentWalletProtocolParameters$
-      );
+    this.protocolParameters = () =>
+      this.trackedCall(networkInfoProvider.protocolParameters, this.stats.protocolParameters$);
     this.genesisParameters = () =>
       this.trackedCall(networkInfoProvider.genesisParameters, this.stats.genesisParameters$);
   }

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -1,12 +1,12 @@
 import { BigIntMath } from '@cardano-sdk/util';
-import { Cardano, ProtocolParametersRequiredByWallet } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { Observable, firstValueFrom } from 'rxjs';
 import { OutputValidation } from '../types';
 import { computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit } from '@cardano-sdk/input-selection';
 import { txInEquals } from './util';
 
 export type ProtocolParametersRequiredByOutputValidator = Pick<
-  ProtocolParametersRequiredByWallet,
+  Cardano.ProtocolParameters,
   'coinsPerUtxoByte' | 'maxValueSize'
 >;
 export interface OutputValidatorContext {

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,11 +1,4 @@
-import {
-  Asset,
-  Cardano,
-  EpochInfo,
-  EraSummary,
-  NetworkInfoProvider,
-  ProtocolParametersRequiredByWallet
-} from '@cardano-sdk/core';
+import { Asset, Cardano, EpochInfo, EraSummary, NetworkInfoProvider } from '@cardano-sdk/core';
 import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { GroupedAddress, SignTransactionOptions, TransactionSigner, cip8 } from '@cardano-sdk/key-management';
@@ -86,7 +79,7 @@ export interface ObservableWallet {
   readonly genesisParameters$: Observable<Cardano.CompactGenesis>;
   readonly eraSummaries$: Observable<EraSummary[]>;
   readonly currentEpoch$: Observable<EpochInfo>;
-  readonly protocolParameters$: Observable<ProtocolParametersRequiredByWallet>;
+  readonly protocolParameters$: Observable<Cardano.ProtocolParameters>;
   readonly addresses$: Observable<GroupedAddress[]>;
   readonly assets$: Observable<Assets>;
   readonly syncStatus: SyncStatus;
@@ -110,5 +103,5 @@ export interface ObservableWallet {
 
 export type WalletNetworkInfoProvider = Pick<
   NetworkInfoProvider,
-  'currentWalletProtocolParameters' | 'ledgerTip' | 'genesisParameters' | 'eraSummaries'
+  'protocolParameters' | 'ledgerTip' | 'genesisParameters' | 'eraSummaries'
 >;

--- a/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
+++ b/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
@@ -21,12 +21,12 @@ export const networkInfo = {
  * Provider stub for testing
  */
 export const mockNetworkInfoProvider = () => ({
-  currentWalletProtocolParameters: jest.fn().mockResolvedValue(protocolParameters),
   eraSummaries: jest.fn().mockResolvedValue(networkInfo.network.eraSummaries),
   genesisParameters: jest.fn().mockResolvedValue(genesisParameters),
   healthCheck: jest.fn().mockResolvedValue({ ok: true }),
   ledgerTip: jest.fn().mockResolvedValue(ledgerTip),
   lovelaceSupply: jest.fn().mockResolvedValue(networkInfo.lovelaceSupply),
+  protocolParameters: jest.fn().mockResolvedValue(protocolParameters),
   stake: jest.fn().mockResolvedValue(networkInfo.stake)
 });
 

--- a/packages/wallet/test/mocks/mockNetworkInfoProvider2.ts
+++ b/packages/wallet/test/mocks/mockNetworkInfoProvider2.ts
@@ -28,12 +28,12 @@ export const mockNetworkInfoProvider2 = (delayMs: number) => {
     jest.fn().mockImplementation(() => delay(delayMs).then(() => resolvedValue));
 
   return {
-    currentWalletProtocolParameters: delayedJestFn(protocolParameters2),
     eraSummaries: jest.fn().mockResolvedValue(networkInfo.network.eraSummaries),
     genesisParameters: delayedJestFn(genesisParameters2),
     healthCheck: delayedJestFn({ ok: true }),
     ledgerTip: delayedJestFn(ledgerTip2),
     lovelaceSupply: jest.fn().mockResolvedValue(networkInfo.lovelaceSupply),
+    protocolParameters: delayedJestFn(protocolParameters2),
     stake: jest.fn().mockResolvedValue(networkInfo.stake)
   };
 };

--- a/packages/wallet/test/services/BalanceTracker.test.ts
+++ b/packages/wallet/test/services/BalanceTracker.test.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-multi-spaces */
 /* eslint-disable space-in-parens */
 import { BehaviorObservable } from '@cardano-sdk/util-rxjs';
-import { Cardano, ProtocolParametersRequiredByWallet, coalesceValueQuantities } from '@cardano-sdk/core';
+import { Cardano, coalesceValueQuantities } from '@cardano-sdk/core';
 import { DelegationTracker, RewardAccount, StakeKeyStatus, createBalanceTracker } from '../../src/services';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 import { utxo, utxo2 } from '../mocks';
@@ -11,7 +11,7 @@ import { utxo, utxo2 } from '../mocks';
 describe('createBalanceTracker', () => {
   it('combines data from rewardsTracker & utxoTracker', () => {
     createTestScheduler().run(({ hot, expectObservable }) => {
-      const protocolParameters$ = hot( 'a------', { a: { stakeKeyDeposit: 2 } as ProtocolParametersRequiredByWallet });
+      const protocolParameters$ = hot( 'a------', { a: { stakeKeyDeposit: 2 } as Cardano.ProtocolParameters });
       const utxoAvailable = hot(       '--a-b--', { a: utxo, b: utxo.slice(1) }) as unknown as BehaviorObservable<Cardano.Utxo[]>;
       const utxoTotal = hot(           '-a-----', { a: utxo }) as unknown as BehaviorObservable<Cardano.Utxo[]>;
       const utxoUnspendable = hot(     '-a-----', { a: utxo2 }) as unknown as BehaviorObservable<Cardano.Utxo[]>;

--- a/packages/wallet/test/services/ProviderTracker/TrackedWalletNetworkInfoProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedWalletNetworkInfoProvider.test.ts
@@ -51,10 +51,10 @@ describe('TrackedNetworkInfoProvider', () => {
     );
 
     test(
-      'currentWalletProtocolParameters',
+      'protocolParameters',
       testFunctionStats(
-        (wp) => wp.currentWalletProtocolParameters(),
-        (stats) => stats.currentWalletProtocolParameters$
+        (wp) => wp.protocolParameters(),
+        (stats) => stats.protocolParameters$
       )
     );
 


### PR DESCRIPTION
# Context

The task is to replace the wallet protocol param types with complete protocol param types.

# Proposed Solution
Provide the complete set of protocol parameters by `cardano-services` (`NetworkInfo` provider) as we extract and map these bits of data from `db-sync`.

# Important Changes Introduced
- rename method `currentWalletProtocolParameters` to `protocolParameters`
- update `/current-wallet-protocol-parameters` -> `/protocol-parameters`
- remove `ProtocolParametersRequiredByWallet` entirely
- support all protocol params by NetworkInfo and Blockfrost providers
- align code base with the introduced changes
- insert cost models fixture db data for tests
