### PR TITLE
Fix/get collateral cip30 return value

### DIFF
--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -128,6 +128,10 @@ export const createWalletApi = (
     logger.debug('getting collateral');
     const wallet = await firstValueFrom(wallet$);
     let unspendables = (await firstValueFrom(wallet.utxo.unspendable$)).sort(compareUtxos);
+
+    // No available unspendable UTXO
+    if (unspendables.length === 0) return null;
+
     if (unspendables.some((utxo) => utxo[1].value.assets && utxo[1].value.assets.size > 0)) {
       scope.dispose();
       throw new ApiError(APIErrorCode.Refused, 'unspendable UTxOs must not contain assets when used as collateral');

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -268,9 +268,9 @@ describe('cip30', () => {
         // 1a004c4b40 Represents a CML.BigNum object of 5 ADA
         await expect(api2.getCollateral({ amount: '1a004c4b40' })).rejects.toThrow(ApiError);
       });
-      test('throws an error when there are no UTxOs in the wallet', async () => {
+      test('returns null when there are no "unspendable" UTxOs in the wallet', async () => {
         // 1a003d0900 Represents a CML.BigNum object of 4 ADA
-        await expect(api3.getCollateral({ amount: '1a003d0900' })).rejects.toThrow(ApiError);
+        expect(await api3.getCollateral({ amount: '1a003d0900' })).toBe(null);
         wallet3.shutdown();
       });
       test('throws when the given amount is greater than max amount', async () => {
@@ -297,8 +297,8 @@ describe('cip30', () => {
         ).not.toThrow();
         expect(utxos).toHaveLength(1);
       });
-      test('throws when there is no given amount and wallet has no UTxOs', async () => {
-        await expect(api3.getCollateral()).rejects.toThrow(ApiError);
+      test('returns null when there is no given amount and wallet has no UTxOs', async () => {
+        expect(await api3.getCollateral()).toBe(null);
       });
       test('throws when unspendable UTxOs contain assets', async () => {
         await expect(api4.getCollateral()).rejects.toThrow(ApiError);

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, sonarjs/no-duplicate-string */
-import { ApiError, DataSignError, TxSendError, TxSignError, WalletApi } from '@cardano-sdk/dapp-connector';
+import {
+  APIErrorCode,
+  ApiError,
+  DataSignError,
+  TxSendError,
+  TxSignError,
+  WalletApi
+} from '@cardano-sdk/dapp-connector';
 import { CML, Cardano, cmlToCore, coreToCml } from '@cardano-sdk/core';
 import { HexBlob, ManagedFreeableScope } from '@cardano-sdk/util';
 import { InMemoryUnspendableUtxoStore, createInMemoryWalletStores } from '../../src/persistence';
@@ -251,6 +258,13 @@ describe('cip30', () => {
         wallet2.shutdown();
         wallet3.shutdown();
         wallet4.shutdown();
+      });
+
+      test('can handle an unknown error', async () => {
+        // YYYY is invalid hex that will throw at serialization
+        await expect(api.getCollateral({ amount: 'YYYY' })).rejects.toThrowError(
+          expect.objectContaining({ code: APIErrorCode.InternalError, info: 'Unknown error' })
+        );
       });
 
       test('returns multiple UTxOs when more than 1 utxo needed to satisfy amount', async () => {


### PR DESCRIPTION
# Context

[getCollateral](https://github.com/input-output-hk/cardano-js-sdk/blob/99a57171e9bead364e8751474213a58522d9e271/packages/wallet/src/cip30.ts#L123) currently[ throws when there are no UTxOs](https://github.com/input-output-hk/cardano-js-sdk/blob/99a57171e9bead364e8751474213a58522d9e271/packages/wallet/test/integration/cip30mapping.test.ts#L267-L275), which, based on the return type of Promise<    Cbor[] | null should be returning null.

# Proposed Solution

getCollateral should then return null, not throw an error in this case.

There should no longer be ApiError(APIErrorCode.InternalError, ‘Nope'); errors in the module. The message could be error?.message || 'Unknown error' or better

# Important Changes Introduced
