### PR TITLE
fix(cardano-services): Fix cache TTL validator

### DIFF
--- a/packages/cardano-services/src/util/validators.ts
+++ b/packages/cardano-services/src/util/validators.ts
@@ -34,12 +34,15 @@ export const existingFileValidator = (filePath: string) => {
   throw new Error(`No file exists at ${filePath}`);
 };
 
-export const cacheTtlValidator = (ttl: string) => {
-  const cacheTtl = Number.parseInt(ttl, 10);
+export const cacheTtlValidator = (ttlInSecs: string) => {
+  const cacheTtlInSecs = Number.parseInt(ttlInSecs, 10);
 
-  if (typeof cacheTtl === 'number' && cacheTtl >= CACHE_TTL_LOWER_LIMIT && cacheTtl <= CACHE_TTL_UPPER_LIMIT) {
-    // The cli script accepts TTLs in minutes, but the underlying level express TTLs in seconds
-    return cacheTtl * 60;
+  if (
+    typeof cacheTtlInSecs === 'number' &&
+    cacheTtlInSecs >= CACHE_TTL_LOWER_LIMIT &&
+    cacheTtlInSecs <= CACHE_TTL_UPPER_LIMIT
+  ) {
+    return cacheTtlInSecs;
   }
 
   throw new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.DbCacheTtl);

--- a/packages/cardano-services/test/util/validators.test.ts
+++ b/packages/cardano-services/test/util/validators.test.ts
@@ -1,0 +1,37 @@
+import {
+  CACHE_TTL_LOWER_LIMIT,
+  CACHE_TTL_UPPER_LIMIT,
+  MissingProgramOption,
+  ProgramOptionDescriptions,
+  ServiceNames
+} from '../../src';
+import { cacheTtlValidator } from '../../src/util/validators';
+
+describe('utils/validators', () => {
+  describe('cacheTtlValidator', () => {
+    it('returns TTL in seconds with a valid value within the range', async () => {
+      const ttl = '240';
+      expect(cacheTtlValidator(ttl)).toEqual(Number.parseInt(ttl, 10));
+    });
+
+    it('throws a validation error if TTL is not a valid number', async () => {
+      expect(() => cacheTtlValidator('not a number')).toThrowError(
+        new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.DbCacheTtl)
+      );
+    });
+
+    it('throws a validation error if TTL is lower than the lower limit', async () => {
+      const ttl = (CACHE_TTL_LOWER_LIMIT - 1).toString();
+      expect(() => cacheTtlValidator(ttl)).toThrowError(
+        new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.DbCacheTtl)
+      );
+    });
+
+    it('throws a validation error if TTL is higher than the upper limit', async () => {
+      const ttl = (CACHE_TTL_UPPER_LIMIT + 1).toString();
+      expect(() => cacheTtlValidator(ttl)).toThrowError(
+        new MissingProgramOption(ServiceNames.NetworkInfo, ProgramOptionDescriptions.DbCacheTtl)
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Context
Currently, both [DbCacheTtl](https://github.com/input-output-hk/cardano-js-sdk/blob/e9c3a5b74a2cc1f69c53f562af8a5b4e693bd20a/packages/cardano-services/src/Program/Options.ts#L4) CLI arg and [InMemoryCache](https://github.com/input-output-hk/cardano-js-sdk/blob/670d0c12589a4385b72c445e5f332e195f3b8000/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts#L10-L16) are aligned and accept the TTL value in seconds since the latest PR [update](https://github.com/input-output-hk/cardano-js-sdk/pull/530/commits/f0eb80f73e61ea48f10809fb3c329fb5c4022e6b).

Noticed we forgot to update the [cacheTtlValidator](https://github.com/input-output-hk/cardano-js-sdk/blob/e9c3a5b74a2cc1f69c53f562af8a5b4e693bd20a/packages/cardano-services/src/util/validators.ts#L37-L46) itself - there is no need to transform minutes to seconds anymore: `cacheTtl * 60` is obsolete

We need to remove the conversion from seconds to minutes and cover it with tests.

# Important Changes Introduced
- removed the obsolete seconds to minutes conversion
- added tests
