### PR TITLE
fix: ledger mapper validity interval prop name

### DIFF
--- a/packages/cardano-services-client/test/tsconfig.json
+++ b/packages/cardano-services-client/test/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../../util/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../util-dev/src"
     }
   ]

--- a/packages/cardano-services/src/tsconfig.json
+++ b/packages/cardano-services/src/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../../ogmios/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../util/src"
     }
   ]

--- a/packages/e2e/src/tsconfig.json
+++ b/packages/e2e/src/tsconfig.json
@@ -26,6 +26,9 @@
       "path": "../../util/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../wallet/src"
     }
   ]

--- a/packages/governance/src/tsconfig.json
+++ b/packages/governance/src/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "../../core/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../key-management/src"
     }
   ]

--- a/packages/governance/test/tsconfig.json
+++ b/packages/governance/test/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../../core/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../key-management/src"
     }
   ]

--- a/packages/key-management/src/tsconfig.json
+++ b/packages/key-management/src/tsconfig.json
@@ -6,6 +6,9 @@
   "references": [
     {
       "path": "../../core/src"
+    },
+    {
+      "path": "../../crypto/src"
     }
   ]
 }

--- a/packages/key-management/src/util/mapHardwareSigningData.ts
+++ b/packages/key-management/src/util/mapHardwareSigningData.ts
@@ -882,7 +882,7 @@ export const txToLedger = async ({
   const ttl = Number(scope.manage(cslTxBody.ttl())?.to_str());
 
   // TX - validityStartInterval
-  const validityStartInterval = Number(scope.manage(cslTxBody.validity_start_interval())?.to_str());
+  const validityIntervalStart = Number(scope.manage(cslTxBody.validity_start_interval())?.to_str());
 
   // TX  - auxiliaryData
   const txBodyAuxDataHash = scope.manage(cslTxBody.auxiliary_data_hash());
@@ -904,7 +904,7 @@ export const txToLedger = async ({
   }
   const additionalWitnessPaths = ledgerMintBundle?.additionalWitnessPaths || [];
 
-  const ledgerTx = {
+  const ledgerTx: ledger.Transaction = {
     auxiliaryData,
     certificates: ledgerCertificatesData?.certs,
     fee,
@@ -916,7 +916,7 @@ export const txToLedger = async ({
     },
     outputs: ledgerOutputs,
     ttl,
-    validityStartInterval,
+    validityIntervalStart,
     withdrawals: ledgerWithdrawals
   };
 

--- a/packages/key-management/test/tsconfig.json
+++ b/packages/key-management/test/tsconfig.json
@@ -6,6 +6,15 @@
   "references": [
     {
       "path": "../src"
+    },
+    {
+      "path": "../../core/src"
+    },
+    {
+      "path": "../../util/src"
+    },
+    {
+      "path": "../../crypto/src"
     }
   ]
 }

--- a/packages/ogmios/src/tsconfig.json
+++ b/packages/ogmios/src/tsconfig.json
@@ -6,6 +6,9 @@
   "references": [
     {
       "path": "../../core/src"
+    },
+    {
+      "path": "../../crypto/src"
     }
   ]
 }

--- a/packages/projection/src/tsconfig.json
+++ b/packages/projection/src/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "../../core/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../util-rxjs/src"
     }
   ]

--- a/packages/projection/test/tsconfig.json
+++ b/packages/projection/test/tsconfig.json
@@ -20,6 +20,9 @@
       "path": "../../util/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../util-rxjs/src"
     },
     {

--- a/packages/wallet/src/tsconfig.json
+++ b/packages/wallet/src/tsconfig.json
@@ -14,6 +14,9 @@
       "path": "../../core/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../key-management/src"
     },
     {

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -366,7 +366,7 @@ describe('SingleAddressWallet creates big UTXO', () => {
       chainHistoryProvider: mocks.mockChainHistoryProvider(),
       networkInfoProvider: mocks.mockNetworkInfoProvider(),
       rewardsProvider: mocks.mockRewardsProvider(),
-      utxoProvider: mocks.mockUtxoProvider(utxoSet)
+      utxoProvider: mocks.mockUtxoProvider({ utxoSet })
     });
 
     const txProps = {
@@ -409,7 +409,7 @@ describe('SingleAddressWallet.fatalError$', () => {
         ledgerTip: jest.fn().mockRejectedValue(new InvalidStringError('Test invalid string error'))
       },
       rewardsProvider: mocks.mockRewardsProvider(),
-      utxoProvider: mocks.mockUtxoProvider(utxoSet)
+      utxoProvider: mocks.mockUtxoProvider({ utxoSet })
     });
 
     // wallet.fatalError$ must be observed till the beginning of time
@@ -436,7 +436,7 @@ describe('SingleAddressWallet.fatalError$', () => {
         ledgerTip: jest.fn().mockResolvedValue(testValue)
       },
       rewardsProvider: mocks.mockRewardsProvider(),
-      utxoProvider: mocks.mockUtxoProvider(utxoSet)
+      utxoProvider: mocks.mockUtxoProvider({ utxoSet })
     });
 
     await expect(firstValueFrom(wallet.tip$)).resolves.toBe(testValue);

