### PR TITLE
Convert static TTL to be calculated from slotLength

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -1,4 +1,4 @@
-import { Cardano, ProviderError, ProviderFailure, SupplySummary } from '@cardano-sdk/core';
+import { Cardano, ProviderError, ProviderFailure, Seconds, SupplySummary } from '@cardano-sdk/core';
 import { CostModelsParamModel, GenesisData, ProtocolParamsModel } from './types';
 import { LedgerTipModel } from '../../util/DbSyncProvider';
 import JSONbig from 'json-bigint';
@@ -102,6 +102,7 @@ export const toProtocolParams = ({
 export const toGenesisParams = (genesis: GenesisData): Cardano.CompactGenesis => ({
   ...genesis,
   networkId: networkIdMap[genesis.networkId],
+  slotLength: Seconds(genesis.slotLength),
   systemStart: new Date(genesis.systemStart)
 });
 

--- a/packages/core/src/Cardano/types/Genesis.ts
+++ b/packages/core/src/Cardano/types/Genesis.ts
@@ -1,5 +1,6 @@
 import { Lovelace } from './Value';
 import { NetworkId, NetworkMagic } from '../ChainId';
+import { Seconds } from '../../util';
 
 /**
  * A compact (without genesis UTxO) representation of the genesis configuration.
@@ -13,7 +14,7 @@ export interface CompactGenesis {
   epochLength: number;
   slotsPerKesPeriod: number;
   maxKesEvolutions: number;
-  slotLength: number;
+  slotLength: Seconds;
   updateQuorum: number;
   maxLovelaceSupply: Lovelace;
 }

--- a/packages/core/src/Cardano/util/index.ts
+++ b/packages/core/src/Cardano/util/index.ts
@@ -5,4 +5,3 @@ export * from './primitives';
 export * from './txSubmissionErrors';
 export * from './resolveInputValue';
 export * from './address';
-export * from './time';

--- a/packages/core/src/CardanoNode/types/CardanoNode.ts
+++ b/packages/core/src/CardanoNode/types/CardanoNode.ts
@@ -3,11 +3,12 @@ import { Block, Lovelace, PoolId, Tip, VrfVkHex } from '../../Cardano';
 // @ts-ignore
 import { CardanoNodeError } from './CardanoNodeErrors';
 import { HealthCheckResponse } from '../../Provider';
+import { Milliseconds } from '../../util';
 
 export interface EraSummary {
   parameters: {
     epochLength: number;
-    slotLength: number;
+    slotLength: Milliseconds;
   };
   start: {
     slot: number;

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -7,3 +7,4 @@ export * from './coalesceValueQuantities';
 export * from './subtractValueQuantities';
 export * from './nativeScript';
 export * as metadatum from './metadatum';
+export * from './time';

--- a/packages/core/src/util/slotCalc.ts
+++ b/packages/core/src/util/slotCalc.ts
@@ -82,7 +82,7 @@ export const createSlotTimeCalc = (eraSummaries: EraSummary[]) => {
     }
     return new Date(
       activeEraSummary.start.time.getTime() +
-        (slotNo.valueOf() - activeEraSummary.start.slot) * activeEraSummary.parameters.slotLength
+        (slotNo.valueOf() - activeEraSummary.start.slot) * activeEraSummary.parameters.slotLength.valueOf()
     );
   };
 };

--- a/packages/core/src/util/time.ts
+++ b/packages/core/src/util/time.ts
@@ -1,4 +1,4 @@
-import { OpaqueNumber } from '.';
+import { OpaqueNumber } from '../Cardano/util';
 
 /**
  * Milliseconds time unit.

--- a/packages/core/test/CardanoNode/mocks.ts
+++ b/packages/core/test/CardanoNode/mocks.ts
@@ -1,9 +1,12 @@
-import { Cardano, EraSummary, HealthCheckResponse, StakeDistribution } from '../../src';
+import { Cardano, EraSummary, HealthCheckResponse, Milliseconds, StakeDistribution } from '../../src';
 
 const mockEraSummaries: EraSummary[] = [
-  { parameters: { epochLength: 21_600, slotLength: 20_000 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
   {
-    parameters: { epochLength: 432_000, slotLength: 1000 },
+    parameters: { epochLength: 21_600, slotLength: Milliseconds(20_000) },
+    start: { slot: 0, time: new Date(1_563_999_616_000) }
+  },
+  {
+    parameters: { epochLength: 432_000, slotLength: Milliseconds(1000) },
     start: { slot: 1_598_400, time: new Date(1_595_964_016_000) }
   }
 ];

--- a/packages/core/test/util/time.test.ts
+++ b/packages/core/test/util/time.test.ts
@@ -1,4 +1,4 @@
-import { Days, Hours, Milliseconds, Minutes, Seconds, TimeSpan } from '../../../src/Cardano/util';
+import { Days, Hours, Milliseconds, Minutes, Seconds, TimeSpan } from '../../src/util';
 
 const oneAndAHalfDay = Milliseconds(129_600_000);
 const twentyMinutesAndTenSeconds = Milliseconds(1_210_000);

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -189,7 +189,7 @@ export const runningAgainstLocalNetwork = async () => {
 
   const estimatedTestDurationInEpochs = 4;
   const localNetworkEpochDuration = 1000 * 0.2;
-  const estimatedTestDuration = epochLength * slotLength * estimatedTestDurationInEpochs;
+  const estimatedTestDuration = epochLength * slotLength.valueOf() * estimatedTestDurationInEpochs;
   if (estimatedTestDuration > localNetworkEpochDuration * estimatedTestDurationInEpochs) {
     return false;
   }

--- a/packages/ogmios/src/CardanoNode/mappers.ts
+++ b/packages/ogmios/src/CardanoNode/mappers.ts
@@ -1,10 +1,10 @@
-import { EraSummary } from '@cardano-sdk/core';
+import { EraSummary, Seconds } from '@cardano-sdk/core';
 import { Schema } from '@cardano-ogmios/client';
 
 export const mapEraSummary = (eraSummary: Schema.EraSummary, systemStart: Date): EraSummary => ({
   parameters: {
     epochLength: eraSummary.parameters.epochLength,
-    slotLength: eraSummary.parameters.slotLength * 1000
+    slotLength: Seconds.toMilliseconds(Seconds(eraSummary.parameters.slotLength))
   },
   start: {
     slot: eraSummary.start.slot,

--- a/packages/ogmios/src/ogmiosToCore/genesis.ts
+++ b/packages/ogmios/src/ogmiosToCore/genesis.ts
@@ -1,4 +1,4 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Seconds } from '@cardano-sdk/core';
 import { Schema } from '@cardano-ogmios/client';
 import omit from 'lodash/omit';
 
@@ -10,5 +10,6 @@ export const genesis = (ogmiosGenesis: Schema.CompactGenesis): Cardano.CompactGe
   })(),
   maxLovelaceSupply: BigInt(ogmiosGenesis.maxLovelaceSupply),
   networkId: ogmiosGenesis.network === 'mainnet' ? Cardano.NetworkId.Mainnet : Cardano.NetworkId.Testnet,
+  slotLength: Seconds(ogmiosGenesis.slotLength),
   systemStart: new Date(ogmiosGenesis.systemStart)
 });

--- a/packages/ogmios/test/CardanoNode/mappers.test.ts
+++ b/packages/ogmios/test/CardanoNode/mappers.test.ts
@@ -1,5 +1,5 @@
 import * as mappers from '../../src/CardanoNode/mappers';
-import { EraSummary } from '@cardano-sdk/core';
+import { EraSummary, Milliseconds } from '@cardano-sdk/core';
 import { Schema } from '@cardano-ogmios/client';
 
 describe('cardano node mappers', () => {
@@ -14,7 +14,7 @@ describe('cardano node mappers', () => {
       expect(result).toEqual<EraSummary>({
         parameters: {
           epochLength: 432_000,
-          slotLength: 1000
+          slotLength: Milliseconds(1000)
         },
         start: {
           slot: 1_598_400,

--- a/packages/projection/test/events/genesisToEraSummary.ts
+++ b/packages/projection/test/events/genesisToEraSummary.ts
@@ -1,9 +1,9 @@
-import { Cardano, EraSummary } from '@cardano-sdk/core';
+import { Cardano, EraSummary, Seconds } from '@cardano-sdk/core';
 
 export const genesisToEraSummary = ({ systemStart, epochLength, slotLength }: Cardano.CompactGenesis): EraSummary => ({
   parameters: {
     epochLength,
-    slotLength
+    slotLength: Seconds.toMilliseconds(slotLength)
   },
   start: {
     slot: 0,

--- a/packages/projection/test/operators/withEpochNo.test.ts
+++ b/packages/projection/test/operators/withEpochNo.test.ts
@@ -1,10 +1,10 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano, ChainSyncEventType, Milliseconds } from '@cardano-sdk/core';
 import { RollForwardEvent, UnifiedProjectorEvent, operators } from '../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 
 const eraSummaries = [
   {
-    parameters: { epochLength: 432_000, slotLength: 1000 },
+    parameters: { epochLength: 432_000, slotLength: Milliseconds(1000) },
     start: { slot: 0, time: new Date(1_595_967_616_000) }
   }
 ];

--- a/packages/util-dev/src/eraSummaries.ts
+++ b/packages/util-dev/src/eraSummaries.ts
@@ -1,13 +1,16 @@
-import { EraSummary } from '@cardano-sdk/core';
+import { EraSummary, Milliseconds } from '@cardano-sdk/core';
 
 /**
  * Valid at 2022-05-28
  */
 
 export const testnetEraSummaries: EraSummary[] = [
-  { parameters: { epochLength: 21_600, slotLength: 20_000 }, start: { slot: 0, time: new Date(1_563_999_616_000) } },
   {
-    parameters: { epochLength: 432_000, slotLength: 1000 },
+    parameters: { epochLength: 21_600, slotLength: Milliseconds(20_000) },
+    start: { slot: 0, time: new Date(1_563_999_616_000) }
+  },
+  {
+    parameters: { epochLength: 432_000, slotLength: Milliseconds(1000) },
     start: { slot: 1_598_400, time: new Date(1_595_967_616_000) }
   }
 ];

--- a/packages/wallet/src/SingleAddressWallet/prepareTx.ts
+++ b/packages/wallet/src/SingleAddressWallet/prepareTx.ts
@@ -6,7 +6,7 @@ import { createTransactionInternals, ensureValidityInterval } from '../Transacti
 import { defaultSelectionConstraints } from '@cardano-sdk/input-selection';
 
 export interface PrepareTxDependencies {
-  wallet: Pick<ObservableWallet, 'tip$' | 'protocolParameters$' | 'addresses$'> & {
+  wallet: Pick<ObservableWallet, 'tip$' | 'protocolParameters$' | 'addresses$' | 'genesisParameters$'> & {
     delegation: Pick<ObservableWallet['delegation'], 'rewardAccounts$'>;
     utxo: Pick<ObservableWallet['utxo'], 'available$'>;
     syncStatus: Pick<ObservableWallet['syncStatus'], 'isSettled$'>;
@@ -34,11 +34,12 @@ export const createTxPreparer =
         wallet.utxo.available$,
         wallet.protocolParameters$,
         wallet.addresses$,
-        withdrawals$
+        withdrawals$,
+        wallet.genesisParameters$
       ]).pipe(
         take(1),
-        map(([tip, utxo, protocolParameters, [{ address: changeAddress }], withdrawals]) => {
-          const validityInterval = ensureValidityInterval(tip.slot, props.options?.validityInterval);
+        map(([tip, utxo, protocolParameters, [{ address: changeAddress }], withdrawals, genesisParameters]) => {
+          const validityInterval = ensureValidityInterval(tip.slot, genesisParameters, props.options?.validityInterval);
           const constraints = defaultSelectionConstraints({
             buildTx: async (inputSelection, scope) => {
               logger.debug('Building TX for selection constraints', inputSelection);

--- a/packages/wallet/src/Transaction/ensureValidityInterval.ts
+++ b/packages/wallet/src/Transaction/ensureValidityInterval.ts
@@ -1,8 +1,39 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Seconds } from '@cardano-sdk/core';
 
+const twoHours = Seconds(2 * 3600);
+
+/**
+ * Calculate the slot number after {@link seconds} time offset, given a {@link startSlot} and a {@link slotLength}.
+ *
+ * @param {Cardano.Slot} startSlot slot number to start the calculation from.
+ * @param {Seconds} seconds time offset expressed in seconds.
+ * @param {Seconds} slotLength duration of a slot expressed in seconds.
+ * @returns slot number after the {@link seconds} time  will have passed.
+ */
+export const calcTimeOffsetSlotNumber = (
+  startSlot: Cardano.Slot,
+  seconds: Seconds,
+  slotLength: Seconds
+): Cardano.Slot => Cardano.Slot(startSlot.valueOf() + seconds.valueOf() * slotLength.valueOf());
+
+/**
+ * Configures {@link Cardano.ValidityInterval.invalidHereafter} to the slot number equivalent to
+ * two hours from the {@link currentSlot} number.
+ *
+ * @param {Cardano.Slot} currentSlot current slot number.
+ * @param {Cardano.CompactGenesis} compactGenesis genesis configuration containing `slotLength`.
+ * @param {Seconds} compactGenesis.slotLength duration of a slot in seconds.
+ * @param {Cardano.ValidityInterval} validityInterval optional object to be amended with the calculated
+ *   `invalidHereafter` slot number. If this object has `invalidHereafter` configured, its value takes
+ *    precedence, ignoring the calculated value.
+ * @returns the optional {@link validityInterval} provided value, amended with the calculated `invalidHereafter`
+ *    if it was not already included in the {@link validityInterval} user configured object.
+ */
 export const ensureValidityInterval = (
   currentSlot: Cardano.Slot,
+  { slotLength }: Pick<Cardano.CompactGenesis, 'slotLength'>,
   validityInterval?: Cardano.ValidityInterval
-): Cardano.ValidityInterval =>
-  // Todo: Based this on slot duration, to equal 2hrs
-  ({ invalidHereafter: Cardano.Slot(currentSlot.valueOf() + 3600), ...validityInterval });
+): Cardano.ValidityInterval => ({
+  invalidHereafter: calcTimeOffsetSlotNumber(currentSlot, twoHours, slotLength),
+  ...validityInterval
+});

--- a/packages/wallet/src/services/TransactionReemitter.ts
+++ b/packages/wallet/src/services/TransactionReemitter.ts
@@ -146,7 +146,7 @@ export const createTransactionReemitter = ({
 
   const reemitSubmittedBefore$ = tipSlot$.pipe(
     withLatestFrom(genesisParameters$),
-    map(([tip, { slotLength }]) => tip.valueOf() - maxInterval / (slotLength * 1000))
+    map(([tip, { slotLength }]) => tip.valueOf() - maxInterval / (slotLength.valueOf() * 1000))
   );
   const reemitUnconfirmed$ = combineLatest([reemitSubmittedBefore$, inFlight$]).pipe(
     mergeMap(([reemitSubmittedBefore, inFlight]) =>

--- a/packages/wallet/test/Transaction/ensureValidityInterval.test.ts
+++ b/packages/wallet/test/Transaction/ensureValidityInterval.test.ts
@@ -1,0 +1,49 @@
+import { Cardano, Seconds } from '@cardano-sdk/core';
+import { calcTimeOffsetSlotNumber, ensureValidityInterval } from '../../src/Transaction';
+
+describe('calcTimeOffsetSlotNumber', () => {
+  it('can calculate using 1 second slot length', () => {
+    const expectedSlotOffset = 100 + 50;
+    expect(calcTimeOffsetSlotNumber(Cardano.Slot(100), Seconds(50), Seconds(1))).toEqual(expectedSlotOffset);
+  });
+
+  it('can calculate using 10 seconds slot length', () => {
+    const expectedSlotOffset = 100 + 50;
+    expect(calcTimeOffsetSlotNumber(Cardano.Slot(100), Seconds(5), Seconds(10))).toEqual(expectedSlotOffset);
+  });
+
+  it('can calculate using 1/10 seconds slot length', () => {
+    const expectedSlotOffset = 100 + 50;
+    expect(calcTimeOffsetSlotNumber(Cardano.Slot(100), Seconds(500), Seconds(0.1))).toEqual(expectedSlotOffset);
+  });
+});
+
+describe('ensureValidityInterval', () => {
+  const twoHours = Seconds(2 * 3600);
+
+  it('configures invalidHereafter to 2h by default', () => {
+    const currentSlot = Cardano.Slot(1);
+    const validityInterval = ensureValidityInterval(currentSlot, { slotLength: Seconds(1) });
+    expect(validityInterval.invalidHereafter).toEqual(Cardano.Slot(twoHours.valueOf() + currentSlot.valueOf()));
+  });
+
+  it('uses calculated invalidHereafter value when user provides a partial ValidityInterval', () => {
+    const currentSlot = Cardano.Slot(1);
+    const validityInterval = ensureValidityInterval(
+      currentSlot,
+      { slotLength: Seconds(1) },
+      { invalidBefore: currentSlot }
+    );
+    expect(validityInterval).toEqual({
+      invalidBefore: currentSlot,
+      invalidHereafter: Cardano.Slot(twoHours.valueOf() + currentSlot.valueOf())
+    });
+  });
+
+  it('ignores calculated invalidHereafter value when user provides a complete ValidityInterval', () => {
+    const currentSlot = Cardano.Slot(1);
+    const userProvided: Cardano.ValidityInterval = { invalidBefore: currentSlot, invalidHereafter: Cardano.Slot(13) };
+    const validityInterval = ensureValidityInterval(currentSlot, { slotLength: Seconds(1) }, userProvided);
+    expect(validityInterval).toEqual(userProvided);
+  });
+});

--- a/packages/wallet/test/mocks/mockData.ts
+++ b/packages/wallet/test/mocks/mockData.ts
@@ -1,4 +1,4 @@
-import { Cardano, EpochRewards } from '@cardano-sdk/core';
+import { Cardano, EpochRewards, Seconds } from '@cardano-sdk/core';
 import { KeyRole } from '@cardano-sdk/key-management';
 
 export const rewardAccount = Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d');
@@ -46,7 +46,7 @@ export const epochRewards = [
 ];
 export const rewardsHistory: Map<Cardano.RewardAccount, EpochRewards[]> = new Map([[rewardAccount, epochRewards]]);
 
-export const genesisParameters = {
+export const genesisParameters: Cardano.CompactGenesis = {
   activeSlotsCoefficient: 0.05,
   epochLength: 432_000,
   maxKesEvolutions: 62,
@@ -54,7 +54,7 @@ export const genesisParameters = {
   networkId: 0,
   networkMagic: 764_824_073,
   securityParameter: 2160,
-  slotLength: 1,
+  slotLength: Seconds(1),
   slotsPerKesPeriod: 129_600,
   systemStart: new Date(1_506_203_091_000),
   updateQuorum: 5


### PR DESCRIPTION
# Context

TTL is calculated as 3600 slots, which should be 1h provided that the slot length is 1s.

# Proposed Solution
Use slotLength to calculate the TTL to 2h

# Breaking Changes Introduced
- Updated CompactGenesis.slotLength type from `number` to `Seconds`.
-  Updated EraSummary.parameters.slotLength type from `number` to `Milliseconds`.
