### PR TITLE
Feat health check enhancement

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
@@ -1,12 +1,6 @@
-import {
-  ActiveStakeModel,
-  CirculatingSupplyModel,
-  EpochModel,
-  LedgerTipModel,
-  ProtocolParamsModel,
-  TotalSupplyModel
-} from './types';
+import { ActiveStakeModel, CirculatingSupplyModel, EpochModel, ProtocolParamsModel, TotalSupplyModel } from './types';
 import { Cardano } from '@cardano-sdk/core';
+import { LedgerTipModel, findLedgerTip } from '../../util/DbSyncProvider';
 import { Logger } from 'ts-log';
 import { Pool, QueryResult } from 'pg';
 import Queries from './queries';
@@ -45,7 +39,7 @@ export class NetworkInfoBuilder {
 
   public async queryLedgerTip() {
     this.#logger.debug('About to query the ledger tip');
-    const result: QueryResult<LedgerTipModel> = await this.#db.query(Queries.findLedgerTip);
+    const result: QueryResult<LedgerTipModel> = await this.#db.query(findLedgerTip);
     return result.rows[0];
   }
 

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -1,5 +1,6 @@
 import { Cardano, ProviderError, ProviderFailure, SupplySummary } from '@cardano-sdk/core';
-import { CostModelsParamModel, GenesisData, LedgerTipModel, ProtocolParamsModel } from './types';
+import { CostModelsParamModel, GenesisData, ProtocolParamsModel } from './types';
+import { LedgerTipModel } from '../../util/DbSyncProvider';
 import JSONbig from 'json-bigint';
 import fs from 'fs';
 import path from 'path';

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -46,13 +46,6 @@ export const findLatestCompleteEpoch = `
     LIMIT 1
 `;
 
-export const findLedgerTip = `
-    SELECT block_no, slot_no, hash
-    FROM block
-    ORDER BY id DESC
-    LIMIT 1;
-`;
-
 export const findProtocolParams = `
     SELECT 
     min_fee_a, 
@@ -93,7 +86,6 @@ const Queries = {
   findActiveStake,
   findCirculatingSupply,
   findLatestCompleteEpoch,
-  findLedgerTip,
   findProtocolParams,
   findTotalSupply
 };

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
@@ -20,12 +20,6 @@ export interface EpochModel {
   no: number;
 }
 
-export interface LedgerTipModel {
-  block_no: number;
-  slot_no: string;
-  hash: Buffer;
-}
-
 export interface CostModelsParamModel {
   PlutusV1?: Cardano.CostModel;
   PlutusV2?: Cardano.CostModel;

--- a/packages/cardano-services/src/util/DbSyncProvider/util.ts
+++ b/packages/cardano-services/src/util/DbSyncProvider/util.ts
@@ -1,13 +1,15 @@
-export interface BlockNoModel {
+export interface LedgerTipModel {
   block_no: number;
+  slot_no: string;
+  hash: Buffer;
 }
 
 export const DB_MAX_SAFE_INTEGER = 2_147_483_647;
 export const DB_BLOCKS_BEHIND_TOLERANCE = 5;
 
-export const findLastBlockNo = `
+export const findLedgerTip = `
     SELECT 
-    block_no
+    block_no, slot_no, hash
     FROM block
     ORDER BY block_no DESC 
     NULLS LAST

--- a/packages/cardano-services/test/Asset/AssetHttpService.test.ts
+++ b/packages/cardano-services/test/Asset/AssetHttpService.test.ts
@@ -10,9 +10,9 @@ import {
   TokenMetadataService
 } from '../../src';
 import { AssetProvider, Cardano } from '@cardano-sdk/core';
-import { BlockNoModel, findLastBlockNo } from '../../src/util/DbSyncProvider';
 import { CreateHttpProviderConfig, assetInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { INFO, createLogger } from 'bunyan';
+import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
 import { createDbSyncMetadataService } from '../../src/Metadata';
@@ -60,7 +60,7 @@ describe('AssetHttpService', () => {
         logger,
         metadataService: createDbSyncMetadataService(db, logger)
       });
-      lastBlockNoInDb = Cardano.BlockNo((await db.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+      lastBlockNoInDb = Cardano.BlockNo((await db.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
       cardanoNode = mockCardanoNode(
         healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
       ) as unknown as OgmiosCardanoNode;

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -3,13 +3,13 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { BlockNoModel, findLastBlockNo } from '../../src/util/DbSyncProvider';
 import { Cardano, ChainHistoryProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { ChainHistoryFixtureBuilder, TxWith } from './fixtures/FixtureBuilder';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider, HttpServer, HttpServerConfig } from '../../src';
 import { CreateHttpProviderConfig, chainHistoryHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DB_MAX_SAFE_INTEGER } from '../../src/ChainHistory/DbSyncChainHistory/queries';
 import { DataMocks } from '../data-mocks';
+import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
 import { createDbSyncMetadataService } from '../../src/Metadata';
@@ -76,7 +76,7 @@ describe('ChainHistoryHttpService', () => {
   describe('healthy state', () => {
     beforeAll(async () => {
       const metadataService = createDbSyncMetadataService(dbConnection, logger);
-      lastBlockNoInDb = Cardano.BlockNo((await dbConnection.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+      lastBlockNoInDb = Cardano.BlockNo((await dbConnection.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
       cardanoNode = mockCardanoNode(
         healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
       ) as unknown as OgmiosCardanoNode;

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -3,8 +3,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 import { APPLICATION_JSON, CONTENT_TYPE, DbSyncUtxoProvider, HttpServer, HttpService, ServiceNames } from '../../src';
-import { BlockNoModel, findLastBlockNo } from '../../src/util/DbSyncProvider';
 import { Cardano, Provider } from '@cardano-sdk/core';
+import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { Logger } from 'ts-log';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
@@ -65,7 +65,7 @@ describe('HttpServer', () => {
   beforeEach(async () => {
     port = await getRandomPort();
     apiUrlBase = `http://localhost:${port}`;
-    lastBlockNoInDb = Cardano.BlockNo((await db.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+    lastBlockNoInDb = Cardano.BlockNo((await db.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
     cardanoNode = mockCardanoNode(
       healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
     ) as unknown as OgmiosCardanoNode;
@@ -420,10 +420,12 @@ describe('HttpServer', () => {
         ok: true,
         services: [
           {
+            details: { ok: true },
             name: ServiceNames.StakePool,
             ok: true
           },
           {
+            details: { ok: true },
             name: ServiceNames.NetworkInfo,
             ok: true
           }
@@ -454,6 +456,7 @@ describe('HttpServer', () => {
         ok: false,
         services: [
           {
+            details: { ok: true },
             name: ServiceNames.StakePool,
             ok: true
           },

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -2,7 +2,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable sonarjs/no-identical-functions */
-import { BlockNoModel, findLastBlockNo } from '../../src/util/DbSyncProvider';
 import { Cardano, NetworkInfoProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, networkInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DbSyncEpochPollService } from '../../src/util';
@@ -10,6 +9,7 @@ import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../src/Net
 import { HttpServer, HttpServerConfig } from '../../src';
 import { INFO, createLogger } from 'bunyan';
 import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../src/InMemoryCache';
+import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { NetworkInfoFixtureBuilder } from './fixtures/FixtureBuilder';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
@@ -55,7 +55,7 @@ describe('NetworkInfoHttpService', () => {
       baseUrl = `http://localhost:${port}/network-info`;
       clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }) };
       config = { listen: { port } };
-      lastBlockNoInDb = Cardano.BlockNo((await db.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+      lastBlockNoInDb = Cardano.BlockNo((await db.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
       cardanoNode = mockCardanoNode(
         healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
       ) as unknown as OgmiosCardanoNode;
@@ -90,7 +90,7 @@ describe('NetworkInfoHttpService', () => {
     beforeAll(async () => {
       port = await getPort();
       baseUrl = `http://localhost:${port}/network-info`;
-      lastBlockNoInDb = Cardano.BlockNo((await db.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+      lastBlockNoInDb = Cardano.BlockNo((await db.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
       cardanoNode = mockCardanoNode(
         healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
       ) as unknown as OgmiosCardanoNode;

--- a/packages/cardano-services/test/Program/services/ogmios.test.ts
+++ b/packages/cardano-services/test/Program/services/ogmios.test.ts
@@ -105,7 +105,7 @@ describe('Service dependency abstractions', () => {
             headers: { 'Content-Type': APPLICATION_JSON }
           });
           expect(res.status).toBe(200);
-          expect(res.data).toEqual(healthCheckResponseMock());
+          expect(res.data).toEqual(healthCheckResponseMock({ withTip: false }));
         });
 
         it('TxSubmitHttpService replies with status 200 OK when /submit endpoint is reached', async () => {
@@ -234,7 +234,7 @@ describe('Service dependency abstractions', () => {
             headers: { 'Content-Type': APPLICATION_JSON }
           });
           expect(res.status).toBe(200);
-          expect(res.data).toEqual(healthCheckResponseMock());
+          expect(res.data).toEqual(healthCheckResponseMock({ withTip: false }));
         });
       });
 
@@ -370,7 +370,7 @@ describe('Service dependency abstractions', () => {
         ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
       });
 
-      await expect(provider.healthCheck()).resolves.toEqual(healthCheckResponseMock());
+      await expect(provider.healthCheck()).resolves.toEqual(healthCheckResponseMock({ withTip: false }));
     });
   });
 

--- a/packages/cardano-services/test/Program/services/postgres.test.ts
+++ b/packages/cardano-services/test/Program/services/postgres.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable max-len */
-import { BlockNoModel, findLastBlockNo } from '../../../src/util/DbSyncProvider';
 import { Cardano } from '@cardano-sdk/core';
 import { DbSyncEpochPollService, EpochMonitor } from '../../../src/util';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../../src/NetworkInfo';
 import { HttpServer, HttpServerConfig, createDnsResolver, getPool } from '../../../src';
 import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../../src/InMemoryCache';
+import { LedgerTipModel, findLedgerTip } from '../../../src/util/DbSyncProvider';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
 import { SrvRecord } from 'dns';
@@ -61,7 +61,7 @@ describe('Service dependency abstractions', () => {
         config = { listen: { port } };
         apiUrlBase = `http://localhost:${port}/network-info`;
         epochMonitor = new DbSyncEpochPollService(db!, 10_000);
-        lastBlockNoInDb = Cardano.BlockNo((await db!.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+        lastBlockNoInDb = Cardano.BlockNo((await db!.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
         cardanoNode = mockCardanoNode(
           healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
         ) as unknown as OgmiosCardanoNode;
@@ -123,7 +123,7 @@ describe('Service dependency abstractions', () => {
         config = { listen: { port } };
         apiUrlBase = `http://localhost:${port}/network-info`;
         epochMonitor = new DbSyncEpochPollService(db!, 1000);
-        lastBlockNoInDb = Cardano.BlockNo((await db!.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+        lastBlockNoInDb = Cardano.BlockNo((await db!.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
         cardanoNode = mockCardanoNode(
           healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
         ) as unknown as OgmiosCardanoNode;

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
-import { BlockNoModel, findLastBlockNo } from '../../src/util/DbSyncProvider';
 import { Cardano, ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, rewardsHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DbSyncRewardsProvider, HttpServer, HttpServerConfig, RewardsHttpService } from '../../src';
 import { INFO, createLogger } from 'bunyan';
+import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
 import { RewardsFixtureBuilder } from './fixtures/FixtureBuilder';
@@ -65,7 +65,7 @@ describe('RewardsHttpService', () => {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('healthy state', () => {
     beforeAll(async () => {
-      lastBlockNoInDb = Cardano.BlockNo((await dbConnection.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+      lastBlockNoInDb = Cardano.BlockNo((await dbConnection.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
       cardanoNode = mockCardanoNode(
         healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
       ) as unknown as OgmiosCardanoNode;

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
-import { BlockNoModel, findLastBlockNo } from '../../src/util/DbSyncProvider';
 import {
   Cardano,
   ProviderError,
@@ -22,6 +21,7 @@ import {
   createHttpStakePoolExtMetadataService
 } from '../../src';
 import { INFO, createLogger } from 'bunyan';
+import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
 import { PoolInfo, PoolWith, StakePoolFixtureBuilder } from './fixtures/FixtureBuilder';
@@ -179,7 +179,7 @@ describe('StakePoolHttpService', () => {
     const clearCacheSpy = jest.spyOn(cache, 'clear');
 
     beforeAll(async () => {
-      lastBlockNoInDb = Cardano.BlockNo((await db.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+      lastBlockNoInDb = Cardano.BlockNo((await db.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
       cardanoNode = mockCardanoNode(
         healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
       ) as unknown as OgmiosCardanoNode;

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -1,11 +1,11 @@
 /* eslint-disable max-len */
 import { AddressWith, UtxoFixtureBuilder } from './fixtures/FixtureBuilder';
 import { Asset, Cardano, ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
-import { BlockNoModel, findLastBlockNo } from '../../src/util/DbSyncProvider';
 import { CreateHttpProviderConfig, utxoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DataMocks } from '../data-mocks';
 import { DbSyncUtxoProvider, HttpServer, HttpServerConfig, UtxoHttpService } from '../../src';
 import { INFO, createLogger } from 'bunyan';
+import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
 import { Pool } from 'pg';
 import { getPort } from 'get-port-please';
@@ -66,7 +66,7 @@ describe('UtxoHttpService', () => {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('healthy state', () => {
     beforeAll(async () => {
-      lastBlockNoInDb = Cardano.BlockNo((await dbConnection.query<BlockNoModel>(findLastBlockNo)).rows[0].block_no);
+      lastBlockNoInDb = Cardano.BlockNo((await dbConnection.query<LedgerTipModel>(findLedgerTip)).rows[0].block_no);
       cardanoNode = mockCardanoNode(
         healthCheckResponseMock({ blockNo: lastBlockNoInDb.valueOf() })
       ) as unknown as OgmiosCardanoNode;

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -30,12 +30,17 @@ const METRICS_ENDPOINT_LABEL_RESPONSE = 'http_request_duration_seconds duration 
 
 const exePath = path.join(__dirname, '..', 'dist', 'cjs', 'cli.js');
 
-const assertServiceHealthy = async (apiUrl: string, serviceName: ServiceNames, usedQueue?: boolean) => {
+const assertServiceHealthy = async (
+  apiUrl: string,
+  serviceName: ServiceNames,
+  usedQueue?: boolean,
+  withTip?: boolean
+) => {
   await serverReady(apiUrl);
   const headers = { 'Content-Type': 'application/json' };
   const res = await axios.post(`${apiUrl}/${serviceName}/health`, { headers });
 
-  const healthCheckResponse = usedQueue ? { ok: true } : healthCheckResponseMock();
+  const healthCheckResponse = usedQueue ? { ok: true } : healthCheckResponseMock({ withTip });
 
   expect(res.status).toBe(200);
   expect(res.data).toEqual(healthCheckResponse);
@@ -206,7 +211,7 @@ describe('CLI', () => {
             await assertServiceHealthy(apiUrl, ServiceNames.ChainHistory);
             await assertServiceHealthy(apiUrl, ServiceNames.NetworkInfo);
             await assertServiceHealthy(apiUrl, ServiceNames.StakePool);
-            await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit);
+            await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit, false, false);
             await assertServiceHealthy(apiUrl, ServiceNames.Utxo);
             await assertServiceHealthy(apiUrl, ServiceNames.Rewards);
           });
@@ -230,7 +235,7 @@ describe('CLI', () => {
             await assertServiceHealthy(apiUrl, ServiceNames.ChainHistory);
             await assertServiceHealthy(apiUrl, ServiceNames.NetworkInfo);
             await assertServiceHealthy(apiUrl, ServiceNames.StakePool);
-            await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit);
+            await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit, false, false);
             await assertServiceHealthy(apiUrl, ServiceNames.Utxo);
             await assertServiceHealthy(apiUrl, ServiceNames.Rewards);
           });
@@ -1029,7 +1034,7 @@ describe('CLI', () => {
                 env: {},
                 stdio: 'pipe'
               });
-              await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit);
+              await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit, false, false);
             });
 
             it('tx-submit uses the default Ogmios configuration if not specified when using env variables', async () => {
@@ -1043,7 +1048,7 @@ describe('CLI', () => {
                 stdio: 'pipe'
               });
 
-              await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit);
+              await assertServiceHealthy(apiUrl, ServiceNames.TxSubmit, false, false);
             });
           });
 

--- a/packages/core/src/Provider/Provider.ts
+++ b/packages/core/src/Provider/Provider.ts
@@ -1,3 +1,4 @@
+import { Cardano } from '..';
 import { Percent } from '../Cardano';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Tip } from '@cardano-ogmios/schema';
@@ -8,6 +9,7 @@ export type HealthCheckResponse = {
     ledgerTip?: Tip;
     networkSync?: Percent;
   };
+  projectedTip?: Cardano.Tip;
 };
 
 export interface Provider {

--- a/packages/core/test/CardanoNode/mocks.ts
+++ b/packages/core/test/CardanoNode/mocks.ts
@@ -48,11 +48,18 @@ export const mockStakeDistribution: StakeDistribution = new Map([
   ]
 ]);
 
+const projectedTip: Cardano.Tip = {
+  blockNo: Cardano.BlockNo(863),
+  hash: Cardano.BlockId('70de6ec951af0a47b000d0f2909270896d6c3d3de3951c96b0979164941bb15f'),
+  slot: Cardano.Slot(8450)
+};
+
 export const healthCheckResponseMock = (opts?: {
   blockNo?: number;
   slot?: number;
   hash?: string;
   networkSync?: Cardano.Percent;
+  withTip?: boolean;
 }) => ({
   localNode: {
     ledgerTip: {
@@ -62,7 +69,8 @@ export const healthCheckResponseMock = (opts?: {
     },
     networkSync: opts?.networkSync ?? Cardano.Percent(0.999)
   },
-  ok: true
+  ok: true,
+  ...(opts?.withTip === false ? undefined : { projectedTip })
 });
 
 export const mockCardanoNode = (healthCheck?: HealthCheckResponse) => ({

--- a/packages/ogmios/test/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.test.ts
+++ b/packages/ogmios/test/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.test.ts
@@ -15,7 +15,7 @@ describe('OgmiosTxSubmitProvider', () => {
   let connection: Connection;
   let provider: OgmiosTxSubmitProvider;
 
-  const responseWithServiceState = healthCheckResponseMock();
+  const responseWithServiceState = healthCheckResponseMock({ withTip: false });
 
   beforeAll(async () => {
     connection = createConnectionObject({ port: await getRandomPort() });


### PR DESCRIPTION
# Context

Not ok health check response may not give enough information about the reason of the failed check.

# Proposed Solution

Added `projectedTip` to the `healthCheck` response of the `Provider`s extending `DbSyncProvider`.

# Important Changes Introduced

- Since the `findLastBlockNo` query used by `DbSyncProvider.healthCheck` becomes as the `findLedgerTip` from `DbSyncNetworkInfoProvider.queryLedgerTip`; the second one was removed to reduce code repetition.
- The same changed was applied the the relative `LedgerTipModel` interface.