### PR TITLE
ci: nightly publish git config & cancel if previous workflow failed

### DIFF
--- a/.github/workflows/nightly-merge.yaml
+++ b/.github/workflows/nightly-merge.yaml
@@ -7,7 +7,7 @@ on:
     - cron:  '0 0 * * *'
 
 jobs:
-  publish:
+  merge:
     runs-on: ubuntu-20.04
     steps:
     - name: 📥 Checkout repository

--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -7,8 +7,21 @@ on:
       - completed
 
 jobs:
+  cancel-self-run:
+    name: "Cancel the self workflow run"
+    if: ${{ github.event.workflow_run.conclusion != 'success' }} 
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Cancel the self workflow run"
+        uses: potiuk/cancel-workflow-runs@master
+        with:
+          cancelMode: self
+          token: ${{ secrets.BOT_GH_TOKEN }}
+          notifyPRCancel: false
+    
   publish:
     runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} 
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -38,6 +38,8 @@ jobs:
     - name: 📤 Publish
       if: steps.precondition.outputs.changed > 0
       run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
         yarn build
         yarn publish:nightly --loglevel silly
       env:

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -7,12 +7,25 @@ on:
       - completed
 
 jobs:
+  cancel-self-run:
+    name: "Cancel the self workflow run"
+    if: ${{ github.event.workflow_run.conclusion != 'success' }} 
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Cancel the self workflow run"
+        uses: potiuk/cancel-workflow-runs@master
+        with:
+          cancelMode: self
+          token: ${{ secrets.BOT_GH_TOKEN }}
+          notifyPRCancel: false
+
   test:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
         nodejs: [ 14, 16, 18.12.0, latest ]
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} 
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -7,7 +7,7 @@ on:
       - completed
 
 jobs:
-  publish:
+  test:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]


### PR DESCRIPTION
# Context

1. `nightly-publish` failed due to missing git config
2. `nightly-publish` was triggered even though one of the `nightly-test` jobs failed

# Proposed Solution

1. add git config to `nightly-publish`
2. use [Cancel Workflow Runs](https://github.com/marketplace/actions/cancel-workflow-runs#cancel-the-self-source-workflow-run) to cancel the run if a previous workflow didn't succeed
