### PR TITLE
ci: nightly and release workflow fixes

### DIFF
--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -8,17 +8,13 @@ on:
       - completed
 
 jobs:
-  cancel-self-run:
-    name: "Cancel the self workflow run"
+  fail:
+    name: "Fail the workflow run by exiting"
     if: ${{ github.event_name != 'workflow_dispatch' && github.event.workflow_run.conclusion != 'success' }} 
     runs-on: ubuntu-20.04
     steps:
-      - name: "Cancel the self workflow run"
-        uses: potiuk/cancel-workflow-runs@master
-        with:
-          cancelMode: self
-          token: ${{ secrets.BOT_GH_TOKEN }}
-          notifyPRCancel: false
+      - name: "exit 1"
+        run: exit 1
     
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -8,17 +8,13 @@ on:
       - completed
 
 jobs:
-  cancel-self-run:
-    name: "Cancel the self workflow run"
+  fail:
+    name: "Fail the workflow run by exiting"
     if: ${{ github.event_name != 'workflow_dispatch' && github.event.workflow_run.conclusion != 'success' }} 
     runs-on: ubuntu-20.04
     steps:
-      - name: "Cancel the self workflow run"
-        uses: potiuk/cancel-workflow-runs@master
-        with:
-          cancelMode: self
-          token: ${{ secrets.BOT_GH_TOKEN }}
-          notifyPRCancel: false
+      - name: "exit 1"
+        run: exit 1
 
   test:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,8 @@ jobs:
         # Omit nighly release CHANGELOG changes
         git restore --source master packages/*/CHANGELOG.md
         git add .
+        # Test build to reduce chance of failure after creating a GH Release
+        yarn build
         # Publish
         yarn publish:release --sign-git-commit --loglevel silly
         # Merge package.json/yarn.lock/CHANGELOG back to nightly

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,8 @@ jobs:
         # Base on nightly branch versions
         git merge --squash nightly
         # Omit nighly release CHANGELOG changes
-        git checkout HEAD packages/*/CHANGELOG.md
+        git restore --source master packages/*/CHANGELOG.md
+        git add .
         # Publish
         yarn publish:release --sign-git-commit --loglevel silly
         # Merge package.json/yarn.lock/CHANGELOG back to nightly

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,4 +59,4 @@ jobs:
         YARN_ENABLE_IMMUTABLE_INSTALLS: false
         NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
         # Used for making a release
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }}


### PR DESCRIPTION
# Context

1. Cancelled nightly workflows have 'succeeded' status. This will make it to attempt to publish the packages if the merge fails.
2. [fails to reset](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/3391733766/jobs/5637178718#step:6:28) CHANGELOGs that don't exist in master

# Proposed Solution

1. Replace cancellation plugin with `exit 1`
2. See commits on release workflow fixes:
- [ci: fix release to restore CHANGELOGs that didn't exist](https://github.com/input-output-hk/cardano-js-sdk/pull/505/commits/d463875ec40cab0f5f8584d50182e5ecb318cdd4)
- [ci: release now attempts to build before making a release to reduce chance of failure](https://github.com/input-output-hk/cardano-js-sdk/pull/505/commits/42e71ceb2858bbfe9c07db5610d50761f85fed25)
- [ci: replace release workflow github.token with BOT_GH_TOKEN secret](https://github.com/input-output-hk/cardano-js-sdk/pull/505/commits/f0c2626724f16a964f2e0b8199b5164ed85f2651)
 
