### PR TITLE
perf(cardano-services): `Cardano-services` optimizations based on processed profiled data

### DIFF
--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -41,7 +41,7 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
     if (!multiAsset)
       throw new ProviderError(ProviderFailure.NotFound, undefined, 'No entries found in multi_asset table');
 
-    const fingerprint = Cardano.AssetFingerprint(multiAsset.fingerprint);
+    const fingerprint = multiAsset.fingerprint as unknown as Cardano.AssetFingerprint;
     const quantities = await this.#builder.queryMultiAssetQuantities(multiAsset.id);
     const quantity = BigInt(quantities.sum);
     const mintOrBurnCount = Number(quantities.count);
@@ -71,7 +71,7 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
       await this.#builder.queryMultiAssetHistory(assetInfo.policyId, assetInfo.name)
     ).map<Asset.AssetMintOrBurn>(({ hash, quantity }) => ({
       quantity: BigInt(quantity),
-      transactionId: Cardano.TransactionId(hash.toString('hex'))
+      transactionId: hash.toString('hex') as unknown as Cardano.TransactionId
     }));
   }
 }

--- a/packages/cardano-services/src/Asset/DbSyncNftMetadataService.ts
+++ b/packages/cardano-services/src/Asset/DbSyncNftMetadataService.ts
@@ -34,7 +34,7 @@ export class DbSyncNftMetadataService implements NftMetadataService {
 
     if (!lastMintedTx) return null;
 
-    const lastMintedTxId = Cardano.TransactionId(lastMintedTx.tx_hash.toString('hex'));
+    const lastMintedTxId = lastMintedTx.tx_hash.toString('hex') as unknown as Cardano.TransactionId;
 
     this.#logger.debug('Querying tx metadata', lastMintedTxId);
     const metadatas = await this.#metadataService.queryTxMetadataByHashes([lastMintedTxId]);

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
@@ -87,7 +87,7 @@ export class ChainHistoryBuilder {
     const result: QueryResult<WithdrawalModel> = await this.#db.query(Queries.findWithdrawal, [byteHashes]);
     const withdrawalMap: TransactionDataMap<Cardano.Withdrawal[]> = new Map();
     for (const withdrawal of result.rows) {
-      const txId = Cardano.TransactionId(withdrawal.tx_id.toString('hex'));
+      const txId = withdrawal.tx_id.toString('hex') as unknown as Cardano.TransactionId;
       const currentWithdrawals = withdrawalMap.get(txId) ?? [];
       withdrawalMap.set(txId, [...currentWithdrawals, mapWithdrawal(withdrawal)]);
     }
@@ -102,7 +102,7 @@ export class ChainHistoryBuilder {
     const result: QueryResult<RedeemerModel> = await this.#db.query(Queries.findRedeemer, [byteHashes]);
     const redeemerMap: TransactionDataMap<Cardano.Redeemer[]> = new Map();
     for (const redeemer of result.rows) {
-      const txId = Cardano.TransactionId(redeemer.tx_id.toString('hex'));
+      const txId = redeemer.tx_id.toString('hex') as unknown as Cardano.TransactionId;
       const currentRedeemers = redeemerMap.get(txId) ?? [];
       redeemerMap.set(txId, [...currentRedeemers, mapRedeemer(redeemer)]);
     }
@@ -139,7 +139,7 @@ export class ChainHistoryBuilder {
 
     const indexedCertsMap: TransactionDataMap<WithCertIndex<Cardano.Certificate>[]> = new Map();
     for (const cert of allCerts) {
-      const txId = Cardano.TransactionId(cert.tx_id.toString('hex'));
+      const txId = cert.tx_id.toString('hex') as unknown as Cardano.TransactionId;
       const currentCerts = indexedCertsMap.get(txId) ?? [];
       const newCert = mapCertificate(cert);
       if (newCert) indexedCertsMap.set(txId, [...currentCerts, newCert]);

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -138,7 +138,7 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
     ]);
 
     return txResults.rows.map((tx) => {
-      const txId = Cardano.TransactionId(tx.id.toString('hex'));
+      const txId = tx.id.toString('hex') as unknown as Cardano.TransactionId;
       const txInputs = orderBy(inputs.filter((input) => input.txInputId === txId).map(mapTxIn), ['index']);
       const txCollaterals = orderBy(collaterals.filter((col) => col.txInputId === txId).map(mapTxIn), ['index']);
       const txOutputs = orderBy(outputs.filter((output) => output.txId === txId).map(mapTxOut), ['index']);

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -30,8 +30,8 @@ import {
 const addMultiAssetToTokenMap = (multiAsset: MultiAssetModel, tokenMap: Cardano.TokenMap): Cardano.TokenMap => {
   const tokens = new Map(tokenMap);
   const assetId = Asset.util.assetIdFromPolicyAndName(
-    Cardano.PolicyId(multiAsset.policy_id.toString('hex')),
-    Cardano.AssetName(multiAsset.asset_name.toString('hex'))
+    multiAsset.policy_id.toString('hex') as unknown as Cardano.PolicyId,
+    multiAsset.asset_name.toString('hex') as unknown as Cardano.AssetName
   );
   const currentQuantity = tokens.get(assetId) ?? 0n;
   tokens.set(assetId, BigIntMath.sum([currentQuantity, BigInt(multiAsset.quantity)]));
@@ -41,7 +41,7 @@ const addMultiAssetToTokenMap = (multiAsset: MultiAssetModel, tokenMap: Cardano.
 export const mapTxTokenMap = (multiAssetModels: MultiAssetModel[]): TxTokenMap => {
   const txTokenMap: TxTokenMap = new Map();
   for (const multiAsset of multiAssetModels) {
-    const txId = Cardano.TransactionId(multiAsset.tx_id.toString('hex'));
+    const txId = multiAsset.tx_id.toString('hex') as unknown as Cardano.TransactionId;
     const currentTokenMap = txTokenMap.get(txId) ?? new Map();
     const tokenMap = addMultiAssetToTokenMap(multiAsset, currentTokenMap);
     txTokenMap.set(txId, tokenMap);
@@ -66,11 +66,11 @@ export const mapTxIn = (txIn: TxInput): Cardano.HydratedTxIn => ({
 });
 
 export const mapTxInModel = (txInModel: TxInputModel): TxInput => ({
-  address: Cardano.Address(txInModel.address),
+  address: txInModel.address as unknown as Cardano.Address,
   id: txInModel.id,
   index: txInModel.index,
-  txInputId: Cardano.TransactionId(txInModel.tx_input_id.toString('hex')),
-  txSourceId: Cardano.TransactionId(txInModel.tx_source_id.toString('hex'))
+  txInputId: txInModel.tx_input_id.toString('hex') as unknown as Cardano.TransactionId,
+  txSourceId: txInModel.tx_source_id.toString('hex') as unknown as Cardano.TransactionId
 });
 
 export const mapTxOut = (txOut: TxOutput): Cardano.TxOut => ({
@@ -82,10 +82,12 @@ export const mapTxOut = (txOut: TxOutput): Cardano.TxOut => ({
 });
 
 export const mapTxOutModel = (txOutModel: TxOutputModel, assets?: Cardano.TokenMap): TxOutput => ({
-  address: Cardano.Address(txOutModel.address),
-  datumHash: txOutModel.datum ? Cardano.util.Hash32ByteBase16(txOutModel.datum.toString('hex')) : undefined,
+  address: txOutModel.address as unknown as Cardano.Address,
+  datumHash: txOutModel.datum
+    ? (txOutModel.datum.toString('hex') as unknown as Cardano.util.Hash32ByteBase16)
+    : undefined,
   index: txOutModel.index,
-  txId: Cardano.TransactionId(txOutModel.tx_id.toString('hex')),
+  txId: txOutModel.tx_id.toString('hex') as unknown as Cardano.TransactionId,
   value: {
     assets: assets && assets.size > 0 ? assets : undefined,
     coins: BigInt(txOutModel.coin_value)
@@ -94,11 +96,11 @@ export const mapTxOutModel = (txOutModel: TxOutputModel, assets?: Cardano.TokenM
 
 export const mapWithdrawal = (withdrawalModel: WithdrawalModel): Cardano.Withdrawal => ({
   quantity: BigInt(withdrawalModel.quantity),
-  stakeAddress: Cardano.RewardAccount(withdrawalModel.stake_address)
+  stakeAddress: withdrawalModel.stake_address as unknown as Cardano.RewardAccount
 });
 
 export const mapRedeemer = (redeemerModel: RedeemerModel): Cardano.Redeemer => ({
-  data: Cardano.util.HexBlob(redeemerModel.script_hash.toString('hex')),
+  data: redeemerModel.script_hash.toString('hex') as unknown as Cardano.util.HexBlob,
   executionUnits: {
     memory: Number(redeemerModel.unit_mem),
     steps: Number(redeemerModel.unit_steps)
@@ -115,7 +117,7 @@ export const mapCertificate = (
       __typename: Cardano.CertificateType.PoolRetirement,
       cert_index: certModel.cert_index,
       epoch: Cardano.EpochNo(certModel.retiring_epoch),
-      poolId: Cardano.PoolId(certModel.pool_id)
+      poolId: certModel.pool_id as unknown as Cardano.PoolId
     } as WithCertIndex<Cardano.PoolRetirementCertificate>;
 
   if (isPoolRegisterCertModel(certModel))
@@ -131,7 +133,7 @@ export const mapCertificate = (
       cert_index: certModel.cert_index,
       pot: certModel.pot === 'reserve' ? Cardano.MirCertificatePot.Reserves : Cardano.MirCertificatePot.Treasury,
       quantity: BigInt(certModel.amount),
-      rewardAccount: Cardano.RewardAccount(certModel.address)
+      rewardAccount: certModel.address as unknown as Cardano.RewardAccount
     } as WithCertIndex<Cardano.MirCertificate>;
 
   if (isStakeCertModel(certModel))
@@ -140,15 +142,15 @@ export const mapCertificate = (
         ? Cardano.CertificateType.StakeKeyRegistration
         : Cardano.CertificateType.StakeKeyDeregistration,
       cert_index: certModel.cert_index,
-      stakeKeyHash: Cardano.Ed25519KeyHash.fromRewardAccount(Cardano.RewardAccount(certModel.address))
+      stakeKeyHash: Cardano.Ed25519KeyHash.fromRewardAccount(certModel.address as unknown as Cardano.RewardAccount)
     } as WithCertIndex<Cardano.StakeAddressCertificate>;
 
   if (isDelegationCertModel(certModel))
     return {
       __typename: Cardano.CertificateType.StakeDelegation,
       cert_index: certModel.cert_index,
-      poolId: Cardano.PoolId(certModel.pool_id),
-      stakeKeyHash: Cardano.Ed25519KeyHash.fromRewardAccount(Cardano.RewardAccount(certModel.address))
+      poolId: certModel.pool_id as unknown as Cardano.PoolId,
+      stakeKeyHash: Cardano.Ed25519KeyHash.fromRewardAccount(certModel.address as unknown as Cardano.RewardAccount)
     } as WithCertIndex<Cardano.StakeDelegationCertificate>;
 
   return null;
@@ -179,7 +181,7 @@ export const mapTxAlonzo = (
       : undefined,
   blockHeader: {
     blockNo: Cardano.BlockNo(txModel.block_no),
-    hash: Cardano.BlockId(txModel.block_hash.toString('hex')),
+    hash: txModel.block_hash.toString('hex') as unknown as Cardano.BlockId,
     slot: Cardano.Slot(Number(txModel.block_slot_no))
   },
   body: {
@@ -195,7 +197,7 @@ export const mapTxAlonzo = (
     },
     withdrawals
   },
-  id: Cardano.TransactionId(txModel.id.toString('hex')),
+  id: txModel.id.toString('hex') as unknown as Cardano.TransactionId,
   index: txModel.index,
   txSize: txModel.size,
   witness: {
@@ -218,16 +220,18 @@ export const mapBlock = (
   fees: BigInt(blockOutputModel?.fees ?? 0),
   header: {
     blockNo: Cardano.BlockNo(blockModel.block_no),
-    hash: Cardano.BlockId(blockModel.hash.toString('hex')),
+    hash: blockModel.hash.toString('hex') as unknown as Cardano.BlockId,
     slot: Cardano.Slot(Number(blockModel.slot_no))
   },
-  nextBlock: blockModel.next_block ? Cardano.BlockId(blockModel.next_block.toString('hex')) : undefined,
-  previousBlock: blockModel.previous_block ? Cardano.BlockId(blockModel.previous_block.toString('hex')) : undefined,
+  nextBlock: blockModel.next_block ? (blockModel.next_block.toString('hex') as unknown as Cardano.BlockId) : undefined,
+  previousBlock: blockModel.previous_block
+    ? (blockModel.previous_block.toString('hex') as unknown as Cardano.BlockId)
+    : undefined,
   size: Cardano.BlockSize(blockModel.size),
   slotLeader: blockModel.slot_leader_pool
     ? Cardano.SlotLeader(blockModel.slot_leader_pool)
     : Cardano.SlotLeader(blockModel.slot_leader_hash.toString('hex')),
   totalOutput: BigInt(blockOutputModel?.output ?? 0),
   txCount: Number(blockModel.tx_count),
-  vrf: Cardano.VrfVkBech32(blockModel.vrf)
+  vrf: blockModel.vrf as unknown as Cardano.VrfVkBech32
 });

--- a/packages/cardano-services/src/Metadata/DbSyncMetadataService.ts
+++ b/packages/cardano-services/src/Metadata/DbSyncMetadataService.ts
@@ -19,7 +19,7 @@ export const createDbSyncMetadataService = (db: Pool, logger: Logger): TxMetadat
     const metadataMap: Map<Cardano.TransactionId, TxMetadataModel[]> = new Map();
 
     for (const metadata of result.rows) {
-      const txId = Cardano.TransactionId(metadata.tx_id.toString('hex'));
+      const txId = metadata.tx_id.toString('hex') as unknown as Cardano.TransactionId;
       const currentMetadata: TxMetadataModel[] = metadataMap.get(txId) ?? [];
       metadataMap.set(txId, [...currentMetadata, metadata]);
     }

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -22,7 +22,7 @@ export const toSupply = ({ circulatingSupply, totalSupply }: ToLovalaceSupplyInp
 
 export const toLedgerTip = ({ block_no, slot_no, hash }: LedgerTipModel): Cardano.Tip => ({
   blockNo: Cardano.BlockNo(Number(block_no)),
-  hash: Cardano.BlockId(hash.toString('hex')),
+  hash: hash.toString('hex') as unknown as Cardano.BlockId,
   slot: Cardano.Slot(Number(slot_no))
 });
 

--- a/packages/cardano-services/src/Rewards/DbSyncRewardProvider/mappers.ts
+++ b/packages/cardano-services/src/Rewards/DbSyncRewardProvider/mappers.ts
@@ -3,7 +3,7 @@ import { RewardEpochModel } from './types';
 
 export const rewardsToCore = (rewards: RewardEpochModel[]): Map<Cardano.RewardAccount, EpochRewards[]> =>
   rewards.reduce((_rewards, current) => {
-    const coreReward = Cardano.RewardAccount(current.address);
+    const coreReward = current.address as unknown as Cardano.RewardAccount;
     const epochRewards = _rewards.get(coreReward);
     const currentEpochReward = { epoch: Cardano.EpochNo(current.epoch), rewards: BigInt(current.quantity) };
     if (epochRewards) {

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
@@ -190,17 +190,17 @@ export const mapPoolData = (poolDataModel: PoolDataModel): PoolData => {
   const toReturn: PoolData = {
     cost: BigInt(poolDataModel.fixed_cost),
     hashId: Number(poolDataModel.hash_id),
-    hexId: Cardano.PoolIdHex(bufferToHexString(poolDataModel.pool_hash)),
-    id: Cardano.PoolId(poolDataModel.pool_id),
+    hexId: bufferToHexString(poolDataModel.pool_hash) as unknown as Cardano.PoolIdHex,
+    id: poolDataModel.pool_id as unknown as Cardano.PoolId,
     margin: { denominator, numerator },
     pledge: BigInt(poolDataModel.pledge),
-    rewardAccount: Cardano.RewardAccount(poolDataModel.reward_address),
+    rewardAccount: poolDataModel.reward_address as unknown as Cardano.RewardAccount,
     updateId: Number(poolDataModel.update_id),
-    vrfKeyHash: Cardano.VrfVkHex(vrfAsHexString)
+    vrfKeyHash: vrfAsHexString as unknown as Cardano.VrfVkHex
   };
   if (poolDataModel.metadata_hash) {
     toReturn.metadataJson = {
-      hash: Cardano.util.Hash32ByteBase16(bufferToHexString(poolDataModel.metadata_hash)),
+      hash: bufferToHexString(poolDataModel.metadata_hash) as unknown as Cardano.util.Hash32ByteBase16,
       url: poolDataModel.metadata_url
     };
   }
@@ -249,20 +249,20 @@ export const mapEpochReward = (epochRewardModel: EpochRewardModel, hashId: numbe
 });
 
 export const mapAddressOwner = (ownerAddressModel: OwnerAddressModel): PoolOwner => ({
-  address: Cardano.RewardAccount(ownerAddressModel.address),
+  address: ownerAddressModel.address as unknown as Cardano.RewardAccount,
   hashId: Number(ownerAddressModel.hash_id)
 });
 
 export const mapPoolRegistration = (poolRegistrationModel: PoolRegistrationModel): PoolRegistration => ({
   activeEpochNo: poolRegistrationModel.active_epoch_no,
   hashId: Number(poolRegistrationModel.hash_id),
-  transactionId: Cardano.TransactionId(bufferToHexString(poolRegistrationModel.tx_hash))
+  transactionId: bufferToHexString(poolRegistrationModel.tx_hash) as unknown as Cardano.TransactionId
 });
 
 export const mapPoolRetirement = (poolRetirementModel: PoolRetirementModel): PoolRetirement => ({
   hashId: Number(poolRetirementModel.hash_id),
   retiringEpoch: poolRetirementModel.retiring_epoch,
-  transactionId: Cardano.TransactionId(bufferToHexString(poolRetirementModel.tx_hash))
+  transactionId: bufferToHexString(poolRetirementModel.tx_hash) as unknown as Cardano.TransactionId
 });
 
 export const mapPoolMetrics = (poolMetricsModel: PoolMetricsModel): PoolMetrics => ({

--- a/packages/cardano-services/src/Utxo/DbSyncUtxoProvider/mappers.ts
+++ b/packages/cardano-services/src/Utxo/DbSyncUtxoProvider/mappers.ts
@@ -29,7 +29,7 @@ const parseReferenceScript = (model: UtxoModel): Cardano.Script => {
         );
       script = {
         __type: Cardano.ScriptType.Plutus,
-        bytes: Cardano.util.HexBlob(model.reference_script_bytes),
+        bytes: model.reference_script_bytes as unknown as Cardano.util.HexBlob,
         version: Cardano.PlutusLanguageVersion.V1
       };
       break;
@@ -41,7 +41,7 @@ const parseReferenceScript = (model: UtxoModel): Cardano.Script => {
         );
       script = {
         __type: Cardano.ScriptType.Plutus,
-        bytes: Cardano.util.HexBlob(model.reference_script_bytes),
+        bytes: model.reference_script_bytes as unknown as Cardano.util.HexBlob,
         version: Cardano.PlutusLanguageVersion.V2
       };
       break;
@@ -75,15 +75,15 @@ export const utxosToCore = (utxosModels: UtxoModel[]): Cardano.Utxo[] => {
       }
       utxos.set(utxoId, [txIn, txOut]);
     } else {
-      const address = Cardano.Address(current.address);
+      const address = current.address as unknown as Cardano.Address;
       const txOut: Cardano.TxOut = {
         address,
         value: {
           coins: BigInt(current.coins)
         }
       };
-      if (isNotNil(current.data_hash)) txOut.datumHash = Cardano.util.Hash32ByteBase16(current.data_hash);
-      if (isNotNil(current.inline_datum)) txOut.datum = Cardano.util.HexBlob(current.inline_datum);
+      if (isNotNil(current.data_hash)) txOut.datumHash = current.data_hash as unknown as Cardano.util.Hash32ByteBase16;
+      if (isNotNil(current.inline_datum)) txOut.datum = current.inline_datum as unknown as Cardano.util.HexBlob;
       if (isNotNil(current.reference_script_type)) txOut.scriptReference = parseReferenceScript(current);
 
       if (isNotNil(current.asset_name) && current.asset_policy && current.asset_quantity) {
@@ -95,7 +95,7 @@ export const utxosToCore = (utxosModels: UtxoModel[]): Cardano.Utxo[] => {
         {
           address,
           index: current.index,
-          txId: Cardano.TransactionId(current.tx_id)
+          txId: current.tx_id as unknown as Cardano.TransactionId
         },
         txOut
       ]);

--- a/packages/cardano-services/src/util/DbSyncProvider/DbSyncProvider.ts
+++ b/packages/cardano-services/src/util/DbSyncProvider/DbSyncProvider.ts
@@ -63,7 +63,7 @@ export const DbSyncProvider = <
 
         const projectedTip: Cardano.Tip = {
           blockNo: Cardano.BlockNo(tip.block_no),
-          hash: Cardano.BlockId(tip.hash.toString('hex')),
+          hash: tip.hash.toString('hex') as unknown as Cardano.BlockId,
           slot: Cardano.Slot(Number(tip.slot_no))
         };
 

--- a/packages/cardano-services/test/Asset/AssetBuilder.test.ts
+++ b/packages/cardano-services/test/Asset/AssetBuilder.test.ts
@@ -26,6 +26,8 @@ describe('AssetBuilder', () => {
     test('query last Mint transaction', async () => {
       const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
       const lastMintTx = await fixtureBuilder.queryLastMintTx(assets[0].policyId, assets[0].name);
+      expect(() => Cardano.TransactionId(lastMintTx.tx_hash.toString('hex'))).not.toThrow();
+
       const result = await builder.queryLastMintTx(assets[0].policyId, assets[0].name);
       expect(result.tx_hash).toEqual(lastMintTx.tx_hash);
     });
@@ -39,6 +41,8 @@ describe('AssetBuilder', () => {
     test('query multi_asset', async () => {
       const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
       const ma = await builder.queryMultiAsset(assets[0].policyId, assets[0].name);
+
+      expect(() => Cardano.AssetFingerprint(ma.fingerprint)).not.toThrow();
       expect(ma.fingerprint).toEqual(Cardano.AssetFingerprint.fromParts(assets[0].policyId, assets[0].name).toString());
       expect(ma).toMatchShapeOf({
         fingerprint: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65',

--- a/packages/cardano-services/test/Asset/AssetHttpService.test.ts
+++ b/packages/cardano-services/test/Asset/AssetHttpService.test.ts
@@ -9,7 +9,7 @@ import {
   NftMetadataService,
   TokenMetadataService
 } from '../../src';
-import { AssetProvider } from '@cardano-sdk/core';
+import { AssetProvider, Cardano } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, assetInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { INFO, createLogger } from 'bunyan';
 import { LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
@@ -172,7 +172,10 @@ describe('AssetHttpService', () => {
         const res = await provider.getAsset({
           assetId: assets[0].id
         });
+
         expect(res.name).toEqual(assets[0].name);
+        expect(() => Cardano.PolicyId(assets[0].policyId as unknown as string)).not.toThrow();
+        expect(() => Cardano.AssetName(assets[0].name as unknown as string)).not.toThrow();
       });
 
       it('returns asset info with extra data when requested', async () => {

--- a/packages/cardano-services/test/Asset/fixtures/FixtureBuilder.ts
+++ b/packages/cardano-services/test/Asset/fixtures/FixtureBuilder.ts
@@ -44,7 +44,7 @@ export class AssetFixtureBuilder {
 
     return result.rows.map(({ hash, quantity }) => ({
       quantity: BigInt(quantity),
-      transactionId: bufferToHexString(hash)
+      transactionId: bufferToHexString(hash) as unknown as Cardano.TransactionId
     }));
   }
 
@@ -68,8 +68,8 @@ export class AssetFixtureBuilder {
     return result.rows.map(({ policy, name, json }) => {
       const hexPolicy = bufferToHexString(policy);
       const hexName = bufferToHexString(name);
-      const policyId = Cardano.PolicyId(hexPolicy);
-      const assetName = Cardano.AssetName(hexName);
+      const policyId = hexPolicy as unknown as Cardano.PolicyId;
+      const assetName = hexName as unknown as Cardano.AssetName;
 
       return {
         id: Cardano.AssetId(`${hexPolicy}${hexName}`),

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -168,9 +168,12 @@ describe('ChainHistoryHttpService', () => {
       });
 
       it('returns an array of blocks', async () => {
-        const response = await provider.blocksByHashes({
-          ids: await fixtureBuilder.getBlockHashes(2)
-        });
+        const blockIds = await fixtureBuilder.getBlockHashes(2);
+        const response = await provider.blocksByHashes({ ids: blockIds });
+
+        expect(() => Cardano.BlockId(blockIds[0] as unknown as string)).not.toThrow();
+        expect(() => Cardano.VrfVkBech32(response[0].vrf as unknown as string)).not.toThrow();
+
         expect(response).toHaveLength(2);
       });
 
@@ -227,8 +230,11 @@ describe('ChainHistoryHttpService', () => {
       });
 
       it('returns an array of transactions', async () => {
-        const response = await provider.transactionsByHashes({ ids: await fixtureBuilder.getTxHashes(5) });
+        const ids = await fixtureBuilder.getTxHashes(5);
+        const response = await provider.transactionsByHashes({ ids });
+
         expect(response).toHaveLength(5);
+        expect(() => Cardano.TransactionId(ids[0] as unknown as string)).not.toThrow();
       });
 
       it('does not include transactions not found', async () => {
@@ -298,7 +304,8 @@ describe('ChainHistoryHttpService', () => {
           const tx: Cardano.Tx = response[0];
           expect(response.length).toEqual(1);
           expect(tx.witness).toMatchShapeOf(DataMocks.Tx.witnessRedeemers);
-          expect(tx.witness.redeemers?.length).toBeGreaterThan(0);
+          expect(tx.witness.redeemers!.length).toBeGreaterThan(0);
+          expect(() => Cardano.util.HexBlob(tx.witness.redeemers![0].data as unknown as string)).not.toThrow();
         });
 
         it('has auxiliary data', async () => {
@@ -367,11 +374,13 @@ describe('ChainHistoryHttpService', () => {
       });
 
       it('returns an array of transactions', async () => {
-        const response = await provider.transactionsByAddresses({
-          addresses: await fixtureBuilder.getDistinctAddresses(2),
-          pagination: { limit: 5, startAt: 0 }
-        });
+        const addresses = await fixtureBuilder.getDistinctAddresses(2);
+        const pagination = { limit: 5, startAt: 0 };
+
+        const response = await provider.transactionsByAddresses({ addresses, pagination });
+
         expect(response.pageResults.length).toEqual(5);
+        expect(() => Cardano.Address(addresses[0] as unknown as string)).not.toThrow();
       });
 
       it('does not include transactions not found', async () => {
@@ -407,6 +416,7 @@ describe('ChainHistoryHttpService', () => {
 
         expect(response.totalResultCount).toEqual(txInRangeCount);
         expect(lowerBound).toBeGreaterThanOrEqual(10);
+        expect(() => Cardano.Address([...addresses][0] as unknown as string)).not.toThrow();
         for (const tx of response.pageResults) expect(tx.blockHeader).toMatchShapeOf(DataMocks.Tx.blockHeader);
       });
 
@@ -500,6 +510,8 @@ describe('ChainHistoryHttpService', () => {
 
         it('finds transactions with address within outputs', async () => {
           const addresses: Cardano.Address[] = await fixtureBuilder.getGenesisAddresses();
+          expect(() => Cardano.Address(addresses[0] as unknown as string)).not.toThrow();
+
           const firstPageResponse = await provider.transactionsByAddresses({
             addresses,
             pagination: { limit: 3, startAt: 0 }

--- a/packages/cardano-services/test/ChainHistory/fixtures/FixtureBuilder.ts
+++ b/packages/cardano-services/test/ChainHistory/fixtures/FixtureBuilder.ts
@@ -62,7 +62,7 @@ export class ChainHistoryFixtureBuilder {
     for (const { address } of results.rows) {
       if (addressesInBlockRange.addresses.size >= desiredQty) break;
 
-      addressesInBlockRange.addresses.add(Cardano.Address(address));
+      addressesInBlockRange.addresses.add(address as unknown as Cardano.Address);
     }
 
     if (results.rows.length < desiredQty) {
@@ -70,7 +70,7 @@ export class ChainHistoryFixtureBuilder {
     }
 
     for (const { address, block_no, tx_id } of results.rows) {
-      if (addressesInBlockRange.addresses.has(Cardano.Address(address))) {
+      if (addressesInBlockRange.addresses.has(address as unknown as Cardano.Address)) {
         txIds.add(tx_id);
         addressesInBlockRange.blockRange.lowerBound = Cardano.BlockNo(
           Math.min(addressesInBlockRange.blockRange.lowerBound.valueOf(), block_no)
@@ -95,7 +95,7 @@ export class ChainHistoryFixtureBuilder {
     } else if (resultsQty < desiredQty) {
       this.#logger.warn(`${desiredQty} blocks desired, only ${resultsQty} results found`);
     }
-    return result.rows.map(({ hash }) => Cardano.BlockId(bufferToHexString(hash)));
+    return result.rows.map(({ hash }) => bufferToHexString(hash) as unknown as Cardano.BlockId);
   }
 
   // eslint-disable-next-line sonarjs/cognitive-complexity,complexity
@@ -132,7 +132,7 @@ export class ChainHistoryFixtureBuilder {
     } else if (resultsQty < desiredQty) {
       this.#logger.warn(`${desiredQty} transactions desired, only ${resultsQty} results found`);
     }
-    return result.rows.map(({ hash }) => Cardano.TransactionId(bufferToHexString(hash)));
+    return result.rows.map(({ hash }) => bufferToHexString(hash) as unknown as Cardano.TransactionId);
   }
 
   public async getMultiAssetTxOutIds(desiredQty: number) {
@@ -144,7 +144,7 @@ export class ChainHistoryFixtureBuilder {
   public async getGenesisAddresses() {
     this.#logger.debug('About to fetch genesis addresses');
     const result: QueryResult<{ address: string }> = await this.#db.query(Queries.genesisUtxoAddresses);
-    return result.rows.map(({ address }) => Cardano.Address(address));
+    return result.rows.map(({ address }) => address as unknown as Cardano.Address);
   }
 
   public async getDistinctAddresses(desiredQty: number): Promise<Cardano.Address[]> {
@@ -158,6 +158,6 @@ export class ChainHistoryFixtureBuilder {
     } else if (resultsQty < desiredQty) {
       this.#logger.warn(`${desiredQty} distinct addresses desired, only ${resultsQty} results found`);
     }
-    return result.rows.map(({ address }) => Cardano.Address(address));
+    return result.rows.map(({ address }) => address as unknown as Cardano.Address);
   }
 }

--- a/packages/cardano-services/test/Metadata/DbSyncMetadataService.test.ts
+++ b/packages/cardano-services/test/Metadata/DbSyncMetadataService.test.ts
@@ -22,6 +22,7 @@ describe('createDbSyncMetadataService', () => {
     expect(result.size).toEqual(2);
     expect(result.get(hashes[0])).toBeDefined();
     expect(result.get(hashes[1])).toBeDefined();
+    expect(() => Cardano.TransactionId(hashes[0] as unknown as string)).not.toThrow();
   });
 
   test('query transaction metadata with empty array', async () => {

--- a/packages/cardano-services/test/Metadata/fixtures/FixtureBuilder.ts
+++ b/packages/cardano-services/test/Metadata/fixtures/FixtureBuilder.ts
@@ -24,6 +24,6 @@ export class MetadataFixtureBuilder {
       this.#logger.warn(`${desiredQty} transactions desired, only ${resultsQty} results found`);
     }
 
-    return result.rows.map(({ tx_id }) => Cardano.TransactionId(bufferToHexString(tx_id)));
+    return result.rows.map(({ tx_id }) => bufferToHexString(tx_id) as unknown as Cardano.TransactionId);
   }
 }

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -238,6 +238,7 @@ describe('RewardsHttpService', () => {
           const rewardAccount = (await fixtureBuilder.getRewardAccounts(1))[0];
           const response = await provider.rewardAccountBalance({ rewardAccount });
           expect(response).toBeGreaterThan(0);
+          expect(() => Cardano.RewardAccount(rewardAccount as unknown as string)).not.toThrow();
         });
 
         it('returns address balance 0 when it has no rewards', async () => {

--- a/packages/cardano-services/test/Reward/fixtures/FixtureBuilder.ts
+++ b/packages/cardano-services/test/Reward/fixtures/FixtureBuilder.ts
@@ -21,6 +21,6 @@ export class RewardsFixtureBuilder {
     } else if (resultsQty < desiredQty) {
       this.#logger.warn(`${desiredQty} reward accounts desired, only ${resultsQty} results found`);
     }
-    return result.rows.map(({ address }) => Cardano.RewardAccount(address));
+    return result.rows.map(({ address }) => address as unknown as Cardano.RewardAccount);
   }
 }

--- a/packages/cardano-services/test/StakePool/fixtures/FixtureBuilder.ts
+++ b/packages/cardano-services/test/StakePool/fixtures/FixtureBuilder.ts
@@ -78,7 +78,7 @@ export class StakePoolFixtureBuilder {
 
     return result.rows.map(({ pool_id, metadata, hash_id, update_id }) => ({
       hashId: Number(hash_id.toString()),
-      id: Cardano.PoolId(pool_id),
+      id: pool_id as unknown as Cardano.PoolId,
       name: metadata?.name,
       ticker: metadata?.ticker,
       updateId: Number(update_id.toString())
@@ -112,6 +112,6 @@ export class StakePoolFixtureBuilder {
       this.#logger.warn(`${desiredQty} pools desired, only ${resultsQty} results found`);
     }
 
-    return result.rows.map(({ pool_id }) => Cardano.PoolId(pool_id));
+    return result.rows.map(({ pool_id }) => pool_id as unknown as Cardano.PoolId);
   }
 }

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -165,15 +165,21 @@ describe('UtxoHttpService', () => {
       it('return UTxOs for a single address', async () => {
         const addresses = await fixtureBuilder.getAddresses(1);
         const res = await provider.utxoByAddresses({ addresses });
+
         expect(res.length).toBeGreaterThan(0);
         expect(res[0]).toMatchShapeOf([DataMocks.Tx.input, DataMocks.Tx.output]);
+        expect(() => Cardano.Address(addresses[0] as unknown as string)).not.toThrow();
       });
 
       it('return UTxO with inline datum', async () => {
         const addresses = await fixtureBuilder.getAddresses(1, { with: [AddressWith.InlineDatum] });
-        const res = await provider.utxoByAddresses({ addresses });
+        const res: Cardano.Utxo[] = await provider.utxoByAddresses({ addresses });
+        const firstTxOut = res[0][1];
+
         expect(res.length).toBeGreaterThan(0);
         expect(res[0]).toMatchShapeOf([DataMocks.Tx.input, DataMocks.Tx.outputWithInlineDatum]);
+        expect(() => Cardano.util.HexBlob(firstTxOut.datum! as unknown as string)).not.toThrow();
+        expect(() => Cardano.util.Hash32ByteBase16(firstTxOut.datumHash! as unknown as string)).not.toThrow();
       });
 
       it('return UTxO with time lock reference script', async () => {

--- a/packages/cardano-services/test/Utxo/fixtures/FixtureBuilder.ts
+++ b/packages/cardano-services/test/Utxo/fixtures/FixtureBuilder.ts
@@ -54,6 +54,6 @@ export class UtxoFixtureBuilder {
       this.#logger.warn(`${desiredQty} distinct addresses desired, only ${resultsQty} results found`);
     }
 
-    return result!.rows.map(({ address }) => Cardano.Address(address));
+    return result!.rows.map(({ address }) => address as unknown as Cardano.Address);
   }
 }


### PR DESCRIPTION
# Context
Based on the "**Loading SPIKE: Wallet with large # of txs uses a lot of CPU in cardano-services**"  and the profiled processed data, we could apply some optimizations in cardano-services backend in order to reduce/resolve the high CPU errors during the performing of intensive E2E tests which are opening/closing a  “heavy” wallet multiple times in a short period of time.


# Proposed Solution
- remove the usage of core types with validation in mappings/utils when data comes from the database as we trust the format of the stored addresses. 
- each validation is hosted to the test scope

This is not only about `Cardano.Address()` validation but also other validations such as `TransactionId()`, `BlockId()`, `RewardAccount()`, and more. The ones which don't perform a type validation should be used in mappers as it is, 
for instance [Cardano.Slot()](https://github.com/input-output-hk/cardano-js-sdk/blob/215844f81944ffd0f7d944ceac17b915333819e3/packages/core/src/Cardano/types/Block.ts#L31)

# Important Changes Introduced
- uses type casting instead of type validation when mapping DB data
- removes type validations in all Fixture Builders (used casting instead)
- keeps the type validations in the test scope and enhances integration tests with assertions for data coming from DB correctness

## List of Cardano core types that contain a validation (with refs to usage in tests):
- Cardano.TransactionId ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-5789295736de3cf2895c6a9e2ce5211ef7ee0b554b84d55d522dd4b449297b9aR25) )
- Cardano.AssetFingerprint ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-fd56d4a217c2a3fb20bbfeaf10583d1547e35c2eed7f251e41fc99da7497a070R44-R45) )
- Cardano.PolicyId ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-39ef57c4f1de9f259d97423989a5f5403e4a5725f26902653f92f548257e40ebR177) )
- Cardano.AssetName ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-39ef57c4f1de9f259d97423989a5f5403e4a5725f26902653f92f548257e40ebR178) )
- Cardano.Address ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-cc6fbcd6f5f3a6dee2c12a90216ba559ea451cb187699b838f8bed6b600d65c3R383) )
- Cardano.util.Hash32ByteBase16 ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-31f793d9d4683e50f675d6caf27ff23c8cc8adb005eb8a03c69b26eb7d6cde63R182) )
- Cardano.RewardAccount ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-3228dafc1269f792176b57dfd8715dc603f6b08273a996c598bd38efc6b95861R241) )
- Cardano.util.HexBlob ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-31f793d9d4683e50f675d6caf27ff23c8cc8adb005eb8a03c69b26eb7d6cde63R181) )
- Cardano.PoolId ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-7bf95288ddba72cc435fbe56613884016d332bdba413afd23c5e1e7bcc69ce42R375) )
- Cardano.BlockId ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-cc6fbcd6f5f3a6dee2c12a90216ba559ea451cb187699b838f8bed6b600d65c3R174) )
- Cardano.VrfVkBech32 ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-cc6fbcd6f5f3a6dee2c12a90216ba559ea451cb187699b838f8bed6b600d65c3R175) )
- Cardano.PoolIdHex ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-7bf95288ddba72cc435fbe56613884016d332bdba413afd23c5e1e7bcc69ce42R376) )
- Cardano.VrfVkHex ( [test scope](https://github.com/input-output-hk/cardano-js-sdk/pull/578/files#diff-7bf95288ddba72cc435fbe56613884016d332bdba413afd23c5e1e7bcc69ce42R377) )
