### PR TITLE
Add support for CIP-0025 version 2

### DIFF
--- a/packages/cardano-services/src/Metadata/queries.ts
+++ b/packages/cardano-services/src/Metadata/queries.ts
@@ -1,9 +1,9 @@
 export const findTxMetadata = `
-	SELECT 
-		meta."key" AS "key",
-		meta."json" AS json_value,
-		tx.hash AS tx_id
-	FROM tx_metadata AS meta
-	JOIN tx ON meta.tx_id = tx.id
-	WHERE tx.hash = ANY($1)
-	ORDER BY meta.id ASC`;
+SELECT
+  key,
+  bytes,
+  hash AS tx_id
+FROM tx_metadata AS meta
+JOIN tx ON tx_id = tx.id
+WHERE hash = ANY($1)
+ORDER BY meta.id ASC`;

--- a/packages/cardano-services/src/Metadata/types.ts
+++ b/packages/cardano-services/src/Metadata/types.ts
@@ -5,7 +5,7 @@ export interface TxMetadataService {
 }
 
 export interface TxMetadataModel {
+  bytes: Uint8Array;
   key: string;
-  json_value: { [k: string]: unknown };
   tx_id: Buffer;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "prepack": "yarn build"
   },
   "devDependencies": {
+    "@cardano-sdk/util-dev": "^0.6.0",
     "@types/lodash": "^4.14.182",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",

--- a/packages/core/src/Asset/util/metadatumToCip25.ts
+++ b/packages/core/src/Asset/util/metadatumToCip25.ts
@@ -2,7 +2,6 @@ import { AssetInfo, ImageMediaType, MediaType, NftMetadata, NftMetadataFile, Uri
 import { Cardano } from '../..';
 import { CustomError } from 'ts-custom-error';
 import { Logger } from 'ts-log';
-import { Metadatum, MetadatumMap } from '../../Cardano/types/AuxiliaryData';
 import { asMetadatumArray, asMetadatumMap } from '../../util/metadatum';
 import { assetIdFromPolicyAndName } from './assetId';
 import { isNotNil } from '@cardano-sdk/util';
@@ -18,7 +17,7 @@ const asString = (obj: unknown): string | undefined => {
   }
 };
 
-const asStringArray = (metadatum: Metadatum | undefined): string[] | undefined => {
+const asStringArray = (metadatum: Cardano.Metadatum | undefined): string[] | undefined => {
   if (Array.isArray(metadatum)) {
     const result = metadatum.map(asString);
     if (result.some((str) => typeof str === 'undefined')) {
@@ -32,13 +31,13 @@ const asStringArray = (metadatum: Metadatum | undefined): string[] | undefined =
   }
 };
 
-const mapOtherProperties = (metadata: MetadatumMap, primaryProperties: string[]) => {
+const mapOtherProperties = (metadata: Cardano.MetadatumMap, primaryProperties: string[]) => {
   const extraProperties = difference([...metadata.keys()].filter(isString), primaryProperties);
   if (extraProperties.length === 0) return;
   return extraProperties.reduce((result, key) => {
     result.set(key, metadata.get(key)!);
     return result;
-  }, new Map<string, Metadatum>());
+  }, new Map<string, Cardano.Metadatum>());
 };
 
 const toArray = <T>(value: T | T[]): T[] => (Array.isArray(value) ? value : [value]);
@@ -46,7 +45,7 @@ const toArray = <T>(value: T | T[]): T[] => (Array.isArray(value) ? value : [val
 const missingFileFieldLogMessage = (fieldType: string, assetId: Cardano.AssetId) =>
   `Omitting cip25 metadata file: missing "${fieldType}". AssetId: ${assetId}`;
 
-const mapFile = (metadatum: Metadatum, assetId: Cardano.AssetId, logger: Logger): NftMetadataFile | null => {
+const mapFile = (metadatum: Cardano.Metadatum, assetId: Cardano.AssetId, logger: Logger): NftMetadataFile | null => {
   const file = asMetadatumMap(metadatum);
   if (!file) throw new InvalidFileError();
 
@@ -85,10 +84,48 @@ const mapFile = (metadatum: Metadatum, assetId: Cardano.AssetId, logger: Logger)
 };
 
 /**
- * Also considers asset name encoded in utf8 within metadata valid
+ * Gets the `Map<AssetName, NFTMetadata>` relative to the given policyId from the given
+ * `Map<PolicyId, Map<AssetName, NFTMetadata>>`.
+ *
+ * The policyId in the `policy` Map can be encoded as per CIP-0025 v1 or v2 specifications.
+ *
+ * @param policy The `MetadatumMap` containing the NFT metadata for all the NFT assets
+ * @returns The `MetadatumMap` containing the NFT metadata for all the NFT assets with the given policyId
  */
-const getAssetMetadata = (policy: MetadatumMap, asset: Pick<AssetInfo, 'name'>) =>
-  asMetadatumMap(policy.get(asset.name.toString()) || policy.get(Buffer.from(asset.name, 'hex').toString('utf8')));
+const getPolicyMetadata = (policy: Cardano.MetadatumMap, policyId: Cardano.PolicyId) => {
+  const policyIdString = policyId.toString();
+
+  return asMetadatumMap(
+    policy.get(policyIdString) ||
+      (() => {
+        for (const [key, value] of policy.entries()) {
+          if (ArrayBuffer.isView(key) && Buffer.from(key).toString('hex') === policyIdString) return value;
+        }
+      })()
+  );
+};
+
+/**
+ * Gets the `NFTMetadata` relative to the given assetName from the given `Map<AssetName, NFTMetadata>`.
+ *
+ * The assetName in the `policy` Map can be encoded as per CIP-0025 v1 (hex or utf8) or v2 specifications.
+ *
+ * @param policy The `MetadatumMap` containing the NFT metadata for all the NFT assets with a specific policyId.
+ * @returns The NFT metadata for the requested asset
+ */
+const getAssetMetadata = (policy: Cardano.MetadatumMap, assetName: Cardano.AssetName) => {
+  const assetNameString = assetName.toString();
+
+  return asMetadatumMap(
+    policy.get(assetNameString) ||
+      policy.get(Buffer.from(assetNameString, 'hex').toString('utf8')) ||
+      (() => {
+        for (const [key, value] of policy.entries()) {
+          if (ArrayBuffer.isView(key) && Buffer.from(key).toString('hex') === assetNameString) return value;
+        }
+      })()
+  );
+};
 
 // TODO: consider hoisting this function together with cip25 types to core or a new cip25 package
 /**
@@ -96,17 +133,16 @@ const getAssetMetadata = (policy: MetadatumMap, asset: Pick<AssetInfo, 'name'>) 
  */
 export const metadatumToCip25 = (
   asset: Pick<AssetInfo, 'policyId' | 'name'>,
-  metadatumMap: MetadatumMap | undefined,
+  metadatumMap: Cardano.MetadatumMap | undefined,
   logger: Logger
 ): NftMetadata | null => {
   const cip25Metadata = metadatumMap?.get(721n);
   if (!cip25Metadata) return null;
   const cip25MetadatumMap = asMetadatumMap(cip25Metadata);
   if (!cip25MetadatumMap) return null;
-  const policy = asMetadatumMap(cip25MetadatumMap.get(asset.policyId.toString())!);
+  const policy = getPolicyMetadata(cip25MetadatumMap, asset.policyId);
   if (!policy) return null;
-  const assetMetadata = getAssetMetadata(policy, asset);
-
+  const assetMetadata = getAssetMetadata(policy, asset.name);
   if (!assetMetadata) return null;
   const name = asString(assetMetadata.get('name'));
   const image = asStringArray(assetMetadata.get('image'));

--- a/packages/core/test/Asset/util/metadatumToCip25.test.ts
+++ b/packages/core/test/Asset/util/metadatumToCip25.test.ts
@@ -2,13 +2,17 @@ import { AssetInfo } from '../../../src/Asset';
 import { AssetName, Metadatum, PolicyId, TxMetadata } from '../../../src/Cardano';
 import { Cardano } from '../../../src';
 import { fromSerializableObject } from '@cardano-sdk/util';
-import { dummyLogger as logger } from 'ts-log';
+import { logger } from '@cardano-sdk/util-dev';
 import { metadatumToCip25 } from '../../../src/Asset/util';
 
 describe('NftMetadata/metadatumToCip25', () => {
+  const assetNameStringUtf8 = 'CIP0025-v2';
+  const assetNameString = Buffer.from(assetNameStringUtf8).toString('hex');
+  const policyIdString = 'b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7';
+
   const asset = {
-    name: AssetName('abc123'),
-    policyId: PolicyId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7')
+    name: AssetName(assetNameString),
+    policyId: PolicyId(policyIdString)
   } as AssetInfo;
 
   const minimalMetadata = new Map([
@@ -174,25 +178,30 @@ describe('NftMetadata/metadatumToCip25', () => {
 
   it('returns null for cip25 metadatum with no metadata for given assetId', () => {
     const metadatum: TxMetadata = new Map([
-      [721n, new Map([[asset.policyId.toString(), new Map([['other_asset_id', minimalMetadata]])]])]
+      [721n, new Map([[policyIdString, new Map([['other_asset_id', minimalMetadata]])]])]
     ]);
     expect(metadatumToCip25(asset, metadatum, logger)).toBeNull();
   });
 
   it('converts minimal metadata', () => {
     const metadatum: TxMetadata = new Map([
-      [721n, new Map([[asset.policyId.toString(), new Map([[asset.name.toString(), minimalMetadata]])]])]
+      [721n, new Map([[policyIdString, new Map([[assetNameString, minimalMetadata]])]])]
     ]);
     expect(metadatumToCip25(asset, metadatum, logger)).toEqual(minimalConvertedMetadata);
   });
 
   it('supports asset name as utf8 string', () => {
     const metadatum: TxMetadata = new Map([
+      [721n, new Map([[policyIdString, new Map([[assetNameStringUtf8, minimalMetadata]])]])]
+    ]);
+    expect(metadatumToCip25(asset, metadatum, logger)).toEqual(minimalConvertedMetadata);
+  });
+
+  it('supports CIP-0025 v2', () => {
+    const metadatum: TxMetadata = new Map([
       [
         721n,
-        new Map([
-          [asset.policyId.toString(), new Map([[Buffer.from(asset.name.toString()).toString('utf8'), minimalMetadata]])]
-        ])
+        new Map([[Buffer.from(policyIdString, 'hex'), new Map([[Buffer.from(assetNameStringUtf8), minimalMetadata]])]])
       ]
     ]);
     expect(metadatumToCip25(asset, metadatum, logger)).toEqual(minimalConvertedMetadata);
@@ -204,9 +213,9 @@ describe('NftMetadata/metadatumToCip25', () => {
         721n,
         new Map([
           [
-            asset.policyId.toString(),
+            policyIdString,
             new Map<Metadatum, Metadatum>([
-              [asset.name.toString(), minimalMetadata],
+              [assetNameString, minimalMetadata],
               ['version', '2.0']
             ])
           ]
@@ -225,10 +234,10 @@ describe('NftMetadata/metadatumToCip25', () => {
         721n,
         new Map([
           [
-            asset.policyId.toString(),
+            policyIdString,
             new Map<Metadatum, Metadatum>([
               [
-                asset.name.toString(),
+                assetNameString,
                 new Map([
                   ...minimalMetadata.entries(),
                   ['description', 'description'],
@@ -266,10 +275,10 @@ describe('NftMetadata/metadatumToCip25', () => {
         721n,
         new Map([
           [
-            asset.policyId.toString(),
+            policyIdString,
             new Map<Metadatum, Metadatum>([
               [
-                asset.name.toString(),
+                assetNameString,
                 new Map<Metadatum, Metadatum>([...minimalMetadata.entries(), ['files', [file1, file2]]])
               ]
             ])

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -113,6 +113,38 @@ Address:    addr_test1qr0c3frkem9cqn5f73dnvqpena27k2fgqew6wct9eaka03agfwkvzr0zyq
 
 You can configure any of these five wallets in your test and use any amount of tADA you need.
 
+### Local Test Network - development version
+
+In addition to the **local-network** npm script there is a script suitable for development, which mounts the `packages` directory in
+the service containers. It helps to apply changes to the components without shutting down the **local-network** each time.
+
+It can be started with:
+
+```bash
+$ yarn workspace @cardano-sdk/e2e local-network:dev
+```
+
+and a good idea is to run following command before starting it.
+
+```bash
+$ yarn cleanup && yarn && yarn build
+```
+
+Restart the http-server:
+
+```bash
+$ docker exec -it local-network-e2e-http-server-1 kill 1
+```
+
+So, if while working on the `core` and `cardano-services` packages simultaneously, we need to restart the http-server
+to check the effect of our ongoing changes, it is enough to issue the following command:
+
+```bash
+$ yarn workspace @cardano-sdk/core build && yarn workspace @cardano-sdk/cardano-services build && docker exec -it local-network-e2e-http-server-1 kill 1
+```
+
+if it exits with error we need to fix our ongoing changes, if it exits silently, the http-server is now running with our changes.
+
 ## Local file server
 
 The end-to-end environment runs a Nginx instance that allows us to serve files directly to the local-network.

--- a/packages/e2e/docker-compose-dev.yml
+++ b/packages/e2e/docker-compose-dev.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+
+services:
+  http-server:
+    volumes:
+      - ..:/app/packages
+  worker:
+    volumes:
+      - ..:/app/packages

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -41,6 +41,7 @@
     "test:web-extension:watch": "run-s test:web-extension:build test:web-extension:watch:bg",
     "test:web-extension:watch:bg": "run-p test:web-extension:watch:build test:web-extension:watch:run",
     "local-network:up": "DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker compose -p local-network-e2e up",
+    "local-network:dev": "DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker compose -f docker-compose.yml -f docker-compose-dev.yml -p local-network-e2e up",
     "local-network:down": "DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 docker compose -p local-network-e2e down -v --remove-orphans",
     "cardano-services:up": "ts-node --transpile-only ../cardano-services/src/cli.ts start-server",
     "cardano-services:up:debug": "npx nodemon --legacy-watch --exec 'node -r ts-node/register --inspect=0.0.0.0:9229 ../cardano-services/src/cli.ts start-server'",

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -287,4 +287,90 @@ describe('SingleAddressWallet.assets/nft', () => {
 
     expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_BURN_INDEX])).toBeUndefined();
   });
+
+  describe('CIP-0025 v1 and v2', () => {
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const CIP0025Test = (testName: string, assetName: string, version: 1 | 2, encoding?: 'hex' | 'utf8') =>
+      it(testName, async () => {
+        const assetNameHex = Buffer.from(assetName).toString('hex');
+        const assetId = Cardano.AssetId(`${policyId}${assetNameHex}`);
+        const fingerprint = Cardano.AssetFingerprint.fromParts(policyId, Cardano.AssetName(assetNameHex));
+        const tokens = new Map([[assetId, 1n]]);
+
+        const txDataMetadatum = new Map([
+          [
+            version === 1 ? policyId.toString() : Buffer.from(policyId.toString(), 'hex'),
+            new Map([
+              [
+                version === 1 ? (encoding === 'hex' ? assetNameHex : assetName) : Buffer.from(assetName),
+                metadatum.jsonToMetadatum({
+                  image: ['ipfs://some_hash1'],
+                  name: assetName,
+                  version: '1.0'
+                })
+              ]
+            ])
+          ]
+        ]);
+
+        const auxiliaryData = { body: { blob: new Map([[721n, txDataMetadatum]]) } };
+
+        const txProps = {
+          auxiliaryData,
+          extraSigners: [policySigner],
+          mint: tokens,
+          outputs: new Set([
+            {
+              address: walletAddress,
+              value: {
+                assets: tokens,
+                coins: 50_000_000n
+              }
+            }
+          ]),
+          scripts: [policyScript]
+        };
+
+        const unsignedTx = await wallet.initializeTx(txProps);
+
+        const finalizeProps = {
+          auxiliaryData,
+          extraSigners: [policySigner],
+          scripts: [policyScript],
+          tx: unsignedTx
+        };
+
+        const signedTx = await wallet.finalizeTx(finalizeProps);
+
+        await submitAndConfirm(wallet, signedTx);
+
+        // try remove the asset.nftMetadata filter
+        const nfts = await firstValueFrom(
+          combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+            filter(([assets, balance]) => assets.size === balance.assets?.size),
+            map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
+          )
+        );
+
+        expect(nfts.find((nft) => nft.assetId === assetId)).toMatchObject({
+          assetId,
+          fingerprint,
+          mintOrBurnCount: 1,
+          name: assetNameHex,
+          nftMetadata: {
+            image: ['ipfs://some_hash1'],
+            name: assetName,
+            otherProperties: new Map([['version', '1.0']]),
+            version: '1.0'
+          },
+          policyId: policyId.toString(),
+          quantity: 1n,
+          tokenMetadata: null
+        });
+      });
+
+    CIP0025Test('supports CIP-25 v1, assetName hex encoded', 'CIP-0025-v1-hex', 1, 'hex');
+    CIP0025Test('supports CIP-25 v1, assetName utf8 encoded', 'CIP-0025-v1-utf8', 1, 'utf8');
+    CIP0025Test('supports CIP-25 v2', 'CIP-0025-v2', 2);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2423,6 +2423,7 @@ __metadata:
     "@cardano-ogmios/schema": 5.5.7
     "@cardano-sdk/crypto": ^0.1.0
     "@cardano-sdk/util": ^0.7.0
+    "@cardano-sdk/util-dev": ^0.6.0
     "@dcspark/cardano-multiplatform-lib-nodejs": ^3.1.1
     "@emurgo/cip14-js": ^3.0.1
     "@types/lodash": ^4.14.182


### PR DESCRIPTION
# Context

We are currently supporting CIP-0025 v1, but not v2

# Proposed Solution

Changed `metadatumToCip25` to support CIP-0025 version 2 as well.

# Important Changes Introduced

-  added the development version of local-network;
- NFT metadata are no longer read from DB in json format as it can be prone to ambiguity; now are read in raw bytes format;
- added an e2e test to assert CIP-0025 v2 is supported.