### PR TITLE
fix: cip30 wallet has to accept hex encoded address

### DIFF
--- a/packages/core/src/Cardano/types/Address.ts
+++ b/packages/core/src/Cardano/types/Address.ts
@@ -1,5 +1,8 @@
+import { usingAutoFree } from '@cardano-sdk/util';
+
+import { CML } from '../../CML';
 import { InvalidStringError } from '../../errors';
-import { OpaqueString, assertIsBech32WithPrefix } from '../util/primitives';
+import { OpaqueString, assertIsBech32WithPrefix, assertIsHexString } from '../util/primitives';
 import { isAddress } from '../util/address';
 
 /**
@@ -21,9 +24,37 @@ const isRewardAccount = (address: string) => {
   }
 };
 
+/**
+ * Transform {@link value} into `Cardano.Address`,
+ * Resulting Address will be base58 in case of Byron era or bech32 in case of Shelley era or newer.
+ *
+ * @param value bech32 string, base58 string or hex-encoded bytes address.
+ * @throws {InvalidStringError} if value is invalid
+ */
+
 export const Address = (value: string): Address => {
-  if (isAddress(value) && !isRewardAccount(value)) {
+  if (isAddress(value)) {
+    if (isRewardAccount(value)) {
+      throw new InvalidStringError(value, 'Address type can only be used for payment addresses');
+    }
     return value as unknown as Address;
   }
-  throw new InvalidStringError(`Invalid address: ${value}`);
+
+  try {
+    assertIsHexString(value);
+  } catch {
+    throw new InvalidStringError(value, 'Expected payment address as bech32, base58 or hex-encoded bytes');
+  }
+
+  return usingAutoFree((scope) => {
+    try {
+      return Address(scope.manage(CML.ByronAddress.from_bytes(Buffer.from(value, 'hex'))).to_base58());
+    } catch {
+      try {
+        return Address(scope.manage(CML.Address.from_bytes(Buffer.from(value, 'hex'))).to_bech32());
+      } catch {
+        throw new InvalidStringError(value, 'Invalid payment address');
+      }
+    }
+  });
 };

--- a/packages/core/test/Cardano/util/address.test.ts
+++ b/packages/core/test/Cardano/util/address.test.ts
@@ -1,4 +1,5 @@
 import * as parseCmlAddress from '../../../src/CML/parseCmlAddress';
+import { Address } from '../../../src/Cardano';
 import { Cardano } from '../../../src';
 
 describe('Cardano.util.address', () => {
@@ -39,6 +40,44 @@ describe('Cardano.util.address', () => {
             '37btjrVyb4KDXBNC4haBVPCrro8AQPHwvCMp3RFhhSVWwfFmZ6wwzSK6JK1hY6wHNmtrpTf1kdbva8TCneM2YsiXT7mrzT21EacHnPpz5YyUdj64na'
           )
         ).toBe(true);
+      });
+    });
+
+    describe('from hex-encoded bytes', () => {
+      it('can return the bech32 shelley address', () => {
+        const expectedBech32Addr =
+          // eslint-disable-next-line max-len
+          'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp';
+        const hexAddr =
+          // eslint-disable-next-line max-len
+          '009493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc';
+
+        expect(Address(hexAddr)).toEqual(expectedBech32Addr);
+      });
+
+      it('can return the base58 byron address', () => {
+        const expectedBase58Addr =
+          // eslint-disable-next-line max-len
+          '37btjrVyb4KDXBNC4haBVPCrro8AQPHwvCMp3RFhhSVWwfFmZ6wwzSK6JK1hY6wHNmtrpTf1kdbva8TCneM2YsiXT7mrzT21EacHnPpz5YyUdj64na';
+
+        const hexAddr =
+          // eslint-disable-next-line max-len
+          '82d818584983581c7e9ee4a9527dea9091e2d580edd6716888c42f75d96276290f98fe0ba201581e581c0cdf39b531d1ac0963cbd183f63e43d895d16a9c567c95e1056e28bd02451a4170cb17001a53249b67';
+
+        expect(Address(hexAddr)).toEqual(expectedBase58Addr);
+      });
+
+      it('throws if address is invalid', () => {
+        // Valid address but it is a reward address
+        expect(() => Address('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d')).toThrowError(
+          'Address type can only be used for payment addresses'
+        );
+        // Does not match any of the supported formats
+        expect(() => Address('nonHex$string')).toThrowError(
+          'Expected payment address as bech32, base58 or hex-encoded bytes'
+        );
+        // Hex string but it's not an address
+        expect(() => Address('deadbeef')).toThrowError('Invalid payment address');
       });
     });
 

