### PR TITLE
build: specify nix expression path to prevent path in yarn-project.nix being inferred

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,7 @@ plugins:
     spec: "https://raw.githubusercontent.com/stephank/yarn-plugin-nixify/main/dist/yarn-plugin-nixify.js"
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs
+nixExprPath: .yarn-project.nix
 
 packageExtensions:
   ts-node@*:


### PR DESCRIPTION
# Context
https://github.com/stephank/yarn-plugin-nixify/issues/47

# Proposed Solution
Use the available configuration option to lock the expression path to the repo root.

# Important Changes Introduced
This makes it possible to run `yarn install` in any workspace directory as per the usual Yarn development practice.