### PR TITLE
fix: cip30 wallet interface now allows submitting raw CBOR transactions

### DIFF
--- a/packages/core/src/CBOR/TxBodyCBOR.ts
+++ b/packages/core/src/CBOR/TxBodyCBOR.ts
@@ -1,0 +1,24 @@
+import { CML } from '../CML/CML';
+import { HexBlob, OpaqueString, usingAutoFree } from '@cardano-sdk/util';
+import type { TxCBOR } from './TxCBOR';
+
+/**
+ * Transaction body serialized as CBOR, encoded as hex string
+ */
+export type TxBodyCBOR = OpaqueString<'TxBodyCbor'>;
+
+/**
+ * @param tx Serialized as CBOR, encoded as hex string
+ * @throws InvalidStringError
+ */
+export const TxBodyCBOR = (tx: string): TxBodyCBOR => HexBlob(tx) as unknown as TxBodyCBOR;
+
+/**
+ * Extract transaction body CBOR without re-serializing
+ */
+TxBodyCBOR.fromTxCBOR = (txCbor: TxCBOR) =>
+  Buffer.from(
+    usingAutoFree((scope) =>
+      scope.manage(scope.manage(CML.Transaction.from_bytes(Buffer.from(txCbor.toString(), 'hex'))).body()).to_bytes()
+    )
+  ).toString('hex') as unknown as TxBodyCBOR;

--- a/packages/core/src/CBOR/TxCBOR.ts
+++ b/packages/core/src/CBOR/TxCBOR.ts
@@ -1,0 +1,25 @@
+import { HexBlob, OpaqueString, bufferToHexString, usingAutoFree } from '@cardano-sdk/util';
+import { cmlUtil, coreToCml } from '../CML';
+import type { Cardano } from '..';
+
+/**
+ * Transaction serialized as CBOR, encoded as hex string
+ */
+export type TxCBOR = OpaqueString<'TxCbor'>;
+
+/**
+ * @param tx Serialized as CBOR, encoded as hex string
+ * @throws InvalidStringError
+ */
+export const TxCBOR = (tx: string): TxCBOR => HexBlob(tx) as unknown as TxCBOR;
+
+/**
+ * Serialize transaction to hex-encoded CBOR
+ */
+TxCBOR.serialize = (tx: Cardano.Tx): TxCBOR =>
+  bufferToHexString(Buffer.from(usingAutoFree((scope) => coreToCml.tx(scope, tx).to_bytes()))) as unknown as TxCBOR;
+
+/**
+ * Deserialize transaction from hex-encoded CBOR
+ */
+TxCBOR.deserialize = (tx: TxCBOR): Cardano.Tx => cmlUtil.deserializeTx(tx.toString());

--- a/packages/core/src/CBOR/index.ts
+++ b/packages/core/src/CBOR/index.ts
@@ -1,0 +1,2 @@
+export * from './TxCBOR';
+export * from './TxBodyCBOR';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export * from './CML';
 export * from './util';
 export * from './errors';
 export * from './CardanoNode';
+export * from './CBOR';

--- a/packages/core/test/CBOR/TxBodyCBOR.test.ts
+++ b/packages/core/test/CBOR/TxBodyCBOR.test.ts
@@ -1,0 +1,26 @@
+import { InvalidStringError } from '@cardano-sdk/util';
+import { TxBodyCBOR, TxCBOR } from '../../src';
+
+describe('TxBodyCBOR', () => {
+  describe('used as a constructor', () => {
+    it('accepts plain hex string', () => {
+      expect(() => TxBodyCBOR('123f')).not.toThrow();
+    });
+    it('throws if string has non-hex characters', () => {
+      expect(() => TxBodyCBOR('123fx')).toThrowError(InvalidStringError);
+    });
+  });
+
+  describe('TxBodyCBOR.fromTxCBOR', () => {
+    it('extracts transaction body part of serialized transaction', () => {
+      const txCbor = TxCBOR(
+        // eslint-disable-next-line max-len
+        '84a60081825820260aed6e7a24044b1254a87a509468a649f522a4e54e830ac10f27ea7b5ec61f01018383581d70b429738bd6cc58b5c7932d001aa2bd05cfea47020a556c8c753d44361a004c4b40582007845f8f3841996e3d8157954e2f5e2fb90465f27112fc5fe9056d916fae245b82583900b1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339ba1a0463676982583900b1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339ba821a00177a6ea2581c648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff198a5447742544319271044774554481a0031f9194577444f47451a0056898d4577555344431a000fc589467753484942411a000103c2581c659ab0b5658687c2e74cd10dba8244015b713bf503b90557769d77a7a14a57696e675269646572731a02269552021a0002e665031a01353f84081a013531740b58204107eada931c72a600a6e3305bd22c7aeb9ada7c3f6823b155f4db85de36a69aa20081825820e686ade5bc97372f271fd2abc06cfd96c24b3d9170f9459de1d8e3dd8fd385575840653324a9dddad004f05a8ac99fa2d1811af5f00543591407fb5206cfe9ac91bb1412404323fa517e0e189684cd3592e7f74862e3f16afbc262519abec958180c0481d8799fd8799fd8799fd8799f581cb1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68ffd8799fd8799fd8799f581c042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339baffffffff581cb1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c681b000001863784a12ed8799fd8799f4040ffd8799f581c648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff1984577444f4745ffffffd8799fd87980190c8efffff5f6'
+      );
+      const bodyCbor = TxBodyCBOR.fromTxCBOR(txCbor);
+      expect(bodyCbor.length).toBeGreaterThan(0);
+      expect(bodyCbor.length).toBeLessThan(txCbor.length);
+      expect(txCbor.includes(bodyCbor.toString())).toBe(true);
+    });
+  });
+});

--- a/packages/core/test/CBOR/TxCBOR.test.ts
+++ b/packages/core/test/CBOR/TxCBOR.test.ts
@@ -1,0 +1,36 @@
+import { InvalidStringError } from '@cardano-sdk/util';
+import { TxCBOR } from '../../src';
+import { babbageTx } from '../CML/testData';
+
+describe('TxCBOR', () => {
+  describe('used as a constructor', () => {
+    it('accepts plain hex string', () => {
+      expect(() => TxCBOR('123f')).not.toThrow();
+    });
+    it('throws if string has non-hex characters', () => {
+      expect(() => TxCBOR('123fx')).toThrowError(InvalidStringError);
+    });
+  });
+
+  describe('TxCBOR.serialize', () => {
+    it('serializes Cardano.Tx into CBOR hex string', () => {
+      const cbor = TxCBOR.serialize(babbageTx);
+      expect(typeof cbor).toBe('string');
+      // hex characters only
+      expect(Buffer.from(cbor, 'hex').toString('hex')).toEqual(cbor);
+    });
+  });
+
+  describe('TxCBOR.deserialize', () => {
+    it('deserializes CBOR hex string into Cardano.Tx', () => {
+      const cbor = TxCBOR(
+        // eslint-disable-next-line max-len
+        '84a60081825820260aed6e7a24044b1254a87a509468a649f522a4e54e830ac10f27ea7b5ec61f01018383581d70b429738bd6cc58b5c7932d001aa2bd05cfea47020a556c8c753d44361a004c4b40582007845f8f3841996e3d8157954e2f5e2fb90465f27112fc5fe9056d916fae245b82583900b1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339ba1a0463676982583900b1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339ba821a00177a6ea2581c648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff198a5447742544319271044774554481a0031f9194577444f47451a0056898d4577555344431a000fc589467753484942411a000103c2581c659ab0b5658687c2e74cd10dba8244015b713bf503b90557769d77a7a14a57696e675269646572731a02269552021a0002e665031a01353f84081a013531740b58204107eada931c72a600a6e3305bd22c7aeb9ada7c3f6823b155f4db85de36a69aa20081825820e686ade5bc97372f271fd2abc06cfd96c24b3d9170f9459de1d8e3dd8fd385575840653324a9dddad004f05a8ac99fa2d1811af5f00543591407fb5206cfe9ac91bb1412404323fa517e0e189684cd3592e7f74862e3f16afbc262519abec958180c0481d8799fd8799fd8799fd8799f581cb1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68ffd8799fd8799fd8799f581c042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339baffffffff581cb1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c681b000001863784a12ed8799fd8799f4040ffd8799f581c648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff1984577444f4745ffffffd8799fd87980190c8efffff5f6'
+      );
+      const tx = TxCBOR.deserialize(cbor);
+      expect(typeof tx.body).toBe('object');
+      expect(typeof tx.witness).toBe('object');
+      expect(typeof tx.id).toBe('string');
+    });
+  });
+});

--- a/packages/core/test/Cardano/types/Transaction.test.ts
+++ b/packages/core/test/Cardano/types/Transaction.test.ts
@@ -1,15 +1,31 @@
-import { Cardano } from '../../../';
+import { Cardano, TxBodyCBOR, TxCBOR } from '../../../';
 import { Ed25519SignatureHex } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