--- a/packages/dapp-connector/src/WalletApi/types.ts
+++ b/packages/dapp-connector/src/WalletApi/types.ts
@@ -143,7 +143,7 @@ export type SignTx = (tx: Cbor, partialSign?: Boolean) => Promise<Cbor>;
  * @throws ApiError
  * @throws DataSignError
  */
-export type SignData = (addr: Cardano.Address, payload: Bytes) => Promise<Cip30DataSignature>;
+export type SignData = (addr: Cardano.Address | Bytes, payload: Bytes) => Promise<Cip30DataSignature>;
 
 /**
  * As wallets should already have this ability, we allow dApps to request that a transaction be sent through it.

--- a/packages/dapp-connector/test/WalletApi/Cip30Wallet.test.ts
+++ b/packages/dapp-connector/test/WalletApi/Cip30Wallet.test.ts
@@ -133,6 +133,15 @@ describe('Wallet', () => {
       expect(signedData).toEqual({});
     });
 
+    test('signData accepts hex format address', async () => {
+      jest.resetAllMocks();
+      const signedData = await api.signData(
+        '60d2696793b60a6e1c619dd16ff02be81e3d9ec435cfb880ac5e32b93a',
+        Buffer.from('').toString('hex')
+      );
+      expect(signedData).toEqual({});
+    });
+
     test('submitTx', async () => {
       expect(api.submitTx).toBeDefined();
       expect(typeof api.submitTx).toBe('function');

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -232,13 +232,14 @@ export const createWalletApi = (
     scope.dispose();
     return cbor;
   },
-  signData: async (addr: Cardano.Address, payload: Bytes): Promise<Cip30DataSignature> => {
+  signData: async (addr: Cardano.Address | Bytes, payload: Bytes): Promise<Cip30DataSignature> => {
     logger.debug('signData');
     const hexBlobPayload = Cardano.util.HexBlob(payload);
+    const signWith = Cardano.Address(addr.toString());
 
     const shouldProceed = await confirmationCallback({
       data: {
-        addr,
+        addr: signWith,
         payload: hexBlobPayload
       },
       type: Cip30ConfirmationCallbackType.SignData
@@ -248,7 +249,7 @@ export const createWalletApi = (
       const wallet = await firstValueFrom(wallet$);
       return wallet.signData({
         payload: hexBlobPayload,
-        signWith: addr
+        signWith
       });
     }
     logger.debug('sign data declined');

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -149,6 +149,22 @@ describe('cip30', () => {
         confirmationCallback.mockRejectedValue(1);
         await expect(api.signData(wallet.addresses$.value![0].address, payload)).rejects.toThrowError(DataSignError);
       });
+
+      test('gets the Cardano.Address equivalent of the hex address', async () => {
+        confirmationCallback.mockClear();
+        confirmationCallback.mockResolvedValueOnce(true);
+
+        const expectedAddr = wallet.addresses$.value![0].address;
+
+        const hexAddr = Buffer.from(scope.manage(CML.Address.from_bech32(expectedAddr.toString())).to_bytes()).toString(
+          'hex'
+        );
+
+        await api.signData(hexAddr, payload);
+        expect(confirmationCallback).toHaveBeenCalledWith(
+          expect.objectContaining({ data: expect.objectContaining({ addr: expectedAddr }) })
+        );
+      });
     });
 
     describe('signTx', () => {


### PR DESCRIPTION
# Context

Using the signData method of cardano-js-sdk with a test dapp with a hex encoded address throws a DataSignError code 2 (Invalid address). This is because cardano-js-sdk only expects it to be in bech32 format.

According to the CIP-30 spec, the address argument should accept either bech32 or hex-encoded bytes. However, it seems that the cardano-js-sdk only accepts bech32. Support for hex-encoded addresses should be added.

# Proposed Solution
Accept hex encoded address. 

# Important Changes Introduced
