### PR TITLE
fix(key-management): compile error in `key-management` package

### DIFF
--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -158,7 +158,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         certificates: [
           {
             __typename: Cardano.CertificateType.PoolRetirement,
-            epoch: 40,
+            epoch: Cardano.EpochNo(40),
             poolId: Cardano.PoolId.fromKeyHash(ownStakeKeyHash)
           }
         ],


### PR DESCRIPTION
# Context
CI build is blocked currently due to a compile error in one test file.

Fix the compile error on the latest _master_ 
![Screenshot 2022-12-01 at 16 11 04](https://user-images.githubusercontent.com/10476819/205074464-e9107d06-d1d0-45d1-9201-db1cafb073b5.png)
