### PR TITLE
Fix/adp 2519 tx id log

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
@@ -46,8 +46,8 @@ export class ChainHistoryBuilder {
   }
 
   public async queryTransactionInputsByHashes(hashes: Cardano.TransactionId[], collateral = false): Promise<TxInput[]> {
+    this.#logger.debug(`About to find inputs (collateral: ${collateral}) for transactions:`, hashes);
     const byteHashes = hashes.map((hash) => hexStringToBuffer(hash.toString()));
-    this.#logger.debug(`About to find inputs (collateral: ${collateral}) for transactions:`, byteHashes);
     const result: QueryResult<TxInputModel> = await this.#db.query(
       collateral ? Queries.findTxCollateralsByHashes : Queries.findTxInputsByHashes,
       [byteHashes]
@@ -62,8 +62,8 @@ export class ChainHistoryBuilder {
   }
 
   public async queryTransactionOutputsByHashes(hashes: Cardano.TransactionId[]): Promise<TxOutput[]> {
+    this.#logger.debug('About to find outputs for transactions:', hashes);
     const byteHashes = hashes.map((hash) => hexStringToBuffer(hash.toString()));
-    this.#logger.debug('About to find outputs for transactions:', byteHashes);
     const result: QueryResult<TxOutputModel> = await this.#db.query(Queries.findTxOutputsByHashes, [byteHashes]);
     if (result.rows.length === 0) return [];
 
@@ -73,8 +73,8 @@ export class ChainHistoryBuilder {
   }
 
   public async queryTxMintByHashes(hashes: Cardano.TransactionId[]): Promise<TxTokenMap> {
+    this.#logger.debug('About to find tx mint for txs:', hashes);
     const byteHashes = hashes.map((hash) => hexStringToBuffer(hash.toString()));
-    this.#logger.debug('About to find tx mint for txs:', byteHashes);
     const result: QueryResult<MultiAssetModel> = await this.#db.query(Queries.findTxMint, [byteHashes]);
     return mapTxTokenMap(result.rows);
   }
@@ -82,8 +82,8 @@ export class ChainHistoryBuilder {
   public async queryWithdrawalsByHashes(
     hashes: Cardano.TransactionId[]
   ): Promise<TransactionDataMap<Cardano.Withdrawal[]>> {
+    this.#logger.debug('About to find withdrawals for txs:', hashes);
     const byteHashes = hashes.map((hash) => hexStringToBuffer(hash.toString()));
-    this.#logger.debug('About to find withdrawals for txs:', byteHashes);
     const result: QueryResult<WithdrawalModel> = await this.#db.query(Queries.findWithdrawal, [byteHashes]);
     const withdrawalMap: TransactionDataMap<Cardano.Withdrawal[]> = new Map();
     for (const withdrawal of result.rows) {
@@ -97,8 +97,8 @@ export class ChainHistoryBuilder {
   public async queryRedeemersByHashes(
     hashes: Cardano.TransactionId[]
   ): Promise<TransactionDataMap<Cardano.Redeemer[]>> {
+    this.#logger.debug('About to find redeemers for txs:', hashes);
     const byteHashes = hashes.map((hash) => hexStringToBuffer(hash.toString()));
-    this.#logger.debug('About to find redeemers for txs:', byteHashes);
     const result: QueryResult<RedeemerModel> = await this.#db.query(Queries.findRedeemer, [byteHashes]);
     const redeemerMap: TransactionDataMap<Cardano.Redeemer[]> = new Map();
     for (const redeemer of result.rows) {
@@ -112,8 +112,8 @@ export class ChainHistoryBuilder {
   public async queryCertificatesByHashes(
     hashes: Cardano.TransactionId[]
   ): Promise<TransactionDataMap<Cardano.Certificate[]>> {
+    this.#logger.debug('About to find certificates for txs:', hashes);
     const byteHashes = hashes.map((hash) => hexStringToBuffer(hash.toString()));
-    this.#logger.debug('About to find certificates for txs:', byteHashes);
     const poolRetireCerts: QueryResult<PoolRetireCertModel> = await this.#db.query(Queries.findPoolRetireCerts, [
       byteHashes
     ]);

--- a/packages/util-dev/src/TestLogger.ts
+++ b/packages/util-dev/src/TestLogger.ts
@@ -29,7 +29,7 @@ export type Logger = { [l in LogLevel]: LogFunction };
  * A unit test dedicated logger. Check
  * https://github.com/input-output-hk/cardano-js-sdk/tree/master/packages/util-dev#testlogger for details.
  */
-export type TestLogger = Logger & { messages: LoggedMessage[] };
+export type TestLogger = Logger & { messages: LoggedMessage[]; reset: () => void };
 
 type TestStream = { columns?: number; isTTY?: boolean; write: Function };
 
@@ -129,8 +129,9 @@ export const createLogger = (options: TestLoggerOptions = {}) => {
   };
 
   const logger = Object.fromEntries((<LoggerEntry[]>Object.entries(logLevels)).map((_) => [_[0], getLogFunction(_)]));
+  const reset = () => <void>(<unknown>(messages.length = 0));
 
-  return <TestLogger>{ messages, ...logger };
+  return <TestLogger>{ messages, reset, ...logger };
 };
 
 /**

--- a/packages/util-dev/test/TestLogger.test.ts
+++ b/packages/util-dev/test/TestLogger.test.ts
@@ -28,24 +28,32 @@ const getPassThrough = () => {
 };
 
 describe('TestLogger', () => {
-  it('records logged messages', () => {
+  describe('logged message record', () => {
     const logger = createLogger({ env: {}, record: true, stream: toVoid });
 
-    logger.trace({ some: 'data' });
-    logger.debug('Debug string');
-    logger.info('Info content', { answer: 42, data: 'test' });
-    logger.warn('Error which can be ignored', new Error('you can ignore me'));
-    logger.error(new TypeError('test error'), 'with data', { answer: 42, test: 'data' });
-    logger.fatal('FATAL ERROR');
+    it('logged messages are correctly logged', () => {
+      logger.trace({ some: 'data' });
+      logger.debug('Debug string');
+      logger.info('Info content', { answer: 42, data: 'test' });
+      logger.warn('Error which can be ignored', new Error('you can ignore me'));
+      logger.error(new TypeError('test error'), 'with data', { answer: 42, test: 'data' });
+      logger.fatal('FATAL ERROR');
 
-    expect(logger.messages).toStrictEqual([
-      { level: 'trace', message: [{ some: 'data' }] },
-      { level: 'debug', message: ['Debug string'] },
-      { level: 'info', message: ['Info content', { answer: 42, data: 'test' }] },
-      { level: 'warn', message: ['Error which can be ignored', new Error('you can ignore me')] },
-      { level: 'error', message: [new TypeError('test error'), 'with data', { answer: 42, test: 'data' }] },
-      { level: 'fatal', message: ['FATAL ERROR'] }
-    ]);
+      expect(logger.messages).toStrictEqual([
+        { level: 'trace', message: [{ some: 'data' }] },
+        { level: 'debug', message: ['Debug string'] },
+        { level: 'info', message: ['Info content', { answer: 42, data: 'test' }] },
+        { level: 'warn', message: ['Error which can be ignored', new Error('you can ignore me')] },
+        { level: 'error', message: [new TypeError('test error'), 'with data', { answer: 42, test: 'data' }] },
+        { level: 'fatal', message: ['FATAL ERROR'] }
+      ]);
+    });
+
+    it('reset method removes all logged messages', () => {
+      logger.reset();
+
+      expect(logger.messages).toStrictEqual([]);
+    });
   });
 
   it('stringifies all logged types', async () => {


### PR DESCRIPTION
# Context

Some messages logged by `DbSyncChainHistoryProvider` contains transaction ids in `Buffer` format; this makes the same messages hard to be read.

# Proposed Solution

Changed the logged messages including the transaction ids in the hex string format.
Added test checks as well in order to ensure the logged format.

# Important Changes Introduced

Added a `TestLogger.reset()` method the reset the recorded messages logged by the `TestLogger`.