### PR TITLE
test(e2e): load test improvements

### DIFF
--- a/packages/e2e/env/.env.load-testing
+++ b/packages/e2e/env/.env.load-testing
@@ -1,7 +1,9 @@
 # Logger
-LOGGER_MIN_SEVERITY=debug
+LOGGER_MIN_SEVERITY=info
 
 # Providers setup
+FAUCET_PROVIDER=cardano-wallet
+FAUCET_PROVIDER_PARAMS='{"baseUrl":"http://localhost:8090/v2","mnemonic":"fire method repair aware foot tray accuse brother popular olive find account sick rocket next"}'
 KEY_MANAGEMENT_PROVIDER=inMemory
 KEY_MANAGEMENT_PARAMS='{"accountIndex": 0, "networkId": 0, "password":"some_password","mnemonic":"vacant violin soft weird deliver render brief always monitor general maid smart jelly core drastic erode echo there clump dizzy card filter option defense"}'
 ASSET_PROVIDER=http
@@ -19,9 +21,13 @@ UTXO_PROVIDER_PARAMS='{"baseUrl":"http://localhost:4000/utxo"}'
 STAKE_POOL_PROVIDER=http
 STAKE_POOL_PROVIDER_PARAMS='{"baseUrl":"http://localhost:4000/stake-pool"}'
 
+# Ogmios interactions
+DB_SYNC_CONNECTION_STRING='postgresql://postgres:doNoUseThisSecret!@localhost:5435/cexplorer'
+OGMIOS_SERVER_URL='ws://localhost:1340/'
+
 # Test Parameters
-OGMIOS_URL=ws://localhost:1337
+OGMIOS_URL=ws://localhost:1340
 TX_SUBMIT_HTTP_URL=http://localhost:3456/tx-submit
-TRANSACTIONS_NUMBER=10
+TRANSACTIONS_NUMBER=50
 START_LOCAL_HTTP_SERVER=true
 WORKER_PARALLEL_TRANSACTION=3

--- a/packages/e2e/env/.env.local-network
+++ b/packages/e2e/env/.env.local-network
@@ -21,5 +21,6 @@ UTXO_PROVIDER_PARAMS='{"baseUrl":"http://localhost:4000/utxo"}'
 STAKE_POOL_PROVIDER=http
 STAKE_POOL_PROVIDER_PARAMS='{"baseUrl":"http://localhost:4000/stake-pool"}'
 
+# Ogmios interactions
 DB_SYNC_CONNECTION_STRING='postgresql://postgres:doNoUseThisSecret!@localhost:5435/cexplorer'
 OGMIOS_SERVER_URL='ws://localhost:1340/'


### PR DESCRIPTION
# Context

Looking for a good test to stress the transaction submission, we found that the tx submissions load test could be a good candidate, but it needs some fixes/improvements.

# Important Changes Introduced

- removed the `try/catch` block around the body of the test which was hiding test failures
- coins are now self sent to the same account to avoid the too many inputs error in subsequent test runs (with high `TRANSACTIONS_NUMBER`)