### PR TITLE
ADP-2330 - feat(key-management): ownSignatureKeyPaths now checks for reward accounts in certificates

### DIFF
--- a/packages/key-management/src/KeyAgentBase.ts
+++ b/packages/key-management/src/KeyAgentBase.ts
@@ -68,14 +68,16 @@ export abstract class KeyAgentBase implements KeyAgent {
     ).to_address();
 
     const rewardAccount = CML.RewardAddress.new(this.networkId, stakeKeyCredential).to_address();
-    const groupedAddress = {
+    const groupedAddress: GroupedAddress = {
       accountIndex: this.accountIndex,
       address: Cardano.Address(address.to_bech32()),
       index,
       networkId: this.networkId,
       rewardAccount: Cardano.RewardAccount(rewardAccount.to_bech32()),
+      stakeKeyDerivationPath: STAKE_KEY_DERIVATION_PATH,
       type
     };
+
     this.knownAddresses = [...this.knownAddresses, groupedAddress];
     return groupedAddress;
   }

--- a/packages/key-management/src/restoreKeyAgent.ts
+++ b/packages/key-management/src/restoreKeyAgent.ts
@@ -13,6 +13,7 @@ import {
 import { InMemoryKeyAgent } from './InMemoryKeyAgent';
 import { InvalidSerializableDataError } from './errors';
 import { LedgerKeyAgent } from './LedgerKeyAgent';
+import { STAKE_KEY_DERIVATION_PATH } from './util';
 import { TrezorKeyAgent } from './TrezorKeyAgent';
 
 // TODO: use this type as 2nd parameter of restoreKeyAgent
@@ -51,6 +52,8 @@ export async function restoreKeyAgent<T extends SerializableKeyAgentData>(
   dependencies: KeyAgentDependencies,
   getPassword?: GetPassword
 ): Promise<KeyAgent> {
+  for (const address of data.knownAddresses) address.stakeKeyDerivationPath ||= STAKE_KEY_DERIVATION_PATH;
+
   switch (data.__typename) {
     case KeyAgentType.InMemory: {
       if (!data.encryptedRootPrivateKeyBytes || data.encryptedRootPrivateKeyBytes.length !== 156) {

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -78,6 +78,7 @@ export interface GroupedAddress {
   accountIndex: number;
   address: Cardano.Address;
   rewardAccount: Cardano.RewardAccount;
+  stakeKeyDerivationPath?: AccountKeyDerivationPath;
 }
 
 export interface TrezorConfig {

--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -4,6 +4,52 @@ import { isNotNil } from '@cardano-sdk/util';
 import uniq from 'lodash/uniq';
 
 /**
+ * Gets whether any certificate in the provided certificate list requires a stake key signature.
+ *
+ * @param rewardAccounts The known reward accounts.
+ * @param certificates The list of certificates.
+ */
+// eslint-disable-next-line complexity
+const isStakingKeySignatureRequired = (
+  rewardAccounts: Cardano.RewardAccount[],
+  certificates: Cardano.Certificate[] | undefined
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+) => {
+  if (!certificates?.length) return false;
+  if (!rewardAccounts?.length) return false;
+
+  for (const account of rewardAccounts) {
+    const stakeKeyHash = Cardano.Ed25519KeyHash.fromRewardAccount(account);
+    const poolId = Cardano.PoolId.fromKeyHash(stakeKeyHash);
+
+    for (const certificate of certificates) {
+      switch (certificate.__typename) {
+        case Cardano.CertificateType.StakeKeyRegistration:
+        case Cardano.CertificateType.StakeKeyDeregistration:
+        case Cardano.CertificateType.StakeDelegation:
+          if (certificate.stakeKeyHash === stakeKeyHash) return true;
+          break;
+        case Cardano.CertificateType.PoolRegistration:
+          // eslint-disable-next-line max-depth
+          for (const owner of certificate.poolParameters.owners) if (owner === account) return true;
+          break;
+        case Cardano.CertificateType.PoolRetirement:
+          if (certificate.poolId === poolId) return true;
+          break;
+        case Cardano.CertificateType.MIR:
+          if (certificate.rewardAccount === account) return true;
+          break;
+        case Cardano.CertificateType.GenesisKeyDelegation:
+        default:
+        // Nothing to do.
+      }
+    }
+  }
+
+  return false;
+};
+
+/**
  * Assumes that a single staking key is used for all addresses (index=0)
  *
  * @returns {AccountKeyDerivationPath[]} derivation paths for keys to sign transaction with
@@ -25,12 +71,11 @@ export const ownSignatureKeyPaths = async (
     ).filter(isNotNil)
   ).map(({ type, index }) => ({ index, role: Number(type) }));
 
-  const rewardAccounts = new Set(knownAddresses.map(({ rewardAccount }) => rewardAccount));
+  const rewardAccounts = [...new Set(knownAddresses.map(({ rewardAccount }) => rewardAccount))];
 
-  const isStakingKeySignatureRequired = txBody.certificates?.length;
   if (
-    isStakingKeySignatureRequired ||
-    txBody.withdrawals?.some((withdrawal) => rewardAccounts.has(withdrawal.stakeAddress))
+    isStakingKeySignatureRequired(rewardAccounts, txBody.certificates) ||
+    txBody.withdrawals?.some((withdrawal) => rewardAccounts.includes(withdrawal.stakeAddress))
   ) {
     return [...paymentKeyPaths, { index: 0, role: KeyRole.Stake }];
   }

--- a/packages/key-management/test/restoreKeyAgent.test.ts
+++ b/packages/key-management/test/restoreKeyAgent.test.ts
@@ -11,36 +11,64 @@ import {
 } from '../src';
 import { Cardano } from '@cardano-sdk/core';
 import { InvalidSerializableDataError } from '../src/errors';
+import { STAKE_KEY_DERIVATION_PATH } from '../src/util';
 
 describe('KeyManagement/restoreKeyAgent', () => {
   const dependencies: KeyAgentDependencies = { inputResolver: { resolveInputAddress: jest.fn() } }; // not called
 
   describe('InMemoryKeyAgent', () => {
-    const inMemoryKeyAgentData: SerializableInMemoryKeyAgentData = {
+    const encryptedRootPrivateKeyBytes = [
+      9, 10, 153, 62, 225, 131, 81, 153, 234, 186, 63, 211, 14, 172, 194, 82, 184, 119, 228, 49, 2, 133, 239, 127, 196,
+      140, 219, 8, 136, 248, 186, 84, 165, 123, 197, 105, 73, 181, 144, 27, 137, 206, 159, 63, 37, 138, 150, 49, 194,
+      164, 58, 66, 200, 97, 242, 184, 110, 11, 39, 106, 131, 156, 196, 138, 219, 29, 7, 71, 117, 172, 111, 88, 44, 103,
+      205, 168, 94, 156, 89, 252, 92, 55, 218, 216, 40, 59, 88, 227, 170, 118, 161, 116, 84, 39, 92, 33, 66, 157, 42,
+      14, 225, 45, 175, 93, 214, 141, 163, 136, 13, 46, 152, 33, 166, 202, 127, 122, 146, 239, 38, 125, 114, 66, 141,
+      241, 161, 163, 19, 81, 122, 125, 149, 49, 175, 149, 111, 48, 138, 254, 189, 69, 35, 135, 62, 177, 43, 152, 95, 7,
+      87, 78, 204, 222, 109, 3, 239, 117
+    ];
+
+    const address = Cardano.Address(
+      'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
+    );
+
+    const extendedAccountPublicKey = Cardano.Bip32PublicKey(
+      // eslint-disable-next-line max-len
+      '6199186adb51974690d7247d2646097d2c62763b767b528816fb7ed3f9f55d396199186adb51974690d7247d2646097d2c62763b767b528816fb7ed3f9f55d39'
+    );
+
+    const rewardAccount = Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr');
+
+    const inMemoryKeyAgentDataWithoutStakeDerivationPath: SerializableInMemoryKeyAgentData = {
       __typename: KeyAgentType.InMemory,
       accountIndex: 0,
-      encryptedRootPrivateKeyBytes: [
-        9, 10, 153, 62, 225, 131, 81, 153, 234, 186, 63, 211, 14, 172, 194, 82, 184, 119, 228, 49, 2, 133, 239, 127,
-        196, 140, 219, 8, 136, 248, 186, 84, 165, 123, 197, 105, 73, 181, 144, 27, 137, 206, 159, 63, 37, 138, 150, 49,
-        194, 164, 58, 66, 200, 97, 242, 184, 110, 11, 39, 106, 131, 156, 196, 138, 219, 29, 7, 71, 117, 172, 111, 88,
-        44, 103, 205, 168, 94, 156, 89, 252, 92, 55, 218, 216, 40, 59, 88, 227, 170, 118, 161, 116, 84, 39, 92, 33, 66,
-        157, 42, 14, 225, 45, 175, 93, 214, 141, 163, 136, 13, 46, 152, 33, 166, 202, 127, 122, 146, 239, 38, 125, 114,
-        66, 141, 241, 161, 163, 19, 81, 122, 125, 149, 49, 175, 149, 111, 48, 138, 254, 189, 69, 35, 135, 62, 177, 43,
-        152, 95, 7, 87, 78, 204, 222, 109, 3, 239, 117
-      ],
-      extendedAccountPublicKey: Cardano.Bip32PublicKey(
-        // eslint-disable-next-line max-len
-        '6199186adb51974690d7247d2646097d2c62763b767b528816fb7ed3f9f55d396199186adb51974690d7247d2646097d2c62763b767b528816fb7ed3f9f55d39'
-      ),
+      encryptedRootPrivateKeyBytes,
+      extendedAccountPublicKey,
       knownAddresses: [
         {
           accountIndex: 0,
-          address: Cardano.Address(
-            'addr1qx52knza2h5x090n4a5r7yraz3pwcamk9ppvuh7e26nfks7pnmhxqavtqy02zezklh27jt9r6z62sav3mugappdc7xnskxy2pn'
-          ),
+          address,
           index: 0,
           networkId: Cardano.NetworkId.mainnet,
-          rewardAccount: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
+          rewardAccount,
+          type: AddressType.External
+        }
+      ],
+      networkId: 0
+    };
+
+    const inMemoryKeyAgentData: SerializableInMemoryKeyAgentData = {
+      __typename: KeyAgentType.InMemory,
+      accountIndex: 0,
+      encryptedRootPrivateKeyBytes,
+      extendedAccountPublicKey,
+      knownAddresses: [
+        {
+          accountIndex: 0,
+          address,
+          index: 0,
+          networkId: Cardano.NetworkId.mainnet,
+          rewardAccount,
+          stakeKeyDerivationPath: STAKE_KEY_DERIVATION_PATH,
           type: AddressType.External
         }
       ],
@@ -48,6 +76,15 @@ describe('KeyManagement/restoreKeyAgent', () => {
     };
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const getPassword: GetPassword = async () => Buffer.from('password');
+
+    it('assumes default stakeKeyDerivationPath if not present in serializable data', async () => {
+      expect.assertions(1);
+      const keyAgent = await restoreKeyAgent(inMemoryKeyAgentDataWithoutStakeDerivationPath, dependencies, getPassword);
+
+      for (const knownAddress of keyAgent.knownAddresses) {
+        expect(knownAddress.stakeKeyDerivationPath).toBe(STAKE_KEY_DERIVATION_PATH);
+      }
+    });
 
     it('can restore key manager from valid data and password', async () => {
       const keyAgent = await restoreKeyAgent(inMemoryKeyAgentData, dependencies, getPassword);
@@ -86,6 +123,7 @@ describe('KeyManagement/restoreKeyAgent', () => {
           index: 0,
           networkId: Cardano.NetworkId.mainnet,
           rewardAccount: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
+          stakeKeyDerivationPath: STAKE_KEY_DERIVATION_PATH,
           type: AddressType.External
         }
       ],
@@ -116,6 +154,7 @@ describe('KeyManagement/restoreKeyAgent', () => {
           index: 0,
           networkId: Cardano.NetworkId.mainnet,
           rewardAccount: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
+          stakeKeyDerivationPath: STAKE_KEY_DERIVATION_PATH,
           type: AddressType.External
         }
       ],
@@ -140,7 +179,8 @@ describe('KeyManagement/restoreKeyAgent', () => {
     await expect(() =>
       restoreKeyAgent(
         {
-          __typename: 'OTHER'
+          __typename: 'OTHER',
+          knownAddresses: []
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,
         dependencies

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -24,9 +24,13 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
   );
 
+  const ownStakeKeyHash = Cardano.Ed25519KeyHash.fromRewardAccount(ownRewardAccount);
+  const otherStakeKeyHash = Cardano.Ed25519KeyHash.fromRewardAccount(otherRewardAccount);
+
+  const knownAddress1 = createGroupedAddress(address1, ownRewardAccount, AddressType.External, 0);
+
   it('returns distinct derivation paths required to sign the transaction', async () => {
     const txBody = {
-      certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration }],
       inputs: [{}, {}, {}]
     } as Cardano.TxBody;
     const knownAddresses = [address1, address2].map((address, index) =>
@@ -45,10 +49,200 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       {
         index: 1,
         role: KeyRole.External
+      }
+    ]);
+  });
+
+  it(
+    'returns stake key derivation path when a StakeKeyRegistration' +
+      // eslint-disable-next-line sonarjs/no-duplicate-string
+      ' certificate with the wallet stake key hash is present',
+    async () => {
+      const txBody = {
+        certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash: ownStakeKeyHash }],
+        inputs: [{}, {}, {}]
+      } as Cardano.NewTxBodyAlonzo;
+      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+        {
+          index: 0,
+          role: KeyRole.External
+        },
+        {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      ]);
+    }
+  );
+
+  it(
+    'returns stake key derivation path when a StakeKeyDeregistration' +
+      ' certificate with the wallet stake key hash is present',
+    async () => {
+      const txBody = {
+        certificates: [{ __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash: ownStakeKeyHash }],
+        inputs: [{}, {}, {}]
+      } as Cardano.NewTxBodyAlonzo;
+      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+        {
+          index: 0,
+          role: KeyRole.External
+        },
+        {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      ]);
+    }
+  );
+
+  it(
+    'returns stake key derivation path when a StakeDelegation' +
+      ' certificate with the wallet stake key hash is present',
+    async () => {
+      const txBody = {
+        certificates: [{ __typename: Cardano.CertificateType.StakeDelegation, stakeKeyHash: ownStakeKeyHash }],
+        inputs: [{}, {}, {}]
+      } as Cardano.NewTxBodyAlonzo;
+      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+        {
+          index: 0,
+          role: KeyRole.External
+        },
+        {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      ]);
+    }
+  );
+
+  // eslint-disable-next-line max-len
+  it('returns stake key derivation path when at least one certificate with the wallet stake key hash is present', async () => {
+    const txBody = {
+      certificates: [
+        { __typename: Cardano.CertificateType.StakeDelegation, stakeKeyHash: ownStakeKeyHash },
+        { __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash: otherStakeKeyHash }
+      ],
+      inputs: [{}, {}, {}]
+    } as Cardano.NewTxBodyAlonzo;
+    const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      {
+        index: 0,
+        role: KeyRole.External
       },
       {
         index: 0,
         role: KeyRole.Stake
+      }
+    ]);
+  });
+
+  it(
+    'returns stake key derivation path when a PoolRetirement' +
+      ' certificate with the wallet stake key hash is present',
+    async () => {
+      const txBody = {
+        certificates: [
+          {
+            __typename: Cardano.CertificateType.PoolRetirement,
+            epoch: 40,
+            poolId: Cardano.PoolId.fromKeyHash(ownStakeKeyHash)
+          }
+        ],
+        inputs: [{}, {}, {}]
+      } as Cardano.NewTxBodyAlonzo;
+      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+        {
+          index: 0,
+          role: KeyRole.External
+        },
+        {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      ]);
+    }
+  );
+
+  it(
+    'returns stake key derivation path when a PoolRegistration' +
+      ' certificate with the wallet stake key hash is present',
+    async () => {
+      const txBody = {
+        certificates: [
+          {
+            __typename: Cardano.CertificateType.PoolRegistration,
+            poolParameters: {
+              cost: 340n,
+              id: Cardano.PoolId.fromKeyHash(ownStakeKeyHash),
+              margin: {
+                denominator: 50,
+                numerator: 10
+              },
+              owners: [ownRewardAccount],
+              pledge: 10_000n,
+              relays: [
+                {
+                  __typename: 'RelayByName',
+                  hostname: 'localhost'
+                }
+              ],
+              rewardAccount: ownRewardAccount,
+              vrf: Cardano.VrfVkHex('641d042ed39c2c258d381060c1424f40ef8abfe25ef566f4cb22477c42b2a014')
+            }
+          }
+        ],
+        inputs: [{}, {}, {}]
+      } as Cardano.NewTxBodyAlonzo;
+      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+        {
+          index: 0,
+          role: KeyRole.External
+        },
+        {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      ]);
+    }
+  );
+
+  it('returns stake key derivation path when a MIR certificate with the wallet stake key hash is present', async () => {
+    const txBody = {
+      certificates: [{ __typename: Cardano.CertificateType.MIR, rewardAccount: ownRewardAccount }],
+      inputs: [{}, {}, {}]
+    } as Cardano.NewTxBodyAlonzo;
+    const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      {
+        index: 0,
+        role: KeyRole.External
+      },
+      {
+        index: 0,
+        role: KeyRole.Stake
+      }
+    ]);
+  });
+
+  // eslint-disable-next-line max-len
+  it('does not return stake key derivation path when no certificate with wallet stake key hash is present', async () => {
+    const txBody = {
+      certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash: otherStakeKeyHash }],
+      inputs: [{}, {}, {}]
+    } as Cardano.NewTxBodyAlonzo;
+    const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
+    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      {
+        index: 0,
+        role: KeyRole.External
       }
     ]);
   });

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -49,6 +49,7 @@ const createWallet = async (stores: WalletStores, providers: Providers, pollingC
         index: 0,
         networkId: Cardano.NetworkId.testnet,
         rewardAccount,
+        stakeKeyDerivationPath: mocks.stakeKeyDerivationPath,
         type: AddressType.External
       };
       const asyncKeyAgent = await testAsyncKeyAgent([groupedAddress], dependencies);

--- a/packages/wallet/test/SingleAddressWallet/methods.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/methods.test.ts
@@ -49,6 +49,7 @@ describe('SingleAddressWallet methods', () => {
       index: 0,
       networkId: Cardano.NetworkId.testnet,
       rewardAccount: mocks.rewardAccount,
+      stakeKeyDerivationPath: mocks.stakeKeyDerivationPath,
       type: AddressType.External
     };
     ({ wallet } = await setupWallet({

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -39,6 +39,7 @@ const createWallet = async (stores: WalletStores, providers: Providers, pollingC
         index: 0,
         networkId: Cardano.NetworkId.testnet,
         rewardAccount,
+        stakeKeyDerivationPath: mocks.stakeKeyDerivationPath,
         type: AddressType.External
       };
       const asyncKeyAgent = await testAsyncKeyAgent([groupedAddress], dependencies);

--- a/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
@@ -40,6 +40,7 @@ describe('LedgerKeyAgent', () => {
           index: 0,
           networkId: Cardano.NetworkId.testnet,
           rewardAccount: mocks.rewardAccount,
+          stakeKeyDerivationPath: mocks.stakeKeyDerivationPath,
           type: AddressType.External
         };
         ledgerKeyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);

--- a/packages/wallet/test/hardware/TrezorKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/TrezorKeyAgent.test.ts
@@ -43,6 +43,7 @@ describe('TrezorKeyAgent', () => {
           index: 0,
           networkId: Cardano.NetworkId.testnet,
           rewardAccount: mocks.rewardAccount,
+          stakeKeyDerivationPath: mocks.stakeKeyDerivationPath,
           type: AddressType.External
         };
         trezorKeyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);

--- a/packages/wallet/test/mocks/mockData.ts
+++ b/packages/wallet/test/mocks/mockData.ts
@@ -1,7 +1,13 @@
 import { Cardano, EpochRewards } from '@cardano-sdk/core';
+import { KeyRole } from '@cardano-sdk/key-management';
 
 export const rewardAccount = Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d');
 export const stakeKeyHash = Cardano.Ed25519KeyHash.fromRewardAccount(rewardAccount);
+
+export const stakeKeyDerivationPath = {
+  index: 0,
+  role: KeyRole.Stake
+};
 
 export const rewardAccountBalance = 33_333n;
 


### PR DESCRIPTION
# Context

ownSignatureKeyPaths is currently not checking the type and .rewardAccount of certificates, so it will just blindly sign with stake key any transactions that have any certificates. We need to have some additional logic to determine if a transaction needs to be signed with the stake key.

# Proposed Solution

ownSignatureKeyPaths now inspect all certificates to determine if the transaction must be signed with the wallet stake key.
