### PR TITLE
feat(cardano-services)!: upgrade /meta endpoint

### DIFF
--- a/packages/cardano-services/copy-assets.sh
+++ b/packages/cardano-services/copy-assets.sh
@@ -4,6 +4,7 @@
 
 cp ./package.json ./dist/cjs/original-package.json
 
+cp ./src/Http/openApi.json ./dist/cjs/Http/openApi.json
 cp ./src/Asset/openApi.json ./dist/cjs/Asset/openApi.json
 cp ./src/ChainHistory/openApi.json ./dist/cjs/ChainHistory/openApi.json
 cp ./src/NetworkInfo/openApi.json ./dist/cjs/NetworkInfo/openApi.json

--- a/packages/cardano-services/src/Http/openApi.json
+++ b/packages/cardano-services/src/Http/openApi.json
@@ -1,0 +1,77 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Server Metadata",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/meta": {
+      "post": {
+        "summary": "HTTP Server metadata POST",
+        "operationId": "server-metadata-post",
+        "responses": {
+          "200": {
+            "description": "HTTP Server metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerMetadata"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "HTTP server metadata GET",
+        "operationId": "server-metadata-get",
+        "responses": {
+          "200": {
+            "description": "HTTP Server metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServerMetadata"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ServerMetadata": {
+        "type": "object",
+        "required": [
+          "startupTime"
+        ],
+        "properties": {
+          "startupTime": {
+            "type": "number"
+          },
+          "lastModified": {
+            "type": "number"
+          },
+          "lastModifiedDate": {
+            "type": "string"
+          },
+          "rev": {
+            "type": "string"
+          },
+          "shortRev": {
+            "type": "string"
+          },
+          "extra": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cardano-services/src/Http/types.ts
+++ b/packages/cardano-services/src/Http/types.ts
@@ -12,6 +12,15 @@ export type ServicesHealthCheckResponse = {
   services: ServiceHealth[];
 };
 
+export type ServerMetadata = {
+  lastModified?: number;
+  lastModifiedDate?: string;
+  rev?: string;
+  shortRev?: string;
+  extra?: JSON;
+  startupTime: number;
+};
+
 export type HttpServerConfig = {
   metrics?: {
     enabled: boolean;
@@ -21,5 +30,8 @@ export type HttpServerConfig = {
     limit?: Options['limit'];
   };
   name?: string;
+  meta?: ServerMetadata;
   listen: net.ListenOptions;
 };
+
+export type BuildInfo = Omit<ServerMetadata, 'extra' | 'startupTime'>;

--- a/packages/cardano-services/src/Program/Options.ts
+++ b/packages/cardano-services/src/Program/Options.ts
@@ -13,6 +13,7 @@ export enum CommonOptionDescriptions {
 
 enum HttpServerOptionDescriptions {
   ApiUrl = 'API URL',
+  BuildInfo = 'HTTP server build info',
   CardanoNodeConfigPath = 'Cardano node config path',
   EpochPollInterval = 'Epoch poll interval',
   EnableMetrics = 'Enable Prometheus Metrics',

--- a/packages/cardano-services/src/Program/loadHttpServer.ts
+++ b/packages/cardano-services/src/Program/loadHttpServer.ts
@@ -7,6 +7,7 @@ import {
   DbSyncNftMetadataService,
   StubTokenMetadataService
 } from '../Asset';
+import { BuildInfo, HttpServer, HttpServerConfig, HttpService } from '../Http';
 import { CardanoNode } from '@cardano-sdk/core';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider } from '../ChainHistory';
 import { CommonProgramOptions, ProgramOptionDescriptions } from './Options';
@@ -16,7 +17,6 @@ import { DbSyncRewardsProvider, RewardsHttpService } from '../Rewards';
 import { DbSyncStakePoolProvider, StakePoolHttpService, createHttpStakePoolExtMetadataService } from '../StakePool';
 import { DbSyncUtxoProvider, UtxoHttpService } from '../Utxo';
 import { DnsResolver, createDnsResolver, shouldInitCardanoNode } from './utils';
-import { HttpServer, HttpServerConfig, HttpService } from '../Http';
 import { InMemoryCache } from '../InMemoryCache';
 import { Logger } from 'ts-log';
 import { MissingProgramOption, MissingServiceDependency, RunnableDependencies, UnknownServiceName } from './errors';
@@ -34,6 +34,7 @@ import pg from 'pg';
 export interface HttpServerOptions extends CommonProgramOptions {
   serviceNames?: ServiceNames[];
   enableMetrics?: boolean;
+  buildInfo?: BuildInfo;
   cardanoNodeConfigPath?: string;
   tokenMetadataCacheTTL?: number;
   tokenMetadataServerUrl?: string;
@@ -210,7 +211,8 @@ export const loadHttpServer = async (args: ProgramArgs, deps: LoadHttpServerDepe
     listen: {
       host: apiUrl.hostname,
       port: Number.parseInt(apiUrl.port)
-    }
+    },
+    meta: { ...options?.buildInfo, startupTime: Date.now() }
   };
   if (options?.enableMetrics) {
     config.metrics = { enabled: options?.enableMetrics };

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -34,7 +34,7 @@ import { DEFAULT_TOKEN_METADATA_CACHE_TTL, DEFAULT_TOKEN_METADATA_SERVER_URL } f
 import { EPOCH_POLL_INTERVAL_DEFAULT } from './util';
 import { InvalidLoggerLevel } from './errors';
 import { URL } from 'url';
-import { cacheTtlValidator } from './util/validators';
+import { buildInfoValidator, cacheTtlValidator, existingFileValidator } from './util/validators';
 import { loggerMethodNames } from '@cardano-sdk/util';
 import clear from 'clear';
 import fs from 'fs';
@@ -58,12 +58,6 @@ const stringToBoolean = (value: string, program: Programs, option: string) => {
   throw new WrongOption(program, option, ['false', 'true']);
 };
 
-const existingFileValidator = (filePath: string) => {
-  if (fs.existsSync(filePath)) {
-    return filePath;
-  }
-  throw new Error(`No file exists at ${filePath}`);
-};
 const getSecret = (secretFilePath?: string, secret?: string) =>
   secretFilePath ? loadSecret(secretFilePath) : secret ? secret : undefined;
 
@@ -155,6 +149,11 @@ commonOptions(
       .argParser((enableMetrics) =>
         stringToBoolean(enableMetrics, Programs.HttpServer, ProgramOptionDescriptions.EnableMetrics)
       )
+  )
+  .addOption(
+    new Option('--build-info <buildInfo>', ProgramOptionDescriptions.BuildInfo)
+      .env('BUILD_INFO')
+      .argParser(buildInfoValidator)
   )
   .addOption(
     new Option(

--- a/packages/cardano-services/src/util/validators.ts
+++ b/packages/cardano-services/src/util/validators.ts
@@ -1,5 +1,38 @@
+import { BuildInfo } from '../Http';
 import { CACHE_TTL_LOWER_LIMIT, CACHE_TTL_UPPER_LIMIT } from '../InMemoryCache';
 import { MissingProgramOption, ProgramOptionDescriptions, ServiceNames } from '../Program';
+import { validate } from 'jsonschema';
+import fs from 'fs';
+
+const buildInfoSchema = {
+  additionalProperties: false,
+  properties: {
+    extra: { type: 'object' },
+    lastModified: { type: 'number' },
+    lastModifiedDate: { type: 'string' },
+    rev: { type: 'string' },
+    shortRev: { type: 'string' }
+  },
+  type: 'object'
+};
+
+export const buildInfoValidator = (buildInfo: string): BuildInfo => {
+  let result: BuildInfo;
+  try {
+    result = JSON.parse(buildInfo || '{}');
+  } catch (error) {
+    throw new Error(`Invalid JSON format of process.env.BUILD_INFO: ${error}`);
+  }
+  validate(result, buildInfoSchema, { throwError: true });
+  return result;
+};
+
+export const existingFileValidator = (filePath: string) => {
+  if (fs.existsSync(filePath)) {
+    return filePath;
+  }
+  throw new Error(`No file exists at ${filePath}`);
+};
 
 export const cacheTtlValidator = (ttl: string) => {
   const cacheTtl = Number.parseInt(ttl, 10);


### PR DESCRIPTION
# Context
There was a [contributed a solution ](https://github.com/input-output-hk/cardano-js-sdk/pull/496)to expose deployment metadata, which has made it possible to understand critical details that are important for dev and test engineers, and is being consumed in this wallet-world document https://github.com/input-output-hk/wallet-world/blob/master/ENVIRONMENTS.md. Feedback has been provided in the PR about how to turn it into a feature we can support, but due to time constraints it was decided to merge as-is, then dedicate some time for improvements in a future sprint.

# Proposed Solution
With provided a valid BUILD_INFO JSON format
![Screenshot 2023-01-10 at 11 20 37](https://user-images.githubusercontent.com/10476819/211555644-0ed2a49a-e7c4-435d-8e24-ba983ab28aa2.png)

With an invalid BUILD_INFO JSON format on server startup
![Screenshot 2023-01-11 at 12 23 01](https://user-images.githubusercontent.com/10476819/211781848-53703585-74b5-4996-8f07-06bec7372b50.png)



# Important Changes Introduced
- introduce `ServerMetadata` type
- add `--build-info` CLI arg and `BUILD_INFO` env
- add metadata JSON validation on startup
- add the endpoint to `OpenApi` def
- add CLI and unit tests

**BREAKING CHANGE:**

Nested `narHash`, `path` and `sourceInfo` under top level `extra` property of BUILD_INFO
