### PR TITLE
test(e2e): wallet init test with new custom measurement and scheduler…

### DIFF
--- a/packages/e2e/jest.config.js
+++ b/packages/e2e/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     project('load-testing'),
     project('local-network'),
     project('long-running'),
+    project('measurement-util'),
     project('ogmios'),
     project('providers'),
     project('wallet')

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -19,7 +19,9 @@
   "scripts": {
     "artillery:stake-pool-query": "WORKERS=1 node -r ts-node/register ../../node_modules/.bin/artillery run test/artillery/StakePoolSearch.yml",
     "artillery:wallet-restoration": "WORKERS=1 node -r ts-node/register ../../node_modules/.bin/artillery run --dotenv ./.env test/artillery/wallet-restoration/WalletRestoration.yml",
+    "load-test-custom:wallet-init": "ts-node test/load-test-custom/wallet-init/wallet-init.test.ts",
     "test": "shx echo 'test' command not implemented yet",
+    "test:measurement-util": "jest -c jest.config.js --forceExit --selectProjects measurement-util --verbose",
     "test:load-testing": "jest -c jest.config.js --forceExit --selectProjects load-testing --runInBand --verbose",
     "test:long-running": "jest -c jest.config.js --forceExit --selectProjects long-running --runInBand --verbose",
     "test:local-network": "jest -c jest.config.js --forceExit --selectProjects local-network --runInBand --verbose",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "artillery:stake-pool-query": "WORKERS=1 node -r ts-node/register ../../node_modules/.bin/artillery run test/artillery/StakePoolSearch.yml",
     "artillery:wallet-restoration": "WORKERS=1 node -r ts-node/register ../../node_modules/.bin/artillery run --dotenv ./.env test/artillery/wallet-restoration/WalletRestoration.yml",
+    "load-test-custom:stake-pool-query": "ts-node test/load-test-custom/stake-pool-search/stake-pool-search.test.ts",
     "load-test-custom:wallet-init": "ts-node test/load-test-custom/wallet-init/wallet-init.test.ts",
     "test": "shx echo 'test' command not implemented yet",
     "test:measurement-util": "jest -c jest.config.js --forceExit --selectProjects measurement-util --verbose",

--- a/packages/e2e/src/index.ts
+++ b/packages/e2e/src/index.ts
@@ -1,3 +1,5 @@
 export * from './factories';
 export * from './FaucetProvider';
 export * from './util';
+export * from './measurement-util';
+export * from './load-test-scheduler';

--- a/packages/e2e/src/load-test-scheduler.ts
+++ b/packages/e2e/src/load-test-scheduler.ts
@@ -1,0 +1,35 @@
+import { Logger } from 'ts-log';
+import { Observable, map, mergeMap, take, timer } from 'rxjs';
+
+export interface LoadTestSchedulerProps<T> {
+  /** Time in seconds during which the scheduler calls the `callUnderTest` */
+  duration: number;
+  /** How many times scheduler will call `callUnderTest` in the given `duration` */
+  callsPerDuration: number;
+  /** Each call will have a unique incrementing numeric id. This is the start value. */
+  idOffset?: number;
+  /** Asynchronous call that will be called `callsPerDuration` times, evenly split in `duration` seconds */
+  callUnderTest: (id: number) => Observable<T>;
+}
+
+export interface LoadTestSchedulerDependencies {
+  logger: Logger;
+}
+
+/** Use `LoadTestSchedulerProps` to schedule calls to `callUnderTest` */
+export const getLoadTestScheduler = <T>(
+  { duration, callsPerDuration, idOffset = 0, callUnderTest }: LoadTestSchedulerProps<T>,
+  { logger }: LoadTestSchedulerDependencies
+): Observable<T> =>
+  new Observable<T>((observer) => {
+    const callIntervalMs = (duration * 1000) / callsPerDuration;
+    logger.info(`Running ${callsPerDuration} calls in ${duration}s, 1 call / ${callIntervalMs}ms`);
+
+    return timer(0, callIntervalMs)
+      .pipe(
+        map((id) => id + idOffset),
+        take(callsPerDuration),
+        mergeMap((id) => callUnderTest(id))
+      )
+      .subscribe(observer);
+  });

--- a/packages/e2e/src/measurement-util.ts
+++ b/packages/e2e/src/measurement-util.ts
@@ -1,0 +1,154 @@
+import { PerformanceObserver, performance } from 'perf_hooks';
+
+export interface MarkerDetail<T> {
+  target: T;
+  id: number;
+}
+
+export interface MeasurementData {
+  /** Stats for targets added with {@link addMeasureMarker} */
+  time?: {
+    total: number;
+    min: number;
+    max: number;
+    avg: number;
+  }; // only for measurement markers done with `addMeasureMarker`
+
+  /** The number of times {@link addStartMarker} was called for a target */
+  calls_count: number;
+}
+
+export type MeasurementResults<T extends string> = Record<T, MeasurementData>;
+
+/**
+ * Wrapper over node perf hooks.
+ * T is a user defined string union of the targets that are being
+ * measured (e.g. 'wallet-initialization | input-selection').
+ */
+export class MeasurementUtil<T extends string> {
+  #performanceObserver: PerformanceObserver;
+
+  /**
+   * Starts observing performance measurements.
+   * Must be called before adding markers.
+   */
+  start(): void {
+    this.#performanceObserver = new PerformanceObserver(() => {
+      /* just an empty callback because we don't want to do anything when markers are added */
+    });
+
+    this.#performanceObserver.observe({ buffered: true, entryTypes: ['measure', 'mark'] });
+  }
+
+  /** Stops observing performance measurements and clears previous markers */
+  stop(): void {
+    performance.clearMarks();
+    performance.clearMeasures();
+    this.#performanceObserver.disconnect();
+  }
+
+  /**
+   * Add a start time marker in the timeline.
+   *
+   * @param target target for which we are setting the marker (e.g. 'wallet-initialization').
+   * @param id a unique numeric id useful when monitoring many instances. Statistics are aggregated for all ids.
+   */
+  addStartMarker(target: T, id: number): void {
+    const detail: MarkerDetail<T> = { id, target };
+    performance.mark(this.#getStartLabel(target, id), { detail });
+  }
+
+  /**
+   * Add a stop time marker in the timeline.
+   * Useful when the {@link addMeasureMarker} is done separately/later than the start&stop markers.
+   * In that case, the measurement is done from startMarker to stopMarker, instead of startMarker to measurementMarker.
+   *
+   * @param target same as {@link addStartMarker}
+   * @param id same as {@link addStartMarker}
+   */
+  addStopMarker(target: T, id: number): void {
+    performance.mark(this.#getStopLabel(target, id));
+  }
+
+  /**
+   * Adds a measurement marker in the timeline for {@link target} with {@link id}.
+   * It measures the time since {@link addStartMarker} with the same `target` and `id` was called.
+   * If {@link useStopMarker} is specified, it measures the time between {@link addStartMarker} and
+   * {@link addStopMarker} called with the same `target` and `id`.
+   *
+   * @param target same as {@link addStartMarker}
+   * @param id same as {@link addStartMarker}
+   * @param useStopMarker Values:
+   *   - `false | undefined`: Measure from start marker until this measure marker.
+   *   - `true`: Measure from start marker until the associated stop marker.
+   */
+  addMeasureMarker(target: T, id: number, useStopMarker = false) {
+    const detail: MarkerDetail<T> = { id, target };
+    performance.measure(this.#getMeasureLabel(target, id), {
+      detail,
+      end: useStopMarker ? this.#getStopLabel(target, id) : undefined,
+      start: this.#getStartLabel(target, id)
+    });
+  }
+
+  /**
+   * Calculates statistics for all {@link targets} added with {@link addMeasureMarker}.
+   *
+   * @param targets an array of user defined strings for which measurement markers were added.
+   * @returns a record indexed with the `target` and having as value a {@link @MeasurementData} object.
+   */
+  getMeasurements(targets: T[]): MeasurementResults<T> {
+    const measurementData: Record<T, MeasurementData> = {} as Record<T, MeasurementData>;
+    const measurementCounters: Record<T, number> = {} as Record<T, number>;
+
+    for (const target of targets) measurementData[target] = { calls_count: 0 };
+
+    for (const measureEntry of performance
+      .getEntriesByType('measure')
+      .map(({ duration, detail }) => ({ duration, target: (detail as MarkerDetail<T>).target }))
+      .filter(({ target }) => targets?.some((t) => t === target))) {
+      const data = measurementData[measureEntry.target];
+      if (!data.time) {
+        measurementCounters[measureEntry.target] = 1;
+        data.time = {
+          avg: measureEntry.duration,
+          max: measureEntry.duration,
+          min: measureEntry.duration,
+          total: measureEntry.duration
+        };
+      } else {
+        measurementCounters[measureEntry.target]++;
+        data.time.total += measureEntry.duration;
+        data.time.min = Math.min(measureEntry.duration, data.time.min);
+        data.time.max = Math.max(measureEntry.duration, data.time.max);
+        data.time.avg = data.time.total / measurementCounters[measureEntry.target];
+      }
+    }
+
+    // Count all the start markers. They all have the 'target' detail added. Stop markers don't have it
+    for (const targetName of performance
+      .getEntriesByType('mark')
+      .map(({ detail }) => (detail as MarkerDetail<T>)?.target)
+      .filter((target) => target && targets?.some((t) => t === target))) {
+      measurementData[targetName].calls_count++;
+    }
+
+    return measurementData;
+  }
+
+  #getStopLabel(target: string, id: number): string {
+    return this.#getLabel(target, id, 'stop');
+  }
+
+  #getStartLabel(target: string, id: number): string {
+    return this.#getLabel(target, id, 'start');
+  }
+
+  #getLabel(target: string, id: number, type: 'start' | 'stop'): string {
+    return `${target}-${type}-${id}`;
+  }
+
+  #getMeasureLabel(target: string, id: number) {
+    return `${target}-${id}`;
+  }
+}