+import { babbageTx } from '../../CML/testData';
 
 describe('Cardano/types/Transaction', () => {
-  it('TransactionId accepts a valid transaction hash hex string', () => {
-    expect(() =>
-      Cardano.TransactionId('3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d')
-    ).not.toThrow();
-    expect(() =>
-      Cardano.TransactionId.fromHexBlob(HexBlob('3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d'))
-    ).not.toThrow();
+  describe('TransactionId', () => {
+    describe('when used as a constructor', () => {
+      it('TransactionId accepts a valid transaction hash hex string', () => {
+        expect(() =>
+          Cardano.TransactionId('3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d')
+        ).not.toThrow();
+        expect(() =>
+          Cardano.TransactionId.fromHexBlob(HexBlob('3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d'))
+        ).not.toThrow();
+      });
+    });
+
+    describe('TransactionId.fromTxBodyCbor', () => {
+      it('computes transaction hash', () => {
+        const bodyCbor = TxBodyCBOR.fromTxCBOR(TxCBOR.serialize(babbageTx));
+        const txId = Cardano.TransactionId.fromTxBodyCbor(bodyCbor);
+        expect(typeof txId).toBe('string');
+        expect(txId).toHaveLength(64);
+        // hex characters only
+        expect(Buffer.from(txId, 'hex').toString('hex')).toEqual(txId);
+      });
+    });
   });
 
   it('Ed25519Signature() accepts a valid signature hex string', () => {

--- a/packages/core/test/Cardano/types/Transaction.test.ts
+++ b/packages/core/test/Cardano/types/Transaction.test.ts
@@ -1,18 +1,27 @@
 import { Cardano, TxBodyCBOR, TxCBOR } from '../../../';
 import { Ed25519SignatureHex } from '@cardano-sdk/crypto';
-import { HexBlob } from '@cardano-sdk/util';
+import { HexBlob, InvalidStringError } from '@cardano-sdk/util';
 import { babbageTx } from '../../CML/testData';
 
 describe('Cardano/types/Transaction', () => {
   describe('TransactionId', () => {
     describe('when used as a constructor', () => {
-      it('TransactionId accepts a valid transaction hash hex string', () => {
+      it('accepts a valid transaction hash hex string', () => {
         expect(() =>
           Cardano.TransactionId('3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d')
         ).not.toThrow();
+      });
+    });
+
+    describe('fromHexBlob', () => {
+      it('accepts a valid length hex string', () => {
         expect(() =>
           Cardano.TransactionId.fromHexBlob(HexBlob('3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d'))
         ).not.toThrow();
+      });
+
+      it('throws when given an invalid length hex string', () => {
+        expect(() => Cardano.TransactionId.fromHexBlob(HexBlob('33018e8293d319e'))).toThrowError(InvalidStringError);
       });
     });
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -58,7 +58,8 @@
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
     "prepack": "yarn build",
-    "test:build:verify": "yarn test:web-extension:build",
+    "test:build:verify:tsc": "tsc --build ./test",
+    "test:build:verify": "run-p test:web-extension:build test:build:verify:tsc",
     "test:debug": "DEBUG=true yarn test",
     "generate-mnemonics": "ts-node src/scripts/mnemonic.ts",
     "wait-for-network": "ts-node src/scripts/is-local-network-ready.ts"

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -102,8 +102,12 @@ export const txConfirmed = (
         })
       ),
       failed$.pipe(
-        mergeMap(({ tx, error, reason }) =>
-          tx.id === id ? throwError(() => error || new Error(`Tx failed due to '${reason}': ${id}`)) : EMPTY
+        mergeMap((outgoingTx) =>
+          outgoingTx.id === id
+            ? throwError(
+                () => outgoingTx.error || new Error(`Tx failed due to '${outgoingTx.reason}': ${outgoingTx.id}`)
+              )
+            : EMPTY
         )
       )
     )

--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -34,7 +34,7 @@ const waitForTx = async (wallet: ObservableWallet, hash: Cardano.TransactionId) 
     combineLatest([
       wallet.transactions.history$.pipe(filter((txs) => txs.some(({ id }) => id === hash))),
       // test that confirmed$ works
-      wallet.transactions.outgoing.confirmed$.pipe(filter(({ tx: { id } }) => id === hash))
+      wallet.transactions.outgoing.confirmed$.pipe(filter(({ id }) => id === hash))
     ]),
     'Tx not confirmed for too long',
     TX_TIMEOUT

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -491,7 +491,7 @@ export class SingleAddressWallet implements ObservableWallet {
   async submitTx(
     input: Cardano.Tx | TxCBOR | OutgoingTx,
     { mightBeAlreadySubmitted }: SubmitTxOptions = {}
-  ): Promise<void> {
+  ): Promise<Cardano.TransactionId> {
     const outgoingTx = processOutgoingTx(input);
     this.#logger.debug(`Submitting transaction ${outgoingTx.id}`);
     this.#newTransactions.submitting$.next(outgoingTx);
@@ -502,6 +502,7 @@ export class SingleAddressWallet implements ObservableWallet {
       const { slot: submittedAt } = await firstValueFrom(this.tip$);
       this.#logger.debug(`Submitted transaction ${outgoingTx.id} at slot ${submittedAt}`);
       this.#newTransactions.pending$.next(outgoingTx);
+      return outgoingTx.id;
     } catch (error) {
       if (
         mightBeAlreadySubmitted &&
@@ -514,7 +515,7 @@ export class SingleAddressWallet implements ObservableWallet {
       ) {
         this.#logger.debug(`Transaction ${outgoingTx.id} appears to be already submitted...`);
         this.#newTransactions.pending$.next(outgoingTx);
-        return;
+        return outgoingTx.id;
       }
       this.#newTransactions.failedToSubmit$.next({
         error: error as CardanoNodeErrors.TxSubmissionError,

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-nested-ternary */
 import {
   AddressType,
   AsyncKeyAgent,
@@ -17,9 +18,10 @@ import {
   ProviderError,
   RewardsProvider,
   StakePoolProvider,
+  TxBodyCBOR,
+  TxCBOR,
   TxSubmitProvider,
-  UtxoProvider,
-  coreToCml
+  UtxoProvider
 } from '@cardano-sdk/core';
 import {
   Assets,
@@ -37,6 +39,7 @@ import {
   ConnectionStatusTracker,
   DelegationTracker,
   FailedTx,
+  OutgoingTx,
   PersistentDocumentTrackerSubject,
   PollingConfig,
   SmartTxSubmitProvider,
@@ -84,14 +87,7 @@ import {
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { InputSelector, roundRobinRandomImprove } from '@cardano-sdk/input-selection';
 import { Logger } from 'ts-log';
-import {
-  ManagedFreeableScope,
-  Shutdown,
-  bufferToHexString,
-  contextLogger,
-  deepEquals,
-  usingAutoFree
-} from '@cardano-sdk/util';
+import { ManagedFreeableScope, Shutdown, contextLogger, deepEquals } from '@cardano-sdk/util';
 import { PrepareTx, createTxPreparer } from './prepareTx';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { TrackedUtxoProvider } from '../services/ProviderTracker/TrackedUtxoProvider';
@@ -131,6 +127,30 @@ export const DEFAULT_POLLING_CONFIG = {
   pollInterval: 5000
 };
 
+const isOutgoingTx = (input: Cardano.Tx | TxCBOR | OutgoingTx): input is OutgoingTx =>
+  typeof input === 'object' && 'cbor' in input;
+const isTxCBOR = (input: Cardano.Tx | TxCBOR | OutgoingTx): input is TxCBOR => typeof input === 'string';
+const processOutgoingTx = (input: Cardano.Tx | TxCBOR | OutgoingTx): OutgoingTx => {
+  // TxCbor
+  if (isTxCBOR(input)) {
+    return {
+      body: TxCBOR.deserialize(input).body,
+      cbor: input,
+      // Do not re-serialize transaction body to compute transaction id
+      id: Cardano.TransactionId.fromTxBodyCbor(TxBodyCBOR.fromTxCBOR(input))
+    };
+  }
+  // OutgoingTx (resubmitted)
+  if (isOutgoingTx(input)) {
+    return input;
+  }
+  return {
+    body: input.body,
+    cbor: TxCBOR.serialize(input),
+    id: input.id
+  };
+};
+
 export class SingleAddressWallet implements ObservableWallet {
   #inputSelector: InputSelector;
   #logger: Logger;
@@ -138,8 +158,8 @@ export class SingleAddressWallet implements ObservableWallet {
   #prepareTx: PrepareTx;
   #newTransactions = {
     failedToSubmit$: new Subject<FailedTx>(),
-    pending$: new Subject<Cardano.Tx>(),
-    submitting$: new Subject<Cardano.Tx>()
+    pending$: new Subject<OutgoingTx>(),
+    submitting$: new Subject<OutgoingTx>()
   };
   #reemitSubscriptions: Subscription;
   #failedFromReemitter$: Subject<FailedTx>;
@@ -359,7 +379,7 @@ export class SingleAddressWallet implements ObservableWallet {
     this.#reemitSubscriptions.add(
       transactionsReemitter.reemit$
         .pipe(
-          mergeMap((transaction) => from(this.submitTx(transaction, { mightBeAlreadySubmitted: true }))),
+          mergeMap((tx) => from(this.submitTx(tx, { mightBeAlreadySubmitted: true }))),
           catchError((err) => {
             this.#logger.error('Failed to resubmit transaction', err);
             return EMPTY;
@@ -468,16 +488,20 @@ export class SingleAddressWallet implements ObservableWallet {
     };
   }
 
-  async submitTx(tx: Cardano.Tx, { mightBeAlreadySubmitted }: SubmitTxOptions = {}): Promise<void> {
-    this.#logger.debug(`Submitting transaction ${tx.id}`);
-    this.#newTransactions.submitting$.next(tx);
+  async submitTx(
+    input: Cardano.Tx | TxCBOR | OutgoingTx,
+    { mightBeAlreadySubmitted }: SubmitTxOptions = {}
+  ): Promise<void> {
+    const outgoingTx = processOutgoingTx(input);
+    this.#logger.debug(`Submitting transaction ${outgoingTx.id}`);
+    this.#newTransactions.submitting$.next(outgoingTx);
     try {
       await this.txSubmitProvider.submitTx({
-        signedTransaction: bufferToHexString(Buffer.from(usingAutoFree((scope) => coreToCml.tx(scope, tx).to_bytes())))
+        signedTransaction: outgoingTx.cbor
       });
       const { slot: submittedAt } = await firstValueFrom(this.tip$);
-      this.#logger.debug(`Submitted transaction ${tx.id} at slot ${submittedAt}`);
-      this.#newTransactions.pending$.next(tx);
+      this.#logger.debug(`Submitted transaction ${outgoingTx.id} at slot ${submittedAt}`);
+      this.#newTransactions.pending$.next(outgoingTx);
     } catch (error) {
       if (
         mightBeAlreadySubmitted &&
@@ -488,18 +512,19 @@ export class SingleAddressWallet implements ObservableWallet {
         (error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError ||
           error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.UnknownOrIncompleteWithdrawalsError)
       ) {
-        this.#logger.debug(`Transaction ${tx.id} appears to be already submitted...`);
-        this.#newTransactions.pending$.next(tx);
+        this.#logger.debug(`Transaction ${outgoingTx.id} appears to be already submitted...`);
+        this.#newTransactions.pending$.next(outgoingTx);
         return;
       }
       this.#newTransactions.failedToSubmit$.next({
         error: error as CardanoNodeErrors.TxSubmissionError,
         reason: TransactionFailure.FailedToSubmit,
-        tx
+        ...outgoingTx
       });
       throw error;
     }
   }
+
   signData(props: SignDataProps): Promise<Cip30DataSignature> {
     return cip8.cip30signData({ keyAgent: this.keyAgent, ...props });
   }

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -13,7 +13,7 @@ import {
   TxSignErrorCode,
   WalletApi
 } from '@cardano-sdk/dapp-connector';
-import { CML, Cardano, cmlToCore, coreToCml, parseCmlAddress } from '@cardano-sdk/core';
+import { CML, Cardano, TxCBOR, cmlToCore, coreToCml, parseCmlAddress } from '@cardano-sdk/core';
 import { HexBlob, ManagedFreeableScope, usingAutoFree } from '@cardano-sdk/util';
 import { Logger } from 'ts-log';
 import { Observable, firstValueFrom } from 'rxjs';
@@ -316,7 +316,7 @@ export const createWalletApi = (
     if (shouldProceed) {
       try {
         const wallet = await firstValueFrom(wallet$);
-        await wallet.submitTx(txData);
+        await wallet.submitTx(TxCBOR(tx));
         return txData.id.toString();
       } catch (error) {
         logger.error(error);

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -59,7 +59,7 @@ export const createPouchDbWalletStores = (
     destroyed: false,
     eraSummaries: new PouchDbEraSummariesStore(docsDbName, 'EraSummaries', logger),
     genesisParameters: new PouchDbGenesisParametersStore(docsDbName, 'genesisParameters', logger),
-    inFlightTransactions: new PouchDbInFlightTransactionsStore(docsDbName, 'transactionsInFlight', logger),
+    inFlightTransactions: new PouchDbInFlightTransactionsStore(docsDbName, 'transactionsInFlight_v2', logger),
     protocolParameters: new PouchDbProtocolParametersStore(docsDbName, 'protocolParameters', logger),
     rewardsBalances: new PouchDbRewardsBalancesStore(`${baseDbName}RewardsBalances`, logger),
     rewardsHistory: new PouchDbRewardsHistoryStore(`${baseDbName}RewardsHistory`, logger),
@@ -79,6 +79,6 @@ export const createPouchDbWalletStores = (
     ),
     unspendableUtxo: new PouchDbUtxoStore({ dbName: `${baseDbName}UnspendableUtxo` }, logger),
     utxo: new PouchDbUtxoStore({ dbName: `${baseDbName}Utxo` }, logger),
-    volatileTransactions: new PouchDbVolatileTransactionsStore(docsDbName, 'volatileTransactions', logger)
+    volatileTransactions: new PouchDbVolatileTransactionsStore(docsDbName, 'volatileTransactions_v2', logger)
   };
 };

--- a/packages/wallet/src/services/TransactionsTracker.ts
+++ b/packages/wallet/src/services/TransactionsTracker.ts
@@ -1,5 +1,5 @@
 import { Cardano, ChainHistoryProvider, Range } from '@cardano-sdk/core';
-import { ConfirmedTx, FailedTx, TransactionFailure, TransactionsTracker, TxInFlight } from './types';
+import { ConfirmedTx, FailedTx, OutgoingTx, TransactionFailure, TransactionsTracker, TxInFlight } from './types';
 import { DocumentStore, OrderedCollectionStore } from '../persistence';
 import {
   EMPTY,
@@ -44,8 +44,8 @@ export interface TransactionsTrackerProps {
   transactionsHistoryStore: OrderedCollectionStore<Cardano.HydratedTx>;
   inFlightTransactionsStore: DocumentStore<TxInFlight[]>;
   newTransactions: {
-    submitting$: Observable<Cardano.Tx>;
-    pending$: Observable<Cardano.Tx>;
+    submitting$: Observable<OutgoingTx>;
+    pending$: Observable<OutgoingTx>;
     failedToSubmit$: Observable<FailedTx>;
   };
   failedFromReemitter$?: Observable<FailedTx>;
@@ -233,16 +233,16 @@ export const createTransactionsTracker = (
   const transactionsSource$ = new TrackerSubject(txSource$);
 
   const historicalTransactions$ = createHistoricalTransactionsTrackerSubject(transactionsSource$);
-  const txConfirmed$ = (tx: Cardano.Tx): Observable<ConfirmedTx> =>
+  const txConfirmed$ = (evt: OutgoingTx): Observable<ConfirmedTx> =>
     newTransactions$(historicalTransactions$).pipe(
-      filter((historyTx) => historyTx.id === tx.id),
+      filter((historyTx) => historyTx.id === evt.id),
       take(1),
-      map((historyTx) => ({ confirmedAt: historyTx.blockHeader.slot, tx })),
-      tap(({ confirmedAt }) => logger.debug(`Transaction ${tx.id} is confirmed in slot ${confirmedAt}`))
+      map((historyTx) => ({ ...evt, confirmedAt: historyTx.blockHeader.slot })),
+      tap(({ confirmedAt }) => logger.debug(`Transaction ${evt.id} is confirmed in slot ${confirmedAt}`))
     );
 
   const submittingOrPreviouslySubmitted$ = merge<TxInFlight[]>(
-    submitting$.pipe(map((tx) => ({ tx }))),
+    submitting$.pipe(map((evt) => evt)),
     newTransactionsStore.get().pipe(
       tap((transactions) => logger.debug(`Store contains ${transactions?.length} in flight transactions`)),
       map((transactions) => transactions.filter(({ submittedAt }) => !!submittedAt)),
@@ -250,7 +250,7 @@ export const createTransactionsTracker = (
     )
   ).pipe(
     // Tx could be re-submitted, so we group by tx id
-    groupBy(({ tx: { id } }) => id),
+    groupBy(({ id }) => id),
     map((group$) => group$.pipe(share())),
     share()
   );
@@ -260,7 +260,7 @@ export const createTransactionsTracker = (
     .pipe(
       mergeMap((group$) =>
         group$.pipe(
-          switchMap(({ tx }) => {
+          switchMap((tx) => {
             const invalidHereafter = tx.body.validityInterval?.invalidHereafter;
             return race(
               rollback$.pipe(
@@ -272,15 +272,15 @@ export const createTransactionsTracker = (
                       `Invalid inputs due to rolled back tx (${rolledBackTxId}}). Try to rebuild and resubmit.`
                     ),
                     reason: TransactionFailure.InvalidTransaction,
-                    tx
+                    ...tx
                   })
                 )
               ),
-              failedToSubmit$.pipe(filter((failed) => failed.tx === tx)),
+              failedToSubmit$.pipe(filter((failed) => failed.id === tx.id)),
               invalidHereafter
                 ? tip$.pipe(
                     filter(({ slot }) => slot > invalidHereafter),
-                    map(() => ({ reason: TransactionFailure.Timeout, tx }))
+                    map(() => ({ reason: TransactionFailure.Timeout, ...tx }))
                   )
                 : EMPTY
             ).pipe(take(1), takeUntil(txConfirmed$(tx)));
@@ -288,21 +288,21 @@ export const createTransactionsTracker = (
         )
       ),
       mergeWith(failedFromReemitter$ || EMPTY),
-      tap((failed) => logger.debug(`Transaction ${failed.tx.id} failed`, failed.reason))
+      tap(({ id, reason }) => logger.debug(`Transaction ${id} failed`, reason))
     )
     .subscribe(failed$);
 
-  const txFailed$ = (tx: Cardano.Tx) =>
+  const txFailed$ = (tx: OutgoingTx) =>
     failed$.pipe(
-      filter((failed) => failed.tx === tx),
+      filter((failed) => failed.id === tx.id),
       take(1)
     );
 
-  const txPending$ = (tx: Cardano.Tx) =>
+  const txPending$ = (tx: OutgoingTx) =>
     pending$.pipe(
-      filter((pending) => pending === tx),
+      filter((pending) => pending.id === tx.id),
       withLatestFrom(tip$),
-      map(([_, { slot }]) => ({ submittedAt: slot, tx }))
+      map(([_, { slot }]) => ({ submittedAt: slot, ...tx }))
     );
 
   const inFlight$ = new TrackerSubject<TxInFlight[]>(
@@ -310,15 +310,15 @@ export const createTransactionsTracker = (
       mergeMap((group$) =>
         group$.pipe(
           // Only keep 1 (latest) inner observable per tx id.
-          switchMap(({ tx, submittedAt }) => {
+          switchMap((tx) => {
             const done$ = race(txConfirmed$(tx), txFailed$(tx)).pipe(
               map(() => ({ op: 'remove' as const, tx })),
               share()
             );
             return merge(
-              of({ op: 'add' as const, submittedAt, tx }),
+              of({ op: 'add' as const, tx }),
               done$,
-              submittedAt
+              tx.submittedAt
                 ? EMPTY
                 : // NOTE: current implementation might incorrectly update 'submittedAt'
                   // if transaction was attempted to resubmit and appeared to be already submitted.
@@ -326,7 +326,10 @@ export const createTransactionsTracker = (
                   // time when transaction got into a mempool - it works more like 'lastAttemptToSubmitAt',
                   // which isn't necessarily bad as it might prevent frequent resubmissions in some cases
                   txPending$(tx).pipe(
-                    map((pending) => ({ op: 'submitted' as const, submittedAt: pending.submittedAt, tx })),
+                    map((pendingTx) => ({
+                      op: 'submitted' as const,
+                      tx: pendingTx
+                    })),
                     takeUntil(done$)
                   )
             );
@@ -334,23 +337,18 @@ export const createTransactionsTracker = (
         )
       ),
       scan((inFlight, props) => {
-        const idx = inFlight.findIndex((txInFlight) => txInFlight.tx === props.tx);
+        const idx = inFlight.findIndex((txInFlight) => txInFlight.id === props.tx.id);
         if (props.op === 'add') {
-          const newInFlightTx = { submittedAt: props.submittedAt, tx: props.tx };
           if (idx >= 0) {
-            return [...inFlight.slice(0, idx), newInFlightTx, ...inFlight.slice(idx + 1)];
+            return [...inFlight.slice(0, idx), props.tx, ...inFlight.slice(idx + 1)];
           }
-          return [...inFlight, newInFlightTx];
+          return [...inFlight, props.tx];
         }
         if (props.op === 'remove') {
           return [...inFlight.slice(0, idx), ...inFlight.slice(idx + 1)];
         }
         // props.op === 'submitted'
-        return [
-          ...inFlight.slice(0, idx),
-          { submittedAt: props.submittedAt, tx: props.tx },
-          ...inFlight.slice(idx + 1)
-        ];
+        return [...inFlight.slice(0, idx), props.tx, ...inFlight.slice(idx + 1)];
       }, [] as TxInFlight[]),
       tap((inFlight) => newTransactionsStore.set(inFlight)),
       tap((inFlight) => logger.debug(`${inFlight.length} in flight transactions`)),
@@ -360,7 +358,7 @@ export const createTransactionsTracker = (
 
   const confirmed$ = new Subject<ConfirmedTx>();
   const confirmedSubscription = submittingOrPreviouslySubmitted$
-    .pipe(mergeMap((group$) => group$.pipe(switchMap(({ tx }) => txConfirmed$(tx).pipe(takeUntil(txFailed$(tx)))))))
+    .pipe(mergeMap((group$) => group$.pipe(switchMap((tx) => txConfirmed$(tx).pipe(takeUntil(txFailed$(tx)))))))
     .subscribe(confirmed$);
 
   return {

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, CardanoNodeErrors, EpochRewards } from '@cardano-sdk/core';
+import { Cardano, CardanoNodeErrors, EpochRewards, TxCBOR } from '@cardano-sdk/core';
 import { Observable } from 'rxjs';
 
 export enum TransactionFailure {
@@ -45,22 +45,32 @@ export interface PollingConfig {
   readonly consideredOutOfSyncAfter?: Milliseconds;
 }
 
-export interface FailedTx {
-  tx: Cardano.Tx;
+export interface OutgoingTx {
+  cbor: TxCBOR;
+  body: Cardano.TxBody;
+  id: Cardano.TransactionId;
+}
+
+export interface FailedTx extends OutgoingTx {
   reason: TransactionFailure;
   error?: CardanoNodeErrors.TxSubmissionError;
 }
 
-export type ConfirmedTx = { tx: Cardano.Tx; confirmedAt: Cardano.PartialBlockHeader['slot'] };
-export type TxInFlight = { tx: Cardano.Tx; submittedAt?: Cardano.PartialBlockHeader['slot'] };
+export interface ConfirmedTx extends OutgoingTx {
+  confirmedAt: Cardano.PartialBlockHeader['slot'];
+}
+
+export interface TxInFlight extends OutgoingTx {
+  submittedAt?: Cardano.PartialBlockHeader['slot'];
+}
 
 export interface TransactionsTracker {
   readonly history$: Observable<Cardano.HydratedTx[]>;
   readonly rollback$: Observable<Cardano.HydratedTx>;
   readonly outgoing: {
     readonly inFlight$: Observable<TxInFlight[]>;
-    readonly submitting$: Observable<Cardano.Tx>;
-    readonly pending$: Observable<Cardano.Tx>;
+    readonly submitting$: Observable<OutgoingTx>;
+    readonly pending$: Observable<OutgoingTx>;
     readonly failed$: Observable<FailedTx>;
     readonly confirmed$: Observable<ConfirmedTx>;
   };

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -104,7 +104,7 @@ export interface ObservableWallet {
   /**
    * @throws CardanoNodeErrors.TxSubmissionError
    */
-  submitTx(tx: Cardano.Tx | TxCBOR): Promise<void>;
+  submitTx(tx: Cardano.Tx | TxCBOR): Promise<Cardano.TransactionId>;
 
   shutdown(): void;
 }

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,5 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { Asset, Cardano, EpochInfo, EraSummary, NetworkInfoProvider } from '@cardano-sdk/core';
+import { Asset, Cardano, EpochInfo, EraSummary, NetworkInfoProvider, TxCBOR } from '@cardano-sdk/core';
 import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { GroupedAddress, SignTransactionOptions, TransactionSigner, cip8 } from '@cardano-sdk/key-management';
@@ -104,7 +104,8 @@ export interface ObservableWallet {
   /**
    * @throws CardanoNodeErrors.TxSubmissionError
    */
-  submitTx(tx: Cardano.Tx): Promise<void>;
+  submitTx(tx: Cardano.Tx | TxCBOR): Promise<void>;
+
   shutdown(): void;
 }
 

--- a/packages/wallet/test/SingleAddressWallet/methods.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/methods.test.ts
@@ -202,8 +202,9 @@ describe('SingleAddressWallet methods', () => {
         const txPending = firstValueFrom(wallet.transactions.outgoing.pending$);
         const txInFlight = firstValueFrom(wallet.transactions.outgoing.inFlight$.pipe(skip(1)));
 
-        await wallet.submitTx(tx);
+        const txId = await wallet.submitTx(tx);
 
+        expect(txId).toBe(tx.id);
         expect(txSubmitProvider.submitTx).toBeCalledTimes(1);
         expect(txSubmitProvider.submitTx).toBeCalledWith({ signedTransaction: outgoingTx.cbor });
         expect(await txSubmitting).toEqual(outgoingTx);

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -16,7 +16,7 @@ import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { filter, firstValueFrom } from 'rxjs';
 import { dummyLogger as logger } from 'ts-log';
 import { testAsyncKeyAgent } from '../../../key-management/test/mocks';
-import { waitForWalletStateSettle } from '../util';
+import { toOutgoingTx, waitForWalletStateSettle } from '../util';
 
 const name = 'Test Wallet';
 const address = mocks.utxo[0][0].address!;
@@ -154,7 +154,7 @@ describe('SingleAddressWallet rollback', () => {
     stores.volatileTransactions.set([
       {
         confirmedAt: rollBackTx.blockHeader.slot,
-        tx
+        ...toOutgoingTx(tx)
       }
     ]);
 

--- a/packages/wallet/test/integration/CustomObservableWallet.test.ts
+++ b/packages/wallet/test/integration/CustomObservableWallet.test.ts
@@ -66,7 +66,8 @@ describe('CustomObservableWallet', () => {
 
     it('does not necessarily have to use SingleAddressWallet, but can still utilize SDK utils', () => {
       // let's say we have an API endpoint to submit transaction as bytes and not as SDK's Cardano.Tx
-      const submitTxBytesHexString: (tx: string) => Promise<void> = () => Promise.resolve();
+      const submitTxBytesHexString: (tx: string) => Promise<Cardano.TransactionId> = () =>
+        Promise.resolve(Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000'));
       // and another endpoint to get wallet addresses
       const getAddresses: () => Promise<GroupedAddress[]> = async () => [];
       // and another endpoint to get wallet's utxo balance

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -7,24 +7,26 @@ import {
   TxSignError,
   WalletApi
 } from '@cardano-sdk/dapp-connector';
-import { CML, Cardano, cmlToCore, coreToCml } from '@cardano-sdk/core';
+import { CML, Cardano, TxCBOR, cmlToCore, coreToCml } from '@cardano-sdk/core';
 import { HexBlob, ManagedFreeableScope } from '@cardano-sdk/util';
 import { InMemoryUnspendableUtxoStore, createInMemoryWalletStores } from '../../src/persistence';
 import { InitializeTxProps, InitializeTxResult, SingleAddressWallet, cip30 } from '../../src';
-import { createWallet } from './util';
+import { Providers, createWallet } from './util';
 import { firstValueFrom, of } from 'rxjs';
 import { dummyLogger as logger } from 'ts-log';
-import { utxo as mockedUtxo, utxosWithLowCoins } from '../mocks';
+import { mockNetworkInfoProvider, mockTxSubmitProvider, utxo as mockedUtxo, utxosWithLowCoins } from '../mocks';
 import { waitForWalletStateSettle } from '../util';
 
-const createWalletAndApiWithStores = async (utxos: Cardano.Utxo[]) => {
+type TestProviders = Required<Pick<Providers, 'txSubmitProvider' | 'networkInfoProvider'>>;
+
+const createWalletAndApiWithStores = async (utxos: Cardano.Utxo[], providers?: TestProviders, settle = true) => {
   const unspendableUtxo = new InMemoryUnspendableUtxoStore();
   unspendableUtxo.setAll(utxos);
   const stores = { ...createInMemoryWalletStores(), unspendableUtxo };
-  const { wallet } = await createWallet(stores);
+  const { wallet } = await createWallet(stores, providers);
   const confirmationCallback = jest.fn().mockResolvedValue(true);
   const api = cip30.createWalletApi(of(wallet), confirmationCallback, { logger });
-  await waitForWalletStateSettle(wallet);
+  if (settle) await waitForWalletStateSettle(wallet);
   return { api, confirmationCallback, wallet };
 };
 
@@ -44,6 +46,49 @@ describe('cip30', () => {
       }
     ])
   };
+
+  describe('with custom ledgerTip', () => {
+    let providers: TestProviders;
+    let resolveTip: (tip: Cardano.Tip) => void;
+
+    beforeEach(async () => {
+      providers = {
+        networkInfoProvider: mockNetworkInfoProvider(),
+        txSubmitProvider: mockTxSubmitProvider()
+      };
+      providers.networkInfoProvider.ledgerTip.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveTip = resolve;
+          })
+      );
+      // CREATE A WALLET
+      ({ wallet, api, confirmationCallback } = await createWalletAndApiWithStores([mockedUtxo[2]], providers, false));
+    });
+
+    afterEach(() => {
+      wallet.shutdown();
+    });
+
+    describe('createWalletApi', () => {
+      describe('api.submitTx', () => {
+        it('can submit a transaction that is not consistently reserialized with CML', async () => {
+          const serializedTx = TxCBOR(
+            // eslint-disable-next-line max-len
+            '84a60081825820260aed6e7a24044b1254a87a509468a649f522a4e54e830ac10f27ea7b5ec61f01018383581d70b429738bd6cc58b5c7932d001aa2bd05cfea47020a556c8c753d44361a004c4b40582007845f8f3841996e3d8157954e2f5e2fb90465f27112fc5fe9056d916fae245b82583900b1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339ba1a0463676982583900b1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339ba821a00177a6ea2581c648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff198a5447742544319271044774554481a0031f9194577444f47451a0056898d4577555344431a000fc589467753484942411a000103c2581c659ab0b5658687c2e74cd10dba8244015b713bf503b90557769d77a7a14a57696e675269646572731a02269552021a0002e665031a01353f84081a013531740b58204107eada931c72a600a6e3305bd22c7aeb9ada7c3f6823b155f4db85de36a69aa20081825820e686ade5bc97372f271fd2abc06cfd96c24b3d9170f9459de1d8e3dd8fd385575840653324a9dddad004f05a8ac99fa2d1811af5f00543591407fb5206cfe9ac91bb1412404323fa517e0e189684cd3592e7f74862e3f16afbc262519abec958180c0481d8799fd8799fd8799fd8799f581cb1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c68ffd8799fd8799fd8799f581c042f1946335c498d2e7556c5c647c4649c6a69d2b645cd1428a339baffffffff581cb1814238b0d287a8a46ce7348c6ad79ab8995b0e6d46010e2d9e1c681b000001863784a12ed8799fd8799f4040ffd8799f581c648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff1984577444f4745ffffffd8799fd87980190c8efffff5f6'
+          );
+          resolveTip({
+            blockNo: Cardano.BlockNo(123),
+            hash: Cardano.BlockId('0000000000000000000000000000000000000000000000000000000000000000'),
+            // Validity interval of serializedTx is 20263284 <= n <= 20266884
+            slot: Cardano.Slot(20_263_285)
+          });
+          await expect(api.submitTx(serializedTx.toString())).resolves.not.toThrow();
+          expect(providers.txSubmitProvider.submitTx).toHaveBeenCalledWith({ signedTransaction: serializedTx });
+        });
+      });
+    });
+  });
 
   describe('with default mock data', () => {
     let scope: ManagedFreeableScope;
@@ -104,7 +149,7 @@ describe('cip30', () => {
           wallet4.shutdown();
         });
 
-	test('can handle an unknown error', async () => {
+        test('can handle an unknown error', async () => {
           // YYYY is invalid hex that will throw at serialization
           await expect(api.getCollateral({ amount: 'YYYY' })).rejects.toThrowError(
             expect.objectContaining({ code: APIErrorCode.InternalError, info: 'Unknown error' })
@@ -122,19 +167,23 @@ describe('cip30', () => {
           ).not.toThrow();
           expect(utxos).toHaveLength(2);
         });
+
         test('throws when there are not enough UTxOs', async () => {
           // 1a004c4b40 Represents a CML.BigNum object of 5 ADA
           await expect(api2.getCollateral({ amount: '1a004c4b40' })).rejects.toThrow(ApiError);
         });
+
         test('returns null when there are no "unspendable" UTxOs in the wallet', async () => {
           // 1a003d0900 Represents a CML.BigNum object of 4 ADA
           expect(await api3.getCollateral({ amount: '1a003d0900' })).toBe(null);
           wallet3.shutdown();
         });
+
         test('throws when the given amount is greater than max amount', async () => {
           // 1a005b8d80 Represents a CML.BigNum object of 6 ADA
           await expect(api2.getCollateral({ amount: '1a005b8d80' })).rejects.toThrow(ApiError);
         });
+
         test('returns first UTxO when amount is 0', async () => {
           // 00 Represents a CML.BigNum object of 0 ADA
           const utxos = await api2.getCollateral({ amount: '00' });
@@ -145,6 +194,7 @@ describe('cip30', () => {
             )
           ).not.toThrow();
         });
+
         test('returns all UTxOs when there is no given amount', async () => {
           const utxos = await api.getCollateral();
           // eslint-disable-next-line sonarjs/no-identical-functions
@@ -155,9 +205,11 @@ describe('cip30', () => {
           ).not.toThrow();
           expect(utxos).toHaveLength(1);
         });
+
         test('returns null when there is no given amount and wallet has no UTxOs', async () => {
           expect(await api3.getCollateral()).toBe(null);
         });
+
         test('throws when unspendable UTxOs contain assets', async () => {
           await expect(api4.getCollateral()).rejects.toThrow(ApiError);
         });

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -274,9 +274,13 @@ describe('cip30', () => {
           cmlTx = coreToCml.tx(scope, finalizedTx).to_bytes();
         });
 
-        it('resolves when submitting a valid transaction', async () => {
-          await expect(api.submitTx(Buffer.from(cmlTx).toString('hex'))).resolves.not.toThrow();
+        it('resolves with transaction id when submitting a valid transaction', async () => {
+          const txId = await api.submitTx(Buffer.from(cmlTx).toString('hex'));
+          expect(txId).toBe(finalizedTx.id);
         });
+
+        // Need to find a transaction that body can't be consistently re-serialized by using our serialization utils
+        it.todo('resolves with original transactionId (not the one computed when re-serializing the transaction)');
 
         it('throws ApiError when submitting a transaction that has invalid encoding', async () => {
           await expect(api.submitTx(Buffer.from(cmlTx).toString('base64'))).rejects.toThrowError(ApiError);

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -32,7 +32,6 @@ describe('cip30', () => {
   let wallet: SingleAddressWallet;
   let api: WalletApi;
   let confirmationCallback: jest.Mock;
-  let scope: ManagedFreeableScope;
 
   const simpleTxProps: InitializeTxProps = {
     outputs: new Set([
@@ -46,276 +45,269 @@ describe('cip30', () => {
     ])
   };
 
-  beforeAll(async () => {
-    // CREATE A WALLET
-    scope = new ManagedFreeableScope();
-    ({ wallet, api, confirmationCallback } = await createWalletAndApiWithStores([mockedUtxo[2]]));
-  });
+  describe('with default mock data', () => {
+    let scope: ManagedFreeableScope;
 
-  afterAll(() => {
-    wallet.shutdown();
-    scope.dispose();
-  });
-
-  describe('createWalletApi', () => {
-    test('api.getNetworkId', async () => {
-      const cip30NetworkId = await api.getNetworkId();
-      expect(cip30NetworkId).toEqual(Cardano.NetworkId.Testnet);
+    beforeAll(async () => {
+      // CREATE A WALLET
+      scope = new ManagedFreeableScope();
+      ({ wallet, api, confirmationCallback } = await createWalletAndApiWithStores([mockedUtxo[2]]));
     });
 
-    test('api.getUtxos', async () => {
-      const utxos = await api.getUtxos();
-      expect(() =>
-        cmlToCore.utxo(
-          utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
-        )
-      ).not.toThrow();
+    afterAll(() => {
+      wallet.shutdown();
+      scope.dispose();
     });
 
-    test('api.getCollateral', async () => {
-      // 1a003d0900 Represents a CML.BigNum object of 4 ADA
-      const utxos = await api.getCollateral({ amount: '1a003d0900' });
-      // eslint-disable-next-line sonarjs/no-identical-functions
-      expect(() =>
-        cmlToCore.utxo(
-          utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
-        )
-      ).not.toThrow();
-    });
-
-    test('api.getBalance', async () => {
-      const balanceCborBytes = Buffer.from(await api.getBalance(), 'hex');
-      expect(() => scope.manage(CML.Value.from_bytes(balanceCborBytes))).not.toThrow();
-    });
-
-    test('api.getUsedAddresses', async () => {
-      const cipUsedAddressess = await api.getUsedAddresses();
-      const [{ address: walletAddress }] = await firstValueFrom(wallet.addresses$);
-      expect(cipUsedAddressess.map((cipAddr) => Cardano.Address(cipAddr))).toEqual([walletAddress]);
-    });
-
-    test('api.getUnusedAddresses', async () => {
-      const cipUsedAddressess = await api.getUnusedAddresses();
-      expect(cipUsedAddressess).toEqual([]);
-    });
-
-    test('api.getChangeAddress', async () => {
-      const cipChangeAddress = await api.getChangeAddress();
-      const [{ address: walletAddress }] = await firstValueFrom(wallet.addresses$);
-      expect(Cardano.Address(cipChangeAddress)).toEqual(walletAddress);
-    });
-
-    test('api.getRewardAddresses', async () => {
-      const cipRewardAddressesCbor = await api.getRewardAddresses();
-      const cipRewardAddresses = cipRewardAddressesCbor.map((cipAddr) =>
-        scope.manage(CML.Address.from_bytes(Buffer.from(cipAddr, 'hex'))).to_bech32()
-      );
-
-      const [{ rewardAccount: walletRewardAccount }] = await firstValueFrom(wallet.addresses$);
-      expect(cipRewardAddresses).toEqual([walletRewardAccount]);
-    });
-
-    test('api.signTx', async () => {
-      const txInternals = await wallet.initializeTx(simpleTxProps);
-      const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
-      const hexTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
-
-      const cip30witnessSet = await api.signTx(hexTx);
-      const signatures = Buffer.from(cip30witnessSet, 'hex');
-      expect(() => scope.manage(CML.TransactionWitnessSet.from_bytes(signatures))).not.toThrow();
-    });
-
-    test('api.signData', async () => {
-      const [{ address }] = await firstValueFrom(wallet.addresses$);
-      const cip30dataSignature = await api.signData(address, HexBlob('abc123').toString());
-      expect(typeof cip30dataSignature.key).toBe('string');
-      expect(typeof cip30dataSignature.signature).toBe('string');
-    });
-
-    test('api.submitTx', async () => {
-      const txInternals = await wallet.initializeTx(simpleTxProps);
-      const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
-      const cmlTx = coreToCml.tx(scope, finalizedTx).to_bytes();
-      await expect(api.submitTx(Buffer.from(cmlTx).toString('hex'))).resolves.not.toThrow();
-    });
-
-    test.todo('errorStates');
-  });
-
-  describe('confirmation callbacks', () => {
-    describe('signData', () => {
-      const payload = 'abc123';
-
-      test('resolves true', async () => {
-        confirmationCallback.mockResolvedValueOnce(true);
-        await expect(api.signData(wallet.addresses$.value![0].address, payload)).resolves.not.toThrow();
+    describe('createWalletApi', () => {
+      test('api.getNetworkId', async () => {
+        const cip30NetworkId = await api.getNetworkId();
+        expect(cip30NetworkId).toEqual(Cardano.NetworkId.Testnet);
       });
 
-      test('resolves false', async () => {
-        confirmationCallback.mockResolvedValueOnce(false);
-        await expect(api.signData(wallet.addresses$.value![0].address, payload)).rejects.toThrowError(DataSignError);
+      test('api.getUtxos', async () => {
+        const utxos = await api.getUtxos();
+        expect(() =>
+          cmlToCore.utxo(
+            utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
+          )
+        ).not.toThrow();
       });
 
-      test('rejects', async () => {
-        confirmationCallback.mockRejectedValue(1);
-        await expect(api.signData(wallet.addresses$.value![0].address, payload)).rejects.toThrowError(DataSignError);
+      describe('api.getCollateral', () => {
+        // Wallet 2
+        let wallet2: SingleAddressWallet;
+        let api2: WalletApi;
+
+        // Wallet 3
+        let wallet3: SingleAddressWallet;
+        let api3: WalletApi;
+
+        // Wallet 4
+        let wallet4: SingleAddressWallet;
+        let api4: WalletApi;
+
+        beforeAll(async () => {
+          // CREATE A WALLET WITH LOW COINS UTXOS
+          ({ wallet: wallet2, api: api2 } = await createWalletAndApiWithStores(utxosWithLowCoins));
+
+          // CREATE A WALLET WITH NO UTXOS
+          ({ wallet: wallet3, api: api3 } = await createWalletAndApiWithStores([]));
+
+          // CREATE A WALLET WITH UTXOS WITH ASSETS
+          ({ wallet: wallet4, api: api4 } = await createWalletAndApiWithStores([mockedUtxo[1], mockedUtxo[2]]));
+        });
+
+        afterAll(() => {
+          wallet2.shutdown();
+          wallet3.shutdown();
+          wallet4.shutdown();
+        });
+
+	test('can handle an unknown error', async () => {
+          // YYYY is invalid hex that will throw at serialization
+          await expect(api.getCollateral({ amount: 'YYYY' })).rejects.toThrowError(
+            expect.objectContaining({ code: APIErrorCode.InternalError, info: 'Unknown error' })
+          );
+        });
+
+        test('returns multiple UTxOs when more than 1 utxo needed to satisfy amount', async () => {
+          // 1a003d0900 Represents a CML.BigNum object of 4 ADA
+          const utxos = await api2.getCollateral({ amount: '1a003d0900' });
+          // eslint-disable-next-line sonarjs/no-identical-functions
+          expect(() =>
+            cmlToCore.utxo(
+              utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
+            )
+          ).not.toThrow();
+          expect(utxos).toHaveLength(2);
+        });
+        test('throws when there are not enough UTxOs', async () => {
+          // 1a004c4b40 Represents a CML.BigNum object of 5 ADA
+          await expect(api2.getCollateral({ amount: '1a004c4b40' })).rejects.toThrow(ApiError);
+        });
+        test('returns null when there are no "unspendable" UTxOs in the wallet', async () => {
+          // 1a003d0900 Represents a CML.BigNum object of 4 ADA
+          expect(await api3.getCollateral({ amount: '1a003d0900' })).toBe(null);
+          wallet3.shutdown();
+        });
+        test('throws when the given amount is greater than max amount', async () => {
+          // 1a005b8d80 Represents a CML.BigNum object of 6 ADA
+          await expect(api2.getCollateral({ amount: '1a005b8d80' })).rejects.toThrow(ApiError);
+        });
+        test('returns first UTxO when amount is 0', async () => {
+          // 00 Represents a CML.BigNum object of 0 ADA
+          const utxos = await api2.getCollateral({ amount: '00' });
+          // eslint-disable-next-line sonarjs/no-identical-functions
+          expect(() =>
+            cmlToCore.utxo(
+              utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
+            )
+          ).not.toThrow();
+        });
+        test('returns all UTxOs when there is no given amount', async () => {
+          const utxos = await api.getCollateral();
+          // eslint-disable-next-line sonarjs/no-identical-functions
+          expect(() =>
+            cmlToCore.utxo(
+              utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
+            )
+          ).not.toThrow();
+          expect(utxos).toHaveLength(1);
+        });
+        test('returns null when there is no given amount and wallet has no UTxOs', async () => {
+          expect(await api3.getCollateral()).toBe(null);
+        });
+        test('throws when unspendable UTxOs contain assets', async () => {
+          await expect(api4.getCollateral()).rejects.toThrow(ApiError);
+        });
       });
 
-      test('gets the Cardano.Address equivalent of the hex address', async () => {
-        confirmationCallback.mockClear();
-        confirmationCallback.mockResolvedValueOnce(true);
+      test('api.getBalance', async () => {
+        const balanceCborBytes = Buffer.from(await api.getBalance(), 'hex');
+        expect(() => scope.manage(CML.Value.from_bytes(balanceCborBytes))).not.toThrow();
+      });
 
-        const expectedAddr = wallet.addresses$.value![0].address;
+      test('api.getUsedAddresses', async () => {
+        const cipUsedAddressess = await api.getUsedAddresses();
+        const [{ address: walletAddress }] = await firstValueFrom(wallet.addresses$);
+        expect(cipUsedAddressess.map((cipAddr) => Cardano.Address(cipAddr))).toEqual([walletAddress]);
+      });
 
-        const hexAddr = Buffer.from(scope.manage(CML.Address.from_bech32(expectedAddr.toString())).to_bytes()).toString(
-          'hex'
+      test('api.getUnusedAddresses', async () => {
+        const cipUsedAddressess = await api.getUnusedAddresses();
+        expect(cipUsedAddressess).toEqual([]);
+      });
+
+      test('api.getChangeAddress', async () => {
+        const cipChangeAddress = await api.getChangeAddress();
+        const [{ address: walletAddress }] = await firstValueFrom(wallet.addresses$);
+        expect(Cardano.Address(cipChangeAddress)).toEqual(walletAddress);
+      });
+
+      test('api.getRewardAddresses', async () => {
+        const cipRewardAddressesCbor = await api.getRewardAddresses();
+        const cipRewardAddresses = cipRewardAddressesCbor.map((cipAddr) =>
+          scope.manage(CML.Address.from_bytes(Buffer.from(cipAddr, 'hex'))).to_bech32()
         );
 
-        await api.signData(hexAddr, payload);
-        expect(confirmationCallback).toHaveBeenCalledWith(
-          expect.objectContaining({ data: expect.objectContaining({ addr: expectedAddr }) })
-        );
+        const [{ rewardAccount: walletRewardAccount }] = await firstValueFrom(wallet.addresses$);
+        expect(cipRewardAddresses).toEqual([walletRewardAccount]);
       });
-    });
 
-    describe('signTx', () => {
-      let hexTx: string;
-      beforeAll(async () => {
+      test('api.signTx', async () => {
         const txInternals = await wallet.initializeTx(simpleTxProps);
         const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
-        hexTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
+        const hexTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
+
+        const cip30witnessSet = await api.signTx(hexTx);
+        const signatures = Buffer.from(cip30witnessSet, 'hex');
+        expect(() => scope.manage(CML.TransactionWitnessSet.from_bytes(signatures))).not.toThrow();
       });
 
-      test('resolves true', async () => {
-        confirmationCallback.mockResolvedValueOnce(true);
-        await expect(api.signTx(hexTx)).resolves.not.toThrow();
+      test('api.signData', async () => {
+        const [{ address }] = await firstValueFrom(wallet.addresses$);
+        const cip30dataSignature = await api.signData(address, HexBlob('abc123').toString());
+        expect(typeof cip30dataSignature.key).toBe('string');
+        expect(typeof cip30dataSignature.signature).toBe('string');
       });
 
-      test('resolves false', async () => {
-        confirmationCallback.mockResolvedValueOnce(false);
-        await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
+      test('api.submitTx', async () => {
+        const txInternals = await wallet.initializeTx(simpleTxProps);
+        const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
+        const cmlTx = coreToCml.tx(scope, finalizedTx).to_bytes();
+        await expect(api.submitTx(Buffer.from(cmlTx).toString('hex'))).resolves.not.toThrow();
       });
 
-      test('rejects', async () => {
-        confirmationCallback.mockRejectedValue(1);
-        await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
-      });
+      test.todo('errorStates');
     });
 
-    describe('submitTx', () => {
-      let cmlTx: string;
-      let txInternals: InitializeTxResult;
-      let finalizedTx: Cardano.Tx<Cardano.TxBody>;
+    describe('confirmation callbacks', () => {
+      describe('signData', () => {
+        const payload = 'abc123';
 
-      beforeAll(async () => {
-        txInternals = await wallet.initializeTx(simpleTxProps);
-        finalizedTx = await wallet.finalizeTx({ tx: txInternals });
+        test('resolves true', async () => {
+          confirmationCallback.mockResolvedValueOnce(true);
+          await expect(api.signData(wallet.addresses$.value![0].address, payload)).resolves.not.toThrow();
+        });
 
-        cmlTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
+        test('resolves false', async () => {
+          confirmationCallback.mockResolvedValueOnce(false);
+          await expect(api.signData(wallet.addresses$.value![0].address, payload)).rejects.toThrowError(DataSignError);
+        });
+
+        test('rejects', async () => {
+          confirmationCallback.mockRejectedValue(1);
+          await expect(api.signData(wallet.addresses$.value![0].address, payload)).rejects.toThrowError(DataSignError);
+        });
+
+        test('gets the Cardano.Address equivalent of the hex address', async () => {
+          confirmationCallback.mockClear();
+          confirmationCallback.mockResolvedValueOnce(true);
+
+          const expectedAddr = wallet.addresses$.value![0].address;
+
+          const hexAddr = Buffer.from(
+            scope.manage(CML.Address.from_bech32(expectedAddr.toString())).to_bytes()
+          ).toString('hex');
+
+          await api.signData(hexAddr, payload);
+          expect(confirmationCallback).toHaveBeenCalledWith(
+            expect.objectContaining({ data: expect.objectContaining({ addr: expectedAddr }) })
+          );
+        });
       });
 
-      test('resolves true', async () => {
-        confirmationCallback.mockResolvedValueOnce(true);
-        await expect(api.submitTx(cmlTx)).resolves.toBe(finalizedTx.id);
+      describe('signTx', () => {
+        let hexTx: string;
+        beforeAll(async () => {
+          const txInternals = await wallet.initializeTx(simpleTxProps);
+          const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
+          hexTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
+        });
+
+        test('resolves true', async () => {
+          confirmationCallback.mockResolvedValueOnce(true);
+          await expect(api.signTx(hexTx)).resolves.not.toThrow();
+        });
+
+        test('resolves false', async () => {
+          confirmationCallback.mockResolvedValueOnce(false);
+          await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
+        });
+
+        test('rejects', async () => {
+          confirmationCallback.mockRejectedValue(1);
+          await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
+        });
       });
 
-      test('resolves false', async () => {
-        confirmationCallback.mockResolvedValueOnce(false);
-        await expect(api.submitTx(cmlTx)).rejects.toThrowError(TxSendError);
-      });
+      describe('submitTx', () => {
+        let cmlTx: string;
+        let txInternals: InitializeTxResult;
+        let finalizedTx: Cardano.Tx<Cardano.TxBody>;
 
-      test('rejects', async () => {
-        confirmationCallback.mockRejectedValue(1);
-        await expect(api.submitTx(cmlTx)).rejects.toThrowError(TxSendError);
-      });
-    });
+        beforeAll(async () => {
+          txInternals = await wallet.initializeTx(simpleTxProps);
+          finalizedTx = await wallet.finalizeTx({ tx: txInternals });
 
-    describe('getCollateral', () => {
-      // Wallet 2
-      let wallet2: SingleAddressWallet;
-      let api2: WalletApi;
+          cmlTx = Buffer.from(coreToCml.tx(scope, finalizedTx).to_bytes()).toString('hex');
+        });
 
-      // Wallet 3
-      let wallet3: SingleAddressWallet;
-      let api3: WalletApi;
+        test('resolves true', async () => {
+          confirmationCallback.mockResolvedValueOnce(true);
+          await expect(api.submitTx(cmlTx)).resolves.toBe(finalizedTx.id);
+        });
 
-      // Wallet 4
-      let wallet4: SingleAddressWallet;
-      let api4: WalletApi;
+        test('resolves false', async () => {
+          confirmationCallback.mockResolvedValueOnce(false);
+          await expect(api.submitTx(cmlTx)).rejects.toThrowError(TxSendError);
+        });
 
-      beforeAll(async () => {
-        // CREATE A WALLET WITH LOW COINS UTXOS
-        ({ wallet: wallet2, api: api2 } = await createWalletAndApiWithStores(utxosWithLowCoins));
-
-        // CREATE A WALLET WITH NO UTXOS
-        ({ wallet: wallet3, api: api3 } = await createWalletAndApiWithStores([]));
-
-        // CREATE A WALLET WITH UTXOS WITH ASSETS
-        ({ wallet: wallet4, api: api4 } = await createWalletAndApiWithStores([mockedUtxo[1], mockedUtxo[2]]));
-      });
-
-      afterAll(() => {
-        wallet2.shutdown();
-        wallet3.shutdown();
-        wallet4.shutdown();
-      });
-
-      test('can handle an unknown error', async () => {
-        // YYYY is invalid hex that will throw at serialization
-        await expect(api.getCollateral({ amount: 'YYYY' })).rejects.toThrowError(
-          expect.objectContaining({ code: APIErrorCode.InternalError, info: 'Unknown error' })
-        );
-      });
-
-      test('returns multiple UTxOs when more than 1 utxo needed to satisfy amount', async () => {
-        // 1a003d0900 Represents a CML.BigNum object of 4 ADA
-        const utxos = await api2.getCollateral({ amount: '1a003d0900' });
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        expect(() =>
-          cmlToCore.utxo(
-            utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
-          )
-        ).not.toThrow();
-        expect(utxos).toHaveLength(2);
-      });
-      test('throws when there are not enough UTxOs', async () => {
-        // 1a004c4b40 Represents a CML.BigNum object of 5 ADA
-        await expect(api2.getCollateral({ amount: '1a004c4b40' })).rejects.toThrow(ApiError);
-      });
-      test('returns null when there are no "unspendable" UTxOs in the wallet', async () => {
-        // 1a003d0900 Represents a CML.BigNum object of 4 ADA
-        expect(await api3.getCollateral({ amount: '1a003d0900' })).toBe(null);
-        wallet3.shutdown();
-      });
-      test('throws when the given amount is greater than max amount', async () => {
-        // 1a005b8d80 Represents a CML.BigNum object of 6 ADA
-        await expect(api2.getCollateral({ amount: '1a005b8d80' })).rejects.toThrow(ApiError);
-      });
-      test('returns first UTxO when amount is 0', async () => {
-        // 00 Represents a CML.BigNum object of 0 ADA
-        const utxos = await api2.getCollateral({ amount: '00' });
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        expect(() =>
-          cmlToCore.utxo(
-            utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
-          )
-        ).not.toThrow();
-      });
-      test('returns all UTxOs when there is no given amount', async () => {
-        const utxos = await api.getCollateral();
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        expect(() =>
-          cmlToCore.utxo(
-            utxos!.map((utxo) => scope.manage(CML.TransactionUnspentOutput.from_bytes(Buffer.from(utxo, 'hex'))))
-          )
-        ).not.toThrow();
-        expect(utxos).toHaveLength(1);
-      });
-      test('returns null when there is no given amount and wallet has no UTxOs', async () => {
-        expect(await api3.getCollateral()).toBe(null);
-      });
-      test('throws when unspendable UTxOs contain assets', async () => {
-        await expect(api4.getCollateral()).rejects.toThrow(ApiError);
+        test('rejects', async () => {
+          confirmationCallback.mockRejectedValue(1);
+          await expect(api.submitTx(cmlTx)).rejects.toThrowError(TxSendError);
+        });
       });
     });
   });

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -98,14 +98,14 @@ describe('integration/withdrawal', () => {
 
     expect(tx.body.withdrawals).toEqual([{ quantity: availableRewards, stakeAddress: rewardAccount }]);
 
-    const confirmedSubscription = wallet.transactions.outgoing.confirmed$.subscribe(({ tx: confirmedTx }) => {
-      if (confirmedTx === tx) {
+    const confirmedSubscription = wallet.transactions.outgoing.confirmed$.subscribe(({ id }) => {
+      if (id === tx.id) {
         // Transaction successful
       }
     });
 
-    const failedSubscription = wallet.transactions.outgoing.failed$.subscribe(({ tx: failedTx, reason }) => {
-      if (failedTx === tx) {
+    const failedSubscription = wallet.transactions.outgoing.failed$.subscribe(({ id, reason }) => {
+      if (id === tx.id) {
         // Transaction failed because of reason, which is most likely:
         expect(reason === TransactionFailure.Timeout || reason === TransactionFailure.FailedToSubmit).toBe(true);
       }

--- a/packages/wallet/test/mocks/mockChainHistoryProvider.ts
+++ b/packages/wallet/test/mocks/mockChainHistoryProvider.ts
@@ -110,8 +110,9 @@ export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
       blockHeader: {
         blockNo: Cardano.BlockNo(10_100),
         slot: Cardano.Slot(ledgerTip.slot.valueOf() - 100_000)
-      },
+      } as Cardano.PartialBlockHeader,
       body: {
+        fee: 123n,
         inputs: [
           {
             address: Cardano.Address(
@@ -133,8 +134,13 @@ export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
           invalidHereafter: Cardano.Slot(ledgerTip.slot.valueOf() + 1)
         }
       },
-      id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
-    } as Cardano.HydratedTx
+      id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
+      index: 1,
+      txSize: 200_000,
+      witness: {
+        signatures: new Map()
+      }
+    }
   ],
   totalResultCount: 2
 };

--- a/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
@@ -23,6 +23,7 @@ import { RetryBackoffConfig } from 'backoff-rxjs';
 import { TxWithEpoch } from '../../../src/services/DelegationTracker/types';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 import { currentEpoch, generateStakePools, mockStakePoolsProvider } from '../../mocks';
+import { dummyCbor } from '../../util';
 
 jest.mock('../../../src/services/util/coldObservableProvider', () => {
   const actual = jest.requireActual('../../../src/services/util/coldObservableProvider');
@@ -34,6 +35,8 @@ const coldObservableProviderMock: jest.Mock =
   jest.requireMock('../../../src/services/util/coldObservableProvider').coldObservableProvider;
 
 describe('RewardAccounts', () => {
+  const txId1 = Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000');
+  const txId2 = Cardano.TransactionId('295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7');
   const poolId1 = Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh');
   const poolId2 = Cardano.PoolId('pool1y6chk7x7fup4ms9leesdr57r4qy9cwxuee0msan72x976a6u0nc');
   const twoRewardAccounts = [
@@ -153,17 +156,25 @@ describe('RewardAccounts', () => {
           } as TxWithEpoch
         ]
       });
-      const transactionsInFlight$ = cold('abaca', {
+      const transactionsInFlight$ = cold<TxInFlight[]>('abaca', {
         a: [],
         b: [
-          { tx: {
-            body: { certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash }] }
-          } as Cardano.Tx }
+          {
+            body: {
+              certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash }]
+            } as Cardano.TxBody,
+            cbor: dummyCbor,
+            id: txId1
+          }
         ],
         c: [
-          { tx: {
-            body: { certificates: [{ __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash }] }
-          } as Cardano.Tx }
+          {
+            body: {
+              certificates: [{ __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash }]
+            } as Cardano.TxBody,
+            cbor: dummyCbor,
+            id: txId2
+          }
         ]
       });
       const tracker$ = addressKeyStatuses([rewardAccount], transactions$, transactionsInFlight$);
@@ -188,11 +199,17 @@ describe('RewardAccounts', () => {
         const acc1PendingWithdrawalQty = 1_000_000n;
         // 'aaa' in the end is to ensure that it's awaiting for rewards update
         // even if more (unrelated) transactions get confirmed
-        const transactionsInFlight$ = hot('a-b--a--b-aaa', {
+        const transactionsInFlight$ = hot<TxInFlight[]>('a-b--a--b-aaa', {
           a: [],
-          b: [{ tx: { body: { withdrawals: [{
-            quantity: acc1PendingWithdrawalQty, stakeAddress: twoRewardAccounts[0] } as Cardano.Withdrawal
-          ] } as Cardano.TxBody } as Cardano.Tx }]
+          b: [{
+            body: {
+              withdrawals: [{
+                quantity: acc1PendingWithdrawalQty, stakeAddress: twoRewardAccounts[0]
+              } as Cardano.Withdrawal]
+            } as Cardano.TxBody,
+            cbor: dummyCbor,
+            id: txId1
+          }]
         });
         const rewardsProvider = () => hot('-a--b-a--b---a', {
           a: [acc1Balance1, acc2Balance],
@@ -224,11 +241,17 @@ describe('RewardAccounts', () => {
         const accBalance2 = 9_000_000n;
 
         const acc1PendingWithdrawalQty = 1_000_000n;
-        const transactionsInFlightEmits = {
-          x: [] as TxInFlight[],
-          y: [{ tx: { body: { withdrawals: [{
-            quantity: acc1PendingWithdrawalQty, stakeAddress: twoRewardAccounts[0] } as Cardano.Withdrawal
-          ] } as Cardano.TxBody } } as TxInFlight]
+        const transactionsInFlightEmits: Record<string, TxInFlight[]> = {
+          x: [],
+          y: [{
+            body: {
+              withdrawals: [{
+                quantity: acc1PendingWithdrawalQty, stakeAddress: twoRewardAccounts[0]
+              } as Cardano.Withdrawal]
+            } as Cardano.TxBody,
+            cbor: dummyCbor,
+            id: txId1
+          }]
         };
         const rewardsProviderEmits = {
           a: [accBalance1],
@@ -264,15 +287,27 @@ describe('RewardAccounts', () => {
     it('emits every epoch and after making a transaction with withdrawals', () => {
       const rewardAccount = Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27');
       createTestScheduler().run(({ cold, expectObservable }) => {
-        const tx2 = { body: { withdrawals: [{ quantity: 5n, stakeAddress: rewardAccount }] } } as Cardano.HydratedTx;
-        const epoch$ = cold(      'a-b--', { a: Cardano.EpochNo(100), b: Cardano.EpochNo(101) });
-        const txConfirmed$ = cold('-a--b', {
-          a: { confirmedAt: Cardano.Slot(1), tx: { body: {
+        const confirmedTx1: ConfirmedTx = {
+          body: {
             withdrawals: [{
               quantity: 3n,
               stakeAddress: Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d')
-            }] } } as Cardano.HydratedTx },
-          b: { confirmedAt: Cardano.Slot(2), tx: tx2 }
+            }]
+          } as Cardano.TxBody,
+          cbor: dummyCbor,
+          confirmedAt: Cardano.Slot(1),
+          id: txId1
+        };
+        const confirmedTx2: ConfirmedTx = {
+          body: { withdrawals: [{ quantity: 5n, stakeAddress: rewardAccount }] } as Cardano.TxBody,
+          cbor: dummyCbor,
+          confirmedAt: Cardano.Slot(2),
+          id: txId2
+        };
+        const epoch$ = cold(      'a-b--', { a: Cardano.EpochNo(100), b: Cardano.EpochNo(101) });
+        const txConfirmed$ = cold('-a--b', {
+          a: confirmedTx1,
+          b: confirmedTx2
         });
         const target$ = fetchRewardsTrigger$(epoch$, txConfirmed$, rewardAccount);
         expectObservable(target$).toBe('a-b-c', {

--- a/packages/wallet/test/util.ts
+++ b/packages/wallet/test/util.ts
@@ -1,7 +1,8 @@
 /* eslint-disable func-style */
 /* eslint-disable jsdoc/require-jsdoc */
 
-import { MaybeValidTx, MaybeValidTxOut, ObservableWallet, ValidTx, ValidTxOut } from '../src';
+import { Cardano, TxCBOR } from '@cardano-sdk/core';
+import { MaybeValidTx, MaybeValidTxOut, ObservableWallet, OutgoingTx, ValidTx, ValidTxOut } from '../src';
 import { Observable, catchError, filter, firstValueFrom, throwError, timeout } from 'rxjs';
 
 const SECOND = 1000;
@@ -36,3 +37,11 @@ export function assertTxIsValid(tx: MaybeValidTx): asserts tx is ValidTx {
 export function assertTxOutIsValid(txOut: MaybeValidTxOut): asserts txOut is ValidTxOut {
   expect(txOut.isValid).toBe(true);
 }
+
+export const toOutgoingTx = (tx: Cardano.Tx): OutgoingTx => ({
+  body: tx.body,
+  cbor: TxCBOR.serialize(tx),
+  id: tx.id
+});
+
+export const dummyCbor = TxCBOR('123');


### PR DESCRIPTION
# Context

The CIP-30 `submitTx` mapping is deserializing the input, to conform with the `ObservableWallet` interface, which results in a round trip that can invalidate the tx, since it can produce a different CBOR representation because there is no reliable way to encode certain structs; It's implementation-specific. For example, an indefinite length array after deserialization/serialization roundtrip can be a definite length array with the same elements. Also, `TransactionOutput` can be serialized in two ways.

We need to rework the wallet to handling hex-encoded blobs, rather than just modelling everything on expecting the SDK `Tx` object to be the source, then pass the raw value submitted via the CIP-30 mapping instead.

# Proposed Solution

## Accept `TxCBOR` in `ObservableWallet.submitTx`
- This method now can handle `Cardano.Tx` and `TxCBOR`
- If the latter is submitted, only use the converted object for supplementary purposes, with the input sent to the provider without round-tripping through a serialization step.
## CIP30 wallet mapping
- Change the Cip30 wallet mapping to use the `TxCBOR` in the wallet submission invocation, using the deserialized object for supplementary purposes.

# Important Changes Introduced
- `ObservableWallet.submitTx` now returns the transaction ID

