### PR TITLE
build(e2e): replace cardano-node hydra build URLs

### DIFF
--- a/packages/e2e/local-network/Dockerfile
+++ b/packages/e2e/local-network/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:${UBUNTU_VERSION} as builder
 ENV DEBIAN_FRONTEND=nonintercative
 
 WORKDIR /build
-ARG CARDANO_NODE_BUILD_URL=https://hydra.iohk.io/build/16159630/download/1/cardano-node-1.35.0-linux.tar.gz
+ARG CARDANO_NODE_BUILD_URL=https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.4-linux.tar.gz
 RUN apt-get update -y && \
   apt-get install -y wget tar && \
   wget $CARDANO_NODE_BUILD_URL -O cardano-node.tar.gz && \

--- a/packages/e2e/local-network/README.md
+++ b/packages/e2e/local-network/README.md
@@ -1,4 +1,4 @@
-**Current node version: 1.35.0**
+**Current node version: 1.35.4**
 
 Run a local test network on the host.
 

--- a/packages/e2e/local-network/scripts/install.sh
+++ b/packages/e2e/local-network/scripts/install.sh
@@ -16,9 +16,7 @@ clean() {
 }
 trap clean EXIT
 
-VERSION="1.35.3"
-LINUX_BUILD="17428084"
-MACOS_BUILD="17428186"
+VERSION="1.35.4"
 
 rm -rf bin
 mkdir -p bin
@@ -26,10 +24,10 @@ mkdir -p bin
 echo "Download binaries from IOG build"
 case $(uname) in
 Darwin)
-  wget -O bin.tar.gz https://hydra.iohk.io/build/${MACOS_BUILD}/download/1/cardano-node-${VERSION}-macos.tar.gz
+  wget -O bin.tar.gz https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-${VERSION}-macos.tar.gz
   ;;
 Linux)
-  wget -O bin.tar.gz https://hydra.iohk.io/build/${LINUX_BUILD}/download/1/cardano-node-${VERSION}-linux.tar.gz
+  wget -O bin.tar.gz https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-${VERSION}-linux.tar.gz
   ;;
 esac
 


### PR DESCRIPTION
# Context
The IOG Hydra service has been discontinued, which we are relying on for `cardano-node` binaries in the e2e package.

# Proposed Solution
Replace the Hydra URLs with the replacement server.

# Important Changes Introduced
We no longer need build numbers, so this is a simpler solution to maintain.