### PR TITLE
ci: Remove Node.js latest testing from nightly workflow

### DIFF
--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        nodejs: [ 14, 16, 18.12.0, latest ]
+        nodejs: [ 14, 16, 18.12.0 ]
     runs-on: ${{ matrix.os }}
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }} 
     steps:


### PR DESCRIPTION
# Context
We're seeing a failure when testing against the latest, which is currently v19.0.1, and cannot
justify the time spent on investigating, but need this workflow to be functional.

# Proposed Solution
Removing now until we can dedicate some time to debug v19 compat.