### PR TITLE
test(e2e): removed browser usage outside of tests

### DIFF
--- a/packages/e2e/test/web-extension/extension/util.ts
+++ b/packages/e2e/test/web-extension/extension/util.ts
@@ -4,8 +4,6 @@ import { RemoteApiProperties, RemoteApiPropertyType } from '@cardano-sdk/web-ext
 
 export const extensionId = 'lgehgfkeagjdklnanflcjoipaphegomm';
 
-export const ownOrigin = globalThis.location.origin;
-
 export const walletName = 'ccvault';
 export const observableWalletNames = ['UserCreatedWallet1', 'UserCreatedWallet2'];
 


### PR DESCRIPTION
# Context
Using `chromedriver` 107.*  in local dev env, observed the following error:
_Unable to load spec files quite likely because they rely on `browser` object that is not fully initialised.
Helper files that use other `browser` commands have to be moved to `before` hook_

# Proposed Solution
Removed unused `ownOrigin` variable.
It was making web-extension tests fail with newer chromedriver versions (107+). The reason was the usage of `browser` like objects outside of tests.

# Important Changes Introduced
