### PR TITLE
ADP-2350: Add a local web server to the e2e environment

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -109,6 +109,20 @@ Address:    addr_test1qr0c3frkem9cqn5f73dnvqpena27k2fgqew6wct9eaka03agfwkvzr0zyq
 
 You can configure any of these five wallets in your test and use any amount of tADA you need.
 
+## Local file server
+
+The end-to-end environment runs a Nginx instance that allows us to serve files directly to the local-network.
+
+Any file added to the `file-server` folder will be served to the docker cluster via `http://file-server/`, for example, `http://file-server/SP1.json`. The contents of this folder can be altered dynamically, and the files will be available instantly to the docker images (no need to restart the container).
+
+It is also possible to access the file server from outside the docker cluster as the instance binds to port `7890` on the host by default:
+
+`http://localhost:7890/SP1.json`
+
+You can override this port mapping by setting the `FILE_SERVER_PORT` environment variable when starting to containers:
+
+`FILE_SERVER_PORT=9874 docker compose -p local-network-e2e up`
+
 ## Load Testing
 
 Cardano services end to end load tests. Please note that you must have several services up before executing the test, to start the environment(from the root):
@@ -268,3 +282,4 @@ Then to run the web-extension tests run:
 ```bash
 $ yarn workspace @cardano-sdk/e2e test:web-extension
 ```
+

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -9,6 +9,10 @@ services:
     volumes:
       - ./local-network/network-files/node-spo1/:/root/network-files/node-spo1
       - ./local-network/config:/root/config
+    depends_on:
+      # We need the file server here in order to calculate the pool metadata hashes
+      file-server:
+        condition: service_healthy
   postgres:
     image: postgres:${POSTGRES_VERSION:-11.5-alpine}
     environment:
@@ -36,6 +40,17 @@ services:
       options:
         max-size: "200k"
         max-file: "10"
+  file-server:
+    image: nginx:${NGINX_VERSION:-1.22.1-alpine}
+    volumes:
+      - ./local-network/file-server:/usr/share/nginx/html
+    ports:
+      - "${FILE_SERVER_PORT:-7890}:80"
+    environment:
+      - NGINX_PORT=80
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -O /dev/null http://localhost || exit 1" ]
+      timeout: 10s
   cardano-node-ogmios:
     image: cardanosolutions/cardano-node-ogmios:${CARDANO_NODE_OGMIOS_VERSION:-v5.5.5_1.35.3}
     logging:
@@ -71,6 +86,8 @@ services:
       cardano-node-ogmios:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      file-server:
         condition: service_healthy
     secrets:
       - postgres_password

--- a/packages/e2e/local-network/Dockerfile
+++ b/packages/e2e/local-network/Dockerfile
@@ -18,7 +18,7 @@ ENV TINI_VERSION v0.19.0
 
 WORKDIR /root
 RUN apt-get update -y && \
-  apt-get install -y tzdata ca-certificates jq coreutils
+  apt-get install -y tzdata ca-certificates jq coreutils curl
 
 HEALTHCHECK --interval=5s --timeout=1s --retries=200 --start-period=100ms \
   CMD /root/scripts/get-epoch.sh | awk '{ if ($0 >= "3") exit 0; else exit 1}'

--- a/packages/e2e/local-network/file-server/SP1.json
+++ b/packages/e2e/local-network/file-server/SP1.json
@@ -1,0 +1,6 @@
+{
+  "name": "Stake Pool - 1",
+  "ticker": "SP1",
+  "description": "This is the stake pool 1 description.",
+  "homepage": "https://stakepool1.com"
+}

--- a/packages/e2e/local-network/file-server/SP2.json
+++ b/packages/e2e/local-network/file-server/SP2.json
@@ -1,0 +1,6 @@
+{
+  "name": "Stake Pool - 2",
+  "ticker": "SP2",
+  "description": "This is the stake pool 2 description.",
+  "homepage": "https://stakepool2.com"
+}

--- a/packages/e2e/local-network/file-server/SP3.json
+++ b/packages/e2e/local-network/file-server/SP3.json
@@ -1,0 +1,6 @@
+{
+  "name": "Stake Pool - 3",
+  "ticker": "SP3",
+  "description": "This is the stake pool 3 description.",
+  "homepage": "https://stakepool3.com"
+}

--- a/packages/e2e/local-network/file-server/index.html
+++ b/packages/e2e/local-network/file-server/index.html
@@ -1,0 +1,1 @@
+healthy!

--- a/packages/e2e/local-network/scripts/update-pools-certificate.sh
+++ b/packages/e2e/local-network/scripts/update-pools-certificate.sh
@@ -9,12 +9,22 @@ cd "$root"
 
 export PATH=$PWD/bin:$PATH
 
-# Pool metadata
-METADATA_URLS=("https://pools.iohk.io/IOG1.json" "https://pools.iohk.io/IOG2.json" "https://pools.iohk.io/IOG3.json")
-METADATA_HASHES=("22cf1de98f4cf4ce61bef2c6bc99890cb39f1452f5143189ce3a69ad70fcde72" "04faac1dce6c68b6bdf406eb261fbc6f57ce0baa9ab039d8e3bb1de8f903f092" "47d5ad9a718bfd40892ab89eb46b34ef2b1ebce9ebba6f5410a1ab96284771ed")
-
 SP_NODES=("1" "2" "3")
 AMOUNT_PER_WALLET='13500000000000000'
+
+# Pool metadata
+METADATA_URLS=("http://file-server/SP1.json" "http://file-server/SP2.json" "http://file-server/SP3.json")
+METADATA_HASHES=()
+
+for ((i = 0; i < ${#METADATA_URLS[@]}; ++i)); do
+  echo "Calculating hash for metadata at ${METADATA_URLS[$i]}..."
+
+  hash=$(cardano-cli stake-pool metadata-hash --pool-metadata-file <(curl -s -L -k "${METADATA_URLS[$i]}"))
+
+  echo "${hash}"
+
+  METADATA_HASHES[${#METADATA_HASHES[@]}]="${hash}"
+done
 
 clean() {
   rm -rf wallets-tx.raw wallets-tx.signed fullUtxo.out balance.out params.json stake.cert pool.cert deleg.cert tx.tmp tx.raw tx.signed


### PR DESCRIPTION
# Context

We need to add a web server to our local network to serve at least small static files as stake pools and asset metadata.

# Proposed Solution

Add to the end-to-end environment a Nginx instance that allows us to serve files directly to the local-network.

Any file added to the `file-server` folder will be served to the docker cluster via `http://files-server/`, for example, `http://files-server/SP1.json`. The contents of this folder can be altered dynamically, and the files will be available instantly to the docker images (no need to restart the container).

It is also possible to access the file server from outside the docker cluster as the instance binds to port `7890` on the host by default:

`http://localhost:7890/SP1.json`

You can override this port mapping by setting the `FILE_SERVER_PORT` environment variable when starting to containers:

`FILE_SERVER_PORT=9874 docker compose -p local-network-e2e up`

# Important Changes Introduced

- Added a new local files server
- The pools metadata now references the files on the local files server rather than from the internet.
