### PR TITLE
Fix/wallet manager worker unassigned runtime

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 0,
     '@typescript-eslint/no-non-null-assertion': 0,
     '@typescript-eslint/no-shadow': ['error'],
+    '@typescript-eslint/no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     // needed for inference from type guards
     '@typescript-eslint/no-var-requires': 0,
@@ -40,7 +41,7 @@ module.exports = {
       }
     ],
     'no-shadow': 'off',
-    'no-unused-expressions': 0,
+    'no-unused-expressions': 'off',
     'no-unused-vars': 0,
     'no-useless-constructor': 0,
     'promise/avoid-new': 0,

--- a/packages/cardano-services/test/Program/services/rabbitmq.test.ts
+++ b/packages/cardano-services/test/Program/services/rabbitmq.test.ts
@@ -210,7 +210,6 @@ describe('Program/services/rabbitmq', () => {
 
         await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
       });
-      ('');
     });
   });
 

--- a/packages/util/test/freeable.test.ts
+++ b/packages/util/test/freeable.test.ts
@@ -81,7 +81,6 @@ describe('freeable', () => {
         resolve(returnValue);
         await expect(result).resolves.toBe(returnValue);
         expect(freeableSpy).toBeCalledTimes(1);
-        reject;
       });
 
       it('returns promise and frees scope after promise rejects', async () => {

--- a/packages/wallet/test/integration/CustomObservableWallet.test.ts
+++ b/packages/wallet/test/integration/CustomObservableWallet.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
 /* eslint-disable sonarjs/no-extra-arguments */
 /* eslint-disable unicorn/consistent-function-scoping */
 import * as mocks from '../mocks';

--- a/packages/web-extension/src/walletManager/walletManagerWorker.ts
+++ b/packages/web-extension/src/walletManager/walletManagerWorker.ts
@@ -47,7 +47,7 @@ export class WalletManagerWorker implements WalletManagerApi {
     this.#walletFactory = walletFactory;
     this.#storesFactory = storesFactory;
     this.#logger = logger;
-    this.#runtime;
+    this.#runtime = runtime;
     this.#hostSubscription = exposeApi(
       {
         api$: this.#api$.asObservable(),


### PR DESCRIPTION
# Context

WalletManagerWorker.runtime is never assigned the value provided in the constructor, which 

# Proposed Solution
Added unit test to catch this problem.
Added  no-unused-expressions typescript eslint rule to catch this kind of errors.

# Important Changes Introduced
