### PR TITLE
Feat/adp 2441 spending transaction to byron address

### DIFF
--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -69,8 +69,12 @@ export const txIn = (input: CML.TransactionInput): Cardano.TxIn =>
 export const txOut = (output: CML.TransactionOutput): Cardano.TxOut =>
   usingAutoFree((scope) => {
     const dataHashBytes = scope.manage(scope.manage(output.datum())?.as_data_hash())?.to_bytes();
+    const cmlAddress = scope.manage(output.address());
+    const byronAddress = scope.manage(cmlAddress.as_byron());
+    const address = byronAddress ? byronAddress.to_base58() : cmlAddress.to_bech32();
+
     return {
-      address: Cardano.Address(scope.manage(output.address()).to_bech32()),
+      address: Cardano.Address(address),
       datum: dataHashBytes ? Cardano.util.Hash32ByteBase16.fromHexBlob(bytesToHex(dataHashBytes)) : undefined,
       value: value(scope.manage(output.amount()))
     };

--- a/packages/core/src/CML/parseCmlAddress.ts
+++ b/packages/core/src/CML/parseCmlAddress.ts
@@ -9,7 +9,7 @@ export const parseCmlAddress = (scope: ManagedFreeableScope, input: string): CML
     return scope.manage(CML.Address.from_bech32(input));
   } catch {
     try {
-      return scope.manage(CML.ByronAddress.from_base58(input).to_address());
+      return scope.manage(scope.manage(CML.ByronAddress.from_base58(input)).to_address());
     } catch {
       return null;
     }

--- a/packages/core/test/CML/cmlToCore.test.ts
+++ b/packages/core/test/CML/cmlToCore.test.ts
@@ -1,7 +1,17 @@
 import { Cardano, cmlToCore, coreToCml } from '../../src';
 import { ManagedFreeableScope } from '@cardano-sdk/util';
 import { NativeScript } from '@dcspark/cardano-multiplatform-lib-nodejs';
-import { mintTokenMap, tx, txBody, txIn, txInWithAddress, txOut, valueCoinOnly, valueWithAssets } from './testData';
+import {
+  mintTokenMap,
+  tx,
+  txBody,
+  txIn,
+  txInWithAddress,
+  txOut,
+  txOutWithByron,
+  valueCoinOnly,
+  valueWithAssets
+} from './testData';
 
 describe('cmlToCore', () => {
   let scope: ManagedFreeableScope;
@@ -34,8 +44,14 @@ describe('cmlToCore', () => {
     });
   });
 
-  it('txOut', () => {
-    expect(cmlToCore.txOut(coreToCml.txOut(scope, txOut))).toEqual(txOut);
+  describe('txOut', () => {
+    it('can convert a CML.TransactionOutput which contains a Shelley address to Core.TxOut', () => {
+      expect(cmlToCore.txOut(coreToCml.txOut(scope, txOut))).toEqual(txOut);
+    });
+
+    it('can convert a CML.TransactionOutput which contains a Byron address to Core.TxOut', () => {
+      expect(cmlToCore.txOut(coreToCml.txOut(scope, txOutWithByron))).toEqual(txOutWithByron);
+    });
   });
 
   it('utxo', () => {

--- a/packages/core/test/CML/testData.ts
+++ b/packages/core/test/CML/testData.ts
@@ -67,6 +67,11 @@ export const txOut: Cardano.TxOut = {
   value: valueWithAssets
 };
 
+export const txOutWithByron: Cardano.TxOut = {
+  address: Cardano.Address('5oP9ib6ym3Xc2XrPGC6S7AaJeHYBCmLjt98bnjKR58xXDhSDgLHr8tht3apMDXf2Mg'),
+  value: valueWithAssets
+};
+
 export const txOutWithDatum: Cardano.TxOut = {
   address: Cardano.Address(
     'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'

--- a/packages/e2e/test/wallet/SingleAddressWallet/byron.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/byron.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { Cardano } from '@cardano-sdk/core';
+import { SingleAddressWallet, buildTx } from '@cardano-sdk/wallet';
+import { assertTxIsValid } from '../../../../wallet/test/util';
+import { filter, firstValueFrom, map, take } from 'rxjs';
+import { getEnv, walletVariables } from '../../environment';
+import { getLogger, getWallet } from '../../../src';
+import { isNotNil } from '@cardano-sdk/util';
+import { normalizeTxBody, walletReady } from '../../util';
+
+const env = getEnv(walletVariables);
+const logger = getLogger(env.LOGGER_MIN_SEVERITY);
+
+describe('SingleAddressWallet/byron', () => {
+  let wallet: SingleAddressWallet;
+
+  beforeAll(async () => {
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
+  });
+
+  afterAll(() => {
+    wallet.shutdown();
+  });
+
+  it('can transfer tADA to a byron address', async () => {
+    await walletReady(wallet);
+
+    const txBuilder = buildTx({ logger, observableWallet: wallet });
+
+    const txOutput = txBuilder
+      .buildOutput()
+      .address(Cardano.Address('5oP9ib6ym3Xc2XrPGC6S7AaJeHYBCmLjt98bnjKR58xXDhSDgLHr8tht3apMDXf2Mg'))
+      .coin(3_000_000n)
+      .toTxOut();
+
+    const unsignedTx = await txBuilder.addOutput(txOutput).build();
+
+    assertTxIsValid(unsignedTx);
+
+    const signedTx = await unsignedTx.sign();
+    await signedTx.submit();
+
+    // Search chain history to see if the transaction is there.
+    const txFoundInHistory = await firstValueFrom(
+      wallet.transactions.history$.pipe(
+        map((txs) => txs.find((tx) => tx.id === signedTx.tx.id)),
+        filter(isNotNil),
+        take(1)
+      )
+    );
+
+    // Assert
+    expect(txFoundInHistory).toBeDefined();
+    expect(txFoundInHistory.id).toEqual(signedTx.tx.id);
+    expect(normalizeTxBody(txFoundInHistory.body)).toEqual(normalizeTxBody(signedTx.tx.body));
+  });
+});


### PR DESCRIPTION
# Context

There was a small bug in the SDK that was causing transactions with Byron era addresses as targets for outputs to fail when being de-serialized. Constructing, signing and submitting a transaction to the blockchain with the SDK involves serializing and de-serializing the transaction at several spots, which means, constructing transaction with Byron addresses was impossible.

# Proposed Solution

Fix the de-serialization of transaction to account for Byron addresses.

# Important Changes Introduced

- Transaction can now include Byron addresses as output targets.
- Added a new unit test to validate deserialization of outputs with Byron addresses.
- Added a new e2e test to validate that outputs can be spend to Byron addresses.
- Fixed a small memory leak when parsing Byron addresses.