--- a/packages/e2e/test/environment.ts
+++ b/packages/e2e/test/environment.ts
@@ -81,6 +81,7 @@ const validators = {
   UTXO_PROVIDER: str(),
   UTXO_PROVIDER_PARAMS: providerParams(),
   VIRTUAL_USERS_COUNT: num(),
+  VIRTUAL_USERS_GENERATE_DURATION: num(),
   WORKER_PARALLEL_TRANSACTION: num()
 } as const;
 

--- a/packages/e2e/test/load-test-custom/stake-pool-search/stake-pool-search.test.ts
+++ b/packages/e2e/test/load-test-custom/stake-pool-search/stake-pool-search.test.ts
@@ -1,0 +1,182 @@
+import * as envalid from 'envalid';
+import { Cardano, QueryStakePoolsArgs } from '@cardano-sdk/core';
+import { Logger } from 'ts-log';
+import { MeasurementUtil, getLoadTestScheduler } from '../../../src';
+import { bufferTime, from, tap } from 'rxjs';
+import { getEnv } from '../../environment';
+import { logger } from '@cardano-sdk/util-dev';
+import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
+
+// Example call:
+/* STAKE_POOL_PROVIDER_URL="http://mhvm:4000/stake-pool" \
+   VIRTUAL_USERS_GENERATE_DURATION=100 \
+   VIRTUAL_USERS_COUNT=5000 \
+   yarn load-test-custom:stake-pool-query
+*/
+
+const { STAKE_POOL_PROVIDER_URL } = envalid.cleanEnv(process.env, { STAKE_POOL_PROVIDER_URL: envalid.str() });
+const provider = stakePoolHttpProvider({ baseUrl: STAKE_POOL_PROVIDER_URL, logger });
+const testLogger: Logger = console;
+const intermediateResultsInterval = 10_000;
+
+const { VIRTUAL_USERS_GENERATE_DURATION: duration, VIRTUAL_USERS_COUNT: callsPerDuration } = getEnv([
+  'VIRTUAL_USERS_GENERATE_DURATION',
+  'VIRTUAL_USERS_COUNT'
+]);
+
+enum MeasureTarget {
+  healthCheckUnhealthy = 'healthCheckUnhealthy',
+  healthCheckError = 'healthCheckError',
+  queryFirstUser = 'queryFirstUser',
+  queryNoFilters = 'queryNoFilters',
+  queryNoFiltersErr = 'queryNoFiltersErr',
+  queryWithStatus = 'queryWithStatus',
+  queryWithStatusErr = 'queryWithStatusErr',
+  queryWithId = 'queryWithId',
+  queryWithIdErr = 'queryWithIdErr',
+  queryWithStatusAndId = 'queryWithStatusAndId',
+  queryWithStatusAndIdErr = 'queryWithStatusAndIdErr'
+}
+
+const PAGE_SIZE = 20;
+
+/**
+ * The set of pools id found while getting results
+ */
+const poolIds: Cardano.PoolId[] = [];
+
+const measurement = new MeasurementUtil<MeasureTarget | string>();
+
+const healthCheck = async (id: number): Promise<boolean> => {
+  try {
+    const result = await provider.healthCheck();
+
+    if (result.ok) return true;
+
+    measurement.addStartMarker(MeasureTarget.healthCheckUnhealthy, id);
+    logger.warn('Not ok healthCheck result', result);
+  } catch (error) {
+    measurement.addStartMarker(MeasureTarget.healthCheckError, id);
+    logger.error('Error thrown while performing healthCheck', error);
+  }
+
+  return false;
+};
+
+const randomizeFilter = () => {
+  const filters: NonNullable<QueryStakePoolsArgs['filters']> = {};
+
+  // Apply a random filter to 80% of the remaining users in the list, or if it's empty.
+  if (poolIds.length === 0 || Math.random() > 0.2) {
+    filters.status = [
+      [
+        Cardano.StakePoolStatus.Activating,
+        Cardano.StakePoolStatus.Active,
+        Cardano.StakePoolStatus.Retired,
+        Cardano.StakePoolStatus.Retiring
+      ][Math.floor(Math.random() * 4)]
+    ];
+  }
+
+  // We can't perform calls with id until we have some ids;
+  // when we have at least one id, we want to perform 80% calls with id and 20% without
+  if (poolIds.length > 0 && Math.random() > 0.2) {
+    // If we have data to randomize: let's do it
+    filters.identifier = {
+      values: [{ id: poolIds[Math.floor(Math.random() * poolIds.length)] }]
+    };
+  }
+
+  return filters;
+};
+
+/**
+ * Gets the name of the stat to measure depending on the filter this user is using to perform the query
+ *
+ * @param isFirstUser First user is the one which does initial query for cache priming.
+ * @returns the name of the stat we are measuring
+ */
+const getStatName = (
+  isFirstUser: boolean,
+  filters: QueryStakePoolsArgs['filters']
+): { statName: MeasureTarget; errorStatName?: MeasureTarget } => {
+  if (isFirstUser) return { statName: MeasureTarget.queryFirstUser };
+
+  const { identifier, status } = filters!;
+  if (identifier && status)
+    return { errorStatName: MeasureTarget.queryWithStatusAndIdErr, statName: MeasureTarget.queryWithStatusAndId };
+  if (identifier) return { errorStatName: MeasureTarget.queryWithIdErr, statName: MeasureTarget.queryWithId };
+  if (status) return { errorStatName: MeasureTarget.queryWithStatusErr, statName: MeasureTarget.queryWithStatus };
+  return { errorStatName: MeasureTarget.queryNoFiltersErr, statName: MeasureTarget.queryNoFilters };
+};
+
+const performQuery = async (id: number, isFirstUser: boolean): Promise<void> => {
+  const healthy = await healthCheck(id);
+  if (!healthy) return;
+
+  const args: QueryStakePoolsArgs = { pagination: { limit: PAGE_SIZE, startAt: 0 } };
+
+  if (!isFirstUser) {
+    args.filters = randomizeFilter();
+  }
+
+  let receivedResultsCount = 0;
+  do {
+    const { statName, errorStatName } = getStatName(isFirstUser, args.filters);
+    try {
+      measurement.addStartMarker(statName, id);
+      const result = await provider.queryStakePools(args);
+
+      receivedResultsCount = result.pageResults.length;
+
+      // Take ids to randomize next requests
+      for (const pool of result.pageResults) poolIds.push(pool.id);
+
+      measurement.addMeasureMarker(statName, id);
+    } catch (error) {
+      errorStatName && measurement.addStartMarker(errorStatName, id);
+      testLogger.error(error);
+      return;
+    }
+
+    args.pagination.startAt += PAGE_SIZE;
+  } while (PAGE_SIZE === receivedResultsCount);
+};
+
+measurement.start();
+
+const showResults = () => {
+  const results = measurement.getMeasurements([
+    MeasureTarget.healthCheckError,
+    MeasureTarget.healthCheckUnhealthy,
+    MeasureTarget.queryFirstUser,
+    MeasureTarget.queryNoFilters,
+    MeasureTarget.queryNoFiltersErr,
+    MeasureTarget.queryWithId,
+    MeasureTarget.queryWithIdErr,
+    MeasureTarget.queryWithStatus,
+    MeasureTarget.queryWithStatusErr,
+    MeasureTarget.queryWithStatusAndId,
+    MeasureTarget.queryWithStatusAndIdErr
+  ]);
+
+  testLogger.info('Measurements:', results);
+};
+
+getLoadTestScheduler<void>(
+  { callUnderTest: (id) => from(performQuery(id, id === 0)), callsPerDuration, duration },
+  { logger: testLogger }
+)
+  .pipe(
+    bufferTime(intermediateResultsInterval),
+    tap(() => {
+      testLogger.info(`\nPartial results every ${intermediateResultsInterval}ms:`);
+      showResults();
+    })
+  )
+  .subscribe({
+    complete: () => {
+      testLogger.info('--------- Final results -----------------');
+      showResults();
+    }
+  });

