### PR TITLE
Feat/adp 2677 handle collateral consumption and rollback

### DIFF
--- a/packages/e2e/test/wallet/SingleAddressWallet/unspendableUtxos.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/unspendableUtxos.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { SingleAddressWallet, buildTx, utxoEquals } from '@cardano-sdk/wallet';
+import { assertTxIsValid } from '../../../../wallet/test/util';
+import { createLogger } from '@cardano-sdk/util-dev';
+import { filter, firstValueFrom, map, take } from 'rxjs';
+import { getEnv, getWallet, walletVariables } from '../../../src';
+import { isNotNil } from '@cardano-sdk/util';
+import { walletReady } from '../../util';
+
+const env = getEnv(walletVariables);
+const logger = createLogger();
+
+describe('SingleAddressWallet/unspendableUtxos', () => {
+  let wallet1: SingleAddressWallet;
+  let wallet2: SingleAddressWallet;
+
+  afterAll(() => {
+    wallet1.shutdown();
+    wallet2.shutdown();
+  });
+
+  // eslint-disable-next-line max-statements
+  it('unsets unspendable UTxOs when no longer in the wallets UTxO set', async () => {
+    // Here we will simulate the scenario of collateral consumption by spending it from another wallet instance.
+    wallet1 = (await getWallet({ env, idx: 0, logger, name: 'Wallet 1', polling: { interval: 50 } })).wallet;
+    wallet2 = (await getWallet({ env, idx: 0, logger, name: 'Wallet 2', polling: { interval: 50 } })).wallet;
+
+    await walletReady(wallet1);
+    await walletReady(wallet2);
+
+    const txBuilder1 = buildTx({ logger, observableWallet: wallet1 });
+    const txBuilder2 = buildTx({ logger, observableWallet: wallet2 });
+
+    const address = (await firstValueFrom(wallet1.addresses$))[0].address;
+
+    // Create a new UTxO to be use as collateral.
+    const txOutput = txBuilder1.buildOutput().address(address).coin(5_000_000n).toTxOut();
+
+    const unsignedTx = await txBuilder1.addOutput(txOutput).build();
+
+    assertTxIsValid(unsignedTx);
+
+    const signedTx = await unsignedTx.sign();
+    await signedTx.submit();
+
+    // Search chain history to see if the transaction is there.
+    let txFoundInHistory = await firstValueFrom(
+      wallet1.transactions.history$.pipe(
+        map((txs) => txs.find((tx) => tx.id === signedTx.tx.id)),
+        filter(isNotNil),
+        take(1)
+      )
+    );
+
+    expect(txFoundInHistory.id).toEqual(signedTx.tx.id);
+
+    // Find the UTxO in the UTxO set.
+    const utxo = await firstValueFrom(
+      wallet1.utxo.available$.pipe(
+        map((utxos) => utxos.find((o) => o[0].txId === signedTx.tx.id && o[1].value.coins === 5_000_000n)),
+        filter(isNotNil),
+        take(1)
+      )
+    );
+
+    expect(utxo).toBeDefined();
+
+    // Set UTxO as unspendable.
+    await wallet1.utxo.setUnspendable([utxo]);
+
+    // Get unspendable UTxO from wallet 1
+    let unspendableUtxo = await firstValueFrom(wallet1.utxo.unspendable$);
+    let totalUtxos = await firstValueFrom(wallet1.utxo.total$);
+    let availableUtxo = await firstValueFrom(wallet1.utxo.available$);
+
+    let totalUtxoHasUnspendable = totalUtxos.find((totalUtxoEntry) => utxoEquals([totalUtxoEntry], unspendableUtxo));
+    let avalableUtxoHasUnspendable = availableUtxo.find((availableUtxoEntry) =>
+      utxoEquals([availableUtxoEntry], unspendableUtxo)
+    );
+
+    expect(unspendableUtxo).toEqual([utxo]);
+    expect(totalUtxoHasUnspendable).toBeTruthy();
+    expect(avalableUtxoHasUnspendable).toBeFalsy();
+
+    // Spend the UTxO from the second wallet which uses a different store. We will transfer the whole balance
+    // to force the input selection to select our UTxO
+    const totalBalance = await firstValueFrom(wallet1.balance.utxo.total$);
+    // We must leave some ADA behind to cover for transaction fees and min ADA of change output, however; this amount
+    // must be less than the collateral UTxO to guarantee that the UTxO is moved.
+    totalBalance.coins -= 4_500_000n;
+
+    const unsignedMoveAdaTx = await txBuilder2
+      .addOutput(txBuilder2.buildOutput().address(address).value(totalBalance).toTxOut())
+      .build();
+
+    assertTxIsValid(unsignedMoveAdaTx);
+
+    const signedMoveAdaTx = await unsignedMoveAdaTx.sign();
+    await signedMoveAdaTx.submit();
+
+    // Search chain history to see if the transaction is there.
+    txFoundInHistory = await firstValueFrom(
+      wallet1.transactions.history$.pipe(
+        map((txs) => txs.find((tx) => tx.id === signedMoveAdaTx.tx.id)),
+        filter(isNotNil),
+        take(1)
+      )
+    );
+
+    expect(txFoundInHistory.id).toEqual(signedMoveAdaTx.tx.id);
+
+    // Try to get the unspendable UTxO from wallet1 again
+    unspendableUtxo = await firstValueFrom(wallet1.utxo.unspendable$);
+    totalUtxos = await firstValueFrom(wallet1.utxo.total$);
+    availableUtxo = await firstValueFrom(wallet1.utxo.available$);
+
+    totalUtxoHasUnspendable = totalUtxos.find((totalUtxoEntry) => utxoEquals([totalUtxoEntry], unspendableUtxo));
+    avalableUtxoHasUnspendable = availableUtxo.find((availableUtxoEntry) =>
+      utxoEquals([availableUtxoEntry], unspendableUtxo)
+    );
+
+    expect(unspendableUtxo).toEqual([]);
+    expect(totalUtxoHasUnspendable).toBeFalsy();
+    expect(avalableUtxoHasUnspendable).toBeFalsy();
+  });
+});

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -51,8 +51,8 @@ import {
   TrackedTxSubmitProvider,
   TrackedWalletNetworkInfoProvider,
   TransactionFailure,
-  TransactionalTracker,
   TransactionsTracker,
+  UtxoTracker,
   WalletUtil,
   coldObservableProvider,
   createAssetsTracker,
@@ -173,7 +173,7 @@ export class SingleAddressWallet implements ObservableWallet {
   readonly stakePoolProvider: TrackedStakePoolProvider;
   readonly assetProvider: TrackedAssetProvider;
   readonly chainHistoryProvider: TrackedChainHistoryProvider;
-  readonly utxo: TransactionalTracker<Cardano.Utxo[]>;
+  readonly utxo: UtxoTracker;
   readonly balance: BalanceTracker;
   readonly transactions: TransactionsTracker & Shutdown;
   readonly delegation: DelegationTracker & Shutdown;
@@ -398,6 +398,7 @@ export class SingleAddressWallet implements ObservableWallet {
       transactionsInFlight$: this.transactions.outgoing.inFlight$,
       utxoProvider: this.utxoProvider
     });
+
     const eraSummaries$ = distinctEraSummaries(this.eraSummaries$);
     this.delegation = createDelegationTracker({
       epoch$,

--- a/packages/wallet/src/services/UtxoTracker.ts
+++ b/packages/wallet/src/services/UtxoTracker.ts
@@ -109,7 +109,9 @@ export const createUtxoTracker = (
 
   return {
     available$,
-    setUnspendable: unspendableUtxoSource$.next.bind(unspendableUtxoSource$),
+    setUnspendable: async (utxo) => {
+      unspendableUtxoSource$.next(utxo);
+    },
     shutdown: () => {
       utxoSource$.complete();
       unspendableUtxoSource$.complete();

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -31,7 +31,7 @@ export interface TransactionalTracker<T> extends TransactionalObservables<T> {
 }
 
 export interface UtxoTracker extends TransactionalTracker<Cardano.Utxo[]> {
-  setUnspendable(utxo: Cardano.Utxo[]): void;
+  setUnspendable(utxo: Cardano.Utxo[]): Promise<void>;
 }
 
 export type Milliseconds = number;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,6 +1,6 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { Asset, Cardano, EpochInfo, EraSummary, NetworkInfoProvider, TxCBOR } from '@cardano-sdk/core';
-import { BalanceTracker, DelegationTracker, TransactionalObservables, TransactionsTracker } from './services';
+import { BalanceTracker, DelegationTracker, TransactionsTracker, UtxoTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { GroupedAddress, SignTransactionOptions, TransactionSigner, cip8 } from '@cardano-sdk/key-management';
 import { Observable } from 'rxjs';
@@ -74,7 +74,7 @@ export interface SyncStatus extends Shutdown {
 export interface ObservableWallet {
   readonly balance: BalanceTracker;
   readonly delegation: DelegationTracker;
-  readonly utxo: TransactionalObservables<Cardano.Utxo[]>;
+  readonly utxo: UtxoTracker;
   readonly transactions: TransactionsTracker;
   readonly tip$: Observable<Cardano.Tip>;
   readonly genesisParameters$: Observable<Cardano.CompactGenesis>;

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -96,7 +96,7 @@ describe('cip30', () => {
     beforeAll(async () => {
       // CREATE A WALLET
       scope = new ManagedFreeableScope();
-      ({ wallet, api, confirmationCallback } = await createWalletAndApiWithStores([mockedUtxo[2]]));
+      ({ wallet, api, confirmationCallback } = await createWalletAndApiWithStores([mockedUtxo[4]]));
     });
 
     afterAll(() => {

--- a/packages/wallet/test/mocks/mockData.ts
+++ b/packages/wallet/test/mocks/mockData.ts
@@ -81,7 +81,7 @@ export const utxosWithLowCoins: Cardano.Utxo[] = [
       address: Cardano.Address(
         'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
       ),
-      index: 0,
+      index: 1,
       txId: Cardano.TransactionId('c7c0973c6bbf1a04a9f306da7814b4fa564db649bf48b0bd93c273bd03143547')
     },
     {
@@ -98,7 +98,7 @@ export const utxosWithLowCoins: Cardano.Utxo[] = [
       address: Cardano.Address(
         'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
       ),
-      index: 0,
+      index: 2,
       txId: Cardano.TransactionId('c7c0973c6bbf1a04a9f306da7814b4fa564db649bf48b0bd93c273bd03143547')
     },
     {

--- a/packages/wallet/test/mocks/mockUtxoProvider.ts
+++ b/packages/wallet/test/mocks/mockUtxoProvider.ts
@@ -45,6 +45,57 @@ export const utxo: Cardano.Utxo[] = [
   [
     {
       address: Cardano.Address(
+        'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+      ),
+      index: 1,
+      txId: Cardano.TransactionId('c7c0973c6bbf1a04a9f306da7814b4fa564db649bf48b0bd93c273bd03143547')
+    },
+    {
+      address: Cardano.Address(
+        'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+      ),
+      value: {
+        coins: 3_289_566n
+      }
+    }
+  ],
+  [
+    {
+      address: Cardano.Address(
+        'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+      ),
+      index: 2,
+      txId: Cardano.TransactionId('c7c0973c6bbf1a04a9f306da7814b4fa564db649bf48b0bd93c273bd03143547')
+    },
+    {
+      address: Cardano.Address(
+        'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+      ),
+      value: {
+        coins: 1_000_000n
+      }
+    }
+  ],
+  [
+    {
+      address: Cardano.Address(
+        'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+      ),
+      index: 3,
+      txId: Cardano.TransactionId('c7c0973c6bbf1a04a9f306da7814b4fa564db649bf48b0bd93c273bd03143547')
+    },
+    {
+      address: Cardano.Address(
+        'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+      ),
+      value: {
+        coins: 5_289_566n
+      }
+    }
+  ],
+  [
+    {
+      address: Cardano.Address(
         'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
       ),
       index: 2,

--- a/packages/wallet/test/services/UtxoTracker.test.ts
+++ b/packages/wallet/test/services/UtxoTracker.test.ts
@@ -150,10 +150,10 @@ describe('createUtxoTracker', () => {
     });
   });
 
-  it('sets unspendable utxos and locks them', () => {
+  it('sets unspendable utxos and locks them', async () => {
     const store = new InMemoryUtxoStore();
     const address = utxo[0][0].address;
-    createTestScheduler().run(({ cold, expectObservable }) => {
+    await createTestScheduler().run(async ({ cold, expectObservable }) => {
       const transactionsInFlight$ = cold('-a--|', { a: [] });
       const utxoTracker = createUtxoTracker(
         {
@@ -172,7 +172,7 @@ describe('createUtxoTracker', () => {
           utxoSource$: cold('a---|', { a: utxo }) as unknown as PersistentCollectionTrackerSubject<Cardano.Utxo>
         }
       );
-      utxoTracker.setUnspendable(utxo.slice(1));
+      await utxoTracker.setUnspendable(utxo.slice(1));
 
       expectObservable(utxoTracker.total$).toBe('-a--|', { a: utxo });
       expectObservable(utxoTracker.unspendable$).toBe('a', { a: utxo.slice(1) });

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -50,6 +50,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
   },
   utxo: {
     available$: RemoteApiPropertyType.HotObservable,
+    setUnspendable: RemoteApiPropertyType.MethodReturningPromise,
     total$: RemoteApiPropertyType.HotObservable,
     unspendable$: RemoteApiPropertyType.HotObservable
   }


### PR DESCRIPTION
# Context

We have no logic for detecting collateral consumption, which will result in transactions being constructed with a UTxO that’s no longer owned by the wallet if a prior transaction produces a phase 2 validation failure.

Chain rollbacks are not being considered either, so a newly created output or consumption could be rolled back without unspendable$ being updated.

 setUnspendable is also not part of the ObservableWallet interface, only the SingleAddressWallet implementation. It needs to be defined in the interface for applications to access via the web extension messaging transport.

# Proposed Solution

1. Unset the unspendables array within the UTxOs tracker by filtering the emitted values by existence in total$ utxo
2. Make setUnspendable asynchronous.
3. Change the type of the utxo property in the ObservableWallet from TransactionalObservables<Cardano.Utxo[]> to UtxoTracker so setUnspendable is available in the 
ObservableWallet interface.
