### PR TITLE
feat(wallet): Enable pouchdb auto-compaction

### DIFF
--- a/packages/wallet/src/persistence/pouchDbStores/PouchDbStore.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/PouchDbStore.ts
@@ -11,7 +11,7 @@ export abstract class PouchDbStore<T extends {}> {
 
   constructor(public dbName: string, logger: Logger) {
     this.logger = logger;
-    this.db = new PouchDB<T>(dbName);
+    this.db = new PouchDB<T>(dbName, { auto_compaction: true });
   }
 
   /**

--- a/packages/wallet/test/persistence/pouchDbStores.test.ts
+++ b/packages/wallet/test/persistence/pouchDbStores.test.ts
@@ -13,7 +13,7 @@ describe('pouchDbStores', () => {
 
   afterAll(async () => {
     // delete files from the filesystem
-    await new PouchDB(dbName).destroy();
+    await new PouchDB(dbName, { auto_compaction: true }).destroy();
   });
 
   describe('PouchDbDocumentStore', () => {


### PR DESCRIPTION
# Context

By default, PouchDB stores all document revisions forever. SingleAddressWallet doesn’t take advantage of it, so we should keep it small.

# Proposed Solution
Enable [auto-compaction](https://pouchdb.com/guides/compact-and-destroy.html#auto-compaction).
