### PR TITLE
ADP-2420 - Fix possible APY calculation overflow on networks with fast epoch

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -358,10 +358,22 @@ export const findPoolAPY = (limit?: number) => `
   pool_apy AS (
     SELECT 
       epochs.hash_id,
-      POWER(
-        1 + (avg_daily_roi.avg_roi * (epochs.epoch_length / 86400000)), 
-        COALESCE(365 / NULLIF(epochs.epoch_length / 86400000, 0), 0)
-      ) - 1 AS apy
+      (
+        LEAST(
+          POWER(
+            (
+              1 + (
+                avg_daily_roi.avg_roi * (epochs.epoch_length / 86400000)
+              )
+            ):: numeric, 
+            COALESCE(
+              365 / NULLIF(epochs.epoch_length / 86400000, 0), 
+              0
+            ):: numeric
+          ), 
+          1E+308
+        ) -1
+      ):: double precision AS apy
     FROM epoch_rewards AS epochs
     JOIN (
       SELECT

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/__snapshots__/StakePoolBuilder.test.ts.snap
@@ -848,7 +848,7 @@ Array [
     "hashId": 1,
   },
   Object {
-    "apy": 0.00227126684541146,
+    "apy": 0.0022712668456358,
     "hashId": 14,
   },
 ]
@@ -857,7 +857,7 @@ Array [
 exports[`StakePoolBuilder queryPoolAPY sort by default sort (APY desc) 1`] = `
 Array [
   Object {
-    "apy": 0.00227126684541146,
+    "apy": 0.0022712668456358,
     "hashId": 14,
   },
   Object {

--- a/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
+++ b/packages/cardano-services/test/StakePool/__snapshots__/StakePoolHttpService.test.ts.snap
@@ -32,7 +32,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -243,7 +243,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -511,7 +511,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -1122,7 +1122,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -1600,7 +1600,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -1999,7 +1999,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -2332,7 +2332,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -2878,7 +2878,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -3273,7 +3273,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -3418,7 +3418,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -3944,7 +3944,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -4339,7 +4339,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -4607,7 +4607,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -5277,7 +5277,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -5545,7 +5545,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -5813,7 +5813,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -6359,7 +6359,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -6758,7 +6758,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -7236,7 +7236,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -8439,7 +8439,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -8513,7 +8513,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -9306,7 +9306,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -9380,7 +9380,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -9969,7 +9969,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -10831,7 +10831,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -11100,7 +11100,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -11778,7 +11778,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -12441,7 +12441,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -12784,7 +12784,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -13052,7 +13052,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -13985,7 +13985,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -14386,7 +14386,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -15115,7 +15115,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -15778,7 +15778,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -15852,7 +15852,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,
@@ -16645,7 +16645,7 @@ Object {
         "url": "https://clio.one/metadata/clio1_testnet.json",
       },
       "metrics": Object {
-        "apy": 0.00227126684541146,
+        "apy": 0.0022712668456358,
         "blocksCreated": "0",
         "delegators": "1",
         "livePledge": 22623299531669n,


### PR DESCRIPTION
# Context

There is a possible overflow error when querying the APY of a pool in the local network. This is because the calculation is sensitive to the network speed, this combined with the reduced amount of pools in the network can produce APY which overflow the 'double precision' postgres SQL type.

# Proposed Solution

The calculation was originally done with  'double precision' numeric types, which can overflow, we can cast the types to 'numeric' (which can hold a value up to 131,072 digits before the decimal point and 16,383 digits after the decimal point.), perform the calculation, clamp it to the max value of  'double precision' and then cast the result back.