--- a/packages/e2e/test/load-test-custom/wallet-init/wallet-init.test.ts
+++ b/packages/e2e/test/load-test-custom/wallet-init/wallet-init.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable import/imports-first */
+import * as dotenv from 'dotenv';
+import path from 'path';
+
+// This line must come before loading the env, to configure the location of the .env file
+dotenv.config({ path: path.join(__dirname, '../../../.env') });
+
+import { Logger } from 'ts-log';
+import { SingleAddressWallet, createLazyWalletUtil } from '@cardano-sdk/wallet';
+import { bufferCount, bufferTime, from, mergeAll, tap } from 'rxjs';
+import { logger } from '@cardano-sdk/util-dev';
+
+import {
+  MeasurementUtil,
+  assetProviderFactory,
+  chainHistoryProviderFactory,
+  getLoadTestScheduler,
+  keyManagementFactory,
+  networkInfoProviderFactory,
+  rewardsProviderFactory,
+  stakePoolProviderFactory,
+  txSubmitProviderFactory,
+  utxoProviderFactory
+} from '../../../src';
+import { getEnv, walletVariables } from '../../environment';
+import { waitForWalletStateSettle } from '../../util';
+
+// Example call that creates 5000 wallets in 10 minutes:
+// VIRTUAL_USERS_GENERATE_DURATION=600 VIRTUAL_USERS_COUNT=5000 yarn load-test-custom:wallet-init
+
+const env = getEnv([...walletVariables, 'VIRTUAL_USERS_COUNT', 'VIRTUAL_USERS_GENERATE_DURATION']);
+const intermediateResultsInterval = 10_000;
+const walletsShutdownBatchSize = 100;
+const testLogger: Logger = console;
+
+enum MeasureTarget {
+  keyAgent = 'keyAgent',
+  wallet = 'wallet'
+}
+
+const measurementUtil = new MeasurementUtil<keyof typeof MeasureTarget>();
+
+// Utility methods to help setup the test. They could be part of another file
+const getProviders = async () => ({
+  assetProvider: await assetProviderFactory.create(env.ASSET_PROVIDER, env.ASSET_PROVIDER_PARAMS, logger),
+  chainHistoryProvider: await chainHistoryProviderFactory.create(
+    env.CHAIN_HISTORY_PROVIDER,
+    env.CHAIN_HISTORY_PROVIDER_PARAMS,
+    logger
+  ),
+  networkInfoProvider: await networkInfoProviderFactory.create(
+    env.NETWORK_INFO_PROVIDER,
+    env.NETWORK_INFO_PROVIDER_PARAMS,
+    logger
+  ),
+  rewardsProvider: await rewardsProviderFactory.create(env.REWARDS_PROVIDER, env.REWARDS_PROVIDER_PARAMS, logger),
+  stakePoolProvider: await stakePoolProviderFactory.create(
+    env.STAKE_POOL_PROVIDER,
+    env.STAKE_POOL_PROVIDER_PARAMS,
+    logger
+  ),
+  txSubmitProvider: await txSubmitProviderFactory.create(env.TX_SUBMIT_PROVIDER, env.TX_SUBMIT_PROVIDER_PARAMS, logger),
+  utxoProvider: await utxoProviderFactory.create(env.UTXO_PROVIDER, env.UTXO_PROVIDER_PARAMS, logger)
+});
+
+const getKeyAgent = async (accountIndex: number) => {
+  const createKeyAgent = await keyManagementFactory.create(
+    env.KEY_MANAGEMENT_PROVIDER,
+    { ...env.KEY_MANAGEMENT_PARAMS, accountIndex },
+    logger
+  );
+  const walletUtil = createLazyWalletUtil();
+  const keyAgent = await createKeyAgent({ inputResolver: walletUtil });
+  return { keyAgent, walletUtil };
+};
+
+const createWallet = async (accountIndex: number): Promise<SingleAddressWallet> => {
+  measurementUtil.addStartMarker(MeasureTarget.keyAgent, accountIndex);
+  const providers = await getProviders();
+  const { keyAgent, walletUtil } = await getKeyAgent(accountIndex);
+  measurementUtil.addMeasureMarker(MeasureTarget.keyAgent, accountIndex);
+
+  measurementUtil.addStartMarker(MeasureTarget.wallet, accountIndex);
+  const wallet = new SingleAddressWallet({ name: `Wallet ${accountIndex}` }, { ...providers, keyAgent, logger });
+  walletUtil.initialize(wallet);
+  return wallet;
+};
+
+const initWallet = async (idx: number) => {
+  const wallet = await createWallet(idx);
+  await waitForWalletStateSettle(wallet);
+  measurementUtil.addMeasureMarker(MeasureTarget.wallet, idx);
+  return wallet;
+};
+
+// A very simple print function. Measurement util returns an object that could be used in any way.
+const showResults = () => {
+  testLogger.info('Measurements:', measurementUtil.getMeasurements([MeasureTarget.wallet, MeasureTarget.keyAgent]));
+};
+
+// Starts observing measurement markers. If this method is not called, no measurements are done.
+measurementUtil.start();
+
+// Simple scheduler that distributes the requested number of calls evenly in the duration time
+getLoadTestScheduler<SingleAddressWallet>(
+  {
+    // callUnderTest must be a method returning an observable
+    callUnderTest: (id) => from(initWallet(id)),
+    callsPerDuration: env.VIRTUAL_USERS_COUNT,
+    duration: env.VIRTUAL_USERS_GENERATE_DURATION
+  },
+  { logger: testLogger }
+)
+  .pipe(
+    bufferTime(intermediateResultsInterval),
+    tap(() => {
+      testLogger.info(`\nPartial results every ${intermediateResultsInterval}ms:`);
+      showResults();
+    }),
+    mergeAll(),
+    bufferCount(walletsShutdownBatchSize)
+  )
+  .subscribe({
+    complete: () => {
+      testLogger.info('--------- Final results -----------------');
+      showResults();
+      measurementUtil.stop();
+    },
+    next: (wallets) => {
+      testLogger.info(`Shutting down ${wallets.length} wallets`);
+      for (const wallet of wallets) wallet.shutdown();
+    }
+  });

