### PR TITLE
feat: Introduce Ogmios transaction to core mapping

### DIFF
--- a/packages/cardano-services-client/src/index.ts
+++ b/packages/cardano-services-client/src/index.ts
@@ -1,4 +1,3 @@
-export { TxSubmitProvider } from '@cardano-sdk/core';
 export * from './AssetInfoProvider';
 export * from './HttpProvider';
 export * from './TxSubmitProvider';

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -96,13 +96,13 @@ export const mapWithdrawal = (withdrawalModel: WithdrawalModel): Cardano.Withdra
 });
 
 export const mapRedeemer = (redeemerModel: RedeemerModel): Cardano.Redeemer => ({
+  data: Cardano.util.HexBlob(redeemerModel.script_hash.toString('hex')),
   executionUnits: {
     memory: Number(redeemerModel.unit_mem),
     steps: Number(redeemerModel.unit_steps)
   },
   index: redeemerModel.index,
-  purpose: redeemerModel.purpose as Cardano.RedeemerPurpose,
-  scriptHash: Cardano.util.Hash28ByteBase16(redeemerModel.script_hash.toString('hex'))
+  purpose: redeemerModel.purpose as Cardano.RedeemerPurpose
 });
 
 export const mapCertificate = (

--- a/packages/cardano-services/src/ChainHistory/openApi.json
+++ b/packages/cardano-services/src/ChainHistory/openApi.json
@@ -361,7 +361,7 @@
               "withdrawal"
             ]
           },
-          "scriptHash": {
+          "data": {
             "type": "string"
           }
         }

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -286,13 +286,13 @@ describe('chain history mappers', () => {
     test('map RedeemerModel to Cardano.Redeemer', () => {
       const result = mappers.mapRedeemer(redeemerModel);
       expect(result).toEqual<Cardano.Redeemer>({
+        data: Cardano.util.HexBlob(hash28ByteBase16),
         executionUnits: {
           memory: 2000,
           steps: 5000
         },
         index: 1,
-        purpose: Cardano.RedeemerPurpose.mint,
-        scriptHash: Cardano.util.Hash28ByteBase16(hash28ByteBase16)
+        purpose: Cardano.RedeemerPurpose.mint
       });
     });
   });
