### PR TITLE
feat(wallet): adds a retry strategy to single address wallet

### DIFF
--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -162,6 +162,7 @@ export class SingleAddressWallet implements ObservableWallet {
   readonly protocolParameters$: TrackerSubject<Cardano.ProtocolParameters>;
   readonly genesisParameters$: TrackerSubject<Cardano.CompactGenesis>;
   readonly assets$: TrackerSubject<Assets>;
+  readonly fatalError$: Subject<unknown>;
   readonly syncStatus: SyncStatus;
   readonly name: string;
   readonly util: WalletUtil;
@@ -244,6 +245,10 @@ export class SingleAddressWallet implements ObservableWallet {
       )
     );
 
+    this.fatalError$ = new Subject();
+
+    const onFatalError = this.fatalError$.next.bind(this.fatalError$);
+
     this.name = name;
     const cancel$ = connectionStatusTracker$.pipe(
       tap((status) => (status === ConnectionStatus.up ? 'Connection UP' : 'Connection DOWN')),
@@ -256,6 +261,7 @@ export class SingleAddressWallet implements ObservableWallet {
       minPollInterval: pollInterval,
       provider$: coldObservableProvider({
         cancel$,
+        onFatalError,
         provider: this.networkInfoProvider.ledgerTip,
         retryBackoffConfig
       }),
@@ -279,6 +285,7 @@ export class SingleAddressWallet implements ObservableWallet {
       coldObservableProvider({
         cancel$,
         equals: deepEquals,
+        onFatalError,
         provider: this.networkInfoProvider.eraSummaries,
         retryBackoffConfig,
         trigger$: eraSummariesTrigger.pipe(tap(() => 'Trigger request era summaries'))
@@ -301,6 +308,7 @@ export class SingleAddressWallet implements ObservableWallet {
       coldObservableProvider({
         cancel$,
         equals: isEqual,
+        onFatalError,
         provider: this.networkInfoProvider.protocolParameters,
         retryBackoffConfig,
         trigger$: epoch$
@@ -311,6 +319,7 @@ export class SingleAddressWallet implements ObservableWallet {
       coldObservableProvider({
         cancel$,
         equals: isEqual,
+        onFatalError,
         provider: this.networkInfoProvider.genesisParameters,
         retryBackoffConfig,
         trigger$: epoch$
@@ -327,6 +336,7 @@ export class SingleAddressWallet implements ObservableWallet {
       inFlightTransactionsStore: stores.inFlightTransactions,
       logger: contextLogger(this.#logger, 'transactions'),
       newTransactions: this.#newTransactions,
+      onFatalError,
       retryBackoffConfig,
       tip$: this.tip$,
       transactionsHistoryStore: stores.transactions
@@ -352,6 +362,7 @@ export class SingleAddressWallet implements ObservableWallet {
     this.utxo = createUtxoTracker({
       addresses$,
       logger: contextLogger(this.#logger, 'utxo'),
+      onFatalError,
       retryBackoffConfig,
       stores,
       tipBlockHeight$,
@@ -363,6 +374,7 @@ export class SingleAddressWallet implements ObservableWallet {
       epoch$,
       eraSummaries$,
       logger: contextLogger(this.#logger, 'delegation'),
+      onFatalError,
       retryBackoffConfig,
       rewardAccountAddresses$: this.addresses$.pipe(
         map((addresses) => addresses.map((groupedAddress) => groupedAddress.rewardAccount))
@@ -379,6 +391,7 @@ export class SingleAddressWallet implements ObservableWallet {
         assetProvider: this.assetProvider,
         balanceTracker: this.balance,
         logger: contextLogger(this.#logger, 'assets$'),
+        onFatalError,
         retryBackoffConfig
       }),
       stores.assets
@@ -503,6 +516,7 @@ export class SingleAddressWallet implements ObservableWallet {
     this.currentEpoch$.complete();
     this.delegation.shutdown();
     this.assets$.complete();
+    this.fatalError$.complete();
     this.syncStatus.shutdown();
     this.#newTransactions.failedToSubmit$.complete();
     this.#newTransactions.pending$.complete();

--- a/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
@@ -57,7 +57,8 @@ export const createQueryStakePoolsProvider =
   (
     stakePoolProvider: TrackedStakePoolProvider,
     store: KeyValueStore<Cardano.PoolId, Cardano.StakePool>,
-    retryBackoffConfig: RetryBackoffConfig
+    retryBackoffConfig: RetryBackoffConfig,
+    onFatalError?: (value: unknown) => void
   ) =>
   (poolIds: Cardano.PoolId[]) => {
     if (poolIds.length === 0) {
@@ -67,6 +68,7 @@ export const createQueryStakePoolsProvider =
     return merge(
       store.getValues(poolIds),
       coldObservableProvider({
+        onFatalError,
         provider: () => allStakePoolsByPoolIds(stakePoolProvider, { poolIds }),
         retryBackoffConfig
       }).pipe(
@@ -108,13 +110,15 @@ export const createRewardsProvider =
     epoch$: Observable<Cardano.EpochNo>,
     txConfirmed$: Observable<ConfirmedTx>,
     rewardsProvider: RewardsProvider,
-    retryBackoffConfig: RetryBackoffConfig
+    retryBackoffConfig: RetryBackoffConfig,
+    onFatalError?: (value: unknown) => void
   ) =>
   (rewardAccounts: Cardano.RewardAccount[], equals = isEqual): Observable<Cardano.Lovelace[]> =>
     combineLatest(
       rewardAccounts.map((rewardAccount) =>
         coldObservableProvider({
           equals,
+          onFatalError,
           provider: () => rewardsProvider.rewardAccountBalance({ rewardAccount }),
           retryBackoffConfig,
           trigger$: fetchRewardsTrigger$(epoch$, txConfirmed$, rewardAccount)

--- a/packages/wallet/src/services/SupplyDistributionTracker.ts
+++ b/packages/wallet/src/services/SupplyDistributionTracker.ts
@@ -17,6 +17,7 @@ export interface SupplyDistributionTrackerProps {
    * Failed request retry strategy
    */
   retryBackoffConfig?: RetryBackoffConfig;
+  onFatalError?: (value: unknown) => void;
 }
 
 export interface SupplyDistributionTrackerDependencies {
@@ -32,12 +33,17 @@ export interface SupplyDistributionTrackerDependencies {
  * @returns object that continuously fetches and emits network stats (StakeSummary and SupplySummary)
  */
 export const createSupplyDistributionTracker = (
-  { trigger$, retryBackoffConfig = { initialInterval: 1000, maxInterval: 60_000 } }: SupplyDistributionTrackerProps,
+  {
+    trigger$,
+    retryBackoffConfig = { initialInterval: 1000, maxInterval: 60_000 },
+    onFatalError
+  }: SupplyDistributionTrackerProps,
   { logger, stores, networkInfoProvider }: SupplyDistributionTrackerDependencies
 ) => {
   const stake$ = new PersistentDocumentTrackerSubject(
     coldObservableProvider({
       equals: isEqual,
+      onFatalError,
       provider: networkInfoProvider.stake,
       retryBackoffConfig,
       trigger$
@@ -48,6 +54,7 @@ export const createSupplyDistributionTracker = (
   const lovelaceSupply$ = new PersistentDocumentTrackerSubject(
     coldObservableProvider({
       equals: isEqual,
+      onFatalError,
       provider: networkInfoProvider.lovelaceSupply,
       retryBackoffConfig,
       trigger$

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -82,6 +82,12 @@ export interface ObservableWallet {
   readonly protocolParameters$: Observable<Cardano.ProtocolParameters>;
   readonly addresses$: Observable<GroupedAddress[]>;
   readonly assets$: Observable<Assets>;
+  /**
+   * This is the catch all Observable for fatal errors emitted by the Wallet.
+   * Once errors are emitted, probably the only available recovery action is to
+   * shutdown the Wallet and to create a new one.
+   */
+  readonly fatalError$: Observable<unknown>;
   readonly syncStatus: SyncStatus;
 
   getName(): Promise<string>;

--- a/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-useless-undefined */
 import { Cardano } from '@cardano-sdk/core';
 import { InMemoryRewardsHistoryStore } from '../../../src/persistence';
 import {
@@ -78,7 +79,11 @@ describe('RewardsHistory', () => {
         });
         flush();
         expect(getRewardsHistory).toBeCalledTimes(1);
-        expect(getRewardsHistory).toBeCalledWith(rewardAccounts, Cardano.EpochNo(calcFirstDelegationEpoch(epoch)));
+        expect(getRewardsHistory).toBeCalledWith(
+          rewardAccounts,
+          Cardano.EpochNo(calcFirstDelegationEpoch(epoch)),
+          undefined
+        );
       });
     });
 
@@ -121,7 +126,11 @@ describe('RewardsHistory', () => {
         });
         flush();
         expect(getRewardsHistory).toBeCalledTimes(1);
-        expect(getRewardsHistory).toBeCalledWith(rewardAccounts, Cardano.EpochNo(calcFirstDelegationEpoch(epoch)));
+        expect(getRewardsHistory).toBeCalledWith(
+          rewardAccounts,
+          Cardano.EpochNo(calcFirstDelegationEpoch(epoch)),
+          undefined
+        );
       });
     });
 

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -23,6 +23,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
     rewardsHistory$: RemoteApiPropertyType.HotObservable
   },
   eraSummaries$: RemoteApiPropertyType.HotObservable,
+  fatalError$: RemoteApiPropertyType.HotObservable,
   finalizeTx: RemoteApiPropertyType.MethodReturningPromise,
   genesisParameters$: RemoteApiPropertyType.HotObservable,
   getName: RemoteApiPropertyType.MethodReturningPromise,


### PR DESCRIPTION
# Context

Currently the wallet is retrying operations even the raised error can't be tried.

# Proposed Solution

Added a _filter_ to `coldObservableProvider` retry strategy.

# Important Changes Introduced

Added a `SingleAddressWallet.error$` observable which emits those errors that can't be retried.