### PR TITLE
chore: add paths created by nix to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ lerna-debug.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# created by nix
+result
+source


### PR DESCRIPTION
`result` is created by `nix build`
`source` is created by `nix develop --unpack`
neither should be tracked by git

# Context

Just adding a couple of directories that nix can create to gitignore.