@@ -303,10 +303,10 @@ describe('chain history mappers', () => {
     const outputs: Cardano.TxOut[] = [{ address: Cardano.Address(address), value: { assets, coins: 20_000_000n } }];
     const redeemers: Cardano.Redeemer[] = [
       {
+        data: Cardano.util.HexBlob(hash28ByteBase16),
         executionUnits: { memory: 1, steps: 2 },
         index: 1,
-        purpose: Cardano.RedeemerPurpose.spend,
-        scriptHash: Cardano.util.Hash28ByteBase16(hash28ByteBase16)
+        purpose: Cardano.RedeemerPurpose.spend
       }
     ];
     const withdrawals: Cardano.Withdrawal[] = [{ quantity: 200n, stakeAddress: Cardano.RewardAccount(stakeAddress) }];

--- a/packages/cardano-services/test/data-mocks/tx.ts
+++ b/packages/cardano-services/test/data-mocks/tx.ts
@@ -132,13 +132,13 @@ export const withWithdrawals: Cardano.HydratedTx = merge(withAssets, {
 export const witnessRedeemers = {
   redeemers: [
     {
+      data: '67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656',
       executionUnits: {
         memory: 1700,
         steps: 476_468
       },
       index: 0,
-      purpose: 'spend',
-      scriptHash: '67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656'
+      purpose: 'spend'
     }
   ],
   signatures: {}
@@ -205,13 +205,13 @@ export const certificate = {
 };
 
 export const redeemer = {
+  data: '67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656',
   executionUnits: {
     memory: 0,
     steps: 0
   },
   index: 0,
-  purpose: 'spend',
-  scriptHash: '67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656'
+  purpose: 'spend'
 };
 
 export const tx = [

--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -350,11 +350,11 @@ export const nativeScript = (script: CML.NativeScript): Cardano.NativeScript =>
         }
         break;
       }
-      case Cardano.NativeScriptKind.RequireMOf: {
+      case Cardano.NativeScriptKind.RequireNOf: {
         const scriptMofK = scope.manage(script.as_script_n_of_k());
         coreScript = {
           __type: Cardano.ScriptType.Native,
-          kind: Cardano.NativeScriptKind.RequireMOf,
+          kind: Cardano.NativeScriptKind.RequireNOf,
           required: scriptMofK!.n(),
           scripts: new Array<Cardano.NativeScript>()
         };

--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -187,10 +187,10 @@ export const txWitnessRedeemers = (redeemers?: CML.Redeemers): Cardano.Redeemer[
       const redeemerTagKind = scope.manage(reedeemer.tag()).kind();
 
       result.push({
+        data: Cardano.util.HexBlob(Buffer.from(data.to_bytes()).toString()),
         executionUnits: { memory: Number(scope.manage(exUnits.mem())), steps: Number(scope.manage(exUnits.steps())) },
         index: Number(index),
-        purpose: Object.values(Cardano.RedeemerPurpose)[redeemerTagKind],
-        scriptHash: Cardano.util.Hash28ByteBase16(Buffer.from(data.to_bytes()).toString())
+        purpose: Object.values(Cardano.RedeemerPurpose)[redeemerTagKind]
       });
     }
     return result;

--- a/packages/core/src/CML/coreToCml/coreToCml.ts
+++ b/packages/core/src/CML/coreToCml/coreToCml.ts
@@ -375,13 +375,13 @@ export const txBody = (
       txInputs(scope, inputs),
       cslOutputs,
       scope.manage(BigNum.from_str(fee.toString())),
-      BigNum.from_str(validityInterval.invalidHereafter ? validityInterval.invalidHereafter.toString() : '0')
+      BigNum.from_str(validityInterval?.invalidHereafter ? validityInterval.invalidHereafter.toString() : '0')
     )
   );
 
-  if (validityInterval.invalidBefore) {
+  if (validityInterval?.invalidBefore) {
     cslBody.set_validity_start_interval(
-      BigNum.from_str(validityInterval.invalidBefore ? validityInterval.invalidBefore.toString() : '0')
+      BigNum.from_str(validityInterval?.invalidBefore ? validityInterval.invalidBefore.toString() : '0')
     );
   }
   if (mint) {

--- a/packages/core/src/CML/coreToCml/coreToCml.ts
+++ b/packages/core/src/CML/coreToCml/coreToCml.ts
@@ -236,7 +236,7 @@ export const nativeScript = (scope: ManagedFreeableScope, script: Cardano.Native
       cslScript = scope.manage(NativeScript.new_script_any(scope.manage(ScriptAny.new(cslScripts2))));
       break;
     }
-    case Cardano.NativeScriptKind.RequireMOf: {
+    case Cardano.NativeScriptKind.RequireNOf: {
       const cslScripts3 = scope.manage(NativeScripts.new());
       for (const subscript of script.scripts) {
         cslScripts3.add(nativeScript(scope, subscript));

--- a/packages/core/src/Cardano/types/Script.ts
+++ b/packages/core/src/Cardano/types/Script.ts
@@ -18,7 +18,7 @@ export enum NativeScriptKind {
   RequireSignature = 0,
   RequireAllOf = 1,
   RequireAnyOf = 2,
-  RequireMOf = 3,
+  RequireNOf = 3,
   RequireTimeAfter = 4,
   RequireTimeBefore = 5
 }
@@ -114,7 +114,7 @@ export interface RequireAtLeastScript {
   /**
    * The native script kind.
    */
-  kind: NativeScriptKind.RequireMOf;
+  kind: NativeScriptKind.RequireNOf;
 }
 
 /**

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AuxiliaryData } from './AuxiliaryData';
-import { Base64Blob, Hash28ByteBase16, Hash32ByteBase16, HexBlob, OpaqueString, typedHex } from '../util/primitives';
+import { Base64Blob, Hash32ByteBase16, HexBlob, OpaqueString, typedHex } from '../util/primitives';
 import { Certificate } from './Certificate';
 import { Datum, Script } from './Script';
 import { Ed25519KeyHash, Ed25519PublicKey } from './Key';
@@ -66,7 +66,7 @@ export enum RedeemerPurpose {
 export interface Redeemer {
   index: number;
   purpose: RedeemerPurpose;
-  scriptHash: Hash28ByteBase16;
+  data: HexBlob;
   executionUnits: ExUnits;
 }
 

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -43,7 +43,7 @@ export interface HydratedTxBody {
   collaterals?: HydratedTxIn[];
   outputs: TxOut[];
   fee: Lovelace;
-  validityInterval: ValidityInterval;
+  validityInterval?: ValidityInterval;
   withdrawals?: Withdrawal[];
   certificates?: Certificate[];
   mint?: TokenMap;

--- a/packages/core/src/Cardano/util/primitives.ts
+++ b/packages/core/src/Cardano/util/primitives.ts
@@ -107,6 +107,13 @@ export const HexBlob = (target: string): HexBlob => typedHex(target);
 HexBlob.fromBytes = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex') as unknown as HexBlob;
 
 /**
+ * Converts a base64 string into a hex (base16) encoded string.
+ *
+ * @param rawData The base64 encoded string.
+ */
+HexBlob.fromBase64 = (rawData: string) => Buffer.from(rawData, 'base64').toString('hex') as unknown as HexBlob;
+
+/**
  * Converts a hex string into a typed bech32 encoded string.
  *
  * @param prefix The prefix of the bech32 string.

--- a/packages/core/test/CML/coreToCml.test.ts
+++ b/packages/core/test/CML/coreToCml.test.ts
@@ -108,9 +108,9 @@ describe('coreToCml', () => {
     expect(Buffer.from(scope.manage(input0.transaction_id()).to_bytes()).toString('hex')).toBe(txBody.inputs[0].txId);
     expect(output0AmountCoin.to_str()).toBe(txBody.outputs[0].value.coins.toString());
     expect(Number(scope.manage(cmlBody.validity_start_interval())?.to_str())).toBe(
-      txBody.validityInterval.invalidBefore
+      txBody.validityInterval!.invalidBefore
     );
-    expect(Number(scope.manage(cmlBody.ttl())?.to_str())).toBe(txBody.validityInterval.invalidHereafter);
+    expect(Number(scope.manage(cmlBody.ttl())?.to_str())).toBe(txBody.validityInterval!.invalidHereafter);
     expect(withdrawal0!.to_str()).toBe(txBody.withdrawals![0].quantity.toString());
     const mint = scope.manage(cmlBody.multiassets())!;
     const scriptHashes = scope.manage(mint.keys());

--- a/packages/core/test/Cardano/util/primitives.test.ts
+++ b/packages/core/test/Cardano/util/primitives.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /* eslint-disable sonarjs/no-duplicate-string */
 import {
   Base64Blob,
@@ -100,6 +101,15 @@ describe('Cardano.util/primitives', () => {
 
     it('fromBytes converts byte array into HexBlob', () => {
       expect(HexBlob.fromBytes(new Uint8Array([112]))).toEqual('70');
+    });
+
+    it('fromBase64 converts a base64 encoded string into HexBlob', () => {
+      const base64String = 'o+KixEeK/nzXNPpZPOM/BoQSVWVtwx06z/SIhM6UeNVjFN1rqHKN5BdBOnmKtuh/aF+5F/gwCzl3KPCGMcFuOQ==';
+      const expectedHexString =
+        'a3e2a2c4478afe7cd734fa593ce33f06841255656dc31d3acff48884ce9478d56314dd6ba8728de417413a798ab6e87f685fb917f8300b397728f08631c16e39';
+      const hexString = HexBlob.fromBase64(base64String);
+      expect(hexString).toEqual(expectedHexString);
+      expect(hexString).toHaveLength(128);
     });
   });
 

--- a/packages/ogmios/src/ogmiosToCore/block.ts
+++ b/packages/ogmios/src/ogmiosToCore/block.ts
@@ -115,8 +115,8 @@ const mapByronBlock = (block: Schema.StandardBlock): Cardano.Block => ({
   vrf: undefined // no vrf key for byron. DbSync doesn't have one either
 });
 
-const mapCommonBlock = (block: CommonBlock): Cardano.Block => ({
-  body: mapCommonBlockBody(block),
+const mapCommonBlock = (block: CommonBlock, kind: BlockKind): Cardano.Block => ({
+  body: mapCommonBlockBody(block, kind),
   fees: mapCommonFees(block),
   header: mapCommonBlockHeader(block),
   issuerVk: mapCommonSlotLeader(block),
@@ -130,7 +130,7 @@ const mapCommonBlock = (block: CommonBlock): Cardano.Block => ({
 const mapBlock = <R>(
   ogmiosBlock: Schema.Block,
   mapStandardBlock: (b: Schema.StandardBlock) => R,
-  mapOtherBlock: (b: CommonBlock) => R
+  mapOtherBlock: (b: CommonBlock, k: BlockKind) => R
 ) => {
   const b = getBlockAndKind(ogmiosBlock);
   if (!b) return null;
@@ -144,7 +144,7 @@ const mapBlock = <R>(
     case 'alonzo':
     case 'mary':
     case 'shelley': {
-      return mapOtherBlock(b.block);
+      return mapOtherBlock(b.block, b.kind);
     }
     default: {
       // eslint-disable-next-line sonarjs/prefer-immediate-return
@@ -162,7 +162,7 @@ const mapBlock = <R>(
  *   - `null` if `block` is the ByronEpochBoundaryBlock. This block can be skipped.
  */
 export const blockHeader = (ogmiosBlock: Schema.Block): Cardano.PartialBlockHeader | null =>
-  mapBlock(ogmiosBlock, mapStandardBlockHeader, mapCommonBlockHeader);
+  mapBlock<Cardano.PartialBlockHeader>(ogmiosBlock, mapStandardBlockHeader, mapCommonBlockHeader);
 
 /**
  * Translate `Ogmios` block to `Cardano.BlockMinimal`
@@ -173,6 +173,6 @@ export const blockHeader = (ogmiosBlock: Schema.Block): Cardano.PartialBlockHead
  *   - `null` if `block` is the ByronEpochBoundaryBlock. This block can be skipped.
  */
 export const block = (ogmiosBlock: Schema.Block): Cardano.Block | null =>
-  mapBlock(ogmiosBlock, mapByronBlock, mapCommonBlock);
+  mapBlock<Cardano.Block>(ogmiosBlock, mapByronBlock, mapCommonBlock);
 
 // byron-shelley-allegra-mary-alonzo-babbage

--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -221,10 +221,10 @@ const mapRedeemer = (key: string, redeemer: Schema.Redeemer): Cardano.Redeemer =
   const purposeAndIndex = key.split(':');
 
   return {
+    data: Cardano.util.HexBlob(redeemer.redeemer),
     executionUnits: redeemer.executionUnits,
     index: Number(purposeAndIndex[1]),
-    purpose: purposeAndIndex[0] as Cardano.RedeemerPurpose,
-    scriptHash: Cardano.util.Hash28ByteBase16(redeemer.redeemer)
+    purpose: purposeAndIndex[0] as Cardano.RedeemerPurpose
   };
 };
 

--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -1,11 +1,32 @@
-import { Cardano, NotImplementedError, addressNetworkId, createRewardAccount } from '@cardano-sdk/core';
-import { CommonBlock } from './types';
+/* eslint-disable max-len */
+import {
+  BYRON_TX_FEE_COEFFICIENT,
+  BYRON_TX_FEE_CONSTANT,
+  isAlonzoOrAbove,
+  isExpiresAt,
+  isMaryOrAbove,
+  isNativeScript,
+  isPlutusV1Script,
+  isPlutusV2Script,
+  isRequireAllOf,
+  isRequireAnyOf,
+  isRequireNOf,
+  isShelleyTx,
+  isStartsAt
+} from './util';
+import { BlockKind, CommonBlock } from './types';
+import {
+  Cardano,
+  NotImplementedError,
+  ProviderUtil,
+  SerializationError,
+  SerializationFailure,
+  addressNetworkId,
+  createRewardAccount
+} from '@cardano-sdk/core';
 import { Schema } from '@cardano-ogmios/client';
 import Fraction from 'fraction.js';
 import omit from 'lodash/omit';
-
-// TODO: implement byron block body mapping
-export const mapByronBlockBody = (_: Schema.BlockByron): Cardano.Block['body'] => [];
 
 const mapMargin = (margin: string): Cardano.Fraction => {
   const { n: numerator, d: denominator } = new Fraction(margin);
@@ -109,12 +130,221 @@ const mapCertificate = (certificate: Schema.Certificate): Cardano.Certificate =>
   throw new NotImplementedError('Unknown certificate mapping');
 };
 
-// TODO: implement full block body mapping
-const mapCommonTx = (tx: CommonBlock['body'][0]): Cardano.Tx =>
-  ({
-    body: {
-      certificates: tx.body.certificates.map(mapCertificate)
-    } as Cardano.TxBody
-  } as Cardano.Tx);
+export const nativeScript = (script: Schema.ScriptNative): Cardano.NativeScript => {
+  let coreScript: Cardano.NativeScript;
 
-export const mapCommonBlockBody = ({ body }: CommonBlock): Cardano.Block['body'] => body.map(mapCommonTx);
+  if (typeof script === 'string') {
+    coreScript = {
+      __type: Cardano.ScriptType.Native,
+      keyHash: Cardano.Ed25519KeyHash(script),
+      kind: Cardano.NativeScriptKind.RequireSignature
+    };
+  } else if (isRequireAllOf(script)) {
+    coreScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireAllOf,
+      scripts: new Array<Cardano.NativeScript>()
+    };
+    for (let i = 0; i < script.all.length; ++i) {
+      coreScript.scripts.push(nativeScript(script.all[i]));
+    }
+  } else if (isRequireAnyOf(script)) {
+    coreScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireAnyOf,
+      scripts: new Array<Cardano.NativeScript>()
+    };
+    for (let i = 0; i < script.any.length; ++i) {
+      coreScript.scripts.push(nativeScript(script.any[i]));
+    }
+  } else if (isRequireNOf(script)) {
+    const required = Number.parseInt(Object.keys(script)[0]);
+    coreScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireNOf,
+      required,
+      scripts: new Array<Cardano.NativeScript>()
+    };
+
+    for (let i = 0; i < script[required].length; ++i) {
+      coreScript.scripts.push(nativeScript(script[required][i]));
+    }
+  } else if (isExpiresAt(script)) {
+    coreScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireTimeBefore,
+      slot: Cardano.Slot(script.expiresAt)
+    };
+  } else if (isStartsAt(script)) {
+    coreScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireTimeAfter,
+      slot: Cardano.Slot(script.startsAt)
+    };
+  } else {
+    throw new SerializationError(
+      SerializationFailure.InvalidNativeScriptKind,
+      `Native Script value '${script}' is not supported.`
+    );
+  }
+
+  return coreScript;
+};
+
+const mapPlutusScript = (script: Schema.PlutusV1 | Schema.PlutusV2): Cardano.PlutusScript => {
+  const version = isPlutusV1Script(script) ? Cardano.PlutusLanguageVersion.V1 : Cardano.PlutusLanguageVersion.V2;
+  const plutusScript = isPlutusV1Script(script) ? script['plutus:v1'] : script['plutus:v2'];
+  return {
+    __type: Cardano.ScriptType.Plutus,
+    bytes: Cardano.util.HexBlob(plutusScript),
+    version
+  };
+};
+
+export const mapScript = (script: Schema.Script): Cardano.Script => {
+  if (isNativeScript(script)) {
+    return nativeScript(script.native);
+  } else if (isPlutusV1Script(script) || isPlutusV2Script(script)) return mapPlutusScript(script);
+
+  throw new SerializationError(SerializationFailure.InvalidScriptType, `Script '${script}' is not supported.`);
+};
+
+const mapBootstrapWitness = (b: Schema.BootstrapWitness): Cardano.BootstrapWitness => ({
+  // Based on the Ogmios maintainer answer  https://github.com/CardanoSolutions/ogmios/discussions/285#discussioncomment-4271726
+  addressAttributes: b.addressAttributes ? Cardano.util.Base64Blob(b.addressAttributes) : undefined,
+  chainCode: b.chainCode ? Cardano.util.HexBlob(b.chainCode) : undefined,
+  key: Cardano.Ed25519PublicKey(b.key!),
+  signature: Cardano.Ed25519Signature(Cardano.util.HexBlob.fromBase64(b.signature!).toString())
+});
+
+const mapRedeemer = (key: string, redeemer: Schema.Redeemer): Cardano.Redeemer => {
+  const purposeAndIndex = key.split(':');
+
+  return {
+    executionUnits: redeemer.executionUnits,
+    index: Number(purposeAndIndex[1]),
+    purpose: purposeAndIndex[0] as Cardano.RedeemerPurpose,
+    scriptHash: Cardano.util.Hash28ByteBase16(redeemer.redeemer)
+  };
+};
+
+const mapAuxiliaryData = (data: Schema.AuxiliaryData | null): Cardano.AuxiliaryData | undefined => {
+  if (data === null) return undefined;
+
+  return {
+    body: {
+      blob: data.body.blob
+        ? new Map(
+            Object.entries(data.body.blob).map(([key, value]) => [BigInt(key), ProviderUtil.jsonToMetadatum(value)])
+          )
+        : undefined,
+      scripts: data.body.scripts ? data.body.scripts.map(mapScript) : undefined
+    },
+    hash: Cardano.util.Hash32ByteBase16(data.hash)
+  };
+};
+
+const mapTxIn = (txIn: Schema.TxIn): Cardano.TxIn => ({
+  index: txIn.index,
+  txId: Cardano.TransactionId(txIn.txId)
+});
+
+const mapDatum = (datum: Schema.TxOut['datum']) => {
+  if (!datum) return;
+  if (typeof datum === 'string') return Cardano.util.Hash32ByteBase16(datum);
+  if (typeof datum === 'object') return Cardano.util.Hash32ByteBase16(JSON.stringify(datum));
+};
+
+const mapTxOut = (txOut: Schema.TxOut): Cardano.TxOut => ({
+  address: Cardano.Address(txOut.address),
+  datum: mapDatum(txOut.datum),
+  value: {
+    assets: txOut.value.assets
+      ? new Map(Object.entries(txOut.value.assets).map(([key, value]) => [Cardano.AssetId(key), value]))
+      : undefined,
+    coins: txOut.value.coins
+  }
+});
+
+const mapMint = (tx: Schema.TxMary): Cardano.TokenMap | undefined => {
+  if (tx.body.mint.assets === undefined) return undefined;
+  return new Map(Object.entries(tx.body.mint.assets).map(([key, value]) => [Cardano.AssetId(key), value]));
+};
+
+const mapScriptIntegrityHash = ({
+  body: { scriptIntegrityHash }
+}: Schema.TxAlonzo): Cardano.util.Hash32ByteBase16 | undefined => {
+  if (scriptIntegrityHash === null) return undefined;
+  return Cardano.util.Hash32ByteBase16(scriptIntegrityHash);
+};
+
+const mapValidityInterval = ({
+  invalidBefore,
+  invalidHereafter
+}: Schema.ValidityInterval): Cardano.ValidityInterval => ({
+  invalidBefore: invalidBefore ? Cardano.Slot(invalidBefore) : undefined,
+  invalidHereafter: invalidHereafter ? Cardano.Slot(invalidHereafter) : undefined
+});
+
+const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.Tx => ({
+  auxiliaryData: mapAuxiliaryData(tx.metadata),
+  body: {
+    certificates: tx.body.certificates.map(mapCertificate),
+    collaterals: isAlonzoOrAbove(kind) ? (tx as Schema.TxAlonzo).body.collaterals.map(mapTxIn) : undefined,
+    fee: tx.body.fee,
+    inputs: tx.body.inputs.map(mapTxIn),
+    mint: isMaryOrAbove(kind) ? mapMint(tx as Schema.TxMary) : undefined,
+    outputs: tx.body.outputs.map(mapTxOut),
+    requiredExtraSignatures: isAlonzoOrAbove(kind)
+      ? (tx as Schema.TxAlonzo).body.requiredExtraSignatures.map(Cardano.Ed25519KeyHash)
+      : undefined,
+    scriptIntegrityHash: isAlonzoOrAbove(kind) ? mapScriptIntegrityHash(tx as Schema.TxAlonzo) : undefined,
+    validityInterval: isShelleyTx(kind)
+      ? undefined
+      : mapValidityInterval((tx as Schema.TxAlonzo).body.validityInterval),
+    withdrawals: Object.entries(tx.body.withdrawals).map(([key, value]) => ({
+      quantity: value,
+      stakeAddress: Cardano.RewardAccount(key)
+    }))
+  },
+  id: Cardano.TransactionId(tx.id),
+  witness: {
+    bootstrap: tx.witness.bootstrap.map(mapBootstrapWitness),
+    datums: isAlonzoOrAbove(kind)
+      ? Object.values((tx as Schema.TxAlonzo).witness.datums).map((d) => Cardano.util.HexBlob(d))
+      : undefined,
+    redeemers: isAlonzoOrAbove(kind)
+      ? Object.entries((tx as Schema.TxAlonzo).witness.redeemers).map(([key, value]) => mapRedeemer(key, value))
+      : undefined,
+    scripts: [...Object.values(tx.witness.scripts).map(mapScript)],
+    signatures: new Map(
+      Object.entries(tx.witness.signatures).map(([key, value]) => [
+        Cardano.Ed25519PublicKey(key),
+        Cardano.Ed25519Signature(Cardano.util.HexBlob.fromBase64(value).toString())
+      ])
+    )
+  }
+});
+
+export const mapCommonBlockBody = ({ body }: CommonBlock, kind: BlockKind): Cardano.Block['body'] =>
+  body.map((blockBody) => mapCommonTx(blockBody, kind));
+
+export const mapByronTxFee = ({ raw }: Schema.TxByron) => {
+  const txSize = Buffer.from(Cardano.util.Base64Blob(raw).toString(), 'base64').length;
+  return BigInt(BYRON_TX_FEE_COEFFICIENT * txSize + BYRON_TX_FEE_CONSTANT);
+};
+
+const mapByronTx = (tx: Schema.TxByron): Cardano.Tx => ({
+  body: {
+    fee: mapByronTxFee(tx),
+    inputs: tx.body.inputs.map(mapTxIn),
+    outputs: tx.body.outputs.map(mapTxOut)
+  },
+  id: Cardano.TransactionId(tx.id),
+  witness: {
+    signatures: new Map()
+  }
+});
+
+export const mapByronBlockBody = ({ body }: Schema.StandardBlock): Cardano.Block['body'] =>
+  body.txPayload.map((txPayload) => mapByronTx(txPayload));

--- a/packages/ogmios/src/ogmiosToCore/util.ts
+++ b/packages/ogmios/src/ogmiosToCore/util.ts
@@ -1,0 +1,32 @@
+import { BlockKind } from './types';
+import { Schema } from '@cardano-ogmios/client';
+
+export const BYRON_TX_FEE_COEFFICIENT = 43_946_000_000;
+export const BYRON_TX_FEE_CONSTANT = 155_381_000_000_000;
+
+export const isNativeScript = (script: Schema.Script): script is Schema.Native => 'native' in script;
+
+export const isPlutusV1Script = (script: Schema.Script): script is Schema.PlutusV1 => 'plutus:v1' in script;
+
+export const isPlutusV2Script = (script: Schema.Script): script is Schema.PlutusV2 => 'plutus:v2' in script;
+
+export const isRequireAllOf = (nativeScript: Schema.ScriptNative): nativeScript is Schema.All =>
+  typeof nativeScript === 'object' && 'all' in nativeScript;
+
+export const isRequireAnyOf = (nativeScript: Schema.ScriptNative): nativeScript is Schema.Any =>
+  typeof nativeScript === 'object' && 'any' in nativeScript;
+
+export const isExpiresAt = (nativeScript: Schema.ScriptNative): nativeScript is Schema.ExpiresAt =>
+  typeof nativeScript === 'object' && 'expiresAt' in nativeScript;
+
+export const isStartsAt = (nativeScript: Schema.ScriptNative): nativeScript is Schema.StartsAt =>
+  typeof nativeScript === 'object' && 'startsAt' in nativeScript;
+
+export const isRequireNOf = (nativeScript: Schema.ScriptNative): nativeScript is Schema.NOf =>
+  typeof nativeScript === 'object' && !Number.isNaN(Number(Object.keys(nativeScript)[0]));
+
+export const isAlonzoOrAbove = (kind: BlockKind) => kind === 'babbage' || kind === 'alonzo';
+
+export const isMaryOrAbove = (kind: BlockKind) => isAlonzoOrAbove(kind) || kind === 'mary';
+
+export const isShelleyTx = (kind: BlockKind) => kind === 'shelley';

--- a/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
+++ b/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
@@ -1,0 +1,842 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ogmiosToCore block can translate from allegra block 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "auxiliaryData": Object {
+        "body": Object {
+          "blob": Map {
+            2n => Map {
+              "list" => Array [
+                Map {
+                  "int" => 9798604473814314674n,
+                },
+                Map {
+                  "bytes" => "7a43",
+                },
+              ],
+            },
+          },
+          "scripts": Array [
+            Object {
+              "__type": "native",
+              "keyHash": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
+              "kind": 0,
+            },
+            Object {
+              "__type": "native",
+              "keyHash": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+              "kind": 0,
+            },
+            Object {
+              "__type": "native",
+              "kind": 1,
+              "scripts": Array [
+                Object {
+                  "__type": "native",
+                  "kind": 2,
+                  "scripts": Array [],
+                },
+                Object {
+                  "__type": "native",
+                  "keyHash": "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7",
+                  "kind": 0,
+                },
+                Object {
+                  "__type": "native",
+                  "kind": 2,
+                  "scripts": Array [
+                    Object {
+                      "__type": "native",
+                      "kind": 5,
+                      "slot": 15272,
+                    },
+                  ],
+                },
+                Object {
+                  "__type": "native",
+                  "kind": 4,
+                  "slot": 44521,
+                },
+                Object {
+                  "__type": "native",
+                  "kind": 4,
+                  "slot": 91998,
+                },
+              ],
+            },
+          ],
+        },
+        "hash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+      },
+      "body": Object {
+        "certificates": Array [],
+        "collaterals": undefined,
+        "fee": 724n,
+        "inputs": Array [
+          Object {
+            "index": 2,
+            "txId": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+          },
+        ],
+        "mint": undefined,
+        "outputs": Array [],
+        "requiredExtraSignatures": undefined,
+        "scriptIntegrityHash": undefined,
+        "validityInterval": Object {
+          "invalidBefore": undefined,
+          "invalidHereafter": 79985,
+        },
+        "withdrawals": Array [],
+      },
+      "id": "8ba812bad0c356ec842365720acb4a4ea18f03d40b03ad1cc785426170d542f5",
+      "witness": Object {
+        "bootstrap": Array [
+          Object {
+            "addressAttributes": "Sn5kyQ==",
+            "chainCode": "beba7627",
+            "key": "e731d1871cc922f6dac49e3130c03fdd706c565e2c9d64c02b6e5a9a5239ba67",
+            "signature": "6f737771796d78737765796e6377626864696e7a677967686163647365616a756d756f747474796f68696275626e6374747a6e65756b67676c6d6a766975696f",
+          },
+          Object {
+            "addressAttributes": "dFA=",
+            "chainCode": undefined,
+            "key": "f0f5ffa432e7936e1f47092aa805ad34f198bd2b00bafb1950b41dc864b47874",
+            "signature": "6975736274637a77706a69617a61696f6a62796a64787364666a746979686976676a78657872776765717763666f6c6661766279626f74766579626d656b6f6c",
+          },
+          Object {
+            "addressAttributes": undefined,
+            "chainCode": "06777003",
+            "key": "501d21a038832a37d1d1cec177697adb498954e3fa4315498108c9ca48d0e51b",
+            "signature": "10f6d6cd30b46e5eee1abf97c67cf426e2376ac410945c101823f3b3b289fea4229ae524993f3755cbf3ae69949272c4613a033ab525f7d65a0fc8569f5f9578",
+          },
+          Object {
+            "addressAttributes": "Mw==",
+            "chainCode": "82",
+            "key": "b99abe31700f07caa60b1ac6f7f55f00e5c926dea06c02451a88eefe9e81a2fa",
+            "signature": "646f736e7a6a69767469656b6c6b75746662687572707762636a616c7463657769616c6a75746573616f7461617a6d7a7576707562716561757471626e6f7465",
+          },
+          Object {
+            "addressAttributes": "LA==",
+            "chainCode": "cc",
+            "key": "cfb0a988516364010755fe4b00982dd37cc678fad4fe67bbf7b8ff85af2da478",
+            "signature": "c0c3181155255a3fa7af837fd91a599a1c5434381e6a38239b2660f22bc7b37882df576c807bbd385275b56647c706b24fc9d6b520083c4f865bd4f4b6b16079",
+          },
+        ],
+        "datums": undefined,
+        "redeemers": undefined,
+        "scripts": Array [],
+        "signatures": Map {
+          "0c6be66a669a7e598d49bac208a3760f702ed2f59369f4efbf4bef3e25a99428" => "52839a987d9d301a0fe1319f2c2b47fdef94796b67400ac61752708934c4ff6378a5d0bc6803fea63f5073e9a7f830eb3f4f8631ad8e10fe63f8eb19eae3caf1",
+          "88d69c23b54b27f253aa51971458bd21b5d700a91f02fea2373bf76e69d33ac1" => "b7a3e4bbf2435b31b7546f7e2173b48a241600f2533c6214518b24f6bf8dcdd7a359ebc91ae5cee218b423b9beaa1251aec6a7fca46661823b8faec73e1eb982",
+        },
+      },
+    },
+  ],
+  "fees": 724n,
+  "header": Object {
+    "blockNo": 13,
+    "hash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+    "slot": 9,
+  },
+  "issuerVk": "60337a64656bf2646f66c90ab4a546bbf3c3f5f8f00bf06fcc1d9f7d01d924f6",
+  "previousBlock": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+  "size": 503,
+  "totalOutput": 0n,
+  "txCount": 1,
+  "vrf": "vrf_vk1njzx6395znzy6p7ene2dqw7y77rq4zfaepyw2v6megqnuhepmfgqkg07xz",
+}
+`;
+
+exports[`ogmiosToCore block can translate from alonzo block 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "auxiliaryData": Object {
+        "body": Object {
+          "blob": Map {
+            674n => Map {
+              "map" => Array [
+                Map {
+                  "k" => Map {
+                    "string" => "msg",
+                  },
+                  "v" => Map {
+                    "list" => Array [
+                      Map {
+                        "string" => "Auto-Loop-Transaction #338666 by ATADA",
+                      },
+                      Map {
+                        "string" => "",
+                      },
+                      Map {
+                        "string" => "Live Epoch 16, we have 061h 17m 32s left until the next one",
+                      },
+                      Map {
+                        "string" => "It's Montag - 22 August 2022 - 12:42:28 in Austria",
+                      },
+                      Map {
+                        "string" => "",
+                      },
+                      Map {
+                        "string" => "📈 The current ADA Price on Kraken is: $0.451502 / ADA",
+                      },
+                      Map {
+                        "string" => "",
+                      },
+                      Map {
+                        "string" => "A random Zen-Quote for you: 🙏",
+                      },
+                      Map {
+                        "string" => "There are three classes of people: those who see. Those who see",
+                      },
+                      Map {
+                        "string" => "when they are shown. Those who do not see. - Leonardo da Vinci",
+                      },
+                      Map {
+                        "string" => "",
+                      },
+                      Map {
+                        "string" => "Node-Revision: 950c4e222086fed5ca53564e642434ce9307b0b9",
+                      },
+                      Map {
+                        "string" => "",
+                      },
+                      Map {
+                        "string" => "PreProd-Chain is awesome, have some fun! 😍",
+                      },
+                      Map {
+                        "string" => " Best regards, Martin :-)",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          "scripts": Array [],
+        },
+        "hash": "0ad6d4a6e10182157142994b2cce2aebee9406e3e2be31bfb1574ed2409a71dc",
+      },
+      "body": Object {
+        "certificates": Array [
+          Object {
+            "__typename": "StakeDelegationCertificate",
+            "poolId": "pool15erywju02scjv9gxkmp885c8catf5n4ke9459h2299fq57u9c3e",
+            "stakeKeyHash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+          },
+          Object {
+            "__typename": "StakeKeyDeregistrationCertificate",
+            "stakeKeyHash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+          },
+          Object {
+            "__typename": "PoolRetirementCertificate",
+            "epoch": 123,
+            "poolId": "pool15erywju02scjv9gxkmp885c8catf5n4ke9459h2299fq57u9c3e",
+          },
+          Object {
+            "__typename": "GenesisKeyDelegationCertificate",
+            "genesisDelegateHash": "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541",
+            "genesisHash": "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5",
+            "vrfKeyHash": "95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3",
+          },
+        ],
+        "collaterals": Array [],
+        "fee": 202549n,
+        "inputs": Array [
+          Object {
+            "index": 0,
+            "txId": "1a3380c51384d151b876de02b7a4c5ca7eda7b1d1d744660aee4647516fd9a81",
+          },
+          Object {
+            "index": 1,
+            "txId": "1a3380c51384d151b876de02b7a4c5ca7eda7b1d1d744660aee4647516fd9a81",
+          },
+        ],
+        "mint": undefined,
+        "outputs": Array [
+          Object {
+            "address": "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc",
+            "datum": undefined,
+            "value": Object {
+              "assets": Map {},
+              "coins": 999978n,
+            },
+          },
+          Object {
+            "address": "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc",
+            "datum": undefined,
+            "value": Object {
+              "assets": Map {},
+              "coins": 8286924731n,
+            },
+          },
+        ],
+        "requiredExtraSignatures": Array [],
+        "scriptIntegrityHash": undefined,
+        "validityInterval": Object {
+          "invalidBefore": undefined,
+          "invalidHereafter": 5581748,
+        },
+        "withdrawals": Array [],
+      },
+      "id": "bb81604e09c4530ad02de6b80a0c13d82949fb307402dd0c2b447e211bdc621d",
+      "witness": Object {
+        "bootstrap": Array [],
+        "datums": Array [],
+        "redeemers": Array [],
+        "scripts": Array [],
+        "signatures": Map {
+          "742d8af3543349b5b18f3cba28f23b2d6e465b9c136c42e1fae6b2390f565427" => "484d0c242bc240163a1ac84568fbf870d83cfff72c2532c2acb51d12a222ba6e7b6333c88123ee6e04ca78c3c61c2d5932ea2062c59093a95fcc4c35c3413206",
+        },
+      },
+    },
+  ],
+  "fees": 202549n,
+  "header": Object {
+    "blockNo": 100000,
+    "hash": "514f8be63ef25c46bee47a90658977f815919c06222c0b480be1e29efbd72c49",
+    "slot": 5481752,
+  },
+  "issuerVk": "a9d974fd26bfaf385749113f260271430276bed6ef4dad6968535de6778471ce",
+  "previousBlock": "518a24a3fb0cc6ee1a31668a63994e4dbda70ede5ff13be494a3b4c1bb7709c8",
+  "size": 836,
+  "totalOutput": 8287924709n,
+  "txCount": 1,
+  "vrf": "vrf_vk1p8s5ysf7dgsvfrw0p0q7zczdytkxc95zsq3p9sfshk9s3z86jfdql5fdft",
+}
+`;
+
+exports[`ogmiosToCore block can translate from babbage block 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "auxiliaryData": Object {
+        "body": Object {
+          "blob": Map {
+            2n => Map {
+              "string" => "",
+            },
+          },
+          "scripts": Array [
+            Object {
+              "__type": "native",
+              "kind": 4,
+              "slot": 63725,
+            },
+          ],
+        },
+        "hash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+      },
+      "body": Object {
+        "certificates": Array [
+          Object {
+            "__typename": "MirCertificate",
+            "pot": "reserve",
+            "quantity": 712n,
+          },
+          Object {
+            "__typename": "PoolRegistrationCertificate",
+            "poolParameters": Object {
+              "cost": 290n,
+              "id": "pool1kkhxvw4w4rjsq9tmma964lt0twsvu46e7lx5zq0uzvh4ge9n0hc",
+              "margin": Object {
+                "denominator": 2,
+                "numerator": 1,
+              },
+              "metadataJson": Object {
+                "hash": "2738e2233800ab7f82bd2212a9a55f52d4851f9147f161684c63e6655bedb562",
+                "url": "https://public.bladepool.com/metadata.json",
+              },
+              "owners": Array [],
+              "pledge": 229n,
+              "relays": Array [
+                Object {
+                  "__typename": "RelayByAddress",
+                  "ipv4": "192.0.2.1",
+                  "ipv6": "2001:db8::1",
+                  "port": undefined,
+                },
+                Object {
+                  "__typename": "RelayByName",
+                  "hostname": "foo.example.com",
+                  "port": undefined,
+                },
+              ],
+              "rewardAccount": "stake_test1urs2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sgcp89zz",
+              "vrf": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+            },
+          },
+        ],
+        "collaterals": Array [
+          Object {
+            "index": 2,
+            "txId": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
+          },
+        ],
+        "fee": 58n,
+        "inputs": Array [],
+        "mint": Map {
+          "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4" => -1n,
+          "1d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4" => 2n,
+        },
+        "outputs": Array [
+          Object {
+            "address": "addr1vxnyv36t3a2rzfs4q6mvyu7nqlr4dxjwkmykkskafg54yzsv3uzfs",
+            "datum": undefined,
+            "value": Object {
+              "assets": Map {},
+              "coins": 2n,
+            },
+          },
+        ],
+        "requiredExtraSignatures": Array [
+          "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4",
+          "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+        ],
+        "scriptIntegrityHash": undefined,
+        "validityInterval": Object {
+          "invalidBefore": 78202,
+          "invalidHereafter": undefined,
+        },
+        "withdrawals": Array [
+          Object {
+            "quantity": 724n,
+            "stakeAddress": "stake1uxnyv36t3a2rzfs4q6mvyu7nqlr4dxjwkmykkskafg54yzssmuy4z",
+          },
+        ],
+      },
+      "id": "c32a4a4f5a4b540d4f79730ca0c658d9a8400be2173e0ba1dc8471004c1cb0db",
+      "witness": Object {
+        "bootstrap": Array [
+          Object {
+            "addressAttributes": undefined,
+            "chainCode": "4d",
+            "key": "de46fb9f52d8a229e3cedc60002564a3d23309dbf21dfaabd38485c4538419b2",
+            "signature": "3f6d08a1b7ab7818a78be8d48ea828b0e9976258a4ca38157f628fe4de1f326a4ef403c40d0348864de77259be9a5c606af20b29ebe7f6aeb594ac40177728aa",
+          },
+          Object {
+            "addressAttributes": "mQ==",
+            "chainCode": "20",
+            "key": "fc1a29ed3f0a4c1a4036298831ce117a23b6b714abba83d0a093d0839e193c39",
+            "signature": "3f1984ded5b35198bcfceaa4d5f44b26cb8e6aa59cde74e578b06f9351bdb17563162374f199980423e52dde6c8b7e42bf4ca120ddbf557241b9a59b730809fe",
+          },
+        ],
+        "datums": Array [],
+        "redeemers": Array [
+          Object {
+            "executionUnits": Object {
+              "memory": 6026711518256058000,
+              "steps": 4749668747002319000,
+            },
+            "index": 0,
+            "purpose": "spend",
+            "scriptHash": "034001ffa222234041b4d8668218da9f2341440302413eff4204e1a1",
+          },
+        ],
+        "scripts": Array [
+          Object {
+            "__type": "plutus",
+            "bytes": "46010000220011",
+            "version": 0,
+          },
+        ],
+        "signatures": Map {
+          "679b8abd1379729475da1c530dda8dc1bf9177eceae449a0a15e4f16f45399be" => "a3e2a2c4478afe7cd734fa593ce33f06841255656dc31d3acff48884ce9478d56314dd6ba8728de417413a798ab6e87f685fb917f8300b397728f08631c16e39",
+          "238287f3ea9a746513acbee2aeb1e980d9feead29bf8157b7756437ffbe8ee5b" => "1e639773425c0cfa6376d7326500efc574d9b87afba2296a4e12157ad83176ce7300600a921bed6087600b3a118ea905746a62cfe90649ea2aa00f46142aad7b",
+        },
+      },
+    },
+  ],
+  "fees": 58n,
+  "header": Object {
+    "blockNo": 4,
+    "hash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+    "slot": 6,
+  },
+  "issuerVk": "f6cc957f17046ce6de24c81d08e9381608ed1acc083284916252f76f65643eae",
+  "previousBlock": undefined,
+  "size": 2,
+  "totalOutput": 2n,
+  "txCount": 1,
+  "vrf": "vrf_vk1mdx46ssmatqxlp4uedjxlnvepts5l6kh20m2a6mtzu0ycnsergpq6653ra",
+}
+`;
+
+exports[`ogmiosToCore block can translate from byron block 1`] = `
+Object {
+  "body": Array [],
+  "fees": undefined,
+  "header": Object {
+    "blockNo": 42,
+    "hash": "5c3103bd0ff5ea85a62b202a1d2500cf3ebe0b9d793ed09e7febfe27ef12c968",
+    "slot": 77761,
+  },
+  "issuerVk": undefined,
+  "previousBlock": "dd8d7559a9b6c1177c0f5a328eb82967af68155d58cbcdc0a59de39a38aaf3f0",
+  "size": undefined,
+  "totalOutput": 0n,
+  "txCount": 0,
+  "vrf": undefined,
+}
+`;
+
+exports[`ogmiosToCore block can translate from mary block 1`] = `
+Object {
+  "body": Array [
+    Object {
+      "auxiliaryData": undefined,
+      "body": Object {
+        "certificates": Array [
+          Object {
+            "__typename": "StakeKeyRegistrationCertificate",
+            "stakeKeyHash": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
+          },
+          Object {
+            "__typename": "GenesisKeyDelegationCertificate",
+            "genesisDelegateHash": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+            "genesisHash": "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4",
+            "vrfKeyHash": "03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314",
+          },
+        ],
+        "collaterals": undefined,
+        "fee": 125n,
+        "inputs": Array [
+          Object {
+            "index": 0,
+            "txId": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
+          },
+        ],
+        "mint": Map {
+          "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a" => -1n,
+        },
+        "outputs": Array [
+          Object {
+            "address": "EqGAuA8vHnNpWh2vRvJSVMGRnu1r5SnDHJMQcHB1vbMSvMxgA8qwpMpsRJeSk2KaTZgJRTKwgDrLNaCQFVK1WisAZLVQ5oXZT6dqLDHDryZAkgwgZqf6S8x",
+            "datum": undefined,
+            "value": Object {
+              "assets": Map {},
+              "coins": 2n,
+            },
+          },
+        ],
+        "requiredExtraSignatures": undefined,
+        "scriptIntegrityHash": undefined,
+        "validityInterval": Object {
+          "invalidBefore": 30892,
+          "invalidHereafter": undefined,
+        },
+        "withdrawals": Array [
+          Object {
+            "quantity": 157n,
+            "stakeAddress": "stake1uyxefct5wvh0n2h88uu44dz9q7l6nq7k2q3uzx54ruxr9eq8cjal2",
+          },
+        ],
+      },
+      "id": "f138917a172058f68c93de999592c5fb7cafc9265add9723eb2e8b9c12654654",
+      "witness": Object {
+        "bootstrap": Array [
+          Object {
+            "addressAttributes": "/0dj0Q==",
+            "chainCode": "57d7",
+            "key": "35d259ed3ad32bda47b0bf2a4f049440f7c298e1c6919518b55cc75e26b06716",
+            "signature": "7169796f776a6c6875646f6768636d6270737a62626861696166747671626c6b7a7a6b6a65616272657a796563726e76746c6978776b6d776f6174706b647262",
+          },
+          Object {
+            "addressAttributes": "GJoe",
+            "chainCode": undefined,
+            "key": "ba1f868037ad35194f719fe964af14509cbf9f611a155a9d1a52aded9ab4ae02",
+            "signature": "290e11ae5da97c332b40aa5f9e649a42e65fa606d21735a58446443d88161c3e2f35d0302a30e1f0455ebd3dbcee12130899efea5c9db7b3d6a17f493d3304d6",
+          },
+          Object {
+            "addressAttributes": "+w==",
+            "chainCode": "336f",
+            "key": "035d0c6528fc5cf842615c5b32fa031b4a3999e9c9bc6c4435bece5bd3cffde5",
+            "signature": "61696e6e707579616a6c6b64747a77656d6178777a6964726d666c706c71797a78646b756579716a736d7170776b77646f7a706372676570697577746e687867",
+          },
+        ],
+        "datums": undefined,
+        "redeemers": undefined,
+        "scripts": Array [
+          Object {
+            "__type": "native",
+            "kind": 2,
+            "scripts": Array [
+              Object {
+                "__type": "native",
+                "kind": 5,
+                "slot": 14448,
+              },
+              Object {
+                "__type": "native",
+                "kind": 5,
+                "slot": 89513,
+              },
+              Object {
+                "__type": "native",
+                "kind": 3,
+                "required": 0,
+                "scripts": Array [],
+              },
+            ],
+          },
+        ],
+        "signatures": Map {},
+      },
+    },
+    Object {
+      "auxiliaryData": Object {
+        "body": Object {
+          "blob": Map {
+            1n => Map {
+              "int" => -16613019303347710699n,
+            },
+            2n => Map {
+              "bytes" => "6573",
+            },
+          },
+          "scripts": Array [],
+        },
+        "hash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
+      },
+      "body": Object {
+        "certificates": Array [
+          Object {
+            "__typename": "PoolRegistrationCertificate",
+            "poolParameters": Object {
+              "cost": 810n,
+              "id": "pool15erywju02scjv9gxkmp885c8catf5n4ke9459h2299fq57u9c3e",
+              "margin": Object {
+                "denominator": 1,
+                "numerator": 0,
+              },
+              "metadataJson": undefined,
+              "owners": Array [
+                "stake_test1uq659t9n5excps5nqgnq6ckrhpa8g2k3f2lc2h4uvuess8sr44gva",
+              ],
+              "pledge": 525n,
+              "relays": Array [],
+              "rewardAccount": "stake_test1uz66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74q9f9d7l",
+              "vrf": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+            },
+          },
+        ],
+        "collaterals": undefined,
+        "fee": 720n,
+        "inputs": Array [
+          Object {
+            "index": 0,
+            "txId": "0268be9dbd0446eaa217e1dec8f399249305e551d7fc1437dd84521f74aa621c",
+          },
+          Object {
+            "index": 0,
+            "txId": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+          },
+        ],
+        "mint": Map {
+          "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4" => 1n,
+        },
+        "outputs": Array [
+          Object {
+            "address": "addr_test1grs2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sgqqqqs2wje25",
+            "datum": undefined,
+            "value": Object {
+              "assets": Map {
+                "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4" => 2n,
+              },
+              "coins": 2n,
+            },
+          },
+          Object {
+            "address": "addr1g8s2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sgqqqqqx8489p",
+            "datum": undefined,
+            "value": Object {
+              "assets": Map {
+                "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541" => 2n,
+              },
+              "coins": 1n,
+            },
+          },
+        ],
+        "requiredExtraSignatures": undefined,
+        "scriptIntegrityHash": undefined,
+        "validityInterval": Object {
+          "invalidBefore": undefined,
+          "invalidHereafter": 83856,
+        },
+        "withdrawals": Array [
+          Object {
+            "quantity": 608n,
+            "stakeAddress": "stake_test17z66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74qvpedfl",
+          },
+          Object {
+            "quantity": 324n,
+            "stakeAddress": "stake17x66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74qttn0dz",
+          },
+        ],
+      },
+      "id": "77c4a3c21573c57f0599499bc780de457c35c1d95bfb7e2370d3328b49327117",
+      "witness": Object {
+        "bootstrap": Array [],
+        "datums": undefined,
+        "redeemers": undefined,
+        "scripts": Array [
+          Object {
+            "__type": "native",
+            "keyHash": "4acf2773917c7b547c576a7ff110d2ba5733c1f1ca9cdc659aea3a56",
+            "kind": 0,
+          },
+          Object {
+            "__type": "native",
+            "kind": 1,
+            "scripts": Array [
+              Object {
+                "__type": "native",
+                "keyHash": "bd039f956f4b302f3ab6fc7c4bac3350a540f44af81a8492194dd2c2",
+                "kind": 0,
+              },
+              Object {
+                "__type": "native",
+                "kind": 2,
+                "scripts": Array [
+                  Object {
+                    "__type": "native",
+                    "kind": 5,
+                    "slot": 14145,
+                  },
+                  Object {
+                    "__type": "native",
+                    "keyHash": "b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5",
+                    "kind": 0,
+                  },
+                  Object {
+                    "__type": "native",
+                    "keyHash": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+                    "kind": 0,
+                  },
+                  Object {
+                    "__type": "native",
+                    "keyHash": "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7",
+                    "kind": 0,
+                  },
+                  Object {
+                    "__type": "native",
+                    "kind": 4,
+                    "slot": 70503,
+                  },
+                ],
+              },
+              Object {
+                "__type": "native",
+                "kind": 3,
+                "required": 0,
+                "scripts": Array [
+                  Object {
+                    "__type": "native",
+                    "kind": 1,
+                    "scripts": Array [
+                      Object {
+                        "__type": "native",
+                        "keyHash": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+                        "kind": 0,
+                      },
+                      Object {
+                        "__type": "native",
+                        "keyHash": "76e607db2a31c9a2c32761d2431a186a550cc321f79cd8d6a82b29b8",
+                        "kind": 0,
+                      },
+                      Object {
+                        "__type": "native",
+                        "keyHash": "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541",
+                        "kind": 0,
+                      },
+                      Object {
+                        "__type": "native",
+                        "keyHash": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
+                        "kind": 0,
+                      },
+                    ],
+                  },
+                  Object {
+                    "__type": "native",
+                    "kind": 3,
+                    "required": 2,
+                    "scripts": Array [
+                      Object {
+                        "__type": "native",
+                        "keyHash": "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541",
+                        "kind": 0,
+                      },
+                      Object {
+                        "__type": "native",
+                        "keyHash": "e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541",
+                        "kind": 0,
+                      },
+                      Object {
+                        "__type": "native",
+                        "keyHash": "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4",
+                        "kind": 0,
+                      },
+                      Object {
+                        "__type": "native",
+                        "keyHash": "3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e",
+                        "kind": 0,
+                      },
+                      Object {
+                        "__type": "native",
+                        "keyHash": "65fc709a5e019b8aba76f6977c1c8770e4b36fa76f434efc588747b7",
+                        "kind": 0,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          Object {
+            "__type": "native",
+            "keyHash": "0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4",
+            "kind": 0,
+          },
+        ],
+        "signatures": Map {
+          "19cfd01741992858afaa1a8b99f2622738b4c03a68b9283027640b943181c4b6" => "9662f9fa099756d8c387463e74b863bd497ae22553751b70d2048ded7edd250711f3b4f27ba64a08d036934bac955acba2a99a89c31d0103ae85a48d95c5b337",
+          "97ba85b5beadd03c8ab7ea260a53f73cd47b87d9c2ef62b98f9bd23934bff852" => "8434465f8f816306f37728c24efb34956470c5a423503238068752aad2c2bec590c1d6a04a74e1f1b92dcdf887c8adf0eb68cfbc6b985e06c2b8c13833df0453",
+          "b005f0e09760c2371b7cc8d6a8b67dd0ba09f71f2febdc9cd794251f18567329" => "56362fa4e48645306b80a92e77e3a9d9b1596bf29d1456bdb166852548c16ccd68dcf07b6be086118361cd448b685b63a4f14aefcb747880065eddbb6d5393c7",
+        },
+      },
+    },
+  ],
+  "fees": 845n,
+  "header": Object {
+    "blockNo": 20,
+    "hash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+    "slot": 3,
+  },
+  "issuerVk": "60337a64656bf2646f66c90ab4a546bbf3c3f5f8f00bf06fcc1d9f7d01d924f6",
+  "previousBlock": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
+  "size": 243,
+  "totalOutput": 5n,
+  "txCount": 2,
+  "vrf": "vrf_vk1njzx6395znzy6p7ene2dqw7y77rq4zfaepyw2v6megqnuhepmfgqkg07xz",
+}
+`;
+
+exports[`ogmiosToCore block can translate from shelley block 1`] = `
+Object {
+  "body": Array [],
+  "fees": 0n,
+  "header": Object {
+    "blockNo": 1087,
+    "hash": "071fceb6c20a412b9a9b57baedfe294e3cd9de641cd44c4cf8d0d56217e083ac",
+    "slot": 107220,
+  },
+  "issuerVk": "8b0960d234bda67d52432c5d1a26aca2bfb5b9a09f966d9592a7bf0c728a1ecd",
+  "previousBlock": "8d5d930981710fc8c6ca9fc8e0628665283f7efb28c7e6bddeee2d289f012dee",
+  "size": 3,
+  "totalOutput": 0n,
+  "txCount": 0,
+  "vrf": "vrf_vk15c2edf9h66wllthgvyttzhzwrngq0rvd0wchzqlw8qray60fq5usfngf29",
+}
+`;

--- a/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
+++ b/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
@@ -254,7 +254,7 @@ Object {
             "txId": "1a3380c51384d151b876de02b7a4c5ca7eda7b1d1d744660aee4647516fd9a81",
           },
         ],
-        "mint": undefined,
+        "mint": Map {},
         "outputs": Array [
           Object {
             "address": "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc",
@@ -426,13 +426,13 @@ Object {
         "datums": Array [],
         "redeemers": Array [
           Object {
+            "data": "a34160029f20a3419c204386a48244e21bd936202004a0ffa3a4435aed90040242b07a210523409f414d429b3f0440ffa09f034001ffa222234041b4d8668218da9f2341440302413eff4204e1a1d866821901939f23ffa0",
             "executionUnits": Object {
               "memory": 6026711518256058000,
               "steps": 4749668747002319000,
             },
             "index": 0,
             "purpose": "spend",
-            "scriptHash": "034001ffa222234041b4d8668218da9f2341440302413eff4204e1a1",
           },
         ],
         "scripts": Array [

--- a/packages/ogmios/test/ogmiosToCore/block.test.ts
+++ b/packages/ogmios/test/ogmiosToCore/block.test.ts
@@ -30,247 +30,27 @@ describe('ogmiosToCore', () => {
 
   describe('block', () => {
     it('can translate from byron block', () => {
-      // using https://preprod.cardanoscan.io/block/42 as source of truth
-      expect(ogmiosToCore.block(mockByronBlock)).toEqual(<Cardano.Block>{
-        body: [],
-        fees: undefined,
-        header: {
-          blockNo: Cardano.BlockNo(42),
-          hash: Cardano.BlockId('5c3103bd0ff5ea85a62b202a1d2500cf3ebe0b9d793ed09e7febfe27ef12c968'),
-          slot: Cardano.Slot(77_761)
-        },
-        issuerVk: undefined,
-
-        previousBlock: Cardano.BlockId('dd8d7559a9b6c1177c0f5a328eb82967af68155d58cbcdc0a59de39a38aaf3f0'),
-        // got size: 626 by querying the postgres db populated by db-sync.
-        // Using size: undefined until we can calculate it
-        size: undefined,
-        totalOutput: 0n,
-        txCount: 0,
-        vrf: undefined
-      });
+      expect(ogmiosToCore.block(mockByronBlock)).toMatchSnapshot();
     });
 
     it('can translate from shelley block', () => {
-      // using https://preprod.cardanoscan.io/block/1087 as source of truth
-      expect(ogmiosToCore.block(mockShelleyBlock)).toEqual(<Cardano.Block>{
-        body: [],
-        fees: 0n,
-        header: {
-          blockNo: Cardano.BlockNo(1087),
-          hash: Cardano.BlockId('071fceb6c20a412b9a9b57baedfe294e3cd9de641cd44c4cf8d0d56217e083ac'),
-          slot: Cardano.Slot(107_220)
-        },
-        issuerVk: Cardano.Ed25519PublicKey('8b0960d234bda67d52432c5d1a26aca2bfb5b9a09f966d9592a7bf0c728a1ecd'),
-        previousBlock: Cardano.BlockId('8d5d930981710fc8c6ca9fc8e0628665283f7efb28c7e6bddeee2d289f012dee'),
-        // got size by querying the postgres db populated by db-sync
-        size: Cardano.BlockSize(3),
-        totalOutput: 0n,
-        txCount: 0,
-        // vrf from https://preprod.cexplorer.io/block/071fceb6c20a412b9a9b57baedfe294e3cd9de641cd44c4cf8d0d56217e083ac
-        vrf: Cardano.VrfVkBech32('vrf_vk15c2edf9h66wllthgvyttzhzwrngq0rvd0wchzqlw8qray60fq5usfngf29')
-      });
+      expect(ogmiosToCore.block(mockShelleyBlock)).toMatchSnapshot();
     });
 
     it('can translate from allegra block', () => {
-      // Verify data extracted from mock structure
-      const ogmiosBlock = mockAllegraBlock.allegra;
-      expect(ogmiosToCore.block(mockAllegraBlock)).toEqual(<Cardano.Block>{
-        body: [
-          {
-            body: {
-              certificates: [] as Cardano.Certificate[]
-            }
-          } as Cardano.HydratedTx
-        ],
-        fees: ogmiosBlock.body[0].body.fee,
-        header: {
-          blockNo: Cardano.BlockNo(ogmiosBlock.header.blockHeight),
-          hash: Cardano.BlockId(ogmiosBlock.headerHash),
-          slot: Cardano.Slot(ogmiosBlock.header.slot)
-        },
-        issuerVk: Cardano.Ed25519PublicKey(ogmiosBlock.header.issuerVk),
-        previousBlock: Cardano.BlockId(ogmiosBlock.header.prevHash),
-        size: Cardano.BlockSize(ogmiosBlock.header.blockSize),
-        totalOutput: 0n,
-        txCount: ogmiosBlock.body.length,
-        vrf: Cardano.VrfVkBech32FromBase64(ogmiosBlock.header.issuerVrf)
-      });
+      expect(ogmiosToCore.block(mockAllegraBlock)).toMatchSnapshot();
     });
 
     it('can translate from mary block', () => {
-      // Verify data extracted from mock structure
-      const ogmiosBlock = mockMaryBlock.mary;
-      expect(ogmiosToCore.block(mockMaryBlock)).toEqual(<Cardano.Block>{
-        body: [
-          {
-            body: {
-              certificates: [
-                {
-                  __typename: Cardano.CertificateType.StakeKeyRegistration,
-                  stakeKeyHash: Cardano.Ed25519KeyHash('b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54')
-                },
-                {
-                  __typename: Cardano.CertificateType.GenesisKeyDelegation,
-                  genesisDelegateHash: 'a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a',
-                  genesisHash: '0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4',
-                  vrfKeyHash: '03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314'
-                }
-              ]
-            }
-          },
-          {
-            body: {
-              certificates: [
-                {
-                  __typename: Cardano.CertificateType.PoolRegistration,
-                  poolParameters: {
-                    cost: 810n,
-                    id: 'pool15erywju02scjv9gxkmp885c8catf5n4ke9459h2299fq57u9c3e',
-                    margin: {
-                      denominator: 1,
-                      numerator: 0
-                    },
-                    metadataJson: undefined,
-                    owners: ['stake_test1uq659t9n5excps5nqgnq6ckrhpa8g2k3f2lc2h4uvuess8sr44gva'],
-                    pledge: 525n,
-                    relays: [],
-                    rewardAccount: 'stake_test1uz66ue36465w2qq40005h2hadad6pnjht8mu6sgplsfj74q9f9d7l',
-                    vrf: 'bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa'
-                  }
-                }
-              ]
-            }
-          }
-        ],
-        fees: ogmiosBlock.body[0].body.fee + ogmiosBlock.body[1].body.fee,
-        header: {
-          blockNo: Cardano.BlockNo(ogmiosBlock.header.blockHeight),
-          hash: Cardano.BlockId(ogmiosBlock.headerHash),
-          slot: Cardano.Slot(ogmiosBlock.header.slot)
-        },
-        issuerVk: Cardano.Ed25519PublicKey(ogmiosBlock.header.issuerVk),
-        previousBlock: Cardano.BlockId(ogmiosBlock.header.prevHash),
-        size: Cardano.BlockSize(ogmiosBlock.header.blockSize),
-        totalOutput:
-          ogmiosBlock.body[0].body.outputs[0].value.coins +
-          ogmiosBlock.body[1].body.outputs[0].value.coins +
-          ogmiosBlock.body[1].body.outputs[1].value.coins,
-        txCount: ogmiosBlock.body.length,
-        vrf: Cardano.VrfVkBech32FromBase64(ogmiosBlock.header.issuerVrf)
-      });
+      expect(ogmiosToCore.block(mockMaryBlock)).toMatchSnapshot();
     });
 
     it('can translate from alonzo block', () => {
-      // using https://preprod.cardanoscan.io/block/100000 as source of truth
-      expect(ogmiosToCore.block(mockAlonzoBlock)).toEqual(<Cardano.Block>{
-        body: [
-          {
-            body: {
-              certificates: [
-                {
-                  __typename: Cardano.CertificateType.StakeDelegation,
-                  poolId: Cardano.PoolId('pool15erywju02scjv9gxkmp885c8catf5n4ke9459h2299fq57u9c3e'),
-                  stakeKeyHash: Cardano.Ed25519KeyHash('f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049')
-                },
-                {
-                  __typename: Cardano.CertificateType.StakeKeyDeregistration,
-                  stakeKeyHash: Cardano.Ed25519KeyHash('f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049')
-                },
-                {
-                  __typename: Cardano.CertificateType.PoolRetirement,
-                  epoch: Cardano.EpochNo(123),
-                  poolId: Cardano.PoolId('pool15erywju02scjv9gxkmp885c8catf5n4ke9459h2299fq57u9c3e')
-                },
-                {
-                  __typename: Cardano.CertificateType.GenesisKeyDelegation,
-                  genesisDelegateHash: 'e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541',
-                  genesisHash: 'b16b56f5ec064be6ac3cab6035efae86b366cc3dc4a0d571603d70e5',
-                  vrfKeyHash: '95c3003a78585e0db8c9496f6deef4de0ff000994b8534cd66d4fe96bb21ddd3'
-                }
-              ] as Cardano.Certificate[]
-            }
-          } as Cardano.HydratedTx
-        ],
-        fees: 202_549n,
-        header: {
-          blockNo: Cardano.BlockNo(100_000),
-          hash: Cardano.BlockId('514f8be63ef25c46bee47a90658977f815919c06222c0b480be1e29efbd72c49'),
-          slot: Cardano.Slot(5_481_752)
-        },
-        issuerVk: Cardano.Ed25519PublicKey('a9d974fd26bfaf385749113f260271430276bed6ef4dad6968535de6778471ce'),
-
-        previousBlock: Cardano.BlockId('518a24a3fb0cc6ee1a31668a63994e4dbda70ede5ff13be494a3b4c1bb7709c8'),
-        // got size by querying the postgres db populated by db-sync
-        size: Cardano.BlockSize(836),
-        totalOutput: 8_287_924_709n,
-        txCount: 1,
-        // vrf from https://preprod.cexplorer.io/block/514f8be63ef25c46bee47a90658977f815919c06222c0b480be1e29efbd72c49
-        vrf: Cardano.VrfVkBech32('vrf_vk1p8s5ysf7dgsvfrw0p0q7zczdytkxc95zsq3p9sfshk9s3z86jfdql5fdft')
-      });
+      expect(ogmiosToCore.block(mockAlonzoBlock)).toMatchSnapshot();
     });
 
     it('can translate from babbage block', () => {
-      // Verify data extracted from mock structure
-      const ogmiosBlock = mockBabbageBlock.babbage;
-      expect(ogmiosToCore.block(mockBabbageBlock)).toEqual(<Cardano.Block>{
-        body: [
-          {
-            body: {
-              certificates: [
-                {
-                  __typename: Cardano.CertificateType.MIR,
-                  pot: 'reserve',
-                  quantity: 712n
-                },
-                {
-                  __typename: Cardano.CertificateType.PoolRegistration,
-                  poolParameters: {
-                    cost: 290n,
-                    id: 'pool1kkhxvw4w4rjsq9tmma964lt0twsvu46e7lx5zq0uzvh4ge9n0hc',
-                    margin: {
-                      denominator: 2,
-                      numerator: 1
-                    },
-                    metadataJson: {
-                      hash: '2738e2233800ab7f82bd2212a9a55f52d4851f9147f161684c63e6655bedb562',
-                      url: 'https://public.bladepool.com/metadata.json'
-                    },
-                    owners: [],
-                    pledge: 229n,
-                    relays: [
-                      {
-                        __typename: 'RelayByAddress',
-                        ipv4: '192.0.2.1',
-                        ipv6: '2001:db8::1',
-                        port: undefined
-                      },
-                      {
-                        __typename: 'RelayByName',
-                        hostname: 'foo.example.com',
-                        port: undefined
-                      }
-                    ],
-                    rewardAccount: 'stake_test1urs2w9p3nqfv8amnhgzwchtt8l7dt2kc2qrgqkcy0vyz2sgcp89zz',
-                    vrf: 'ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25'
-                  }
-                }
-              ]
-            }
-          }
-        ],
-        fees: ogmiosBlock.body[0].body.fee,
-        header: {
-          blockNo: Cardano.BlockNo(ogmiosBlock.header.blockHeight),
-          hash: Cardano.BlockId(ogmiosBlock.headerHash),
-          slot: Cardano.Slot(ogmiosBlock.header.slot)
-        },
-        issuerVk: Cardano.Ed25519PublicKey(ogmiosBlock.header.issuerVk),
-        size: Cardano.BlockSize(ogmiosBlock.header.blockSize),
-        totalOutput: ogmiosBlock.body[0].body.outputs[0].value.coins,
-        txCount: ogmiosBlock.body.length,
-        vrf: Cardano.VrfVkBech32FromBase64(ogmiosBlock.header.issuerVrf)
-      });
+      expect(ogmiosToCore.block(mockBabbageBlock)).toMatchSnapshot();
     });
   });
 });

--- a/packages/ogmios/test/ogmiosToCore/testData.ts
+++ b/packages/ogmios/test/ogmiosToCore/testData.ts
@@ -109,7 +109,7 @@ export const mockAlonzoBlock: Ogmios.Schema.Alonzo = {
             { index: 0, txId: '1a3380c51384d151b876de02b7a4c5ca7eda7b1d1d744660aee4647516fd9a81' },
             { index: 1, txId: '1a3380c51384d151b876de02b7a4c5ca7eda7b1d1d744660aee4647516fd9a81' }
           ],
-          mint: { assets: {}, coins: 0n },
+          mint: { coins: 0n },
           network: null,
           outputs: [
             {
@@ -589,8 +589,8 @@ export const mockBabbageBlock: Ogmios.Schema.Babbage = {
           inputs: [],
           mint: {
             assets: {
-              'e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541.00': -1n,
-              'e0a714319812c3f773ba04ec5d6b3ffcd5aad85006805b047b082541.01': 2n
+              '0d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4': -1n,
+              '1d94e174732ef9aae73f395ab44507bfa983d65023c11a951f0c32e4': 2n
             },
             coins: 0n
           },
@@ -642,8 +642,7 @@ export const mockBabbageBlock: Ogmios.Schema.Babbage = {
             'spend:0': {
               // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
               executionUnits: { memory: 6_026_711_518_256_058_765, steps: 4_749_668_747_002_318_509 },
-              redeemer:
-                'a34160029f20a3419c204386a48244e21bd936202004a0ffa3a4435aed90040242b07a210523409f414d429b3f0440ffa09f034001ffa222234041b4d8668218da9f2341440302413eff4204e1a1d866821901939f23ffa0'
+              redeemer: '034001ffa222234041b4d8668218da9f2341440302413eff4204e1a1'
             }
           },
           scripts: {

--- a/packages/ogmios/test/ogmiosToCore/testData.ts
+++ b/packages/ogmios/test/ogmiosToCore/testData.ts
@@ -109,7 +109,7 @@ export const mockAlonzoBlock: Ogmios.Schema.Alonzo = {
             { index: 0, txId: '1a3380c51384d151b876de02b7a4c5ca7eda7b1d1d744660aee4647516fd9a81' },
             { index: 1, txId: '1a3380c51384d151b876de02b7a4c5ca7eda7b1d1d744660aee4647516fd9a81' }
           ],
-          mint: { coins: 0n },
+          mint: { assets: {}, coins: 0n },
           network: null,
           outputs: [
             {
@@ -642,7 +642,8 @@ export const mockBabbageBlock: Ogmios.Schema.Babbage = {
             'spend:0': {
               // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
               executionUnits: { memory: 6_026_711_518_256_058_765, steps: 4_749_668_747_002_318_509 },
-              redeemer: '034001ffa222234041b4d8668218da9f2341440302413eff4204e1a1'
+              redeemer:
+                'a34160029f20a3419c204386a48244e21bd936202004a0ffa3a4435aed90040242b07a210523409f414d429b3f0440ffa09f034001ffa222234041b4d8668218da9f2341440302413eff4204e1a1d866821901939f23ffa0'
             }
           },
           scripts: {

--- a/packages/wallet/src/services/SmartTxSubmitProvider.ts
+++ b/packages/wallet/src/services/SmartTxSubmitProvider.ts
@@ -51,28 +51,28 @@ export class SmartTxSubmitProvider implements TxSubmitProvider {
 
   submitTx(args: SubmitTxArgs): Promise<void> {
     const {
-      body: {
-        validityInterval: { invalidBefore, invalidHereafter }
-      }
+      body: { validityInterval }
     } = cmlUtil.deserializeTx(args.signedTransaction);
+
     const onlineAndWithinValidityInterval$ = combineLatest([this.#connectionStatus$, this.#tip$]).pipe(
       tap(([_, { slot }]) => {
-        if (slot >= (invalidHereafter || Number.POSITIVE_INFINITY))
+        if (slot >= (validityInterval?.invalidHereafter || Number.POSITIVE_INFINITY))
           throw new ProviderError(
             ProviderFailure.BadRequest,
             new CardanoNodeErrors.TxSubmissionErrors.OutsideOfValidityIntervalError({
               outsideOfValidityInterval: {
                 currentSlot: slot.valueOf(),
                 interval: {
-                  invalidBefore: invalidBefore?.valueOf() || null,
-                  invalidHereafter: invalidHereafter?.valueOf() || null
+                  invalidBefore: validityInterval?.invalidBefore?.valueOf() || null,
+                  invalidHereafter: validityInterval?.invalidHereafter?.valueOf() || null
                 }
               }
             })
           );
       }),
       filter(
-        ([connectionStatus, { slot }]) => connectionStatus === ConnectionStatus.up && slot >= (invalidBefore || 0)
+        ([connectionStatus, { slot }]) =>
+          connectionStatus === ConnectionStatus.up && slot >= (validityInterval?.invalidBefore || 0)
       ),
       take(1)
     );

--- a/packages/wallet/src/services/TransactionsTracker.ts
+++ b/packages/wallet/src/services/TransactionsTracker.ts
@@ -252,7 +252,7 @@ export const createTransactionsTracker = (
       mergeMap((group$) =>
         group$.pipe(
           switchMap(({ tx }) => {
-            const invalidHereafter = tx.body.validityInterval.invalidHereafter;
+            const invalidHereafter = tx.body.validityInterval?.invalidHereafter;
             return race(
               rollback$.pipe(
                 map((rolledBackTx) => rolledBackTx.id),

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -133,7 +133,9 @@ describe('SingleAddressWallet rollback', () => {
 
     const histTx1 = mocks.queryTransactionsResult.pageResults[0];
     const rollBackTx = { ...mocks.queryTransactionsResult.pageResults[1], id: tx.id };
-    rollBackTx.body.validityInterval.invalidHereafter = Cardano.Slot(secondTip.slot.valueOf() + 1);
+    if (rollBackTx.body.validityInterval?.invalidHereafter) {
+      rollBackTx.body.validityInterval.invalidHereafter = Cardano.Slot(secondTip.slot.valueOf() + 1);
+    }
 
     const newTx = {
       ...rollBackTx,


### PR DESCRIPTION
# Context

Currently, only certificates are mapped. We need to map the rest of the transactions.

Since transaction types are supposed to be backward-compatible, this should be straightforward. Properties not available in every epoch should be `nullable?.`

Search the code for any other era-specific types and see if they can be generalized

# Important Changes Introduced
Mostly all of them are expressed by commit messages:
- align the name for one of the native script types (`RequireMOf` -> `RequireNOf`)
- change core Block's body type from `HydratedTx[]` to `Tx[]` due to Ogmios translation compatibility as agreed with @mkazlauskas  (`HydratedTxIn.address` is not available in Ogmios types)
- amend the `TxBody.validityInterval` field as `optional` due to Ogmios compatibility (some of the props are introduced after a specific era in Ogmios)
- introduce Ogmios transaction to core mappings
# Notes
- the unit tests for type mappings now use snapshots due to the complexity of the produced object after the whole tx mapping, here is the [thread](https://input-output-rnd.slack.com/archives/G01MHNME0UV/p1669306768642949) 
- Ogmios to core [nativeScript(script)](https://github.com/input-output-hk/cardano-js-sdk/blob/ce687b37e8b13b4c788796a673f1f5a7821264eb/packages/ogmios/src/ogmiosToCore/tx.ts#L131-L190) mapper took [cmlToCore](https://github.com/input-output-hk/cardano-js-sdk/blob/8589258e3e82fdec727eb0b30a260eea79e33681/packages/core/src/CML/cmlToCore/cmlToCore.ts#L312) recursive mapping impl as a reference for Native scripts translation
