### PR TITLE
chore: bump cardano-db-sync to version 13.1.0.0

### DIFF
--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - node-ipc:/ipc
 
   cardano-db-sync:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.0.4}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.1.0.0}
     command:
       [
         "--config",

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - node-db:/db
       - node-ipc:/ipc
   cardano-db-sync:
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.0.4}
+    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.1.0.0}
     command:
       [
         "--config",


### PR DESCRIPTION
# Context

A new release of DBSync has been tagged (13.1.0.0 ). We must update our docker-compose files to bump the DBSync version.
