### PR TITLE
fix(core): omits NFT metadata files with invalid format

### DIFF
--- a/packages/core/test/Asset/util/metadatumToCip25.test.ts
+++ b/packages/core/test/Asset/util/metadatumToCip25.test.ts
@@ -1,5 +1,7 @@
 import { AssetInfo } from '../../../src/Asset';
 import { AssetName, Metadatum, PolicyId, TxMetadata } from '../../../src/Cardano';
+import { Cardano } from '../../../src';
+import { fromSerializableObject } from '@cardano-sdk/util';
 import { dummyLogger as logger } from 'ts-log';
 import { metadatumToCip25 } from '../../../src/Asset/util';
 
@@ -19,6 +21,146 @@ describe('NftMetadata/metadatumToCip25', () => {
     name: 'test nft',
     version: '1.0'
   };
+
+  describe('invalid metadata on optional fields', () => {
+    const assetName = 'Cardano Timeline 2022';
+
+    const createMetadatumWithFiles = (files: { __type: 'Map'; value: string[][] }[]) =>
+      fromSerializableObject<Cardano.MetadatumMap>({
+        __type: 'Map',
+        value: [
+          [
+            {
+              __type: 'bigint',
+              value: '721'
+            },
+            {
+              __type: 'Map',
+              value: [
+                [
+                  '41b20f83bdf559fa1580caf7960fd188e6aafacf5e81dfb089e82486',
+                  {
+                    __type: 'Map',
+                    value: [
+                      [
+                        assetName,
+                        {
+                          __type: 'Map',
+                          value: [
+                            ['era', 'ALL'],
+                            ['name', assetName],
+                            ['unit', 'none'],
+                            ['files', files],
+                            ['image', 'ipfs://QmWS6DgF8Ma8oooBn7CtD3ChHyzzMw5NXWfnDbVFTip8af'],
+                            ['edition', '2022'],
+                            ['project', 'CTimelines'],
+                            ['twitter', 'https://twitter.com/CTimelines1_io'],
+                            ['website', 'https://ctimelines1.io'],
+                            ['copyright', 'CTimelines 2021'],
+                            ['mediaType', 'image/gif'],
+                            ['collection', assetName]
+                          ]
+                        }
+                      ]
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      });
+
+    it('omits files with a missing file name', () => {
+      const metadatum = createMetadatumWithFiles([
+        {
+          __type: 'Map',
+          value: [
+            ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cuf'],
+            ['mediaType', 'image/png']
+          ]
+        },
+        {
+          __type: 'Map',
+          value: [
+            ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cu8'],
+            ['mediaType', 'image/png'],
+            ['name', 'BRAVO']
+          ]
+        }
+      ]);
+      const result = metadatumToCip25(
+        {
+          name: Cardano.AssetName('43617264616e6f2054696d656c696e652032303232'), // 'Cardano Timeline 2022'
+          policyId: Cardano.PolicyId('41b20f83bdf559fa1580caf7960fd188e6aafacf5e81dfb089e82486')
+        },
+        metadatum,
+        logger
+      );
+      expect(result).toBeTruthy();
+      expect(result?.files).toHaveLength(1);
+    });
+
+    it('omits files with a missing file media type', () => {
+      const metadatum = createMetadatumWithFiles([
+        {
+          __type: 'Map',
+          value: [
+            ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cuh'],
+            ['name', 'BRAVO']
+          ]
+        },
+        {
+          __type: 'Map',
+          value: [
+            ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cuv'],
+            ['mediaType', 'image/png'],
+            ['name', 'BRAVO']
+          ]
+        }
+      ]);
+      const result = metadatumToCip25(
+        {
+          name: Cardano.AssetName('43617264616e6f2054696d656c696e652032303232'), // 'Cardano Timeline 2022'
+          policyId: Cardano.PolicyId('41b20f83bdf559fa1580caf7960fd188e6aafacf5e81dfb089e82486')
+        },
+        metadatum,
+        logger
+      );
+      expect(result).toBeTruthy();
+      expect(result?.files).toHaveLength(1);
+    });
+
+    it('omits files with a missing file source', () => {
+      const metadatum = createMetadatumWithFiles([
+        {
+          __type: 'Map',
+          value: [
+            ['mediaType', 'image/png'],
+            ['name', 'BRAVO']
+          ]
+        },
+        {
+          __type: 'Map',
+          value: [
+            ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cuq'],
+            ['mediaType', 'image/png'],
+            ['name', 'BRAVO']
+          ]
+        }
+      ]);
+      const result = metadatumToCip25(
+        {
+          name: Cardano.AssetName('43617264616e6f2054696d656c696e652032303232'), // 'Cardano Timeline 2022'
+          policyId: Cardano.PolicyId('41b20f83bdf559fa1580caf7960fd188e6aafacf5e81dfb089e82486')
+        },
+        metadatum,
+        logger
+      );
+      expect(result).toBeTruthy();
+      expect(result?.files).toHaveLength(1);
+    });
+  });
 
   it('returns null for non-cip25 metadatum', () => {
     const metadatum: TxMetadata = new Map([[123n, 'metadatum']]);


### PR DESCRIPTION
# Context
Currently, we return `null` for the whole [NftMetadata](https://github.com/input-output-hk/cardano-js-sdk/blob/f92bca87dbc84ae1ad58daef6017d9a9e86a411a/packages/core/src/Asset/types/NftMetadata.ts#L44-L55) if `metadatum` input has missing data fields. 
We need to omit those ones with invalid format/missing and return the rest data as nft metadata.

# Proposed Solution
- omits NFT metadata files with missing fields (`name`, `src`, `mediaType`) 

# Important Changes Introduced
