### PR TITLE
feat: Rename era-specific types

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -53,7 +53,7 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
     addresses,
     pagination,
     blockRange
-  }: TransactionsByAddressesArgs): Promise<Paginated<Cardano.TxAlonzo>> {
+  }: TransactionsByAddressesArgs): Promise<Paginated<Cardano.HydratedTx>> {
     if (addresses.length > this.#paginationPageSizeLimit) {
       throw new ProviderError(
         ProviderFailure.BadRequest,
@@ -104,7 +104,7 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
     };
   }
 
-  public async transactionsByHashes({ ids }: TransactionsByIdsArgs): Promise<Cardano.TxAlonzo[]> {
+  public async transactionsByHashes({ ids }: TransactionsByIdsArgs): Promise<Cardano.HydratedTx[]> {
     if (ids.length > this.#paginationPageSizeLimit) {
       throw new ProviderError(
         ProviderFailure.BadRequest,

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -59,7 +59,7 @@ export const mapTxOutTokenMap = (multiAssetModels: TxOutMultiAssetModel[]): TxOu
   return txTokenMap;
 };
 
-export const mapTxIn = (txIn: TxInput): Cardano.TxIn => ({
+export const mapTxIn = (txIn: TxInput): Cardano.HydratedTxIn => ({
   address: txIn.address,
   index: txIn.index,
   txId: txIn.txSourceId
@@ -153,20 +153,20 @@ export const mapCertificate = (
 };
 
 interface TxAlonzoData {
-  inputs: Cardano.TxIn[];
+  inputs: Cardano.HydratedTxIn[];
   outputs: Cardano.TxOut[];
   mint?: Cardano.TokenMap;
   withdrawals?: Cardano.Withdrawal[];
   redeemers?: Cardano.Redeemer[];
   metadata?: Cardano.TxMetadata;
-  collaterals?: Cardano.TxIn[];
+  collaterals?: Cardano.HydratedTxIn[];
   certificates?: Cardano.Certificate[];
 }
 
 export const mapTxAlonzo = (
   txModel: TxModel,
   { inputs, outputs, mint, withdrawals, redeemers, metadata, collaterals, certificates }: TxAlonzoData
-): Cardano.TxAlonzo => ({
+): Cardano.HydratedTx => ({
   auxiliaryData:
     metadata && metadata.size > 0
       ? {

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -225,7 +225,7 @@ describe('ChainHistoryHttpService', () => {
         it('has outputs with multi-assets', async () => {
           const ids = await fixtureBuilder.getTxHashes(1, { with: [TxWith.MultiAsset] });
           const response = await provider.transactionsByHashes({ ids });
-          const tx: Cardano.TxAlonzo = response[0];
+          const tx: Cardano.HydratedTx = response[0];
 
           // A transaction involving multi assets could also have outputs without multi assets, so we must first
           // find the index of the output inside the transaction with the native tokens.
@@ -240,7 +240,7 @@ describe('ChainHistoryHttpService', () => {
           const response = await provider.transactionsByHashes({
             ids: await fixtureBuilder.getTxHashes(1, { with: [TxWith.Mint] })
           });
-          const tx: Cardano.TxAlonzo = response[0];
+          const tx: Cardano.HydratedTx = response[0];
           expect(response.length).toEqual(1);
           expect(tx.body.mint).toMatchShapeOf(DataMocks.Tx.mint);
           expect(tx.body.mint?.size).toBeGreaterThan(0);
@@ -250,7 +250,7 @@ describe('ChainHistoryHttpService', () => {
           const response = await provider.transactionsByHashes({
             ids: await fixtureBuilder.getTxHashes(1, { with: [TxWith.Withdrawal] })
           });
-          const tx: Cardano.TxAlonzo = response[0];
+          const tx: Cardano.HydratedTx = response[0];
           expect(response.length).toEqual(1);
           expect(tx.body.withdrawals!).toMatchShapeOf(DataMocks.Tx.withdrawals);
           expect(tx.body.withdrawals?.length).toBeGreaterThan(0);
@@ -261,7 +261,7 @@ describe('ChainHistoryHttpService', () => {
             ids: await fixtureBuilder.getTxHashes(1, { with: [TxWith.Redeemer] })
           });
 
-          const tx: Cardano.NewTxAlonzo = response[0];
+          const tx: Cardano.Tx = response[0];
           expect(response.length).toEqual(1);
           expect(tx.witness).toMatchShapeOf(DataMocks.Tx.witnessRedeemers);
           expect(tx.witness.redeemers?.length).toBeGreaterThan(0);
@@ -271,7 +271,7 @@ describe('ChainHistoryHttpService', () => {
           const response = await provider.transactionsByHashes({
             ids: await fixtureBuilder.getTxHashes(1, { with: [TxWith.AuxiliaryData] })
           });
-          const tx: Cardano.TxAlonzo = response[0];
+          const tx: Cardano.HydratedTx = response[0];
           expect(response.length).toEqual(1);
           expect(tx.auxiliaryData).toBeDefined();
         });
@@ -280,7 +280,7 @@ describe('ChainHistoryHttpService', () => {
           const response = await provider.transactionsByHashes({
             ids: await fixtureBuilder.getTxHashes(1, { with: [TxWith.CollateralInput] })
           });
-          const tx: Cardano.TxAlonzo = response[0];
+          const tx: Cardano.HydratedTx = response[0];
           expect(response.length).toEqual(1);
 
           expect(tx.body.collaterals).toMatchShapeOf(DataMocks.Tx.collateralInputs);
@@ -292,8 +292,8 @@ describe('ChainHistoryHttpService', () => {
             ids: await fixtureBuilder.getTxHashes(2, { with: [TxWith.DelegationCertificate] })
           });
 
-          const tx1: Cardano.TxAlonzo = response[0];
-          const tx2: Cardano.TxAlonzo = response[1];
+          const tx1: Cardano.HydratedTx = response[0];
+          const tx2: Cardano.HydratedTx = response[1];
 
           expect(response.length).toEqual(2);
           expect(tx1.body.certificates?.length).toBeGreaterThan(0);

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -297,7 +297,7 @@ describe('chain history mappers', () => {
     });
   });
   describe('mapTxAlonzo', () => {
-    const inputs: Cardano.TxIn[] = [
+    const inputs: Cardano.HydratedTxIn[] = [
       { address: Cardano.Address(address), index: 1, txId: Cardano.TransactionId(transactionHash) }
     ];
     const outputs: Cardano.TxOut[] = [{ address: Cardano.Address(address), value: { assets, coins: 20_000_000n } }];
@@ -318,7 +318,7 @@ describe('chain history mappers', () => {
       }
     ];
 
-    const expected: Cardano.TxAlonzo = {
+    const expected: Cardano.HydratedTx = {
       blockHeader: { blockNo: 200, hash: Cardano.BlockId(blockHash), slot: 250 },
       body: { fee: 170_000n, inputs, outputs, validityInterval: { invalidBefore: 300, invalidHereafter: 500 } },
       id: Cardano.TransactionId(transactionHash),
@@ -326,18 +326,18 @@ describe('chain history mappers', () => {
       txSize: 20,
       witness: { signatures: new Map() }
     };
-    test('map TxModel to Cardano.TxAlonzo with minimal data', () => {
+    test('map TxModel to Cardano.HydratedTx with minimal data', () => {
       const result = mappers.mapTxAlonzo(txModel, { inputs, outputs });
-      expect(result).toEqual<Cardano.TxAlonzo>(expected);
+      expect(result).toEqual<Cardano.HydratedTx>(expected);
     });
-    test('map TxModel with null fields to Cardano.TxAlonzo', () => {
+    test('map TxModel with null fields to Cardano.HydratedTx', () => {
       const result = mappers.mapTxAlonzo(
         { ...txModel, invalid_before: null, invalid_hereafter: null },
         { inputs, outputs }
       );
-      expect(result).toEqual<Cardano.TxAlonzo>({ ...expected, body: { ...expected.body, validityInterval: {} } });
+      expect(result).toEqual<Cardano.HydratedTx>({ ...expected, body: { ...expected.body, validityInterval: {} } });
     });
-    test('map TxModel to Cardano.TxAlonzo with extra data', () => {
+    test('map TxModel to Cardano.HydratedTx with extra data', () => {
       const result = mappers.mapTxAlonzo(txModel, {
         certificates,
         collaterals: inputs,
@@ -348,7 +348,7 @@ describe('chain history mappers', () => {
         redeemers,
         withdrawals
       });
-      expect(result).toEqual<Cardano.TxAlonzo>({
+      expect(result).toEqual<Cardano.HydratedTx>({
         ...expected,
         auxiliaryData: { body: { blob: metadata } },
         body: { ...expected.body, certificates, collaterals: inputs, mint: assets, withdrawals },
@@ -369,9 +369,9 @@ describe('chain history mappers', () => {
     });
   });
   describe('mapTxIn', () => {
-    test('map TxInput to Cardano.TxIn', () => {
+    test('map TxInput to Cardano.HydratedTxIn', () => {
       const result = mappers.mapTxIn(txInput);
-      expect(result).toEqual<Cardano.TxIn>({
+      expect(result).toEqual<Cardano.HydratedTxIn>({
         address: Cardano.Address(address),
         index: 1,
         txId: Cardano.TransactionId(sourceTransactionHash)

--- a/packages/cardano-services/test/data-mocks/tx.ts
+++ b/packages/cardano-services/test/data-mocks/tx.ts
@@ -25,7 +25,7 @@ export const txOutWithCoinOnly: Cardano.TxOut = { ...txOutBase, value: valueWith
 
 export const txOutWithAssets: Cardano.TxOut = { ...txOutBase, value: valueWithAssets };
 
-export const txIn: Cardano.TxIn = {
+export const txIn: Cardano.HydratedTxIn = {
   address: Cardano.Address('addr_test1wrsexavz37208qda7mwwu4k7hcpg26cz0ce86f5e9kul3hqzlh22t'),
   index: 0,
   txId: Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819')
@@ -41,7 +41,7 @@ export const base = {
     blockNo: 3_157_934,
     hash: Cardano.BlockId('f03084089ec7e74a79e69a5929b2d3c0836d6f12279bd103d0875847c740ae27'),
     slot: 45_286_016
-  } as Cardano.TxAlonzo['blockHeader'],
+  } as Cardano.HydratedTx['blockHeader'],
   body: {
     fee: 191_109n,
     inputs: [txIn],
@@ -50,7 +50,7 @@ export const base = {
       invalidBefore: undefined,
       invalidHereafter: undefined
     }
-  } as Omit<Cardano.TxAlonzo['body'], 'outputs'>,
+  } as Omit<Cardano.HydratedTx['body'], 'outputs'>,
   id: Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819'),
   index: 30,
   txSize: 711,
@@ -59,11 +59,11 @@ export const base = {
   }
 };
 
-export const withCoinOnly: Cardano.TxAlonzo = merge(base, {
+export const withCoinOnly: Cardano.HydratedTx = merge(base, {
   body: { outputs: [txOutWithCoinOnly] }
 });
 
-export const withAssets: Cardano.TxAlonzo = merge(base, {
+export const withAssets: Cardano.HydratedTx = merge(base, {
   body: {
     ...base.body,
     outputs: [txOutWithAssets]
@@ -73,7 +73,7 @@ export const withAssets: Cardano.TxAlonzo = merge(base, {
   }
 });
 
-export const withMint: Cardano.TxAlonzo = merge(withAssets, {
+export const withMint: Cardano.HydratedTx = merge(withAssets, {
   body: {
     mint: new Map([
       [Cardano.AssetId('57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259'), 10_000_000n]
@@ -85,7 +85,7 @@ export const mint: Cardano.TokenMap = new Map([
   [Cardano.AssetId('57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259'), 10_000_000n]
 ]);
 
-export const withAuxiliaryData: Cardano.TxAlonzo = merge(withAssets, {
+export const withAuxiliaryData: Cardano.HydratedTx = merge(withAssets, {
   auxiliaryData: {
     body: {
       blob: new Map([[1, 'abc']])
@@ -107,7 +107,7 @@ export const collateralInputs = [
   }
 ];
 
-export const withValidityInterval: Cardano.TxAlonzo = merge(withAssets, {
+export const withValidityInterval: Cardano.HydratedTx = merge(withAssets, {
   body: {
     validityInterval: {
       invalidBefore: 1,
@@ -123,7 +123,7 @@ export const withdrawals = [
   }
 ];
 
-export const withWithdrawals: Cardano.TxAlonzo = merge(withAssets, {
+export const withWithdrawals: Cardano.HydratedTx = merge(withAssets, {
   body: {
     withdrawals
   }
@@ -163,7 +163,7 @@ export const output = {
 
 export const outputs = [output];
 
-export const blockHeader: Cardano.TxAlonzo['blockHeader'] = {
+export const blockHeader: Cardano.HydratedTx['blockHeader'] = {
   blockNo: 3_157_934,
   hash: Cardano.BlockId('f03084089ec7e74a79e69a5929b2d3c0836d6f12279bd103d0875847c740ae27'),
   slot: 45_286_016

--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -57,7 +57,7 @@ export const value = (cslValue: CML.Value): Cardano.Value =>
     return result;
   });
 
-export const txIn = (input: CML.TransactionInput): Cardano.NewTxIn =>
+export const txIn = (input: CML.TransactionInput): Cardano.TxIn =>
   usingAutoFree((scope) => ({
     index: Number(scope.manage(input.index()).to_str()),
     txId: Cardano.TransactionId.fromHexBlob(util.bytesToHex(scope.manage(input.transaction_id()).to_bytes()))
@@ -82,9 +82,9 @@ export const txOutputs = (outputs: CML.TransactionOutputs): Cardano.TxOut[] =>
     return result;
   });
 
-export const txInputs = (inputs: CML.TransactionInputs): Cardano.NewTxIn[] =>
+export const txInputs = (inputs: CML.TransactionInputs): Cardano.TxIn[] =>
   usingAutoFree((scope) => {
-    const result: Cardano.NewTxIn[] = [];
+    const result: Cardano.TxIn[] = [];
     for (let i = 0; i < inputs.len(); i++) {
       result.push(txIn(scope.manage(inputs.get(i))));
     }
@@ -126,7 +126,7 @@ export const txMint = (assets?: CML.Mint): Cardano.TokenMap | undefined =>
     return assetMap;
   });
 
-export const txBody = (body: CML.TransactionBody): Cardano.NewTxBodyAlonzo =>
+export const txBody = (body: CML.TransactionBody): Cardano.TxBody =>
   usingAutoFree((scope) => {
     const cslScriptDataHash = scope.manage(body.script_data_hash());
     const cslCollaterals = scope.manage(body.collateral());
@@ -292,7 +292,7 @@ export const utxo = (cslUtxos: CML.TransactionUnspentOutput[]) =>
     cslUtxos.map((cslUtxo) => [txIn(scope.manage(cslUtxo.input())), txOut(scope.manage(cslUtxo.output()))])
   );
 
-export const newTx = (cslTx: CML.Transaction): Cardano.NewTxAlonzo =>
+export const newTx = (cslTx: CML.Transaction): Cardano.Tx =>
   usingAutoFree((scope) => {
     const transactionHash = Cardano.TransactionId.fromHexBlob(
       util.bytesToHex(scope.manage(CML.hash_transaction(scope.manage(cslTx.body()))).to_bytes())

--- a/packages/core/src/CML/coreToCml/coreToCml.ts
+++ b/packages/core/src/CML/coreToCml/coreToCml.ts
@@ -99,7 +99,7 @@ export const value = (scope: ManagedFreeableScope, { coins, assets }: Cardano.Va
   return result;
 };
 
-export const txIn = (scope: ManagedFreeableScope, core: Cardano.NewTxIn): TransactionInput =>
+export const txIn = (scope: ManagedFreeableScope, core: Cardano.TxIn): TransactionInput =>
   scope.manage(
     TransactionInput.new(
       scope.manage(TransactionHash.from_bytes(Buffer.from(core.txId, 'hex'))),
@@ -321,7 +321,7 @@ export const txAuxiliaryData = (
   return result;
 };
 
-const txInputs = (scope: ManagedFreeableScope, coreInputs: Cardano.NewTxIn[]) => {
+const txInputs = (scope: ManagedFreeableScope, coreInputs: Cardano.TxIn[]) => {
   const cslInputs = scope.manage(TransactionInputs.new());
   for (const input of coreInputs) {
     cslInputs.add(txIn(scope, input));
@@ -363,7 +363,7 @@ export const txBody = (
     collaterals,
     requiredExtraSignatures,
     scriptIntegrityHash
-  }: Cardano.NewTxBodyAlonzo,
+  }: Cardano.TxBody,
   auxiliaryData?: Cardano.AuxiliaryData
 ): TransactionBody => {
   const cslOutputs = scope.manage(TransactionOutputs.new());
@@ -464,7 +464,7 @@ export const witnessSet = (scope: ManagedFreeableScope, witness: Cardano.Witness
   return cslWitnessSet;
 };
 
-export const tx = (scope: ManagedFreeableScope, { body, witness, auxiliaryData }: Cardano.NewTxAlonzo): Transaction => {
+export const tx = (scope: ManagedFreeableScope, { body, witness, auxiliaryData }: Cardano.Tx): Transaction => {
   const txWitnessSet = witnessSet(scope, witness);
   // Possible optimization: only convert auxiliary data once
   return scope.manage(

--- a/packages/core/src/CML/util.ts
+++ b/packages/core/src/CML/util.ts
@@ -2,7 +2,7 @@
 import { BigNum } from '@dcspark/cardano-multiplatform-lib-nodejs';
 import { CML } from './CML';
 import { HexBlob } from '../Cardano/util/primitives';
-import { NewTxAlonzo, NewTxBodyAlonzo } from '../Cardano/types';
+import { Tx, TxBody } from '../Cardano/types';
 import { newTx } from './cmlToCore';
 import { usingAutoFree } from '@cardano-sdk/util';
 
@@ -39,4 +39,4 @@ export const deserializeTx = ((txBody: Buffer | Uint8Array | string) => usingAut
     const txDecoded = scope.manage(CML.Transaction.from_bytes(buffer));
 
     return newTx(txDecoded);
-  })) as (txBody: HexBlob | Buffer | Uint8Array | string) => NewTxAlonzo<NewTxBodyAlonzo>;
+  })) as (txBody: HexBlob | Buffer | Uint8Array | string) => Tx<TxBody>;

--- a/packages/core/src/Cardano/types/Block.ts
+++ b/packages/core/src/Cardano/types/Block.ts
@@ -3,8 +3,8 @@ import { Ed25519PublicKey } from './Key';
 import { Hash28ByteBase16, Hash32ByteBase16, OpaqueString, typedBech32 } from '../util/primitives';
 import { InvalidStringError } from '../../errors';
 import { Lovelace } from './Value';
-import { NewTxAlonzo } from './Transaction';
 import { PoolId } from './StakePool/primitives';
+import { Tx } from './Transaction';
 
 /**
  * The block size in bytes
@@ -108,7 +108,7 @@ export interface BlockInfo {
 }
 
 export interface Block extends BlockInfo {
-  body: NewTxAlonzo[];
+  body: Tx[];
 }
 
 export interface ExtendedBlockInfo

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -5,8 +5,8 @@ import { Certificate } from './Certificate';
 import { Datum, Script } from './Script';
 import { Ed25519KeyHash, Ed25519PublicKey } from './Key';
 import { ExUnits, ValidityInterval } from './ProtocolParameters';
+import { HydratedTxIn, TxIn, TxOut } from './Utxo';
 import { Lovelace, TokenMap } from './Value';
-import { NewTxIn, TxIn, TxOut } from './Utxo';
 import { PartialBlockHeader } from './Block';
 import { RewardAccount } from './RewardAccount';
 
@@ -38,9 +38,9 @@ export interface Withdrawal {
   quantity: Lovelace;
 }
 
-export interface TxBodyAlonzo {
-  inputs: TxIn[];
-  collaterals?: TxIn[];
+export interface HydratedTxBody {
+  inputs: HydratedTxIn[];
+  collaterals?: HydratedTxIn[];
   outputs: TxOut[];
   fee: Lovelace;
   validityInterval?: ValidityInterval;
@@ -51,9 +51,9 @@ export interface TxBodyAlonzo {
   requiredExtraSignatures?: Ed25519KeyHash[];
 }
 
-export interface NewTxBodyAlonzo extends Omit<TxBodyAlonzo, 'inputs' | 'collaterals'> {
-  inputs: NewTxIn[];
-  collaterals?: NewTxIn[];
+export interface TxBody extends Omit<HydratedTxBody, 'inputs' | 'collaterals'> {
+  inputs: TxIn[];
+  collaterals?: TxIn[];
 }
 
 export enum RedeemerPurpose {
@@ -92,21 +92,21 @@ export type Witness = {
   datums?: Datum[];
 };
 
-export interface NewTxAlonzo<TBody extends NewTxBodyAlonzo = NewTxBodyAlonzo> {
+export interface Tx<TBody extends TxBody = TxBody> {
   id: TransactionId;
   body: TBody;
   witness: Witness;
   auxiliaryData?: AuxiliaryData;
 }
 
-export interface TxAlonzo extends NewTxAlonzo<TxBodyAlonzo> {
+export interface HydratedTx extends Tx<HydratedTxBody> {
   index: number;
   blockHeader: PartialBlockHeader;
-  body: TxBodyAlonzo;
+  body: HydratedTxBody;
   txSize: number;
 }
 
 export type TxBodyWithHash = {
   hash: TransactionId;
-  body: NewTxBodyAlonzo;
+  body: TxBody;
 };

--- a/packages/core/src/Cardano/types/Utxo.ts
+++ b/packages/core/src/Cardano/types/Utxo.ts
@@ -3,12 +3,12 @@ import { Hash32ByteBase16 } from '../util/primitives';
 import { TransactionId } from './Transaction';
 import { Value } from './Value';
 
-export interface NewTxIn {
+export interface TxIn {
   txId: TransactionId;
   index: number;
 }
 
-export interface TxIn extends NewTxIn {
+export interface HydratedTxIn extends TxIn {
   address: Address;
 }
 
@@ -18,4 +18,4 @@ export interface TxOut {
   datum?: Hash32ByteBase16;
 }
 
-export type Utxo = [TxIn, TxOut];
+export type Utxo = [HydratedTxIn, TxOut];

--- a/packages/core/src/Cardano/util/address.ts
+++ b/packages/core/src/Cardano/util/address.ts
@@ -1,4 +1,4 @@
-import { Address, NewTxIn, TxAlonzo, TxIn } from '../types';
+import { Address, HydratedTx, HydratedTxIn, TxIn } from '../types';
 import { CML } from '../../CML/CML';
 
 /**
@@ -18,16 +18,16 @@ export const isAddressWithin =
  * Receives a transaction and a set of addresses to check if
  * some of them are included in the transaction inputs
  *
- * @returns {TxIn[]} array of inputs that contain any of the addresses
+ * @returns {HydratedTxIn[]} array of inputs that contain any of the addresses
  */
-export const inputsWithAddresses = (tx: TxAlonzo, ownAddresses: Address[]): TxIn[] =>
+export const inputsWithAddresses = (tx: HydratedTx, ownAddresses: Address[]): HydratedTxIn[] =>
   tx.body.inputs.filter(isAddressWithin(ownAddresses));
 
 /**
  * @param txIn transaction input to resolve address from
  * @returns input owner address
  */
-export type ResolveInputAddress = (txIn: NewTxIn) => Promise<Address | null>;
+export type ResolveInputAddress = (txIn: TxIn) => Promise<Address | null>;
 
 export interface InputResolver {
   resolveInputAddress: ResolveInputAddress;

--- a/packages/core/src/Cardano/util/computeImplicitCoin.ts
+++ b/packages/core/src/Cardano/util/computeImplicitCoin.ts
@@ -1,6 +1,6 @@
 import { BigIntMath } from '@cardano-sdk/util';
 import { Cardano } from '../..';
-import { CertificateType, Lovelace, TxBodyAlonzo } from '../types';
+import { CertificateType, HydratedTxBody, Lovelace } from '../types';
 
 /**
  * Implicit coin quantities used in the transaction
@@ -21,7 +21,7 @@ export interface ImplicitCoin {
  */
 export const computeImplicitCoin = (
   { stakeKeyDeposit, poolDeposit }: Pick<Cardano.ProtocolParameters, 'stakeKeyDeposit' | 'poolDeposit'>,
-  { certificates, withdrawals }: Pick<TxBodyAlonzo, 'certificates' | 'withdrawals'>
+  { certificates, withdrawals }: Pick<HydratedTxBody, 'certificates' | 'withdrawals'>
 ): ImplicitCoin => {
   const stakeKeyDepositBigint = stakeKeyDeposit && BigInt(stakeKeyDeposit);
   const poolDepositBigint = poolDeposit && BigInt(poolDeposit);

--- a/packages/core/src/Cardano/util/resolveInputValue.ts
+++ b/packages/core/src/Cardano/util/resolveInputValue.ts
@@ -1,13 +1,13 @@
-import { TxAlonzo, TxIn, Value } from '../types';
+import { HydratedTx, HydratedTxIn, Value } from '../types';
 
 /**
  * Resolves the value of an input by looking for the matching output in a list of transactions
  *
- * @param {TxIn} input input to resolve value for
- * @param {TxAlonzo[]} transactions list of transactions to find the matching output
+ * @param {HydratedTxIn} input input to resolve value for
+ * @param {HydratedTx[]} transactions list of transactions to find the matching output
  * @returns {Value | undefined} input value or undefined if not found
  */
-export const resolveInputValue = (input: TxIn, transactions: TxAlonzo[]): Value | undefined => {
+export const resolveInputValue = (input: HydratedTxIn, transactions: HydratedTx[]): Value | undefined => {
   const tx = transactions.find((transaction) => transaction.id === input.txId);
   return tx?.body.outputs[input.index]?.value;
 };

--- a/packages/core/src/Provider/ChainHistoryProvider/types.ts
+++ b/packages/core/src/Provider/ChainHistoryProvider/types.ts
@@ -17,16 +17,16 @@ export interface ChainHistoryProvider extends Provider {
    * @param {Cardano.Address[]} addresses array of addresses
    * @param {Cardano.PaginationArgs} [pagination] pagination args
    * @param {Range<Cardano.BlockNo>} [blockRange] transactions in specified block ranges (lower and upper bounds inclusive)
-   * @returns {Cardano.TxAlonzo[]} an array of transactions involving the addresses
+   * @returns {Cardano.HydratedTx[]} an array of transactions involving the addresses
    */
-  transactionsByAddresses: (args: TransactionsByAddressesArgs) => Promise<Paginated<Cardano.TxAlonzo>>;
+  transactionsByAddresses: (args: TransactionsByAddressesArgs) => Promise<Paginated<Cardano.HydratedTx>>;
   /**
    * Gets the transactions matching the provided hashes.
    *
    * @param {Cardano.TransactionId[]} ids array of transaction ids
-   * @returns {Cardano.TxAlonzo[]} an array of transactions
+   * @returns {Cardano.HydratedTx[]} an array of transactions
    */
-  transactionsByHashes: (args: TransactionsByIdsArgs) => Promise<Cardano.TxAlonzo[]>;
+  transactionsByHashes: (args: TransactionsByIdsArgs) => Promise<Cardano.HydratedTx[]>;
   /**
    * Gets the blocks matching the provided hashes.
    *

--- a/packages/core/src/util/txInspector.ts
+++ b/packages/core/src/util/txInspector.ts
@@ -5,6 +5,8 @@ import {
   Certificate,
   CertificateType,
   Ed25519KeyHash,
+  HydratedTx,
+  HydratedTxIn,
   Lovelace,
   Metadatum,
   PolicyId,
@@ -16,8 +18,6 @@ import {
   StakeAddressCertificate,
   StakeDelegationCertificate,
   TokenMap,
-  TxAlonzo,
-  TxIn,
   Value
 } from '../Cardano/types';
 import { BigIntMath } from '@cardano-sdk/util';
@@ -28,9 +28,9 @@ import { nativeScriptPolicyId } from './nativeScript';
 import { resolveInputValue } from '../Cardano/util/resolveInputValue';
 import { subtractValueQuantities } from './subtractValueQuantities';
 
-type Inspector<Inspection> = (tx: TxAlonzo) => Inspection;
+type Inspector<Inspection> = (tx: HydratedTx) => Inspection;
 type Inspectors = { [k: string]: Inspector<unknown> };
-type TxInspector<T extends Inspectors> = (tx: TxAlonzo) => {
+type TxInspector<T extends Inspectors> = (tx: HydratedTx) => {
   [k in keyof T]: ReturnType<T[k]>;
 };
 
@@ -43,7 +43,7 @@ export type PoolRetirementInspection = PoolRetirementCertificate[];
 
 export type WithdrawalInspection = Lovelace;
 export interface SentInspection {
-  inputs: TxIn[];
+  inputs: HydratedTxIn[];
   certificates: Certificate[];
 }
 export type SignedCertificatesInspection = Certificate[];
@@ -68,7 +68,7 @@ interface SentInspectorArgs {
 export type SentInspector = (args: SentInspectorArgs) => Inspector<SentInspection>;
 export type TotalAddressInputsValueInspector = (
   ownAddresses: Address[],
-  getHistoricalTxs: () => TxAlonzo[]
+  getHistoricalTxs: () => HydratedTx[]
 ) => Inspector<SendReceiveValueInspection>;
 export type SendReceiveValueInspector = (ownAddresses: Address[]) => Inspector<SendReceiveValueInspection>;
 export type DelegationInspector = Inspector<DelegationInspection>;
@@ -88,7 +88,7 @@ export type PoolRetirementInspector = Inspector<PoolRetirementInspection>;
  * containing any of the provided addresses.
  *
  * @param {Address[]} ownAddresses own wallet's addresses
- * @param {() => TxAlonzo[]} getHistoricalTxs wallet's historical transactions
+ * @param {() => HydratedTx[]} getHistoricalTxs wallet's historical transactions
  * @returns {Value} total value in inputs
  */
 export const totalAddressInputsValueInspector: TotalAddressInputsValueInspector =
@@ -212,7 +212,7 @@ const certificateInspector =
 /**
  * Inspects a transaction for a stake delegation certificate.
  *
- * @param {TxAlonzo} tx transaction to inspect
+ * @param {HydratedTx} tx transaction to inspect
  * @returns {DelegationInspection} array of delegation certificates
  */
 export const delegationInspector: DelegationInspector = certificateInspector<DelegationInspection>(
@@ -222,7 +222,7 @@ export const delegationInspector: DelegationInspector = certificateInspector<Del
 /**
  * Inspects a transaction for a stake key deregistration certificate.
  *
- * @param {TxAlonzo} tx transaction to inspect
+ * @param {HydratedTx} tx transaction to inspect
  * @returns {StakeKeyRegistrationInspection} array of stake key deregistration certificates
  */
 export const stakeKeyDeregistrationInspector: StakeKeyRegistrationInspector =
@@ -231,7 +231,7 @@ export const stakeKeyDeregistrationInspector: StakeKeyRegistrationInspector =
 /**
  * Inspects a transaction for a stake key registration certificate.
  *
- * @param {TxAlonzo} tx transaction to inspect
+ * @param {HydratedTx} tx transaction to inspect
  * @returns {StakeKeyRegistrationInspection} array of stake key registration certificates
  */
 export const stakeKeyRegistrationInspector: StakeKeyRegistrationInspector =
@@ -240,7 +240,7 @@ export const stakeKeyRegistrationInspector: StakeKeyRegistrationInspector =
 /**
  * Inspects a transaction for pool registration certificates.
  *
- * @param {TxAlonzo} tx transaction to inspect.
+ * @param {HydratedTx} tx transaction to inspect.
  * @returns {PoolRegistrationInspection} array of pool registration certificates.
  */
 export const poolRegistrationInspector: PoolRegistrationInspector = certificateInspector<PoolRegistrationInspection>(
@@ -250,7 +250,7 @@ export const poolRegistrationInspector: PoolRegistrationInspector = certificateI
 /**
  * Inspects a transaction for pool retirement certificates.
  *
- * @param {TxAlonzo} tx transaction to inspect.
+ * @param {HydratedTx} tx transaction to inspect.
  * @returns {PoolRetirementInspection} array of pool retirement certificates.
  */
 export const poolRetirementInspector: PoolRetirementInspector = certificateInspector<PoolRetirementInspection>(
@@ -260,7 +260,7 @@ export const poolRetirementInspector: PoolRetirementInspector = certificateInspe
 /**
  * Inspects a transaction for withdrawals.
  *
- * @param {TxAlonzo} tx transaction to inspect
+ * @param {HydratedTx} tx transaction to inspect
  * @returns {WithdrawalInspection} accumulated withdrawal quantities
  */
 export const withdrawalInspector: WithdrawalInspector = (tx) =>
@@ -340,7 +340,7 @@ export const assetsBurnedInspector: AssetsMintedInspector = mintInspector((quant
 /**
  * Inspects a transaction for its metadata.
  *
- * @param {TxAlonzo} tx transaction to inspect.
+ * @param {HydratedTx} tx transaction to inspect.
  */
 export const metadataInspector: MetadataInspector = (tx) => tx.auxiliaryData?.body?.blob ?? new Map();
 

--- a/packages/core/test/CML/cmlToCore.test.ts
+++ b/packages/core/test/CML/cmlToCore.test.ts
@@ -39,7 +39,7 @@ describe('cmlToCore', () => {
   });
 
   it('utxo', () => {
-    const utxo: Cardano.Utxo[] = [[txIn as Cardano.TxIn, txOut]];
+    const utxo: Cardano.Utxo[] = [[txIn as Cardano.HydratedTxIn, txOut]];
     expect(cmlToCore.utxo(coreToCml.utxo(scope, utxo))).toEqual(utxo);
   });
 

--- a/packages/core/test/CML/testData.ts
+++ b/packages/core/test/CML/testData.ts
@@ -53,7 +53,7 @@ export const txIn = {
   txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
 };
 
-export const txInWithAddress: Cardano.TxIn = {
+export const txInWithAddress: Cardano.HydratedTxIn = {
   address: Cardano.Address(
     'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
   ),
@@ -75,7 +75,7 @@ export const txOutWithDatum: Cardano.TxOut = {
   value: valueWithAssets
 };
 
-export const txBody: Cardano.NewTxBodyAlonzo = {
+export const txBody: Cardano.TxBody = {
   certificates: [
     {
       __typename: Cardano.CertificateType.PoolRetirement,
@@ -114,7 +114,7 @@ export const vkey = '6199186adb51974690d7247d2646097d2c62763b767b528816fb7ed3f9f
 export const signature =
   // eslint-disable-next-line max-len
   'bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755';
-export const tx: Cardano.NewTxAlonzo = {
+export const tx: Cardano.Tx = {
   auxiliaryData: {
     body: {
       blob: new Map<bigint, Cardano.Metadatum>([

--- a/packages/core/test/Cardano/util/address.test.ts
+++ b/packages/core/test/Cardano/util/address.test.ts
@@ -70,7 +70,7 @@ describe('Cardano.util.address', () => {
             }
           ]
         }
-      } as Cardano.TxAlonzo;
+      } as Cardano.HydratedTx;
 
       it('returns the transaction inputs that contain any of the addresses', () => {
         expect(Cardano.util.inputsWithAddresses(tx, addresses)).toEqual([

--- a/packages/core/test/Cardano/util/resolveInputValue.test.ts
+++ b/packages/core/test/Cardano/util/resolveInputValue.test.ts
@@ -1,27 +1,27 @@
 import { Cardano } from '../../../src';
 
 describe('Cardano.util.resolveInputValue', () => {
-  const txs: Cardano.TxAlonzo[] = [
+  const txs: Cardano.HydratedTx[] = [
     {
       body: {
         outputs: [{ value: { coins: 5_000_000n } }, { value: { coins: 1_000_000n } }, { value: { coins: 9_825_963n } }]
       },
       id: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a')
-    } as Cardano.TxAlonzo,
+    } as Cardano.HydratedTx,
     {
       body: { outputs: [{ value: { coins: 3_000_000n } }] },
       id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
-    } as Cardano.TxAlonzo
+    } as Cardano.HydratedTx
   ];
   it('should resolve the value for the input from the list of transactions', () => {
     const input1 = {
       index: 1,
       txId: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a')
-    } as Cardano.TxIn;
+    } as Cardano.HydratedTxIn;
     const input2 = {
       index: 0,
       txId: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
-    } as Cardano.TxIn;
+    } as Cardano.HydratedTxIn;
     expect(Cardano.util.resolveInputValue(input1, txs)).toEqual({ coins: 1_000_000n });
     expect(Cardano.util.resolveInputValue(input2, txs)).toEqual({ coins: 3_000_000n });
   });
@@ -29,14 +29,14 @@ describe('Cardano.util.resolveInputValue', () => {
     const input = {
       index: 0,
       txId: Cardano.TransactionId('01d7366549986d83edeea262e97b68eca3430d3bb052ed1c37d2202fd5458872')
-    } as Cardano.TxIn;
+    } as Cardano.HydratedTxIn;
     expect(Cardano.util.resolveInputValue(input, txs)).toEqual(undefined);
   });
   it('should return undefined if the input could match the transaction but not the output index', () => {
     const input = {
       index: 4,
       txId: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a')
-    } as Cardano.TxIn;
+    } as Cardano.HydratedTxIn;
     expect(Cardano.util.resolveInputValue(input, txs)).toEqual(undefined);
   });
 });

--- a/packages/core/test/util/txInspector.test.ts
+++ b/packages/core/test/util/txInspector.test.ts
@@ -10,6 +10,8 @@ import {
   Ed25519KeyHash,
   Ed25519PublicKey,
   Ed25519Signature,
+  HydratedTx,
+  HydratedTxIn,
   NativeScriptKind,
   PolicyId,
   PoolId,
@@ -21,8 +23,6 @@ import {
   StakeDelegationCertificate,
   TokenMap,
   TransactionId,
-  TxAlonzo,
-  TxIn,
   TxOut,
   VrfVkHex,
   Withdrawal,
@@ -114,7 +114,7 @@ describe('txInspector', () => {
     }
   ];
 
-  const historicalTxs: TxAlonzo[] = [
+  const historicalTxs: HydratedTx[] = [
     {
       body: {
         outputs: [
@@ -139,7 +139,7 @@ describe('txInspector', () => {
         ]
       },
       id: TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
-    } as unknown as TxAlonzo
+    } as unknown as HydratedTx
   ];
 
   const mockPolicy1 = 'b8fdbcbe003cef7e47eb5307d328e10191952bd02901a850699e7e35';
@@ -198,7 +198,7 @@ describe('txInspector', () => {
 
   const buildMockTx = (
     args: {
-      inputs?: TxIn[];
+      inputs?: HydratedTxIn[];
       outputs?: TxOut[];
       certificates?: Certificate[];
       withdrawals?: Withdrawal[];
@@ -206,7 +206,7 @@ describe('txInspector', () => {
       witness?: Witness;
       includeAuxData?: boolean;
     } = {}
-  ): TxAlonzo =>
+  ): HydratedTx =>
     ({
       auxiliaryData: args.includeAuxData ? auxiliaryData : undefined,
       blockHeader: {
@@ -268,7 +268,7 @@ describe('txInspector', () => {
       id: TransactionId('e3a443363eb6ee3d67c5e75ec10b931603787581a948d68fa3b2cd3ff2e0d2ad'),
       index: 0,
       witness: args.witness ?? { scripts: [mockScript1], signatures: new Map<Ed25519PublicKey, Ed25519Signature>() }
-    } as TxAlonzo);
+    } as HydratedTx);
 
   describe('transaction sent inspector', () => {
     test('a transaction with inputs with provided addresses produces an inspection containing those inputs', () => {

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -69,7 +69,7 @@ export const walletReady = (wallet: ObservableWallet) =>
     SYNC_TIMEOUT
   );
 
-export const normalizeTxBody = (body: Cardano.TxBodyAlonzo | Cardano.NewTxBodyAlonzo) => {
+export const normalizeTxBody = (body: Cardano.HydratedTxBody | Cardano.TxBody) => {
   body.collaterals ||= [];
   // TODO: inputs should be a Set since they're unordered.
   // Then Jest should correctly compare it with toEqual.
@@ -85,7 +85,7 @@ export const txConfirmed = (
       outgoing: { failed$ }
     }
   }: ObservableWallet,
-  { id }: Pick<Cardano.NewTxAlonzo, 'id'>,
+  { id }: Pick<Cardano.Tx, 'id'>,
   numConfirmations = 3
 ) =>
   firstValueFrom(
@@ -108,11 +108,10 @@ export const txConfirmed = (
     )
   );
 
-const submit = (wallet: ObservableWallet, tx: Cardano.NewTxAlonzo | SignedTx) =>
+const submit = (wallet: ObservableWallet, tx: Cardano.Tx | SignedTx) =>
   'submit' in tx ? tx.submit() : wallet.submitTx(tx);
-const confirm = (wallet: ObservableWallet, tx: Cardano.NewTxAlonzo | SignedTx) =>
-  txConfirmed(wallet, 'tx' in tx ? tx.tx : tx);
-export const submitAndConfirm = (wallet: ObservableWallet, tx: Cardano.NewTxAlonzo | SignedTx) =>
+const confirm = (wallet: ObservableWallet, tx: Cardano.Tx | SignedTx) => txConfirmed(wallet, 'tx' in tx ? tx.tx : tx);
+export const submitAndConfirm = (wallet: ObservableWallet, tx: Cardano.Tx | SignedTx) =>
   Promise.all([submit(wallet, tx), confirm(wallet, tx)]);
 
 export type RequestCoinsProps = {

--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -9,7 +9,7 @@ import uniq from 'lodash/uniq';
  * @returns {AccountKeyDerivationPath[]} derivation paths for keys to sign transaction with
  */
 export const ownSignatureKeyPaths = async (
-  txBody: Cardano.NewTxBodyAlonzo,
+  txBody: Cardano.TxBody,
   knownAddresses: GroupedAddress[],
   inputResolver: Cardano.util.InputResolver
 ): Promise<AccountKeyDerivationPath[]> => {

--- a/packages/key-management/src/util/stubSignTransaction.ts
+++ b/packages/key-management/src/util/stubSignTransaction.ts
@@ -8,7 +8,7 @@ const randomHexChar = () => Math.floor(Math.random() * 16).toString(16);
 const randomPublicKey = () => Cardano.Ed25519PublicKey(Array.from({ length: 64 }).map(randomHexChar).join(''));
 
 export const stubSignTransaction = async (
-  txBody: Cardano.NewTxBodyAlonzo,
+  txBody: Cardano.TxBody,
   knownAddresses: GroupedAddress[],
   inputResolver: Cardano.util.InputResolver,
   extraSigners?: TransactionSigner[],

--- a/packages/key-management/test/InMemoryKeyAgent.test.ts
+++ b/packages/key-management/test/InMemoryKeyAgent.test.ts
@@ -89,7 +89,7 @@ describe('InMemoryKeyAgent', () => {
       { index: 0, role: 0 },
       { index: 0, role: 2 }
     ]);
-    const body = {} as unknown as Cardano.TxBodyAlonzo;
+    const body = {} as unknown as Cardano.HydratedTxBody;
     const witnessSet = await keyAgent.signTransaction({
       body,
       hash: Cardano.TransactionId('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec')

--- a/packages/key-management/test/util/createAsyncKeyAgent.test.ts
+++ b/packages/key-management/test/util/createAsyncKeyAgent.test.ts
@@ -33,7 +33,7 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
     );
     inputResolver.resolveInputAddress.mockResolvedValue(null);
     const txInternals = {
-      body: { fee: 20_000n, inputs: [], outputs: [], validityInterval: {} } as Cardano.TxBodyAlonzo,
+      body: { fee: 20_000n, inputs: [], outputs: [], validityInterval: {} } as Cardano.HydratedTxBody,
       hash: Cardano.TransactionId('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec')
     };
     await expect(asyncKeyAgent.signTransaction(txInternals)).resolves.toEqual(

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -28,7 +28,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     const txBody = {
       certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration }],
       inputs: [{}, {}, {}]
-    } as Cardano.NewTxBodyAlonzo;
+    } as Cardano.TxBody;
     const knownAddresses = [address1, address2].map((address, index) =>
       createGroupedAddress(address, ownRewardAccount, AddressType.External, index)
     );
@@ -57,7 +57,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     const txBody = {
       inputs: [{}, {}, {}],
       withdrawals: [{ quantity: 1n, stakeAddress: ownRewardAccount }]
-    } as Cardano.NewTxBodyAlonzo;
+    } as Cardano.TxBody;
     const knownAddresses = [createGroupedAddress(address1, ownRewardAccount, AddressType.External, 0)];
     const resolveInputAddress = jest.fn().mockReturnValue(address1);
     expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInputAddress })).toEqual([
@@ -76,7 +76,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     const txBody = {
       inputs: [{}, {}, {}],
       withdrawals: [{ quantity: 1n, stakeAddress: otherRewardAccount }]
-    } as Cardano.NewTxBodyAlonzo;
+    } as Cardano.TxBody;
     const knownAddresses = [createGroupedAddress(address1, ownRewardAccount, AddressType.External, 0)];
     const resolveInputAddress = jest.fn().mockReturnValue(address1);
     expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInputAddress })).toEqual([

--- a/packages/key-management/test/util/stubSignTransaction.test.ts
+++ b/packages/key-management/test/util/stubSignTransaction.test.ts
@@ -7,7 +7,7 @@ const { ownSignatureKeyPaths } = jest.requireMock('../../src/util/ownSignatureKe
 describe('KeyManagement.util.stubSignTransaction', () => {
   it('returns as many signatures as number of keys returned by ownSignaturePaths', async () => {
     const inputResolver = {} as Cardano.util.InputResolver; // not called
-    const txBody = {} as Cardano.TxBodyAlonzo;
+    const txBody = {} as Cardano.HydratedTxBody;
     const knownAddresses = [{} as GroupedAddress];
     ownSignatureKeyPaths.mockReturnValueOnce(['a']).mockReturnValueOnce(['a', 'b']);
     expect((await util.stubSignTransaction(txBody, knownAddresses, inputResolver)).size).toBe(1);

--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -241,7 +241,7 @@ const mapAuxiliaryData = (data: Schema.AuxiliaryData | null): Cardano.AuxiliaryD
   };
 };
 
-const mapTxIn = (txIn: Schema.TxIn): Cardano.NewTxIn => ({
+const mapTxIn = (txIn: Schema.TxIn): Cardano.TxIn => ({
   index: txIn.index,
   txId: Cardano.TransactionId(txIn.txId)
 });
@@ -278,7 +278,7 @@ const mapValidityInterval = ({
   invalidHereafter: invalidHereafter ?? undefined
 });
 
-const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.NewTxAlonzo => ({
+const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.Tx => ({
   auxiliaryData: mapAuxiliaryData(tx.metadata),
   body: {
     certificates: tx.body.certificates.map(mapCertificate),
@@ -293,7 +293,7 @@ const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.NewTx
     scriptIntegrityHash: isAlonzoOrAbove(kind) ? mapScriptIntegrityHash(tx as Schema.TxAlonzo) : undefined,
     validityInterval: isShelleyTx(kind)
       ? undefined
-      : mapValidityInterval((tx as Schema.TxAlonzo).body.validityInterval),
+      : mapValidityInterval((tx as Schema.TxAllegra).body.validityInterval),
     withdrawals: Object.entries(tx.body.withdrawals).map(([key, value]) => ({
       quantity: value,
       stakeAddress: Cardano.RewardAccount(key)
@@ -321,7 +321,7 @@ const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.NewTx
 export const mapCommonBlockBody = ({ body }: CommonBlock, kind: BlockKind): Cardano.Block['body'] =>
   body.map((blockBody) => mapCommonTx(blockBody, kind));
 
-const mapByronTx = (tx: Schema.TxByron): Cardano.NewTxAlonzo => ({
+const mapByronTx = (tx: Schema.TxByron): Cardano.Tx => ({
   body: {
     fee: 0n, // Not sure how to calculate the fee from ByronTx there is no fee?
     inputs: tx.body.inputs.map(mapTxIn),

--- a/packages/projection/test/operators/certificates/withCertificates.test.ts
+++ b/packages/projection/test/operators/certificates/withCertificates.test.ts
@@ -15,7 +15,7 @@ const rollForwardEvent = (slot: Cardano.Slot, txs: Cardano.Certificate[][]) =>
         (certificates) =>
           ({
             body: { certificates }
-          } as Cardano.NewTxAlonzo)
+          } as Cardano.Tx)
       ),
       header: { slot }
     },

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -138,8 +138,8 @@ export class SingleAddressWallet implements ObservableWallet {
   #prepareTx: PrepareTx;
   #newTransactions = {
     failedToSubmit$: new Subject<FailedTx>(),
-    pending$: new Subject<Cardano.NewTxAlonzo>(),
-    submitting$: new Subject<Cardano.NewTxAlonzo>()
+    pending$: new Subject<Cardano.Tx>(),
+    submitting$: new Subject<Cardano.Tx>()
   };
   #resubmitSubscription: Subscription;
   #trackedTxSubmitProvider: TrackedTxSubmitProvider;
@@ -426,7 +426,7 @@ export class SingleAddressWallet implements ObservableWallet {
     return { body, hash, inputSelection };
   }
 
-  async finalizeTx(props: FinalizeTxProps, stubSign = false): Promise<Cardano.NewTxAlonzo> {
+  async finalizeTx(props: FinalizeTxProps, stubSign = false): Promise<Cardano.Tx> {
     const addresses = await firstValueFrom(this.addresses$);
     const signatures = stubSign
       ? await keyManagementUtil.stubSignTransaction(
@@ -446,7 +446,7 @@ export class SingleAddressWallet implements ObservableWallet {
     };
   }
 
-  async submitTx(tx: Cardano.NewTxAlonzo, { mightBeAlreadySubmitted }: SubmitTxOptions = {}): Promise<void> {
+  async submitTx(tx: Cardano.Tx, { mightBeAlreadySubmitted }: SubmitTxOptions = {}): Promise<void> {
     this.#logger.debug(`Submitting transaction ${tx.id}`);
     this.#newTransactions.submitting$.next(tx);
     try {

--- a/packages/wallet/src/SingleAddressWallet/prepareTx.ts
+++ b/packages/wallet/src/SingleAddressWallet/prepareTx.ts
@@ -12,7 +12,7 @@ export interface PrepareTxDependencies {
     syncStatus: Pick<ObservableWallet['syncStatus'], 'isSettled$'>;
   };
   signer: {
-    stubFinalizeTx(props: FinalizeTxProps): Observable<Cardano.NewTxAlonzo>;
+    stubFinalizeTx(props: FinalizeTxProps): Observable<Cardano.Tx>;
   };
   logger: Logger;
 }

--- a/packages/wallet/src/Transaction/createTransactionInternals.ts
+++ b/packages/wallet/src/Transaction/createTransactionInternals.ts
@@ -9,7 +9,7 @@ export type CreateTxInternalsProps = {
   certificates?: Cardano.Certificate[];
   withdrawals?: Cardano.Withdrawal[];
   auxiliaryData?: Cardano.AuxiliaryData;
-  collaterals?: Set<Cardano.NewTxIn>;
+  collaterals?: Set<Cardano.TxIn>;
   mint?: Cardano.TokenMap;
   scriptIntegrityHash?: Cardano.util.Hash32ByteBase16;
   requiredExtraSignatures?: Cardano.Ed25519KeyHash[];
@@ -35,7 +35,7 @@ export const createTransactionInternals = async ({
         value
       });
     }
-    const body: Cardano.NewTxBodyAlonzo = {
+    const body: Cardano.TxBody = {
       certificates,
       fee: inputSelection.fee,
       inputs: [...inputSelection.inputs].map(([txIn]) => txIn),

--- a/packages/wallet/src/TxBuilder/buildTx.ts
+++ b/packages/wallet/src/TxBuilder/buildTx.ts
@@ -88,7 +88,7 @@ const createSignedTx = async ({
  * Usage examples are in the unit/integration tests from `builtTx.test.ts`.
  */
 export class ObservableWalletTxBuilder implements TxBuilder {
-  partialTxBody: Partial<Cardano.NewTxBodyAlonzo> = {};
+  partialTxBody: Partial<Cardano.TxBody> = {};
   auxiliaryData?: Cardano.AuxiliaryData;
   extraSigners?: TransactionSigner[];
   signingOptions?: SignTransactionOptions;

--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { Cardano } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 
@@ -112,7 +113,7 @@ export interface OutputBuilder {
 }
 
 export interface SignedTx {
-  readonly tx: Cardano.NewTxAlonzo;
+  readonly tx: Cardano.Tx;
   /**
    * Once the transaction is successfully submitted, calls to the same txBuilder {@link TxBuilder.build} method
    * will fail with {@link TxAlreadySubmittedError} exception.
@@ -122,7 +123,7 @@ export interface SignedTx {
 
 /** Transaction body built with {@link TxBuilder.build}. */
 export interface ValidTxBody {
-  readonly body: Cardano.NewTxBodyAlonzo;
+  readonly body: Cardano.TxBody;
   readonly auxiliaryData?: Cardano.AuxiliaryData;
   readonly extraSigners?: TransactionSigner[];
   readonly signingOptions?: SignTransactionOptions;
@@ -139,15 +140,15 @@ export type MaybeValidTx = ValidTx | InvalidTx;
 export interface TxBuilder {
   /**
    * Transaction body that is updated by `TxBuilder` methods.
-   * It should not be updated directly, but this is not restricted to allow experimental TxBody changes that are not
+   * It should not be updated directly, but this is not restricted to allow experimental HydratedTxBody changes that are not
    * yet available in the TxBuilder interface.
    * Every method call recreates the partialTxBody, thus updating it immutably.
    */
-  partialTxBody: Partial<Cardano.NewTxBodyAlonzo>;
+  partialTxBody: Partial<Cardano.TxBody>;
   /**
    * TxMetadata to be added in the transaction auxiliary data body blob, after {@link TxBuilder.build}.
    * Configured using {@link TxBuilder.setMetadata} method.
-   * It should not be updated directly, but this is not restricted to allow experimental TxBody changes that are not.
+   * It should not be updated directly, but this is not restricted to allow experimental HydratedTxBody changes that are not.
    */
   auxiliaryData?: Cardano.AuxiliaryData;
   extraSigners?: TransactionSigner[];

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -41,12 +41,12 @@ export type SignDataCallbackParams = {
 
 export type SignTxCallbackParams = {
   type: Cip30ConfirmationCallbackType.SignTx;
-  data: Cardano.NewTxAlonzo;
+  data: Cardano.Tx;
 };
 
 export type SubmitTxCallbackParams = {
   type: Cip30ConfirmationCallbackType.SubmitTx;
-  data: Cardano.NewTxAlonzo;
+  data: Cardano.Tx;
 };
 
 export type CallbackConfirmation = (
@@ -291,7 +291,7 @@ export const createWalletApi = (
   },
   submitTx: async (tx: Cbor): Promise<string> => {
     logger.debug('submitting tx');
-    const txData: Cardano.NewTxAlonzo = usingAutoFree((scope) =>
+    const txData: Cardano.Tx = usingAutoFree((scope) =>
       cmlToCore.newTx(scope.manage(CML.Transaction.from_bytes(Buffer.from(tx, 'hex'))))
     );
     const shouldProceed = await confirmationCallback({

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -18,7 +18,7 @@ export class InMemoryAddressesStore extends InMemoryDocumentStore<GroupedAddress
 export class InMemoryInFlightTransactionsStore extends InMemoryDocumentStore<TxInFlight[]> {}
 export class InMemoryVolatileTransactionsStore extends InMemoryDocumentStore<ConfirmedTx[]> {}
 
-export class InMemoryTransactionsStore extends InMemoryCollectionStore<Cardano.TxAlonzo> {}
+export class InMemoryTransactionsStore extends InMemoryCollectionStore<Cardano.HydratedTx> {}
 export class InMemoryUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}
 export class InMemoryUnspendableUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}
 

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -19,7 +19,7 @@ export class PouchDbAddressesStore extends PouchDbDocumentStore<GroupedAddress[]
 export class PouchDbInFlightTransactionsStore extends PouchDbDocumentStore<TxInFlight[]> {}
 export class PouchDbVolatileTransactionsStore extends PouchDbDocumentStore<ConfirmedTx[]> {}
 
-export class PouchDbTransactionsStore extends PouchDbCollectionStore<Cardano.TxAlonzo> {}
+export class PouchDbTransactionsStore extends PouchDbCollectionStore<Cardano.HydratedTx> {}
 export class PouchDbUtxoStore extends PouchDbCollectionStore<Cardano.Utxo> {}
 
 export class PouchDbRewardsHistoryStore extends PouchDbKeyValueStore<Cardano.RewardAccount, EpochRewards[]> {}

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -73,7 +73,7 @@ export interface WalletStores extends Destroyable {
   tip: DocumentStore<Cardano.Tip>;
   utxo: CollectionStore<Cardano.Utxo>;
   unspendableUtxo: CollectionStore<Cardano.Utxo>;
-  transactions: OrderedCollectionStore<Cardano.TxAlonzo>;
+  transactions: OrderedCollectionStore<Cardano.HydratedTx>;
   inFlightTransactions: DocumentStore<TxInFlight[]>;
   volatileTransactions: DocumentStore<ConfirmedTx[]>;
   rewardsHistory: KeyValueStore<Cardano.RewardAccount, EpochRewards[]>;

--- a/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
@@ -82,7 +82,7 @@ export const createQueryStakePoolsProvider =
 export type ObservableStakePoolProvider = ReturnType<typeof createQueryStakePoolsProvider>;
 
 const getWithdrawalQuantity = (
-  withdrawals: Cardano.TxBodyAlonzo['withdrawals'],
+  withdrawals: Cardano.HydratedTxBody['withdrawals'],
   rewardAccount?: Cardano.RewardAccount
 ): Cardano.Lovelace =>
   BigIntMath.sum(

--- a/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
+++ b/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
@@ -38,7 +38,7 @@ export const isLastStakeKeyCertOfType = (
 };
 
 export const transactionsWithCertificates = (
-  transactions$: Observable<Cardano.TxAlonzo[]>,
+  transactions$: Observable<Cardano.HydratedTx[]>,
   rewardAccounts$: Observable<Cardano.RewardAccount[]>,
   certificateTypes: Cardano.CertificateType[]
 ) =>

--- a/packages/wallet/src/services/DelegationTracker/types.ts
+++ b/packages/wallet/src/services/DelegationTracker/types.ts
@@ -1,6 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
 
 export interface TxWithEpoch {
-  tx: Cardano.TxAlonzo;
+  tx: Cardano.HydratedTx;
   epoch: Cardano.EpochNo;
 }

--- a/packages/wallet/src/services/TransactionReemitter.ts
+++ b/packages/wallet/src/services/TransactionReemitter.ts
@@ -52,7 +52,7 @@ export const createTransactionReemitter = ({
   maxInterval,
   genesisParameters$,
   logger
-}: TransactionReemitterProps): Observable<Cardano.NewTxAlonzo> => {
+}: TransactionReemitterProps): Observable<Cardano.Tx> => {
   const volatileTransactions$ = merge(
     stores.volatileTransactions.get().pipe(
       tap((txs) => logger.debug(`Store contains ${txs.length} volatile transactions`)),
@@ -118,7 +118,7 @@ export const createTransactionReemitter = ({
     filter((tx) => !!tx),
     withLatestFrom(volatileTransactions$),
     map(([tx, volatiles]) => {
-      // Get the confirmed NewTxAlonzo transaction to be retried
+      // Get the confirmed Tx transaction to be retried
       const reemitTx = volatiles.find(({ tx: txVolatile }) => txVolatile.id === tx!.id);
       if (!reemitTx) {
         const err = new TransactionReemitError(

--- a/packages/wallet/src/services/TransactionsTracker.ts
+++ b/packages/wallet/src/services/TransactionsTracker.ts
@@ -40,19 +40,19 @@ export interface TransactionsTrackerProps {
   addresses$: Observable<Cardano.Address[]>;
   tip$: Observable<Cardano.Tip>;
   retryBackoffConfig: RetryBackoffConfig;
-  transactionsHistoryStore: OrderedCollectionStore<Cardano.TxAlonzo>;
+  transactionsHistoryStore: OrderedCollectionStore<Cardano.HydratedTx>;
   inFlightTransactionsStore: DocumentStore<TxInFlight[]>;
   newTransactions: {
-    submitting$: Observable<Cardano.NewTxAlonzo>;
-    pending$: Observable<Cardano.NewTxAlonzo>;
+    submitting$: Observable<Cardano.Tx>;
+    pending$: Observable<Cardano.Tx>;
     failedToSubmit$: Observable<FailedTx>;
   };
   logger: Logger;
 }
 
 export interface TransactionsTrackerInternals {
-  transactionsSource$: Observable<Cardano.TxAlonzo[]>;
-  rollback$: Observable<Cardano.TxAlonzo>;
+  transactionsSource$: Observable<Cardano.HydratedTx[]>;
+  rollback$: Observable<Cardano.HydratedTx>;
 }
 
 export interface TransactionsTrackerInternalsProps {
@@ -60,7 +60,7 @@ export interface TransactionsTrackerInternalsProps {
   addresses$: Observable<Cardano.Address[]>;
   retryBackoffConfig: RetryBackoffConfig;
   tipBlockHeight$: Observable<number>;
-  store: OrderedCollectionStore<Cardano.TxAlonzo>;
+  store: OrderedCollectionStore<Cardano.HydratedTx>;
   logger: Logger;
 }
 
@@ -70,10 +70,10 @@ export const PAGE_SIZE = 25;
 const allTransactionsByAddresses = async (
   chainHistoryProvider: ChainHistoryProvider,
   { addresses, blockRange }: { addresses: Cardano.Address[]; blockRange: Range<Cardano.BlockNo> }
-): Promise<Cardano.TxAlonzo[]> => {
+): Promise<Cardano.HydratedTx[]> => {
   let startAt = 0;
-  let response: Cardano.TxAlonzo[] = [];
-  let pageResults: Cardano.TxAlonzo[] = [];
+  let response: Cardano.HydratedTx[] = [];
+  let pageResults: Cardano.HydratedTx[] = [];
   do {
     pageResults = (
       await chainHistoryProvider.transactionsByAddresses({
@@ -97,7 +97,7 @@ export const createAddressTransactionsProvider = ({
   store,
   logger
 }: TransactionsTrackerInternalsProps): TransactionsTrackerInternals => {
-  const rollback$ = new Subject<Cardano.TxAlonzo>();
+  const rollback$ = new Subject<Cardano.HydratedTx>();
   const storedTransactions$ = store.getAll().pipe(share());
   return {
     rollback$: rollback$.asObservable(),
@@ -107,9 +107,9 @@ export const createAddressTransactionsProvider = ({
           logger.debug(`Stored history transactions count: ${storedTransactions?.length || 0}`)
         )
       ),
-      combineLatest([addresses$, storedTransactions$.pipe(defaultIfEmpty([] as Cardano.TxAlonzo[]))]).pipe(
+      combineLatest([addresses$, storedTransactions$.pipe(defaultIfEmpty([] as Cardano.HydratedTx[]))]).pipe(
         switchMap(([addresses, storedTransactions]) => {
-          let localTransactions: Cardano.TxAlonzo[] = [...storedTransactions];
+          let localTransactions: Cardano.HydratedTx[] = [...storedTransactions];
 
           return coldObservableProvider({
             // Do not re-fetch transactions twice on load when tipBlockHeight$ loads from storage first
@@ -120,7 +120,7 @@ export const createAddressTransactionsProvider = ({
             provider: async () => {
               // eslint-disable-next-line no-constant-condition
               while (true) {
-                const lastStoredTransaction: Cardano.TxAlonzo | undefined =
+                const lastStoredTransaction: Cardano.HydratedTx | undefined =
                   localTransactions[localTransactions.length - 1];
 
                 lastStoredTransaction &&
@@ -168,8 +168,8 @@ export const createAddressTransactionsProvider = ({
 };
 
 const createHistoricalTransactionsTrackerSubject = (
-  transactions$: Observable<Cardano.TxAlonzo[]>
-): TrackerSubject<Cardano.TxAlonzo[]> =>
+  transactions$: Observable<Cardano.HydratedTx[]>
+): TrackerSubject<Cardano.HydratedTx[]> =>
   new TrackerSubject(
     transactions$.pipe(
       map((transactions) =>
@@ -182,7 +182,7 @@ const createHistoricalTransactionsTrackerSubject = (
     )
   );
 
-const newTransactions$ = (transactions$: Observable<Cardano.TxAlonzo[]>) =>
+const newTransactions$ = (transactions$: Observable<Cardano.HydratedTx[]>) =>
   transactions$.pipe(
     take(1),
     map((transactions) => transactions.map(({ id }) => id)),
@@ -224,7 +224,7 @@ export const createTransactionsTracker = (
   const transactionsSource$ = new TrackerSubject(txSource$);
 
   const historicalTransactions$ = createHistoricalTransactionsTrackerSubject(transactionsSource$);
-  const txConfirmed$ = (tx: Cardano.NewTxAlonzo): Observable<ConfirmedTx> =>
+  const txConfirmed$ = (tx: Cardano.Tx): Observable<ConfirmedTx> =>
     newTransactions$(historicalTransactions$).pipe(
       filter((historyTx) => historyTx.id === tx.id),
       take(1),
@@ -282,13 +282,13 @@ export const createTransactionsTracker = (
     )
     .subscribe(failed$);
 
-  const txFailed$ = (tx: Cardano.NewTxAlonzo) =>
+  const txFailed$ = (tx: Cardano.Tx) =>
     failed$.pipe(
       filter((failed) => failed.tx === tx),
       take(1)
     );
 
-  const txPending$ = (tx: Cardano.NewTxAlonzo) =>
+  const txPending$ = (tx: Cardano.Tx) =>
     pending$.pipe(
       filter((pending) => pending === tx),
       withLatestFrom(tip$),

--- a/packages/wallet/src/services/UtxoTracker.ts
+++ b/packages/wallet/src/services/UtxoTracker.ts
@@ -91,7 +91,7 @@ export const createUtxoTracker = (
               )
           )
           .map((txOut): Cardano.Utxo => {
-            const txIn: Cardano.TxIn = {
+            const txIn: Cardano.HydratedTxIn = {
               address: txOut.address, // not necessarily correct in multi-address wallet
               index: tx.body.outputs.indexOf(txOut),
               txId: tx.id

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -106,7 +106,7 @@ export const createOutputValidator = ({ protocolParameters$ }: OutputValidatorCo
 };
 
 export const createInputResolver = ({ utxo }: InputResolverContext): Cardano.util.InputResolver => ({
-  async resolveInputAddress(input: Cardano.NewTxIn) {
+  async resolveInputAddress(input: Cardano.TxIn) {
     const utxoAvailable = await firstValueFrom(utxo.available$);
     return utxoAvailable?.find(([txIn]) => txInEquals(txIn, input))?.[1].address || null;
   }

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -46,21 +46,21 @@ export interface PollingConfig {
 }
 
 export interface FailedTx {
-  tx: Cardano.NewTxAlonzo;
+  tx: Cardano.Tx;
   reason: TransactionFailure;
   error?: CardanoNodeErrors.TxSubmissionError;
 }
 
-export type ConfirmedTx = { tx: Cardano.NewTxAlonzo; confirmedAt: Cardano.PartialBlockHeader['slot'] };
-export type TxInFlight = { tx: Cardano.NewTxAlonzo; submittedAt?: Cardano.PartialBlockHeader['slot'] };
+export type ConfirmedTx = { tx: Cardano.Tx; confirmedAt: Cardano.PartialBlockHeader['slot'] };
+export type TxInFlight = { tx: Cardano.Tx; submittedAt?: Cardano.PartialBlockHeader['slot'] };
 
 export interface TransactionsTracker {
-  readonly history$: Observable<Cardano.TxAlonzo[]>;
-  readonly rollback$: Observable<Cardano.TxAlonzo>;
+  readonly history$: Observable<Cardano.HydratedTx[]>;
+  readonly rollback$: Observable<Cardano.HydratedTx>;
   readonly outgoing: {
     readonly inFlight$: Observable<TxInFlight[]>;
-    readonly submitting$: Observable<Cardano.NewTxAlonzo>;
-    readonly pending$: Observable<Cardano.NewTxAlonzo>;
+    readonly submitting$: Observable<Cardano.Tx>;
+    readonly pending$: Observable<Cardano.Tx>;
     readonly failed$: Observable<FailedTx>;
     readonly confirmed$: Observable<ConfirmedTx>;
   };

--- a/packages/wallet/src/services/util/equals.ts
+++ b/packages/wallet/src/services/util/equals.ts
@@ -10,11 +10,11 @@ export const shallowArrayEquals = <T>(a: T[], b: T[]) => arrayEquals(a, b, stric
 
 export const tipEquals = (a: Cardano.Tip, b: Cardano.Tip) => a.hash === b.hash;
 
-export const txEquals = (a: Cardano.TxAlonzo, b: Cardano.TxAlonzo) => a.id === b.id;
+export const txEquals = (a: Cardano.HydratedTx, b: Cardano.HydratedTx) => a.id === b.id;
 
-export const transactionsEquals = (a: Cardano.TxAlonzo[], b: Cardano.TxAlonzo[]) => arrayEquals(a, b, txEquals);
+export const transactionsEquals = (a: Cardano.HydratedTx[], b: Cardano.HydratedTx[]) => arrayEquals(a, b, txEquals);
 
-export const txInEquals = (a: Cardano.NewTxIn, b: Cardano.NewTxIn) => a.txId === b.txId && a.index === b.index;
+export const txInEquals = (a: Cardano.TxIn, b: Cardano.TxIn) => a.txId === b.txId && a.index === b.index;
 
 export const utxoEquals = (a: Cardano.Utxo[], b: Cardano.Utxo[]) =>
   arrayEquals(a, b, ([aTxIn], [bTxIn]) => txInEquals(aTxIn, bTxIn));

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -13,7 +13,7 @@ export type InitializeTxProps = {
   options?: {
     validityInterval?: Cardano.ValidityInterval;
   };
-  collaterals?: Set<Cardano.NewTxIn>;
+  collaterals?: Set<Cardano.TxIn>;
   mint?: Cardano.TokenMap;
   scriptIntegrityHash?: Cardano.util.Hash32ByteBase16;
   requiredExtraSignatures?: Cardano.Ed25519KeyHash[];
@@ -89,7 +89,7 @@ export interface ObservableWallet {
    * @throws InputSelectionError
    */
   initializeTx(props: InitializeTxProps): Promise<InitializeTxResult>;
-  finalizeTx(props: FinalizeTxProps): Promise<Cardano.NewTxAlonzo>;
+  finalizeTx(props: FinalizeTxProps): Promise<Cardano.Tx>;
   /**
    * @throws Cip30DataSignError
    */
@@ -97,7 +97,7 @@ export interface ObservableWallet {
   /**
    * @throws CardanoNodeErrors.TxSubmissionError
    */
-  submitTx(tx: Cardano.NewTxAlonzo): Promise<void>;
+  submitTx(tx: Cardano.Tx): Promise<void>;
   shutdown(): void;
 }
 

--- a/packages/wallet/test/SingleAddressWallet/methods.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/methods.test.ts
@@ -150,7 +150,7 @@ describe('SingleAddressWallet methods', () => {
   describe('creating transactions', () => {
     const props = {
       collaterals: new Set([utxo[2][0]]),
-      inputs: new Set<Cardano.TxIn>([utxo[1][0]]),
+      inputs: new Set<Cardano.HydratedTxIn>([utxo[1][0]]),
       mint: new Map([
         [AssetId.PXL, 5n],
         [AssetId.TSLA, 20n]

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -87,7 +87,7 @@ const txOut: Cardano.TxOut = {
   }
 };
 
-const txBody: Cardano.NewTxBodyAlonzo = {
+const txBody: Cardano.TxBody = {
   fee: 10n,
   inputs: [
     {
@@ -105,7 +105,7 @@ const vkey = '6199186adb51974690d7247d2646097d2c62763b767b528816fb7ed3f9f55d39';
 const signature =
   // eslint-disable-next-line max-len
   'bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755';
-const tx: Cardano.NewTxAlonzo = {
+const tx: Cardano.Tx = {
   body: txBody,
   id: Cardano.TransactionId('de9d33f66cffff721673219b19470aec81d96bc9253182369e41eec58389a448'),
   witness: {

--- a/packages/wallet/test/Transaction/createTransactionInternals.test.ts
+++ b/packages/wallet/test/Transaction/createTransactionInternals.test.ts
@@ -67,7 +67,7 @@ describe('Transaction.createTransactionInternals', () => {
     };
     const txInternals = await createSimpleTransactionInternals(() => props);
     expect(txInternals.body.outputs).toHaveLength(2);
-    expect(txInternals.body.collaterals).toEqual<Cardano.NewTxIn[]>([utxo[2][0]]);
+    expect(txInternals.body.collaterals).toEqual<Cardano.TxIn[]>([utxo[2][0]]);
     expect(txInternals.body.mint).toEqual<Cardano.TokenMap>(props.mint);
     expect(txInternals.body.requiredExtraSignatures).toEqual<Cardano.Ed25519KeyHash[]>(props.requiredExtraSignatures);
     expect(txInternals.body.scriptIntegrityHash).toEqual<Cardano.util.Hash32ByteBase16>(props.scriptIntegrityHash);

--- a/packages/wallet/test/integration/CustomObservableWallet.test.ts
+++ b/packages/wallet/test/integration/CustomObservableWallet.test.ts
@@ -64,7 +64,7 @@ describe('CustomObservableWallet', () => {
     });
 
     it('does not necessarily have to use SingleAddressWallet, but can still utilize SDK utils', () => {
-      // let's say we have an API endpoint to submit transaction as bytes and not as SDK's Cardano.NewTxAlonzo
+      // let's say we have an API endpoint to submit transaction as bytes and not as SDK's Cardano.Tx
       const submitTxBytesHexString: (tx: string) => Promise<void> = () => Promise.resolve();
       // and another endpoint to get wallet addresses
       const getAddresses: () => Promise<GroupedAddress[]> = async () => [];
@@ -120,7 +120,7 @@ describe('CustomObservableWallet', () => {
             trigger$: walletUpdateTrigger$
           })
         },
-        submitTx(tx: Cardano.NewTxAlonzo) {
+        submitTx(tx: Cardano.Tx) {
           // can use utils from SDK, in this case `coreToCml.tx`
           // if you want to submit hex-encoded tx, there is also cslToCore.newTx for the reverse
           const txBytes = Buffer.from(usingAutoFree((scope) => coreToCml.tx(scope, tx).to_bytes())).toString('hex');

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -178,7 +178,7 @@ describe('cip30', () => {
     describe('submitTx', () => {
       let cmlTx: string;
       let txInternals: InitializeTxResult;
-      let finalizedTx: Cardano.NewTxAlonzo<Cardano.NewTxBodyAlonzo>;
+      let finalizedTx: Cardano.Tx<Cardano.TxBody>;
 
       beforeAll(async () => {
         txInternals = await wallet.initializeTx(simpleTxProps);

--- a/packages/wallet/test/mocks/mockChainHistoryProvider.ts
+++ b/packages/wallet/test/mocks/mockChainHistoryProvider.ts
@@ -13,7 +13,7 @@ const address = Cardano.Address(
   'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
 );
 
-export const generateTxAlonzo = (qty: number): Cardano.TxAlonzo[] =>
+export const generateTxAlonzo = (qty: number): Cardano.HydratedTx[] =>
   [...Array.from({ length: qty }).keys()].map((index) => ({
     blockHeader: {
       blockNo: 10_669,
@@ -46,7 +46,7 @@ export const generateTxAlonzo = (qty: number): Cardano.TxAlonzo[] =>
     }
   }));
 
-export const queryTransactionsResult: Paginated<Cardano.TxAlonzo> = {
+export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
   pageResults: [
     {
       blockHeader: {
@@ -134,12 +134,12 @@ export const queryTransactionsResult: Paginated<Cardano.TxAlonzo> = {
         }
       },
       id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
-    } as Cardano.TxAlonzo
+    } as Cardano.HydratedTx
   ],
   totalResultCount: 2
 };
 
-export const queryTransactionsResult2: Paginated<Cardano.TxAlonzo> = {
+export const queryTransactionsResult2: Paginated<Cardano.HydratedTx> = {
   pageResults: [
     ...queryTransactionsResult.pageResults,
     {
@@ -149,7 +149,7 @@ export const queryTransactionsResult2: Paginated<Cardano.TxAlonzo> = {
         slot: ledgerTip.slot - 50_000
       },
       id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99caa')
-    } as Cardano.TxAlonzo
+    } as Cardano.HydratedTx
   ],
   totalResultCount: 3
 };

--- a/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
@@ -158,12 +158,12 @@ describe('RewardAccounts', () => {
         b: [
           { tx: {
             body: { certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash }] }
-          } as Cardano.NewTxAlonzo }
+          } as Cardano.Tx }
         ],
         c: [
           { tx: {
             body: { certificates: [{ __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash }] }
-          } as Cardano.NewTxAlonzo }
+          } as Cardano.Tx }
         ]
       });
       const tracker$ = addressKeyStatuses([rewardAccount], transactions$, transactionsInFlight$);
@@ -192,7 +192,7 @@ describe('RewardAccounts', () => {
           a: [],
           b: [{ tx: { body: { withdrawals: [{
             quantity: acc1PendingWithdrawalQty, stakeAddress: twoRewardAccounts[0] } as Cardano.Withdrawal
-          ] } as Cardano.NewTxBodyAlonzo } as Cardano.NewTxAlonzo }]
+          ] } as Cardano.TxBody } as Cardano.Tx }]
         });
         const rewardsProvider = () => hot('-a--b-a--b---a', {
           a: [acc1Balance1, acc2Balance],
@@ -228,7 +228,7 @@ describe('RewardAccounts', () => {
           x: [] as TxInFlight[],
           y: [{ tx: { body: { withdrawals: [{
             quantity: acc1PendingWithdrawalQty, stakeAddress: twoRewardAccounts[0] } as Cardano.Withdrawal
-          ] } as Cardano.NewTxBodyAlonzo } } as TxInFlight]
+          ] } as Cardano.TxBody } } as TxInFlight]
         };
         const rewardsProviderEmits = {
           a: [accBalance1],
@@ -264,14 +264,14 @@ describe('RewardAccounts', () => {
     it('emits every epoch and after making a transaction with withdrawals', () => {
       const rewardAccount = Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27');
       createTestScheduler().run(({ cold, expectObservable }) => {
-        const tx2 = { body: { withdrawals: [{ quantity: 5n, stakeAddress: rewardAccount }] } } as Cardano.TxAlonzo;
+        const tx2 = { body: { withdrawals: [{ quantity: 5n, stakeAddress: rewardAccount }] } } as Cardano.HydratedTx;
         const epoch$ = cold(      'a-b--', { a: 100, b: 101 });
         const txConfirmed$ = cold('-a--b', {
           a: { confirmedAt: 1, tx: { body: {
             withdrawals: [{
               quantity: 3n,
               stakeAddress: Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d')
-            }] } } as Cardano.TxAlonzo },
+            }] } } as Cardano.HydratedTx },
           b: { confirmedAt: 2, tx: tx2 }
         });
         const target$ = fetchRewardsTrigger$(epoch$, txConfirmed$, rewardAccount);

--- a/packages/wallet/test/services/DelegationTracker/stub-tx.ts
+++ b/packages/wallet/test/services/DelegationTracker/stub-tx.ts
@@ -9,4 +9,4 @@ export const createStubTxWithCertificates = (certificates?: Cardano.Certificate[
     body: {
       certificates: certificates?.map((cert) => ({ ...cert, ...commonCertProps }))
     }
-  } as Cardano.TxAlonzo);
+  } as Cardano.HydratedTx);

--- a/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
@@ -51,11 +51,11 @@ describe('transactionCertificates', () => {
             } as Cardano.Certificate
           ]
         }
-      } as Cardano.TxAlonzo;
+      } as Cardano.HydratedTx;
       const outgoing$ = cold('abc', {
         a: [],
-        b: [{ body: { certificates: [{ __typename: Cardano.CertificateType.MIR }] } } as Cardano.TxAlonzo],
-        c: [{ body: {} } as Cardano.TxAlonzo, tx]
+        b: [{ body: { certificates: [{ __typename: Cardano.CertificateType.MIR }] } } as Cardano.HydratedTx],
+        c: [{ body: {} } as Cardano.HydratedTx, tx]
       });
       const rewardAccounts$ = cold('a', {
         a: [rewardAccount]

--- a/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
+++ b/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
@@ -25,7 +25,7 @@ describe('SmartTxSubmitProvider', () => {
   });
 
   describe('submitTx', () => {
-    const txWithoutValidityInterval: Cardano.NewTxAlonzo = {
+    const txWithoutValidityInterval: Cardano.Tx = {
       body: {
         fee: 0n,
         inputs: [],

--- a/packages/wallet/test/services/TransactionReemitter.test.ts
+++ b/packages/wallet/test/services/TransactionReemitter.test.ts
@@ -66,8 +66,8 @@ describe('TransactionReemiter', () => {
       const tipSlot$ = hot<Cardano.Slot>('-|');
       const genesisParameters$ = cold<Cardano.CompactGenesis>('-|');
       const confirmed$ = cold<ConfirmedTx>('-|');
-      const rollback$ = cold<Cardano.TxAlonzo>('-|');
-      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const rollback$ = cold<Cardano.HydratedTx>('-|');
+      const submitting$ = cold<Cardano.Tx>('-|');
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
@@ -97,8 +97,8 @@ describe('TransactionReemiter', () => {
       const tipSlot$ = hot<Cardano.Slot>('----|');
       const genesisParameters$ = cold<Cardano.CompactGenesis>('a---|', { a: genesisParameters });
       const confirmed$ = cold<ConfirmedTx>('-b-c|', { b: volatileTransactions[1], c: volatileTransactions[2] });
-      const rollback$ = cold<Cardano.TxAlonzo>('----|');
-      const submitting$ = cold<Cardano.NewTxAlonzo>('----|');
+      const rollback$ = cold<Cardano.HydratedTx>('----|');
+      const submitting$ = cold<Cardano.Tx>('----|');
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
@@ -128,8 +128,8 @@ describe('TransactionReemiter', () => {
       const tipSlot$ = hot<Cardano.Slot>('--|');
       const genesisParameters$ = cold<Cardano.CompactGenesis>('a-|', { a: genesisParameters });
       const confirmed$ = cold<ConfirmedTx>('--|');
-      const rollback$ = cold<Cardano.TxAlonzo>('--|');
-      const submitting$ = cold<Cardano.NewTxAlonzo>('-b|', { b: volatileTransactions[0].tx });
+      const rollback$ = cold<Cardano.HydratedTx>('--|');
+      const submitting$ = cold<Cardano.Tx>('-b|', { b: volatileTransactions[0].tx });
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
@@ -164,8 +164,8 @@ describe('TransactionReemiter', () => {
         b: volatileSlot200,
         c: volatileSlot300
       });
-      const rollback$ = cold<Cardano.TxAlonzo>('---|');
-      const submitting$ = cold<Cardano.NewTxAlonzo>('---|');
+      const rollback$ = cold<Cardano.HydratedTx>('---|');
+      const submitting$ = cold<Cardano.Tx>('---|');
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
@@ -191,12 +191,12 @@ describe('TransactionReemiter', () => {
   it('Emits transactions that were rolled back and still valid', () => {
     const LAST_TIP_SLOT = 400;
     const [volatileA, volatileB, volatileC, volatileD] = volatileTransactions;
-    const rollbackA: Cardano.TxAlonzo = { body: volatileA.tx.body, id: volatileA.tx.id } as Cardano.TxAlonzo;
-    const rollbackC: Cardano.TxAlonzo = {
+    const rollbackA: Cardano.HydratedTx = { body: volatileA.tx.body, id: volatileA.tx.id } as Cardano.HydratedTx;
+    const rollbackC: Cardano.HydratedTx = {
       body: { validityInterval: { invalidHereafter: LAST_TIP_SLOT - 1 } },
       id: volatileC.tx.id
-    } as Cardano.TxAlonzo;
-    const rollbackD: Cardano.TxAlonzo = { body: volatileD.tx.body, id: volatileD.tx.id } as Cardano.TxAlonzo;
+    } as Cardano.HydratedTx;
+    const rollbackD: Cardano.HydratedTx = { body: volatileD.tx.body, id: volatileD.tx.id } as Cardano.HydratedTx;
 
     // eslint-disable-next-line @typescript-eslint/no-shadow
     logger.error = jest.fn();
@@ -210,8 +210,8 @@ describe('TransactionReemiter', () => {
         c: volatileC,
         d: volatileD
       });
-      const rollback$ = cold<Cardano.TxAlonzo>('--a--c--d|', { a: rollbackA, c: rollbackC, d: rollbackD });
-      const submitting$ = cold<Cardano.NewTxAlonzo>('---------|');
+      const rollback$ = cold<Cardano.HydratedTx>('--a--c--d|', { a: rollbackA, c: rollbackC, d: rollbackD });
+      const submitting$ = cold<Cardano.Tx>('---------|');
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
@@ -236,7 +236,7 @@ describe('TransactionReemiter', () => {
 
   it('Logs error message for rolledback transactions not found in volatiles', () => {
     const [volatileA, volatileB, volatileC] = volatileTransactions;
-    const rollbackC: Cardano.TxAlonzo = { body: volatileC.tx.body, id: volatileC.tx.id } as Cardano.TxAlonzo;
+    const rollbackC: Cardano.HydratedTx = { body: volatileC.tx.body, id: volatileC.tx.id } as Cardano.HydratedTx;
     // eslint-disable-next-line @typescript-eslint/no-shadow
     const logger = dummyLogger;
     logger.error = jest.fn();
@@ -248,8 +248,8 @@ describe('TransactionReemiter', () => {
         a: volatileA,
         b: volatileB
       });
-      const rollback$ = cold<Cardano.TxAlonzo>('--c|', { c: rollbackC });
-      const submitting$ = cold<Cardano.NewTxAlonzo>('---|');
+      const rollback$ = cold<Cardano.HydratedTx>('--c|', { c: rollbackC });
+      const submitting$ = cold<Cardano.Tx>('---|');
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
@@ -289,8 +289,8 @@ describe('TransactionReemiter', () => {
       const tipSlot$ = hot<Cardano.Slot>('-|');
       const genesisParameters$ = cold<Cardano.CompactGenesis>('-|');
       const confirmed$ = cold<ConfirmedTx>('-|');
-      const rollback$ = cold<Cardano.TxAlonzo>('-|');
-      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const rollback$ = cold<Cardano.HydratedTx>('-|');
+      const submitting$ = cold<Cardano.Tx>('-|');
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({
         genesisParameters$,
@@ -319,8 +319,8 @@ describe('TransactionReemiter', () => {
       const tipSlot$ = hot<Cardano.Slot>('-a|', { a: tip });
       const genesisParameters$ = hot('a|', { a: genesisParameters });
       const confirmed$ = cold<ConfirmedTx>('-|');
-      const rollback$ = cold<Cardano.TxAlonzo>('-|');
-      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const rollback$ = cold<Cardano.HydratedTx>('-|');
+      const submitting$ = cold<Cardano.Tx>('-|');
       const inFlight$ = cold<TxInFlight[]>('a|', {
         a: [
           { submittedAt: tip - 1, tx: volatileTransactions[0].tx },
@@ -355,8 +355,8 @@ describe('TransactionReemiter', () => {
       const tipSlot$ = hot<Cardano.Slot>('-a--|', { a: tip });
       const genesisParameters$ = cold('a-b|', { a: genesisParameters, b: genesisParameters });
       const confirmed$ = cold<ConfirmedTx>('-|');
-      const rollback$ = cold<Cardano.TxAlonzo>('-|');
-      const submitting$ = cold<Cardano.NewTxAlonzo>('-|');
+      const rollback$ = cold<Cardano.HydratedTx>('-|');
+      const submitting$ = cold<Cardano.Tx>('-|');
       const inFlight$ = cold<TxInFlight[]>('a|', {
         a: [
           { submittedAt: tip - 1, tx: volatileTransactions[0].tx },

--- a/packages/wallet/test/services/UtxoTracker.test.ts
+++ b/packages/wallet/test/services/UtxoTracker.test.ts
@@ -50,7 +50,7 @@ describe('createUtxoTracker', () => {
           outputs: tx1Outputs
         },
         id: transactionId1
-      } as unknown as Cardano.NewTxAlonzo;
+      } as unknown as Cardano.Tx;
       const chainableUtxoFromTx1 = [
         { address: ownAddress, index: tx1Outputs.indexOf(tx1ChangeOutput), txId: transactionId1 },
         tx1ChangeOutput
@@ -65,7 +65,7 @@ describe('createUtxoTracker', () => {
           outputs: tx2Outputs
         },
         id: transactionId2
-      } as unknown as Cardano.NewTxAlonzo;
+      } as unknown as Cardano.Tx;
       const transactionsInFlight$ = cold('-a-b-c|', {
         a: [],
         b: [{ tx: inFlightTx1 }],

--- a/packages/wallet/test/services/util/equals.test.ts
+++ b/packages/wallet/test/services/util/equals.test.ts
@@ -38,14 +38,16 @@ describe('equals', () => {
   });
 
   test('txEquals', () => {
-    expect(txEquals({ id: txId1 } as Cardano.TxAlonzo, { id: txId2 } as Cardano.TxAlonzo)).toBe(false);
-    expect(txEquals({ id: txId1 } as Cardano.TxAlonzo, { id: txId1 } as Cardano.TxAlonzo)).toBe(true);
+    expect(txEquals({ id: txId1 } as Cardano.HydratedTx, { id: txId2 } as Cardano.HydratedTx)).toBe(false);
+    expect(txEquals({ id: txId1 } as Cardano.HydratedTx, { id: txId1 } as Cardano.HydratedTx)).toBe(true);
   });
 
   test('transactionsEquals', () => {
     expect(transactionsEquals([], [])).toBe(true);
-    expect(transactionsEquals([{ id: txId1 } as Cardano.TxAlonzo], [{ id: txId2 } as Cardano.TxAlonzo])).toBe(false);
-    expect(transactionsEquals([{ id: txId1 } as Cardano.TxAlonzo], [{ id: txId1 } as Cardano.TxAlonzo])).toBe(true);
+    expect(transactionsEquals([{ id: txId1 } as Cardano.HydratedTx], [{ id: txId2 } as Cardano.HydratedTx])).toBe(
+      false
+    );
+    expect(transactionsEquals([{ id: txId1 } as Cardano.HydratedTx], [{ id: txId1 } as Cardano.HydratedTx])).toBe(true);
   });
 
   test('utxoEquals ', () => {


### PR DESCRIPTION
# Context

Rename all era-specific types in `core` package

# Important Changes Introduced
- `TxAlonzo` -> `HydratedTx`
- `TxBodyAlonzo` -> `HydratedTxBody`
- `TxIn` -> `HydratedTxIn`

- `NewTxAlonzo` -> `Tx`
- `NewTxBodyAlonzo` -> `TxBody`
- `NewTxIn` -> `TxIn`