--- a/packages/e2e/test/measurement-util/measurement-util.test.ts
+++ b/packages/e2e/test/measurement-util/measurement-util.test.ts
@@ -1,0 +1,96 @@
+import { PerformanceEntry, performance } from 'perf_hooks';
+
+import { MeasurementUtil } from '../../src';
+
+const mockPerformanceObserver = {
+  disconnect: jest.fn(),
+  observe: jest.fn()
+};
+
+jest.mock('perf_hooks', () => ({
+  PerformanceObserver: jest.fn().mockImplementation(() => mockPerformanceObserver),
+  performance: {
+    clearMarks: () => jest.fn(),
+    clearMeasures: () => jest.fn(),
+    getEntriesByType: () => jest.fn()
+  }
+}));
+
+type measureTargets = 't1' | 't2';
+describe('MeasurementUtil', () => {
+  let measurementUtil: MeasurementUtil<measureTargets>;
+  let mockData: Partial<PerformanceEntry>[];
+
+  beforeEach(() => {
+    measurementUtil = new MeasurementUtil<measureTargets>();
+
+    mockData = [
+      { detail: { id: 0, target: 't1' }, duration: 5 },
+      { detail: { id: 1, target: 't1' }, duration: 7 },
+      { detail: { id: 2, target: 't1' }, duration: 9 },
+      { detail: { id: 0, target: 't2' }, duration: 80 },
+      { detail: { id: 1, target: 't2' }, duration: 40 }
+    ];
+
+    performance.getEntriesByType = jest.fn().mockReturnValue(mockData);
+  });
+
+  afterEach(() => {
+    mockPerformanceObserver.observe.mockClear();
+    mockPerformanceObserver.disconnect.mockClear();
+  });
+
+  it('on start creates PerformanceObserver and starts observing it', () => {
+    measurementUtil.start();
+    expect(mockPerformanceObserver.observe).toHaveBeenCalled();
+  });
+
+  it('returns number of calls to addStartMarker', () => {
+    const measuredData = measurementUtil.getMeasurements(['t1', 't2']);
+    expect(performance.getEntriesByType).toHaveBeenCalled();
+    expect(measuredData.t1.calls_count).toBe(3);
+    expect(measuredData.t2.calls_count).toBe(2);
+  });
+
+  it('calculates times correctly', () => {
+    const measuredData = measurementUtil.getMeasurements(['t1', 't2']);
+    expect(performance.getEntriesByType).toHaveBeenCalled();
+    expect(measuredData.t1.time).toEqual({ avg: 7, max: 9, min: 5, total: 21 });
+    expect(measuredData.t2.time).toEqual({ avg: 60, max: 80, min: 40, total: 120 });
+  });
+
+  it('returns measurements only requested targets', () => {
+    expect(measurementUtil.getMeasurements(['t1']).t2).toBeUndefined();
+    expect(measurementUtil.getMeasurements(['t2']).t1).toBeUndefined();
+  });
+
+  it('identifies stop markers by missing "details" property and does not count them', () => {
+    performance.getEntriesByType = jest.fn(
+      (type) =>
+        (type === 'measure'
+          ? mockData
+          : [...mockData, { name: 't1-stop-0' }, { name: 't1-stop-1' }]) as PerformanceEntry[]
+    );
+    expect(measurementUtil.getMeasurements(['t1']).t1.calls_count).toBe(3);
+  });
+
+  it('builds correct labels and details object based on target name', () => {
+    const mockMarkFn = jest.fn();
+    performance.mark = mockMarkFn;
+
+    measurementUtil.addStartMarker('t1', 22);
+    expect(performance.mark).toHaveBeenCalledWith('t1-start-22', { detail: { id: 22, target: 't1' } });
+
+    mockMarkFn.mockClear();
+    measurementUtil.addStopMarker('t1', 22);
+    expect(performance.mark).toHaveBeenCalledWith('t1-stop-22');
+
+    performance.measure = jest.fn();
+    measurementUtil.addMeasureMarker('t1', 22, true);
+    expect(performance.measure).toHaveBeenCalledWith('t1-22', {
+      detail: { id: 22, target: 't1' },
+      end: 't1-stop-22',
+      start: 't1-start-22'
+    });
+  });
+});


### PR DESCRIPTION


Added `MeasurementUtil` helper class based on node perf hooks. Added `getLoadTestScheduler` util that schedules a given number of calls in a timeframe. Added wallet initialization load test using the two utils.

# Context

Performance/load test libraries are focused on REST/websocket primitives.
This is a POC for custom helpers for load tests.

# Proposed Solution
Solution is made up from 2 parts:
1. `MeasurementUtil` class: a wrapper over node performance hooks. Provides type safe string values for the markers and hides the complexity of matching the strings when measuring.
2. `getLoadTestScheduler` method: a helper for scheduling a number of calls in a given timeframe, using rxjs observables.

See `packages/e2e/test/load-test-custom/wallet-init.test.ts` for a usage example.

Doc comments provide more details.

# TODO:
Once the POC is validated and agreed upon:
- [x] Extend measurementUtil with more stats: min/max/avg. For now it only measures the total time.
- [x] Migrate existing stake pool search artillery.io test

