### PR TITLE
feat: update rewards history limit default

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -10,7 +10,14 @@ import {
 import { CommonPoolInfo, OrderedResult, PoolAPY, PoolData, PoolMetrics, PoolSortType, PoolUpdate } from './types';
 import { DbSyncProvider, DbSyncProviderDependencies, Disposer, EpochMonitor } from '../../util';
 import { GenesisData, InMemoryCache, StakePoolExtMetadataService, UNLIMITED_CACHE_TTL } from '../..';
-import { IDS_NAMESPACE, StakePoolsSubQuery, emptyPoolsExtraInfo, getStakePoolSortType, queryCacheKey } from './util';
+import {
+  IDS_NAMESPACE,
+  REWARDS_HISTORY_LIMIT_DEFAULT,
+  StakePoolsSubQuery,
+  emptyPoolsExtraInfo,
+  getStakePoolSortType,
+  queryCacheKey
+} from './util';
 import { RunnableModule, isNotNil } from '@cardano-sdk/util';
 import { StakePoolBuilder } from './StakePoolBuilder';
 import { toStakePoolResults } from './mappers';
@@ -166,7 +173,7 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
   }
 
   public async queryStakePools(options: QueryStakePoolsArgs): Promise<Paginated<Cardano.StakePool>> {
-    const { filters, pagination, rewardsHistoryLimit } = options;
+    const { filters, pagination, rewardsHistoryLimit = REWARDS_HISTORY_LIMIT_DEFAULT } = options;
 
     if (pagination.limit > this.#paginationPageSizeLimit) {
       throw new ProviderError(

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/util.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/util.ts
@@ -8,6 +8,8 @@ import {
 } from '@cardano-sdk/core';
 import BigNumber from 'bignumber.js';
 
+export const REWARDS_HISTORY_LIMIT_DEFAULT = 3;
+
 export const getStakePoolSortType = (field: string): PoolSortType => {
   if (isPoolDataSortField(field)) return 'data';
   if (isPoolMetricsSortField(field)) return 'metrics';

--- a/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
+++ b/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
@@ -43,7 +43,7 @@ export interface QueryStakePoolsArgs {
     status?: Cardano.StakePoolStatus[];
   };
   /**
-   * Will fetch all stake pool reward history if not specified
+   * Will fetch stake pool reward history up to 3 epochs back if not specified
    */
   rewardsHistoryLimit?: number;
   /**


### PR DESCRIPTION
# Context
Following our dev huddle with the team, we decided to change the default behavior of Stake pool data fetching with defaulting rewardsHistoryLimit to 3 if not provided as an argument. That would be one of the optimizations related to the bad performance of the stake pool’s load test against `mainnet` .

# Important Changes Introduced
- default rewards history limit to 3 if not specified
