### PR TITLE
fix(cardano-services): `OgmiosTxSubmitProvider` is not initialized error

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,14 +80,13 @@
 
           mkdir -p $out/libexec/$sourceRoot $out/bin
 
-          test -f ${production-deps}/libexec/$sourceRoot/packages/cardano-services/node_modules && cp -r ${production-deps}/libexec/$sourceRoot/node_modules $out/libexec/$sourceRoot/node_modules
+          cp -r ${production-deps}/libexec/$sourceRoot/node_modules $out/libexec/$sourceRoot/node_modules
           cp -r scripts $out/libexec/$sourceRoot/scripts
           for p in cardano-services core ogmios util; do
             mkdir -p $out/libexec/$sourceRoot/packages/$p
             cp -r packages/$p/dist $out/libexec/$sourceRoot/packages/$p/dist
             cp -r packages/$p/package.json $out/libexec/$sourceRoot/packages/$p/package.json
           done
-          test -f ${production-deps}/libexec/$sourceRoot/packages/cardano-services/node_modules && cp -r ${production-deps}/libexec/$sourceRoot/packages/cardano-services/node_modules $out/libexec/$sourceRoot/packages/cardano-services/node_modules
           cp -r ${production-deps}/libexec/$sourceRoot/packages/cardano-services/config $out/libexec/$sourceRoot/packages/cardano-services/config
 
           cd "$out/libexec/$sourceRoot"
@@ -103,6 +102,7 @@
           chmod a+x $out/bin/cli
         '';
         meta.mainProgram = "cli";
+        passthru.production-deps = production-deps;
       });
 
     apps = flake-utils.lib.eachDefaultSystemMap (system: let

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,7 @@
           chmod a+x $out/bin/cli
         '';
         meta.mainProgram = "cli";
+        passthru.nodejs = pkgs.nodejs;
         passthru.production-deps = production-deps;
       });
 

--- a/packages/cardano-services/test/Program/services/ogmios.test.ts
+++ b/packages/cardano-services/test/Program/services/ogmios.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable max-len */
-import { CardanoNodeErrors, TxSubmitProvider } from '@cardano-sdk/core';
+import { CardanoNodeErrors } from '@cardano-sdk/core';
 import { Connection } from '@cardano-ogmios/client';
 import { DbSyncEpochPollService, listenPromise, serverClosePromise } from '../../../src/util';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../../src/NetworkInfo';
@@ -52,7 +52,7 @@ describe('Service dependency abstractions', () => {
     let apiUrlBase: string;
     let ogmiosServer: http.Server;
     let ogmiosConnection: Connection;
-    let txSubmitProvider: TxSubmitProvider;
+    let txSubmitProvider: OgmiosTxSubmitProvider;
     let ogmiosCardanoNode: OgmiosCardanoNode;
     let httpServer: HttpServer;
     let port: number;
@@ -92,6 +92,10 @@ describe('Service dependency abstractions', () => {
           await httpServer.shutdown();
         });
 
+        it('txSubmitProvider state should be running when http server has started', () => {
+          expect(txSubmitProvider.state).toEqual('running');
+        });
+
         it('txSubmitProvider should be instance of a Proxy ', () => {
           expect(types.isProxy(txSubmitProvider)).toEqual(true);
         });
@@ -102,6 +106,15 @@ describe('Service dependency abstractions', () => {
           });
           expect(res.status).toBe(200);
           expect(res.data).toEqual(healthCheckResponseMock());
+        });
+
+        it('TxSubmitHttpService replies with status 200 OK when /submit endpoint is reached', async () => {
+          const res = await axios.post(
+            `${apiUrlBase}/submit`,
+            { signedTransaction: bufferToHexString(Buffer.from(new Uint8Array())) },
+            { headers: { 'Content-Type': APPLICATION_JSON } }
+          );
+          expect(res.status).toBe(200);
         });
       });
 
@@ -142,6 +155,10 @@ describe('Service dependency abstractions', () => {
           await httpServer.shutdown();
         });
 
+        it('ogmiosCardanoNode state should be running when http server has started', () => {
+          expect(ogmiosCardanoNode.state).toEqual('running');
+        });
+
         it('ogmiosCardanoNode should be instance of a Proxy ', () => {
           expect(types.isProxy(ogmiosCardanoNode)).toEqual(true);
         });
@@ -152,6 +169,13 @@ describe('Service dependency abstractions', () => {
           });
           expect(res.status).toBe(200);
           expect(res.data).toEqual(healthCheckResponseMock());
+        });
+
+        it('NetworkInfoHttpService replies with status 200 OK when /stake endpoint is reached', async () => {
+          const res = await axios.post(`${apiUrlBase}/stake`, undefined, {
+            headers: { 'Content-Type': APPLICATION_JSON }
+          });
+          expect(res.status).toBe(200);
         });
       });
     });

--- a/packages/cardano-services/test/util.ts
+++ b/packages/cardano-services/test/util.ts
@@ -21,7 +21,11 @@ export const ogmiosServerReady = (connection: Ogmios.Connection): Promise<void> 
 export const createHealthyMockOgmiosServer = (submitTxHook?: () => void) =>
   createMockOgmiosServer({
     healthCheck: { response: { networkSynchronization: 0.999, success: true } },
-    stateQuery: { eraSummaries: { response: { success: true } }, systemStart: { response: { success: true } } },
+    stateQuery: {
+      eraSummaries: { response: { success: true } },
+      stakeDistribution: { response: { success: true } },
+      systemStart: { response: { success: true } }
+    },
     submitTx: { response: { success: true } },
     submitTxHook
   });


### PR DESCRIPTION
# Context

The Lace team raised an issue related to OgmiosTxSubmitProvider not being initialized: 
```
{"name":"http-server","hostname":"9d06efc80cb7","pid":1,"level":50,"err":{"message":"submitTx cannot be called until OgmiosTxSubmitProvider is initialized","name":"NotInitializedError","stack":"NotInitializedError: submitTx cannot be called until OgmiosTxSubmitProvider is initialized\n    at OgmiosTxSubmitProvider.submitTx (/nix/store/gg5qhqwjfmyw4xlpvvrgii4sbm4kjzi8-cardano-
```
# Proposed Solution
Setting the Runnable prototype explicitly of the Proxy class abstraction

# Important Changes Introduced
- set explicitly a Runnable prototype of the Proxy abstractions
