### PR TITLE
fix(cardano-services): stake pool query by metrics results no longer …

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -114,21 +114,8 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
     );
     let poolDatas: PoolData[] = [];
     if (sortType !== 'data') {
-      // If queryPoolData is not the one used to sort there could be more stake pools that should be fetched
-      // but might not appear in the orderByQuery result
       this.logger.debug('About to query stake pools data');
       poolDatas = await this.#builder.queryPoolData(orderedResultUpdateIds);
-      // If not reached, try to fill the pagination limit using pool data default order
-      if (options?.pagination?.limit && orderedResult.length < options.pagination.limit) {
-        const restOfPoolUpdateIds = updatesIds.filter((updateId) => !orderedResultUpdateIds.includes(updateId));
-        this.logger.debug('About to query rest of stake pools data');
-        const restOfPoolData = await this.#builder.queryPoolData(restOfPoolUpdateIds, {
-          pagination: { limit: options.pagination.limit - orderedResult.length, startAt: 0 }
-        });
-        poolDatas.push(...restOfPoolData);
-        orderedResultUpdateIds.push(...restOfPoolData.map(({ updateId }) => updateId));
-        orderedResultHashIds.push(...restOfPoolData.map(({ hashId }) => hashId));
-      }
     } else {
       poolDatas = orderedResult as PoolData[];
     }


### PR DESCRIPTION
# Context

The `DbSyncStakePoolProvider` in case of query sorted by metrics or apy, in case the requested pagination parameters exceed the total stake pools count, fills the page anyway.
This behavior was introduced as workaround when some pools couldn't be found by the query.
Another problem of the same workaround is that, in such cases, the result does not respect the requested sort.

# Proposed Solution

Being the problem no longer live, the workaround was removed.
