### PR TITLE
ci: regenerate yarn-project.nix & yarn.lock after nightly merge in master

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,7 +24,14 @@ jobs:
       run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
+        # checkout yarn-project.nix to avoid merge conflict
+        git checkout origin/master -- yarn-project.nix
+        git checkout origin/master -- yarn.lock
+        git commit -m "chore: checkout yarn-project.nix and yarn.lock from master" || echo "No changes in yarn-project.nix"
         git merge origin/master
+        yarn
+        git add .
+        git commit -m "chore: regenerate yarn-project.nix and yarn.lock" || echo "No changes in yarn-project.nix"
         git push --force
 
     - name: 🧰 Setup Node.js


### PR DESCRIPTION
# Context

`nightly` workflow often fails due to not being able to automatically merge `yarn-project.nix` file

# Proposed Solution

Update `nightly` workflow to:
1. Checkout `yarn-project.nix` from `master`, so that it's identical to the one being merged in
2. Regenerate `yarn-project.nix` after merging

It creates 2 extra commits when there are changes in yarn-project.nix when merging. Could potentially reduce it to 2 commits by amending the merge commit instead of adding a commit on top of it. See commits created [here](https://github.com/input-output-hk/cardano-js-sdk/commits/nightly). 

CI nightly run using a workflow from this branch [here](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/3376433258/jobs/5604149590)