--- a/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
@@ -14,7 +14,7 @@ import { AssetId, createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { CML, Cardano } from '@cardano-sdk/core';
 import { SingleAddressWallet, setupWallet } from '../../src';
 import { dummyLogger as logger } from 'ts-log';
-import { mockKeyAgentDependencies } from '@cardano-sdk/key-management/test/mocks';
+import { mockKeyAgentDependencies } from '../../../key-management/test/mocks';
 import DeviceConnection from '@cardano-foundation/ledgerjs-hw-app-cardano';
 
 describe('LedgerKeyAgent', () => {

--- a/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
@@ -1,10 +1,10 @@
+/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
 import * as mocks from '../mocks';
 import {
   AddressType,
   CommunicationType,
-  GroupedAddress,
   LedgerKeyAgent,
   LedgerTransportType,
   SerializableLedgerKeyAgentData,
@@ -12,14 +12,13 @@ import {
 } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { CML, Cardano } from '@cardano-sdk/core';
-import { SingleAddressWallet, setupWallet } from '../../src';
+import { InitializeTxProps, InitializeTxResult, SingleAddressWallet, setupWallet } from '../../src';
 import { dummyLogger as logger } from 'ts-log';
 import { mockKeyAgentDependencies } from '../../../key-management/test/mocks';
 import DeviceConnection from '@cardano-foundation/ledgerjs-hw-app-cardano';
 
 describe('LedgerKeyAgent', () => {
   let keyAgent: LedgerKeyAgent;
-  const address = mocks.utxo[0][0].address;
   let txSubmitProvider: mocks.TxSubmitProviderStub;
   let wallet: SingleAddressWallet;
 
@@ -27,34 +26,22 @@ describe('LedgerKeyAgent', () => {
     txSubmitProvider = mocks.mockTxSubmitProvider();
     ({ keyAgent, wallet } = await setupWallet({
       bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
-      createKeyAgent: async (dependencies) => {
-        const ledgerKeyAgent = await LedgerKeyAgent.createWithDevice(
+      createKeyAgent: async (dependencies) =>
+        await LedgerKeyAgent.createWithDevice(
           {
             chainId: Cardano.ChainIds.LegacyTestnet,
             communicationType: CommunicationType.Node
           },
           dependencies
-        );
-        const groupedAddress: GroupedAddress = {
-          accountIndex: 0,
-          address,
-          index: 0,
-          networkId: Cardano.NetworkId.Testnet,
-          rewardAccount: mocks.rewardAccount,
-          stakeKeyDerivationPath: mocks.stakeKeyDerivationPath,
-          type: AddressType.External
-        };
-        ledgerKeyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);
-        ledgerKeyAgent.knownAddresses.push(groupedAddress);
-        return ledgerKeyAgent;
-      },
+        ),
       createWallet: async (ledgerKeyAgent) => {
+        const { address, rewardAccount } = await ledgerKeyAgent.deriveAddress({ index: 0, type: AddressType.External });
         const assetProvider = mocks.mockAssetProvider();
         const stakePoolProvider = createStubStakePoolProvider();
         const networkInfoProvider = mocks.mockNetworkInfoProvider();
-        const utxoProvider = mocks.mockUtxoProvider();
-        const rewardsProvider = mocks.mockRewardsProvider();
-        const chainHistoryProvider = mocks.mockChainHistoryProvider();
+        const utxoProvider = mocks.mockUtxoProvider({ address });
+        const rewardsProvider = mocks.mockRewardsProvider({ rewardAccount });
+        const chainHistoryProvider = mocks.mockChainHistoryProvider({ rewardAccount });
         const asyncKeyAgent = util.createAsyncKeyAgent(ledgerKeyAgent);
         return new SingleAddressWallet(
           { name: 'HW Wallet' },
@@ -112,7 +99,7 @@ describe('LedgerKeyAgent', () => {
     expect(typeof keyAgent.extendedAccountPublicKey).toBe('string');
   });
 
-  test('sign tx', async () => {
+  describe('signTransaction', () => {
     const outputs = [
       {
         address: Cardano.Address(
@@ -130,16 +117,34 @@ describe('LedgerKeyAgent', () => {
         }
       }
     ];
-    const props = {
+    const props: InitializeTxProps = {
+      options: {
+        validityInterval: {
+          invalidBefore: Cardano.Slot(1),
+          invalidHereafter: Cardano.Slot(999_999_999)
+        }
+      },
       outputs: new Set<Cardano.TxOut>(outputs)
     };
+    let txInternals: InitializeTxResult;
 
-    const txInternals = await wallet.initializeTx(props);
-    const signatures = await keyAgent.signTransaction({
-      body: txInternals.body,
-      hash: txInternals.hash
+    beforeAll(async () => {
+      txInternals = await wallet.initializeTx(props);
     });
-    expect(signatures.size).toBe(2);
+
+    it('successfully signs a transaction with assets and validity interval', async () => {
+      const signatures = await keyAgent.signTransaction(txInternals);
+      expect(signatures.size).toBe(2);
+    });
+
+    it('throws if signed transaction hash doesnt match hash computed by the wallet', async () => {
+      await expect(
+        keyAgent.signTransaction({
+          ...txInternals,
+          hash: 'non-matching' as unknown as Cardano.TransactionId
+        })
+      ).rejects.toThrow();
+    });
   });
 
   describe('establish, check and re-establish device connection', () => {

--- a/packages/wallet/test/mocks/mockRewardsProvider.ts
+++ b/packages/wallet/test/mocks/mockRewardsProvider.ts
@@ -1,13 +1,13 @@
 import { Cardano, Paginated, StakePoolProvider } from '@cardano-sdk/core';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
+import { epochRewards, rewardAccountBalance, rewardAccountBalance2, rewardsHistory, rewardsHistory2 } from './mockData';
 import { getRandomTxId } from './mockChainHistoryProvider';
-import { rewardAccountBalance, rewardAccountBalance2, rewardsHistory, rewardsHistory2 } from './mockData';
 import delay from 'delay';
 
-export const mockRewardsProvider = () => ({
+export const mockRewardsProvider = ({ rewardAccount }: { rewardAccount?: Cardano.RewardAccount } = {}) => ({
   healthCheck: jest.fn().mockResolvedValue({ ok: true }),
   rewardAccountBalance: jest.fn().mockResolvedValue(rewardAccountBalance),
-  rewardsHistory: jest.fn().mockResolvedValue(rewardsHistory)
+  rewardsHistory: jest.fn().mockResolvedValue(rewardAccount ? new Map([[rewardAccount, epochRewards]]) : rewardsHistory)
 });
 
 export const mockRewardsProvider2 = (delayMs: number) => {

--- a/packages/wallet/test/mocks/mockUtxoProvider.ts
+++ b/packages/wallet/test/mocks/mockUtxoProvider.ts
@@ -66,13 +66,23 @@ export const utxo2 = utxo.slice(1);
 /**
  * Provider stub for testing
  *
- * @param utxoSet The set of UTXOs to be included in the wallet state.
+ * @param The options
+ * @param The.address patch utxos to use a specific utxo output address
+ * @param The.utxoSet The set of UTXOs to be included in the wallet state.
  *
  * returns UtxoProvider-compatible object
  */
-export const mockUtxoProvider = (utxoSet?: Cardano.Utxo[]): UtxoProvider => ({
+export const mockUtxoProvider = ({
+  address,
+  utxoSet = utxo
+}: {
+  address?: Cardano.Address;
+  utxoSet?: Cardano.Utxo[];
+} = {}): UtxoProvider => ({
   healthCheck: jest.fn().mockResolvedValue({ ok: true }),
-  utxoByAddresses: jest.fn().mockResolvedValue(utxoSet ? utxoSet : utxo)
+  utxoByAddresses: jest
+    .fn()
+    .mockResolvedValue(address ? utxoSet.map(([txIn, txOut]) => [txIn, { ...txOut, address }]) : utxoSet)
 });
 
 export const mockUtxoProvider2 = (delayMs: number): UtxoProvider => {

--- a/packages/wallet/test/tsconfig.json
+++ b/packages/wallet/test/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../../util/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../util-dev/src"
     },
     {

--- a/packages/web-extension/test/tsconfig.json
+++ b/packages/web-extension/test/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../../core/src"
     },
     {
+      "path": "../../crypto/src"
+    },
+    {
       "path": "../../util-dev/src"
     },
     {


### PR DESCRIPTION
# Context

Ledger was signing a different transaction hash due to incorrect property name when mapping transaction props

# Proposed Solution

Fix it to the correct property name and also add a check to throw an error if Ledger signs a different transaction hash

# Important Changes Introduced

A few chores that fix minor issues with SDK setup:
- 389f8d4eff9c29543ff4a14c282ec87107635bd7
- 5a96d0b2f0829159b0046848cb8c7473cbdccfdd
