### PR TITLE
fix(wallet): sign entire transaction in cip30 mapping instead of transaction body

### DIFF
--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -107,9 +107,9 @@ describe('cip30', () => {
     test('api.signTx', async () => {
       const txInternals = await wallet.initializeTx(simpleTxProps);
       const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
-      const hexTxBody = Buffer.from(coreToCml.tx(scope, finalizedTx).body().to_bytes()).toString('hex');
+      const hexTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
 
-      const cip30witnessSet = await api.signTx(hexTxBody);
+      const cip30witnessSet = await api.signTx(hexTx);
       const signatures = Buffer.from(cip30witnessSet, 'hex');
       expect(() => scope.manage(CML.TransactionWitnessSet.from_bytes(signatures))).not.toThrow();
     });
@@ -152,26 +152,26 @@ describe('cip30', () => {
     });
 
     describe('signTx', () => {
-      let hexTxBody: string;
+      let hexTx: string;
       beforeAll(async () => {
         const txInternals = await wallet.initializeTx(simpleTxProps);
         const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
-        hexTxBody = Buffer.from(coreToCml.tx(scope, finalizedTx).body().to_bytes()).toString('hex');
+        hexTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
       });
 
       test('resolves true', async () => {
         confirmationCallback.mockResolvedValueOnce(true);
-        await expect(api.signTx(hexTxBody)).resolves.not.toThrow();
+        await expect(api.signTx(hexTx)).resolves.not.toThrow();
       });
 
       test('resolves false', async () => {
         confirmationCallback.mockResolvedValueOnce(false);
-        await expect(api.signTx(hexTxBody)).rejects.toThrowError(TxSignError);
+        await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
       });
 
       test('rejects', async () => {
         confirmationCallback.mockRejectedValue(1);
-        await expect(api.signTx(hexTxBody)).rejects.toThrowError(TxSignError);
+        await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
       });
     });
 


### PR DESCRIPTION
# Context

The cip30 method `signTx` should take and sign an entire transaction, not just the transaction body

# Proposed Solution
update `cip30.ts` to sign an entire transaction, as well as associated tests