### PR TITLE
feat(cardano-services): include healthCheck response as detail in Provider.Unhealthy errors

### DIFF
--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -41,8 +41,9 @@ export abstract class HttpService extends RunnableModule {
   async initializeImpl(): Promise<void> {
     if (this.provider instanceof RunnableModule) await this.provider.initialize();
 
-    if (!(await this.healthCheck()).ok) {
-      throw new ProviderError(ProviderFailure.Unhealthy);
+    const health = await this.healthCheck();
+    if (!health.ok) {
+      throw new ProviderError(ProviderFailure.Unhealthy, null, JSON.stringify(health, null, 2));
     }
   }
 

--- a/packages/cardano-services/src/TxSubmit/rabbitmq/TxSubmitWorker.ts
+++ b/packages/cardano-services/src/TxSubmit/rabbitmq/TxSubmitWorker.ts
@@ -156,9 +156,9 @@ export class TxSubmitWorker extends EventEmitter {
     }
     this.#dependencies.logger.info(`${moduleName} init: checking tx submission provider health status`);
 
-    const { ok } = await this.#dependencies.txSubmitProvider.healthCheck();
+    const health = await this.#dependencies.txSubmitProvider.healthCheck();
 
-    if (!ok) throw new ProviderError(ProviderFailure.Unhealthy);
+    if (!health.ok) throw new ProviderError(ProviderFailure.Unhealthy, null, JSON.stringify(health, null, 2));
 
     try {
       this.#dependencies.logger.info(`${moduleName} init: opening RabbitMQ connection`);

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -67,9 +67,17 @@ describe('ChainHistoryHttpService', () => {
     });
 
     it('throws during service initialization if the ChainHistoryProvider is unhealthy', async () => {
+      expect.assertions(2);
       service = new ChainHistoryHttpService({ chainHistoryProvider, logger });
       httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+      try {
+        await httpServer.initialize();
+      } catch (error: unknown) {
+        if (error instanceof ProviderError) {
+          expect(error.name).toBe('ProviderError');
+          expect(error.reason).toBe('UNHEALTHY');
+        }
+      }
     });
   });
 

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -87,9 +87,17 @@ describe('NetworkInfoHttpService', () => {
     });
 
     it('throws during service initialization if the NetworkInfoProvider is unhealthy', async () => {
+      expect.assertions(2);
       service = new NetworkInfoHttpService({ logger, networkInfoProvider });
       httpServer = new HttpServer(config, { logger, runnableDependencies: [cardanoNode], services: [service] });
-      await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+      try {
+        await httpServer.initialize();
+      } catch (error: unknown) {
+        if (error instanceof ProviderError) {
+          expect(error.name).toBe('ProviderError');
+          expect(error.reason).toBe('UNHEALTHY');
+        }
+      }
     });
   });
 

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -56,9 +56,17 @@ describe('RewardsHttpService', () => {
     });
 
     it('throws during service initialization if the RewardsProvider is unhealthy', async () => {
+      expect.assertions(2);
       service = new RewardsHttpService({ logger, rewardsProvider });
       httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+      try {
+        await httpServer.initialize();
+      } catch (error: unknown) {
+        if (error instanceof ProviderError) {
+          expect(error.name).toBe('ProviderError');
+          expect(error.reason).toBe('UNHEALTHY');
+        }
+      }
     });
   });
 

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -167,9 +167,17 @@ describe('StakePoolHttpService', () => {
     });
 
     it('throws during service initialization if the StakePoolProvider is unhealthy', async () => {
+      expect.assertions(2);
       service = new StakePoolHttpService({ logger, stakePoolProvider });
       httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+      try {
+        await httpServer.initialize();
+      } catch (error: unknown) {
+        if (error instanceof ProviderError) {
+          expect(error.name).toBe('ProviderError');
+          expect(error.reason).toBe('UNHEALTHY');
+        }
+      }
     });
   });
 

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -57,9 +57,17 @@ describe('UtxoHttpService', () => {
     });
 
     it('throws during service initialization if the UtxoProvider is unhealthy', async () => {
+      expect.assertions(2);
       service = new UtxoHttpService({ logger, utxoProvider });
       httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      await expect(httpServer.initialize()).rejects.toThrow(new ProviderError(ProviderFailure.Unhealthy));
+      try {
+        await httpServer.initialize();
+      } catch (error: unknown) {
+        if (error instanceof ProviderError) {
+          expect(error.name).toBe('ProviderError');
+          expect(error.reason).toBe('UNHEALTHY');
+        }
+      }
     });
   });
 


### PR DESCRIPTION
# Context
We're currently lacking detail to help understand the reason for throwing `Provider.Unhealthy` errors.

![image](https://user-images.githubusercontent.com/303881/216323048-4a2f0ed7-0081-4033-b892-5b15e4f34faf.png)

# Proposed Solution
Include the `healthCheck` response as stringified JSON in the error detail. I've elected to leave [this](https://github.com/input-output-hk/cardano-js-sdk/blob/1058e5491d19b34789289826250055f6728ca148/packages/cardano-services/src/TxSubmit/TxSubmitHttpService.ts#L41-L42) instance alone due to the error handling logic being different and the intent to refactor it anyway.

``` console
{"name":"http-server","hostname":"741e2e41edef","pid":1,"level":30,"msg":"[OgmiosCardanoNode] Initialized","time":"2023-02-02T12:26:08.726Z","v":0}
{"name":"http-server","hostname":"741e2e41edef","pid":1,"level":30,"msg":"[asset] Initializing...","time":"2023-02-02T12:26:08.726Z","v":0}
ProviderError: UNHEALTHY ({
  "localNode": {
    "ledgerTip": {
      "slot": 12747005,
      "hash": "cb4b27f6096e6eb2b83befddb73613418409a4c84b386b7ad0ecc1e7fe2d8c41",
      "blockNo": 274973
    },
    "networkSync": 0.67554
  },
  "ok": false,
  "projectedTip": {
    "blockNo": 267674,
    "hash": "7137509e0209cdf3cdefaa04db2807df91238a71e0df25c8ba902daef7b44b41",
    "slot": 12594484
  }
})
```
