### PR TITLE
fix(web-extension): do not replay values from disabled remote api obj…

### DIFF
--- a/packages/web-extension/src/messaging/types.ts
+++ b/packages/web-extension/src/messaging/types.ts
@@ -134,3 +134,6 @@ export interface MessengerApiDependencies {
   messenger: Messenger;
   logger: Logger;
 }
+
+export type InternalMsgType = 'apiObjDisabled';
+export type InternalMsg = { remoteApiInternalMsg: InternalMsgType };

--- a/packages/web-extension/src/messaging/util.ts
+++ b/packages/web-extension/src/messaging/util.ts
@@ -3,6 +3,7 @@ import {
   AnyMessage,
   ChannelName,
   EmitMessage,
+  InternalMsg,
   MethodRequest,
   ObservableCompletionMessage,
   RequestMessage,
@@ -41,3 +42,10 @@ export const senderOrigin = (sender?: Runtime.MessageSender): string | null => {
 export const newMessageId = uuidv4;
 
 export const deriveChannelName = (channel: ChannelName, path: string): ChannelName => `${channel}-${path}`;
+
+const isInternalMsg = (msg: unknown): msg is InternalMsg => (msg as InternalMsg)?.remoteApiInternalMsg !== undefined;
+export const disabledApiMsg: InternalMsg = {
+  remoteApiInternalMsg: 'apiObjDisabled'
+};
+export const isNotDisabledApiMsg = (msg: unknown) =>
+  !isInternalMsg(msg) || msg.remoteApiInternalMsg !== disabledApiMsg.remoteApiInternalMsg;


### PR DESCRIPTION
# Context

RemoteApi: once the exposed api is disabled, consumer subscriptions should not emit until a new api object is enabled and it has values. Instead, it repeats the last known value.

# Proposed Solution
When api is disabled (got null for api object), emit an internal message to inform consumerApi to not replay the last known value.

# Important Changes Introduced
