### PR TITLE
fix(wallet):  Incorrect Rewards Amount

### DIFF
--- a/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
@@ -12,6 +12,11 @@ import first from 'lodash/first';
 import flatten from 'lodash/flatten';
 import groupBy from 'lodash/groupBy';
 
+const DELEGATION_EPOCHS_AHEAD_COUNT = 2;
+
+export const calcFirstDelegationEpoch = (epoch: Cardano.EpochNo): number =>
+  epoch.valueOf() + DELEGATION_EPOCHS_AHEAD_COUNT;
+
 const sumRewards = (arrayOfRewards: EpochRewards[]) => BigIntMath.sum(arrayOfRewards.map(({ rewards }) => rewards));
 const avgReward = (arrayOfRewards: EpochRewards[]) => sumRewards(arrayOfRewards) / BigInt(arrayOfRewards.length);
 
@@ -49,7 +54,7 @@ const firstDelegationEpoch$ = (transactions$: Observable<TxWithEpoch[]>, rewardA
         })
       )
     ),
-    map((tx) => (isNotNil(tx) ? tx.epoch.valueOf() + 3 : null)),
+    map((tx) => (isNotNil(tx) ? calcFirstDelegationEpoch(tx.epoch) : null)),
     distinctUntilChanged()
   );
 

--- a/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
@@ -4,6 +4,7 @@ import {
   RewardsHistory,
   RewardsHistoryProvider,
   TrackedRewardsProvider,
+  calcFirstDelegationEpoch,
   createRewardsHistoryProvider,
   createRewardsHistoryTracker
 } from '../../../src/services';
@@ -39,7 +40,7 @@ describe('RewardsHistory', () => {
   });
 
   describe('createRewardsHistoryTracker', () => {
-    it('queries and maps reward history starting from first delegation epoch+3', () => {
+    it('queries and maps reward history starting from first delegation epoch+2', () => {
       createTestScheduler().run(({ cold, expectObservable, flush }) => {
         const accountRewardsHistory = rewardsHistory.get(rewardAccount)!;
         const epoch = accountRewardsHistory[0].epoch;
@@ -77,7 +78,7 @@ describe('RewardsHistory', () => {
         });
         flush();
         expect(getRewardsHistory).toBeCalledTimes(1);
-        expect(getRewardsHistory).toBeCalledWith(rewardAccounts, Cardano.EpochNo(epoch.valueOf() + 3));
+        expect(getRewardsHistory).toBeCalledWith(rewardAccounts, Cardano.EpochNo(calcFirstDelegationEpoch(epoch)));
       });
     });
 
@@ -120,7 +121,7 @@ describe('RewardsHistory', () => {
         });
         flush();
         expect(getRewardsHistory).toBeCalledTimes(1);
-        expect(getRewardsHistory).toBeCalledWith(rewardAccounts, Cardano.EpochNo(epoch.valueOf() + 3));
+        expect(getRewardsHistory).toBeCalledWith(rewardAccounts, Cardano.EpochNo(calcFirstDelegationEpoch(epoch)));
       });
     });
 


### PR DESCRIPTION
# Context
Some Lace Open Beta testing feedback has highlighted that the “total rewards” displayed (in the delegation centre) are incorrect when compared to Eternl or [Cardano Explorer | Stake pools | Cexplorer.io](http://preprod.cexplorer.io/). For the user who reported this, their rewards balance shown was 37.31 tADA (incorrect), according to Eternl and [Cexplorer.io](http://cexplorer.io/) their actual “total rewards” were 32.73 tADA (correct). This is causing confusion for users. Other users have not reported this yet, and this may be an issue when restoring a wallet that already has staking rewards available. 

The value the user is familiar with & reporting is actually "Rewards Withdrawn" which is arguably different to “Total Rewards”.

# Proposed Solution
Investigation details and solution in the [thread](https://input-output-rnd.slack.com/archives/G01MHNME0UV/p1671113387674349)

# Important Changes Introduced
- fix the formula for determining the first delegation epoch, included in the rewards calculation afterward
