### PR TITLE
Feat/hydrated tx input source

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -142,10 +142,14 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
       const txInputs = orderBy(inputs.filter((input) => input.txInputId === txId).map(mapTxIn), ['index']);
       const txCollaterals = orderBy(collaterals.filter((col) => col.txInputId === txId).map(mapTxIn), ['index']);
       const txOutputs = orderBy(outputs.filter((output) => output.txId === txId).map(mapTxOut), ['index']);
+      const inputSource: Cardano.InputSource = tx.valid_contract
+        ? Cardano.InputSource.inputs
+        : Cardano.InputSource.collaterals;
 
       return mapTxAlonzo(tx, {
         certificates: certificates.get(txId),
         collaterals: txCollaterals,
+        inputSource,
         inputs: txInputs,
         metadata: metadata.get(txId),
         mint: mints.get(txId),

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -156,6 +156,7 @@ export const mapCertificate = (
 };
 
 interface TxAlonzoData {
+  inputSource: Cardano.InputSource;
   inputs: Cardano.HydratedTxIn[];
   outputs: Cardano.TxOut[];
   mint?: Cardano.TokenMap;
@@ -168,7 +169,7 @@ interface TxAlonzoData {
 
 export const mapTxAlonzo = (
   txModel: TxModel,
-  { inputs, outputs, mint, withdrawals, redeemers, metadata, collaterals, certificates }: TxAlonzoData
+  { inputSource, inputs, outputs, mint, withdrawals, redeemers, metadata, collaterals, certificates }: TxAlonzoData
 ): Cardano.HydratedTx => ({
   auxiliaryData:
     metadata && metadata.size > 0
@@ -198,6 +199,7 @@ export const mapTxAlonzo = (
   },
   id: txModel.id.toString('hex') as unknown as Cardano.TransactionId,
   index: txModel.index,
+  inputSource,
   txSize: txModel.size,
   witness: {
     // TODO: fetch bootstrap witnesses, datums and scripts

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -136,6 +136,7 @@ export const findTransactionsByHashes = `
 		tx.fee AS fee,
 		tx.invalid_before AS invalid_before,
 		tx.invalid_hereafter AS invalid_hereafter,
+		tx.valid_contract AS valid_contract,
 		block.block_no AS block_no,
 		block.hash AS block_hash,
 		block.slot_no AS block_slot_no

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -37,6 +37,7 @@ export interface TxModel {
   index: number;
   size: number;
   fee: string;
+  valid_contract: boolean;
   invalid_before: string | null;
   invalid_hereafter: string | null;
   block_no: number;

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -109,7 +109,8 @@ const txModel: TxModel = {
   index: 1,
   invalid_before: '300',
   invalid_hereafter: '500',
-  size: 20
+  size: 20,
+  valid_contract: true
 };
 
 describe('chain history mappers', () => {
@@ -315,6 +316,8 @@ describe('chain history mappers', () => {
     ];
     const withdrawals: Cardano.Withdrawal[] = [{ quantity: 200n, stakeAddress: Cardano.RewardAccount(stakeAddress) }];
     const metadata: Cardano.TxMetadata = new Map([[1n, 'data']]);
+    const inputSource = Cardano.InputSource.inputs;
+
     const certificates: Cardano.Certificate[] = [
       {
         __typename: Cardano.CertificateType.StakeKeyRegistration,
@@ -332,17 +335,18 @@ describe('chain history mappers', () => {
       },
       id: Cardano.TransactionId(transactionHash),
       index: 1,
+      inputSource: Cardano.InputSource.inputs,
       txSize: 20,
       witness: { signatures: new Map() }
     };
     test('map TxModel to Cardano.HydratedTx with minimal data', () => {
-      const result = mappers.mapTxAlonzo(txModel, { inputs, outputs });
+      const result = mappers.mapTxAlonzo(txModel, { inputSource, inputs, outputs });
       expect(result).toEqual<Cardano.HydratedTx>(expected);
     });
     test('map TxModel with null fields to Cardano.HydratedTx', () => {
       const result = mappers.mapTxAlonzo(
         { ...txModel, invalid_before: null, invalid_hereafter: null },
-        { inputs, outputs }
+        { inputSource, inputs, outputs }
       );
       expect(result).toEqual<Cardano.HydratedTx>({ ...expected, body: { ...expected.body, validityInterval: {} } });
     });
@@ -350,6 +354,7 @@ describe('chain history mappers', () => {
       const result = mappers.mapTxAlonzo(txModel, {
         certificates,
         collaterals: inputs,
+        inputSource,
         inputs,
         metadata,
         mint: assets,

--- a/packages/cardano-services/test/data-mocks/tx.ts
+++ b/packages/cardano-services/test/data-mocks/tx.ts
@@ -62,7 +62,8 @@ export const base = {
 };
 
 export const withCoinOnly: Cardano.HydratedTx = merge(base, {
-  body: { outputs: [txOutWithCoinOnly] }
+  body: { outputs: [txOutWithCoinOnly] },
+  inputSource: Cardano.InputSource.inputs
 });
 
 export const withAssets: Cardano.HydratedTx = merge(base, {
@@ -70,6 +71,7 @@ export const withAssets: Cardano.HydratedTx = merge(base, {
     ...base.body,
     outputs: [txOutWithAssets]
   },
+  inputSource: Cardano.InputSource.inputs,
   witness: {
     signatures: new Map()
   }
@@ -80,7 +82,8 @@ export const withMint: Cardano.HydratedTx = merge(withAssets, {
     mint: new Map([
       [Cardano.AssetId('57fca08abbaddee36da742a839f7d83a7e1d2419f1507fcbf3916522534245525259'), 10_000_000n]
     ])
-  }
+  },
+  inputSource: Cardano.InputSource.inputs
 });
 
 export const mint: Cardano.TokenMap = new Map([
@@ -92,7 +95,8 @@ export const withAuxiliaryData: Cardano.HydratedTx = merge(withAssets, {
     body: {
       blob: new Map([[1, 'abc']])
     }
-  }
+  },
+  inputSource: Cardano.InputSource.inputs
 });
 
 export const delegationCertificate: Cardano.StakeDelegationCertificate = {
@@ -115,7 +119,8 @@ export const withValidityInterval: Cardano.HydratedTx = merge(withAssets, {
       invalidBefore: 1,
       invalidHereafter: 2
     }
-  }
+  },
+  inputSource: Cardano.InputSource.inputs
 });
 
 export const withdrawals = [
@@ -128,7 +133,8 @@ export const withdrawals = [
 export const withWithdrawals: Cardano.HydratedTx = merge(withAssets, {
   body: {
     withdrawals
-  }
+  },
+  inputSource: Cardano.InputSource.inputs
 });
 
 export const witnessRedeemers = {

--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -490,6 +490,7 @@ export const newTx = (cslTx: CML.Transaction): Cardano.Tx =>
       auxiliaryData: txAuxiliaryData(auxiliary_data),
       body: txBody(scope.manage(cslTx.body())),
       id: transactionHash,
+      isValid: cslTx.is_valid(),
       witness: txWitnessSet(witnessSet)
     };
   });

--- a/packages/core/src/CML/coreToCml/coreToCml.ts
+++ b/packages/core/src/CML/coreToCml/coreToCml.ts
@@ -574,10 +574,14 @@ export const witnessSet = (scope: ManagedFreeableScope, witness: Cardano.Witness
   return txWitnessSet;
 };
 
-export const tx = (scope: ManagedFreeableScope, { body, witness, auxiliaryData }: Cardano.Tx): Transaction => {
+export const tx = (scope: ManagedFreeableScope, { body, witness, auxiliaryData, isValid }: Cardano.Tx): Transaction => {
   const txWitnessSet = witnessSet(scope, witness);
   // Possible optimization: only convert auxiliary data once
-  return scope.manage(
+  const cmlTx = scope.manage(
     Transaction.new(txBody(scope, body, auxiliaryData), txWitnessSet, txAuxiliaryData(scope, auxiliaryData))
   );
+
+  if (typeof isValid !== 'undefined') cmlTx.set_is_valid(isValid);
+
+  return cmlTx;
 };

--- a/packages/core/src/Cardano/types/Block.ts
+++ b/packages/core/src/Cardano/types/Block.ts
@@ -2,8 +2,8 @@ import * as Crypto from '@cardano-sdk/crypto';
 import { CML } from '../../CML/CML';
 import { InvalidStringError, OpaqueNumber, OpaqueString, typedBech32 } from '@cardano-sdk/util';
 import { Lovelace } from './Value';
+import { OnChainTx } from './Transaction';
 import { PoolId } from './StakePool/primitives';
-import { Tx } from './Transaction';
 
 /**
  * The block size in bytes
@@ -111,7 +111,7 @@ export interface BlockInfo {
 }
 
 export interface Block extends BlockInfo {
-  body: Tx[];
+  body: OnChainTx[];
 }
 
 export interface ExtendedBlockInfo

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -80,6 +80,11 @@ export interface TxBody extends Omit<HydratedTxBody, 'inputs' | 'collaterals' | 
   referenceInputs?: TxIn[];
 }
 
+export enum InputSource {
+  inputs = 'inputs',
+  collaterals = 'collaterals'
+}
+
 export enum RedeemerPurpose {
   spend = 'spend',
   mint = 'mint',
@@ -123,7 +128,11 @@ export interface Tx<TBody extends TxBody = TxBody> {
   auxiliaryData?: AuxiliaryData;
 }
 
-export interface HydratedTx extends Tx<HydratedTxBody> {
+export interface OnChainTx<TBody extends TxBody = TxBody> extends Omit<Tx<TBody>, 'isValid'> {
+  inputSource: InputSource;
+}
+
+export interface HydratedTx extends OnChainTx<HydratedTxBody> {
   index: number;
   blockHeader: PartialBlockHeader;
   body: HydratedTxBody;

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -126,6 +126,13 @@ export interface Tx<TBody extends TxBody = TxBody> {
   body: TBody;
   witness: Witness;
   auxiliaryData?: AuxiliaryData;
+  /**
+   * Transactions containing Plutus scripts that are expected to fail validation can still be submitted if
+   * this value is set to false.
+   *
+   * Remark: Sending transactions with invalid scripts will cause the collateral of the transaction to be lost.
+   */
+  isValid?: boolean;
 }
 
 export interface OnChainTx<TBody extends TxBody = TxBody> extends Omit<Tx<TBody>, 'isValid'> {

--- a/packages/core/src/Cardano/util/index.ts
+++ b/packages/core/src/Cardano/util/index.ts
@@ -3,3 +3,4 @@ export * from './computeImplicitCoin';
 export * from './estimateStakePoolAPY';
 export * from './txSubmissionErrors';
 export * from './resolveInputValue';
+export * from './phase2Validation';

--- a/packages/core/src/Cardano/util/phase2Validation.ts
+++ b/packages/core/src/Cardano/util/phase2Validation.ts
@@ -1,0 +1,5 @@
+import { Cardano } from '../..';
+import { OnChainTx } from '../types';
+
+export const isPhase2ValidationErrTx = ({ inputSource }: Pick<OnChainTx, 'inputSource'>): boolean =>
+  inputSource === Cardano.InputSource.collaterals;

--- a/packages/core/test/CML/testData.ts
+++ b/packages/core/test/CML/testData.ts
@@ -207,6 +207,7 @@ export const tx: Cardano.Tx = {
   },
   body: txBody,
   id: Cardano.TransactionId('8d2feeab1087e0aa4ad06e878c5269eaa2edcef5264bcc97542a28c189b2cbc5'),
+  isValid: true,
   witness: {
     // bootstrap values from ogmios.wsp.json
     bootstrap: [

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -19,7 +19,7 @@ import {
   timeout
 } from 'rxjs';
 import { InMemoryKeyAgent } from '@cardano-sdk/key-management';
-import { ObservableWallet, SignedTx, SingleAddressWallet, buildTx } from '@cardano-sdk/wallet';
+import { InitializeTxProps, ObservableWallet, SignedTx, SingleAddressWallet, buildTx } from '@cardano-sdk/wallet';
 import { TestWallet, faucetProviderFactory, getEnv, networkInfoProviderFactory, walletVariables } from '../src';
 import { assertTxIsValid } from '../../wallet/test/util';
 import { logger } from '@cardano-sdk/util-dev';
@@ -222,7 +222,7 @@ export const getTxConfirmationEpoch = async (wallet: SingleAddressWallet, tx: Ca
  */
 export const submitCertificate = async (certificate: Cardano.Certificate, wallet: TestWallet) => {
   const walletAddress = (await firstValueFrom(wallet.wallet.addresses$))[0].address;
-  const txProps = {
+  const txProps: InitializeTxProps = {
     certificates: [certificate],
     outputs: new Set([{ address: walletAddress, value: { coins: 3_000_000n } }])
   };

--- a/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
@@ -4,16 +4,66 @@ import {
   FinalizeTxProps,
   InitializeTxProps,
   SingleAddressWallet,
+  TransactionFailure,
+  buildTx
 } from '@cardano-sdk/wallet';
-import { isNotNil } from '@cardano-sdk/util';
+import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
+import { HexBlob, isNotNil } from '@cardano-sdk/util';
 import { KeyRole, util } from '@cardano-sdk/key-management';
+import { assertTxIsValid } from '../../../../wallet/test/util';
 import { createLogger } from '@cardano-sdk/util-dev';
-import { createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
+import { createStandaloneKeyAgent, firstValueFromTimed, submitAndConfirm, walletReady } from '../../util';
 import { filter, firstValueFrom, map, take } from 'rxjs';
 import { getEnv, getWallet, walletVariables } from '../../../src';
 
 const env = getEnv(walletVariables);
 const logger = createLogger();
+
+/**
+ * Creates an output suitable legacy collateral.
+ *
+ * @param wallet The wallet which will set the collateral.
+ */
+const createCollateral = async (
+  wallet: SingleAddressWallet
+): Promise<{ collateralInput: Cardano.TxIn; collateralCoinValue: bigint }> => {
+  const txBuilder = buildTx({ logger, observableWallet: wallet });
+
+  const address = (await firstValueFrom(wallet.addresses$))[0].address;
+
+  // Create a new UTxO to be use as collateral.
+  const txOutput = txBuilder.buildOutput().address(address).coin(5_000_000n).toTxOut();
+
+  const unsignedTx = await txBuilder.addOutput(txOutput).build();
+
+  assertTxIsValid(unsignedTx);
+
+  const signedTx = await unsignedTx.sign();
+  await signedTx.submit();
+
+  // Wait for transaction to be on chain.
+  await firstValueFrom(
+    wallet.transactions.history$.pipe(
+      map((txs) => txs.find((tx) => tx.id === signedTx.tx.id)),
+      filter(isNotNil),
+      take(1)
+    )
+  );
+
+  // Find the collateral UTxO in the UTxO set.
+  const utxo = await firstValueFrom(
+    wallet.utxo.available$.pipe(
+      map((utxos) => utxos.find((o) => o[0].txId === signedTx.tx.id && o[1].value.coins === 5_000_000n)),
+      filter(isNotNil),
+      take(1)
+    )
+  );
+
+  // Set UTxO as unspendable.
+  await wallet.utxo.setUnspendable([utxo]);
+
+  return { collateralCoinValue: utxo[1].value.coins, collateralInput: utxo[0] };
+};
 
 describe('SingleAddressWallet/mint', () => {
   let wallet: SingleAddressWallet;
@@ -109,5 +159,97 @@ describe('SingleAddressWallet/mint', () => {
     expect(value!.assets!.has(assetId)).toBeTruthy();
     expect(value!.assets!.get(assetId)).toBe(1n);
     expect(txFoundInHistory.inputSource).toBe(Cardano.InputSource.inputs);
+  });
+
+  it('can detect a phase2 validation failure and emit the transaction as failed', async () => {
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+
+    // Plutus script that always returns false.
+    const alwaysFailScript: Cardano.PlutusScript = {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob(
+        // eslint-disable-next-line max-len
+        '5907620100003232323232323232323232323232332232323232322232325335320193333573466e1cd55cea80124000466442466002006004646464646464646464646464646666ae68cdc39aab9d500c480008cccccccccccc88888888888848cccccccccccc00403403002c02802402001c01801401000c008cd4050054d5d0a80619a80a00a9aba1500b33501401635742a014666aa030eb9405cd5d0a804999aa80c3ae501735742a01066a02803e6ae85401cccd54060081d69aba150063232323333573466e1cd55cea801240004664424660020060046464646666ae68cdc39aab9d5002480008cc8848cc00400c008cd40a9d69aba15002302b357426ae8940088c98c80b4cd5ce01701681589aab9e5001137540026ae854008c8c8c8cccd5cd19b8735573aa004900011991091980080180119a8153ad35742a00460566ae84d5d1280111931901699ab9c02e02d02b135573ca00226ea8004d5d09aba2500223263202933573805405204e26aae7940044dd50009aba1500533501475c6ae854010ccd540600708004d5d0a801999aa80c3ae200135742a004603c6ae84d5d1280111931901299ab9c026025023135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d55cf280089baa00135742a004601c6ae84d5d1280111931900b99ab9c018017015101613263201633573892010350543500016135573ca00226ea800448c88c008dd6000990009aa80a911999aab9f0012500a233500930043574200460066ae880080508c8c8cccd5cd19b8735573aa004900011991091980080180118061aba150023005357426ae8940088c98c8050cd5ce00a80a00909aab9e5001137540024646464646666ae68cdc39aab9d5004480008cccc888848cccc00401401000c008c8c8c8cccd5cd19b8735573aa0049000119910919800801801180a9aba1500233500f014357426ae8940088c98c8064cd5ce00d00c80b89aab9e5001137540026ae854010ccd54021d728039aba150033232323333573466e1d4005200423212223002004357426aae79400c8cccd5cd19b875002480088c84888c004010dd71aba135573ca00846666ae68cdc3a801a400042444006464c6403666ae7007006c06406005c4d55cea80089baa00135742a00466a016eb8d5d09aba2500223263201533573802c02a02626ae8940044d5d1280089aab9e500113754002266aa002eb9d6889119118011bab00132001355012223233335573e0044a010466a00e66442466002006004600c6aae754008c014d55cf280118021aba200301213574200222440042442446600200800624464646666ae68cdc3a800a40004642446004006600a6ae84d55cf280191999ab9a3370ea0049001109100091931900819ab9c01101000e00d135573aa00226ea80048c8c8cccd5cd19b875001480188c848888c010014c01cd5d09aab9e500323333573466e1d400920042321222230020053009357426aae7940108cccd5cd19b875003480088c848888c004014c01cd5d09aab9e500523333573466e1d40112000232122223003005375c6ae84d55cf280311931900819ab9c01101000e00d00c00b135573aa00226ea80048c8c8cccd5cd19b8735573aa004900011991091980080180118029aba15002375a6ae84d5d1280111931900619ab9c00d00c00a135573ca00226ea80048c8cccd5cd19b8735573aa002900011bae357426aae7940088c98c8028cd5ce00580500409baa001232323232323333573466e1d4005200c21222222200323333573466e1d4009200a21222222200423333573466e1d400d2008233221222222233001009008375c6ae854014dd69aba135744a00a46666ae68cdc3a8022400c4664424444444660040120106eb8d5d0a8039bae357426ae89401c8cccd5cd19b875005480108cc8848888888cc018024020c030d5d0a8049bae357426ae8940248cccd5cd19b875006480088c848888888c01c020c034d5d09aab9e500b23333573466e1d401d2000232122222223005008300e357426aae7940308c98c804ccd5ce00a00980880800780700680600589aab9d5004135573ca00626aae7940084d55cf280089baa0012323232323333573466e1d400520022333222122333001005004003375a6ae854010dd69aba15003375a6ae84d5d1280191999ab9a3370ea0049000119091180100198041aba135573ca00c464c6401866ae700340300280244d55cea80189aba25001135573ca00226ea80048c8c8cccd5cd19b875001480088c8488c00400cdd71aba135573ca00646666ae68cdc3a8012400046424460040066eb8d5d09aab9e500423263200933573801401200e00c26aae7540044dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6401466ae7002c02802001c0184d55cea80089baa0012323333573466e1d40052002212200223333573466e1d40092000200823263200633573800e00c00800626aae74dd5000a4c2400292010350543100122001112323001001223300330020020011'
+      ),
+      version: Cardano.PlutusLanguageVersion.V2
+    };
+
+    // Script minting policy id.
+    const policyId = Cardano.PolicyId('38299ce86f8cbef9ebeecc2e94370cb49196d60c93797fffb71d3932');
+    const scriptRedeemer: Cardano.Redeemer = {
+      // CBOR for Void redeemer.
+      data: HexBlob('d8799fff'),
+      executionUnits: {
+        memory: 13_421_562,
+        steps: 9_818_438_928
+      },
+      // Hardcoded to 0 since we only have one script
+      index: 0,
+      purpose: Cardano.RedeemerPurpose.mint
+    };
+
+    // Script data hash was precomputed with the CML (hash of datums, redeemers and language views).
+    const scriptDataHash = Hash32ByteBase16('b6eb57092c330973b23784ac39426921eebd8376343409c03f613fa1a2017126');
+
+    await walletReady(wallet);
+
+    const { collateralInput, collateralCoinValue } = await createCollateral(wallet);
+    const assetId = Cardano.AssetId(`${policyId}707572706C65`);
+    const tokens = new Map([[assetId, 1n]]);
+
+    const walletAddress = (await firstValueFrom(wallet.addresses$))[0].address;
+
+    const txProps: InitializeTxProps = {
+      collaterals: new Set([collateralInput]),
+      mint: tokens,
+      options: {
+        validityInterval: {
+          invalidBefore: undefined,
+          // eslint-disable-next-line max-len
+          invalidHereafter: undefined // HACK: setting any valid interval cause an error in the node: Uncomputable slot arithmetic; transaction's validity bounds go beyond the foreseeable end of the current era
+        }
+      },
+      outputs: new Set([
+        {
+          address: walletAddress,
+          value: {
+            assets: tokens,
+            coins: 3_000_000n
+          }
+        }
+      ]),
+      scriptIntegrityHash: scriptDataHash,
+      scripts: [alwaysFailScript],
+      witness: { redeemers: [scriptRedeemer] }
+    };
+
+    const unsignedTx = await wallet.initializeTx(txProps);
+    const finalizeProps: FinalizeTxProps = {
+      isValid: false,
+      scripts: [alwaysFailScript],
+      tx: unsignedTx,
+      witness: { redeemers: [scriptRedeemer] }
+    };
+
+    const signedTx = await wallet.finalizeTx(finalizeProps);
+
+    const [, failedTx, txFoundInHistory] = await Promise.all([
+      wallet.submitTx(signedTx),
+      firstValueFromTimed(wallet.transactions.outgoing.failed$),
+      firstValueFromTimed(
+        wallet.transactions.history$.pipe(
+          map((txs) => txs.find((tx) => tx.id === signedTx.id)),
+          filter(isNotNil),
+          take(1)
+        )
+      )
+    ]);
+
+    // Transaction should be part of the history
+    expect(txFoundInHistory).toBeTruthy();
+    // But it should also be failed since it failed the phase2 validation
+    expect(failedTx.id).toEqual(signedTx.id);
+    expect(failedTx.reason).toBe(TransactionFailure.Phase2Validation);
+    expect(txFoundInHistory.body.fee).toEqual(collateralCoinValue);
   });
 });

--- a/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Cardano, nativeScriptPolicyId } from '@cardano-sdk/core';
+import { FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
 import { KeyRole, util } from '@cardano-sdk/key-management';
-import { SingleAddressWallet } from '@cardano-sdk/wallet';
 import { createLogger } from '@cardano-sdk/util-dev';
 import { createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { filter, firstValueFrom } from 'rxjs';
@@ -73,8 +73,7 @@ describe('SingleAddressWallet/multisignature', () => {
 
     const walletAddress = (await firstValueFrom(wallet.addresses$))[0].address;
 
-    const txProps = {
-      extraSigners: [alicePolicySigner, bobPolicySigner],
+    const txProps: InitializeTxProps = {
       mint: tokens,
       outputs: new Set([
         {
@@ -85,15 +84,16 @@ describe('SingleAddressWallet/multisignature', () => {
           }
         }
       ]),
-      scripts: [policyScript]
+      scripts: [policyScript],
+      witness: { extraSigners: [alicePolicySigner, bobPolicySigner] }
     };
 
     const unsignedTx = await wallet.initializeTx(txProps);
 
-    const finalizeProps = {
-      extraSigners: [alicePolicySigner, bobPolicySigner],
+    const finalizeProps: FinalizeTxProps = {
       scripts: [policyScript],
-      tx: unsignedTx
+      tx: unsignedTx,
+      witness: { extraSigners: [alicePolicySigner, bobPolicySigner] }
     };
 
     const signedTx = await wallet.finalizeTx(finalizeProps);

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Cardano, metadatum, nativeScriptPolicyId } from '@cardano-sdk/core';
+import { FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
 import { KeyRole, TransactionSigner, util } from '@cardano-sdk/key-management';
-import { SingleAddressWallet } from '@cardano-sdk/wallet';
 import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
 import { createLogger } from '@cardano-sdk/util-dev';
 import { createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
@@ -124,9 +124,8 @@ describe('SingleAddressWallet.assets/nft', () => {
       }
     };
 
-    const txProps = {
+    const txProps: InitializeTxProps = {
       auxiliaryData,
-      extraSigners: [policySigner],
       mint: tokens,
       outputs: new Set([
         {
@@ -137,16 +136,17 @@ describe('SingleAddressWallet.assets/nft', () => {
           }
         }
       ]),
-      scripts: [policyScript]
+      scripts: [policyScript],
+      witness: { extraSigners: [policySigner] }
     };
 
     const unsignedTx = await wallet.initializeTx(txProps);
 
-    const finalizeProps = {
+    const finalizeProps: FinalizeTxProps = {
       auxiliaryData,
-      extraSigners: [policySigner],
       scripts: [policyScript],
-      tx: unsignedTx
+      tx: unsignedTx,
+      witness: { extraSigners: [policySigner] }
     };
 
     const signedTx = await wallet.finalizeTx(finalizeProps);
@@ -246,8 +246,7 @@ describe('SingleAddressWallet.assets/nft', () => {
     const availableBalance = await firstValueFrom(wallet.balance.utxo.available$);
     const assetBalance = availableBalance.assets!.get(assetIds[TOKEN_BURN_INDEX])!;
     expect(assetBalance).toBeGreaterThan(0n);
-    const txProps = {
-      extraSigners: [policySigner],
+    const txProps: InitializeTxProps = {
       mint: new Map([[assetIds[TOKEN_BURN_INDEX], -assetBalance]]),
       outputs: new Set([
         {
@@ -257,15 +256,16 @@ describe('SingleAddressWallet.assets/nft', () => {
           }
         }
       ]),
-      scripts: [policyScript]
+      scripts: [policyScript],
+      witness: { extraSigners: [policySigner] }
     };
 
     const unsignedTx = await wallet.initializeTx(txProps);
 
-    const finalizeProps = {
-      extraSigners: [policySigner],
+    const finalizeProps: FinalizeTxProps = {
       scripts: [policyScript],
-      tx: unsignedTx
+      tx: unsignedTx,
+      witness: { extraSigners: [policySigner] }
     };
 
     const signedTx = await wallet.finalizeTx(finalizeProps);
@@ -315,9 +315,8 @@ describe('SingleAddressWallet.assets/nft', () => {
 
         const auxiliaryData = { body: { blob: new Map([[721n, txDataMetadatum]]) } };
 
-        const txProps = {
+        const txProps: InitializeTxProps = {
           auxiliaryData,
-          extraSigners: [policySigner],
           mint: tokens,
           outputs: new Set([
             {
@@ -328,16 +327,17 @@ describe('SingleAddressWallet.assets/nft', () => {
               }
             }
           ]),
-          scripts: [policyScript]
+          scripts: [policyScript],
+          witness: { extraSigners: [policySigner] }
         };
 
         const unsignedTx = await wallet.initializeTx(txProps);
 
-        const finalizeProps = {
+        const finalizeProps: FinalizeTxProps = {
           auxiliaryData,
-          extraSigners: [policySigner],
           scripts: [policyScript],
-          tx: unsignedTx
+          tx: unsignedTx,
+          witness: { extraSigners: [policySigner] }
         };
 
         const signedTx = await wallet.finalizeTx(finalizeProps);

--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -69,10 +69,11 @@ export const ownSignatureKeyPaths = async (
   knownAddresses: GroupedAddress[],
   inputResolver: Cardano.InputResolver
 ): Promise<AccountKeyDerivationPath[]> => {
+  const txInputs = [...txBody.inputs, ...(txBody.collaterals ? txBody.collaterals : [])];
   const paymentKeyPaths = uniq(
     (
       await Promise.all(
-        txBody.inputs.map(async (input) => {
+        txInputs.map(async (input) => {
           const ownAddress = await inputResolver.resolveInputAddress(input);
           if (!ownAddress) return null;
           return knownAddresses.find(({ address }) => address === ownAddress);

--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -292,7 +292,7 @@ const mapValidityInterval = ({
   invalidHereafter: invalidHereafter ? Cardano.Slot(invalidHereafter) : undefined
 });
 
-const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.Tx => ({
+const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.OnChainTx => ({
   auxiliaryData: mapAuxiliaryData(tx.metadata),
   body: {
     certificates: tx.body.certificates.map(mapCertificate),
@@ -314,6 +314,9 @@ const mapCommonTx = (tx: CommonBlock['body'][0], kind: BlockKind): Cardano.Tx =>
     }))
   },
   id: Cardano.TransactionId(tx.id),
+  inputSource: isAlonzoOrAbove(kind)
+    ? Cardano.InputSource[(tx as Schema.TxAlonzo).inputSource]
+    : Cardano.InputSource.inputs,
   witness: {
     bootstrap: tx.witness.bootstrap.map(mapBootstrapWitness),
     datums: isAlonzoOrAbove(kind)
@@ -340,13 +343,14 @@ export const mapByronTxFee = ({ raw }: Schema.TxByron) => {
   return BigInt(BYRON_TX_FEE_COEFFICIENT * txSize + BYRON_TX_FEE_CONSTANT);
 };
 
-const mapByronTx = (tx: Schema.TxByron): Cardano.Tx => ({
+const mapByronTx = (tx: Schema.TxByron): Cardano.OnChainTx => ({
   body: {
     fee: mapByronTxFee(tx),
     inputs: tx.body.inputs.map(mapTxIn),
     outputs: tx.body.outputs.map(mapTxOut)
   },
   id: Cardano.TransactionId(tx.id),
+  inputSource: Cardano.InputSource.inputs,
   witness: {
     signatures: new Map()
   }

--- a/packages/ogmios/test/CardanoNode/__snapshots__/ObservableOgmiosCardanoNode.test.ts.snap
+++ b/packages/ogmios/test/CardanoNode/__snapshots__/ObservableOgmiosCardanoNode.test.ts.snap
@@ -68,6 +68,7 @@ Array [
             "withdrawals": Array [],
           },
           "id": "a278b540fb192eb8276a0d49004968076c9f9f026fa8727c3f9981a4aac25cc9",
+          "inputSource": "inputs",
           "witness": Object {
             "bootstrap": Array [],
             "datums": Array [

--- a/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
+++ b/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
@@ -91,6 +91,7 @@ Object {
         "withdrawals": Array [],
       },
       "id": "8ba812bad0c356ec842365720acb4a4ea18f03d40b03ad1cc785426170d542f5",
+      "inputSource": "inputs",
       "witness": Object {
         "bootstrap": Array [
           Object {
@@ -286,6 +287,7 @@ Object {
         "withdrawals": Array [],
       },
       "id": "bb81604e09c4530ad02de6b80a0c13d82949fb307402dd0c2b447e211bdc621d",
+      "inputSource": "inputs",
       "witness": Object {
         "bootstrap": Array [],
         "datums": Array [],
@@ -432,6 +434,7 @@ Object {
         ],
       },
       "id": "c32a4a4f5a4b540d4f79730ca0c658d9a8400be2173e0ba1dc8471004c1cb0db",
+      "inputSource": "collaterals",
       "witness": Object {
         "bootstrap": Array [
           Object {
@@ -561,6 +564,7 @@ Object {
         ],
       },
       "id": "f138917a172058f68c93de999592c5fb7cafc9265add9723eb2e8b9c12654654",
+      "inputSource": "inputs",
       "witness": Object {
         "bootstrap": Array [
           Object {
@@ -707,6 +711,7 @@ Object {
         ],
       },
       "id": "77c4a3c21573c57f0599499bc780de457c35c1d95bfb7e2370d3328b49327117",
+      "inputSource": "inputs",
       "witness": Object {
         "bootstrap": Array [],
         "datums": undefined,

--- a/packages/ogmios/test/ogmiosToCore/testData.ts
+++ b/packages/ogmios/test/ogmiosToCore/testData.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+import { Cardano } from '@cardano-sdk/core';
 import { Ogmios } from '../../src';
 
 // Mock data extracted using ogmios chain-sync api from the preprod network
@@ -132,7 +133,7 @@ export const mockAlonzoBlock: Ogmios.Schema.Alonzo = {
           withdrawals: {}
         },
         id: 'bb81604e09c4530ad02de6b80a0c13d82949fb307402dd0c2b447e211bdc621d',
-        inputSource: 'inputs',
+        inputSource: Cardano.InputSource.inputs,
         metadata: {
           body: {
             blob: {
@@ -623,7 +624,7 @@ export const mockBabbageBlock: Ogmios.Schema.Babbage = {
           withdrawals: { stake1uxnyv36t3a2rzfs4q6mvyu7nqlr4dxjwkmykkskafg54yzssmuy4z: 724n }
         },
         id: 'c32a4a4f5a4b540d4f79730ca0c658d9a8400be2173e0ba1dc8471004c1cb0db',
-        inputSource: 'collaterals',
+        inputSource: Cardano.InputSource.collaterals,
         metadata: {
           body: { blob: { '2': { string: '\u0013' } }, scripts: [{ native: { startsAt: 63_725 } }] },
           hash: 'bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa'

--- a/packages/projection/src/operators/certificates/withCertificates.ts
+++ b/packages/projection/src/operators/certificates/withCertificates.ts
@@ -26,16 +26,18 @@ const blockCertificates = ({
     body
   }
 }: WithBlock) =>
-  body.flatMap(({ body: { certificates = [] } }, txIndex) =>
-    certificates.map((certificate, certIndex) => ({
-      certificate,
-      pointer: {
-        certIndex,
-        slot,
-        txIndex
-      }
-    }))
-  );
+  body
+    .filter((tx) => !Cardano.util.isPhase2ValidationErrTx(tx))
+    .flatMap(({ body: { certificates = [] } }, txIndex) =>
+      certificates.map((certificate, certIndex) => ({
+        certificate,
+        pointer: {
+          certIndex,
+          slot,
+          txIndex
+        }
+      }))
+    );
 
 /**
  * Map ChainSyncEvents to a flat array of certificates.

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -484,6 +484,7 @@ export class SingleAddressWallet implements ObservableWallet {
       auxiliaryData: props.auxiliaryData,
       body: props.tx.body,
       id: props.tx.hash,
+      isValid: props.isValid,
       witness: {
         ...props.witness,
         scripts: props.scripts,

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -515,7 +515,9 @@ export class SingleAddressWallet implements ObservableWallet {
         // - checking if ValueNotConservedError produced === 0 (all utxos invalid)
         // - check if UnknownOrIncompleteWithdrawalsError available withdrawal amount === wallet's reward acc balance
         (error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError ||
-          error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.UnknownOrIncompleteWithdrawalsError)
+          error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.UnknownOrIncompleteWithdrawalsError ||
+          error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.CollectErrorsError ||
+          error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.BadInputsError)
       ) {
         this.#logger.debug(`Transaction ${outgoingTx.id} appears to be already submitted...`);
         this.#newTransactions.pending$.next(outgoingTx);

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -520,7 +520,9 @@ export class SingleAddressWallet implements ObservableWallet {
           error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.CollectErrorsError ||
           error.innerError instanceof CardanoNodeErrors.TxSubmissionErrors.BadInputsError)
       ) {
-        this.#logger.debug(`Transaction ${outgoingTx.id} appears to be already submitted...`);
+        this.#logger.debug(
+          `Transaction ${outgoingTx.id} failed with ${error.innerError}, but it appears to be already submitted...`
+        );
         this.#newTransactions.pending$.next(outgoingTx);
         return outgoingTx.id;
       }

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -476,16 +476,19 @@ export class SingleAddressWallet implements ObservableWallet {
           props.tx.body,
           addresses,
           this.util,
-          props.extraSigners,
+          props.witness?.extraSigners,
           props.signingOptions
         )
-      : await this.#getSignatures(props.tx, props.extraSigners, props.signingOptions);
+      : await this.#getSignatures(props.tx, props.witness?.extraSigners, props.signingOptions);
     return {
       auxiliaryData: props.auxiliaryData,
       body: props.tx.body,
       id: props.tx.hash,
-      // TODO: add support for the rest of the witness properties
-      witness: { scripts: props.scripts, signatures }
+      witness: {
+        ...props.witness,
+        scripts: props.scripts,
+        signatures
+      }
     };
   }
 

--- a/packages/wallet/src/SingleAddressWallet/prepareTx.ts
+++ b/packages/wallet/src/SingleAddressWallet/prepareTx.ts
@@ -62,10 +62,10 @@ export const createTxPreparer =
               return await firstValueFrom(
                 signer.stubFinalizeTx({
                   auxiliaryData: props.auxiliaryData,
-                  extraSigners: props.extraSigners,
                   scripts: props.scripts,
                   signingOptions: props.signingOptions,
-                  tx: txInternals
+                  tx: txInternals,
+                  witness: props.witness
                 })
               );
             },

--- a/packages/wallet/src/services/TransactionReemitter.ts
+++ b/packages/wallet/src/services/TransactionReemitter.ts
@@ -84,9 +84,14 @@ export const createTransactionReemitter = ({
           break;
         }
         case txSource.submitting: {
-          // Transactions in submitting are the ones reemitted. Remove them from volatiles
-          logger.debug(`Transaction ${vt.tx.id} is being resubmitted. Remove it from volatiles`);
-          volatiles = volatiles.filter((tx) => tx.id !== vt.tx.id);
+          volatiles = volatiles.filter((tx) => {
+            const isResubmittedTx = tx.id === vt.tx.id;
+            if (isResubmittedTx) {
+              // Volatile transactions in submitting are the ones reemitted. Remove them from volatiles
+              logger.debug(`Transaction ${vt.tx.id} is being resubmitted. Remove it from volatiles`);
+            }
+            return !isResubmittedTx;
+          });
           stores.volatileTransactions.set(volatiles);
           break;
         }
@@ -143,7 +148,8 @@ export const createTransactionReemitter = ({
   // Submission might have failed and could be retryable, so we should attempt to re-submit it.
   const unsubmitted$ = stores.inFlightTransactions.get().pipe(
     map((txs) => txs.filter(({ submittedAt }) => !submittedAt)),
-    mergeMap((txs) => from(txs))
+    mergeMap((txs) => from(txs)),
+    tap((tx) => logger.debug('Reemitting in-flight tx that was never submitted', tx.id))
   );
 
   const reemitSubmittedBefore$ = tipSlot$.pipe(
@@ -153,7 +159,8 @@ export const createTransactionReemitter = ({
   const reemitUnconfirmed$ = combineLatest([reemitSubmittedBefore$, inFlight$]).pipe(
     mergeMap(([reemitSubmittedBefore, inFlight]) =>
       from(inFlight.filter(({ submittedAt }) => submittedAt && submittedAt < reemitSubmittedBefore))
-    )
+    ),
+    tap((tx) => logger.debug('Reemitting unconfirmed in-flight tx', tx.id, 'submitted at slot', tx.submittedAt))
   );
 
   return {

--- a/packages/wallet/src/services/TransactionReemitter.ts
+++ b/packages/wallet/src/services/TransactionReemitter.ts
@@ -108,6 +108,7 @@ export const createTransactionReemitter = ({
   );
 
   const rollbacks$ = rollback$.pipe(
+    filter((tx) => !Cardano.util.isPhase2ValidationErrTx(tx)),
     withLatestFrom(volatileTransactions$),
     map(([tx, volatiles]) => {
       // Get the confirmed Tx transaction to be retried

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -6,7 +6,8 @@ export enum TransactionFailure {
   FailedToSubmit = 'FAILED_TO_SUBMIT',
   Unknown = 'UNKNOWN',
   CannotTrack = 'CANNOT_TRACK',
-  Timeout = 'TIMEOUT'
+  Timeout = 'TIMEOUT',
+  Phase2Validation = 'PHASE_2_VALIDATION'
 }
 
 export interface TransactionalObservables<T> {

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -7,10 +7,21 @@ import { Observable } from 'rxjs';
 import { SelectionSkeleton } from '@cardano-sdk/input-selection';
 import { Shutdown } from '@cardano-sdk/util';
 
-export type InitializeTxProps = {
+export interface TxProps {
+  auxiliaryData?: Cardano.AuxiliaryData;
+  witness?: {
+    datums?: Cardano.Datum[];
+    redeemers?: Cardano.Redeemer[];
+    bootstrap?: Cardano.BootstrapWitness[];
+    extraSigners?: TransactionSigner[];
+  };
+  scripts?: Cardano.Script[];
+  signingOptions?: SignTransactionOptions;
+}
+
+export interface InitializeTxProps extends TxProps {
   outputs?: Set<Cardano.TxOut>;
   certificates?: Cardano.Certificate[];
-  auxiliaryData?: Cardano.AuxiliaryData;
   options?: {
     validityInterval?: Cardano.ValidityInterval;
   };
@@ -18,17 +29,10 @@ export type InitializeTxProps = {
   mint?: Cardano.TokenMap;
   scriptIntegrityHash?: Crypto.Hash32ByteBase16;
   requiredExtraSignatures?: Crypto.Ed25519KeyHashHex[];
-  extraSigners?: TransactionSigner[];
-  signingOptions?: SignTransactionOptions;
-  scripts?: Cardano.Script[];
-};
+}
 
-export interface FinalizeTxProps {
+export interface FinalizeTxProps extends TxProps {
   tx: Cardano.TxBodyWithHash;
-  auxiliaryData?: Cardano.AuxiliaryData;
-  scripts?: Cardano.Script[];
-  extraSigners?: TransactionSigner[];
-  signingOptions?: SignTransactionOptions;
 }
 
 export type Assets = Map<Cardano.AssetId, Asset.AssetInfo>;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -33,6 +33,7 @@ export interface InitializeTxProps extends TxProps {
 
 export interface FinalizeTxProps extends TxProps {
   tx: Cardano.TxBodyWithHash;
+  isValid?: boolean;
 }
 
 export type Assets = Map<Cardano.AssetId, Asset.AssetInfo>;

--- a/packages/wallet/test/mocks/mockChainHistoryProvider.ts
+++ b/packages/wallet/test/mocks/mockChainHistoryProvider.ts
@@ -40,6 +40,7 @@ export const generateTxAlonzo = (qty: number): Cardano.HydratedTx[] =>
     },
     id: Cardano.TransactionId(getRandomTxId()),
     index,
+    inputSource: Cardano.InputSource.inputs,
     txSize: 100_000,
     witness: {
       signatures: new Map()
@@ -101,6 +102,7 @@ export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
       },
       id: Cardano.TransactionId('12fa9af65e21b36ec4dc4cbce478e911d52585adb46f2b4fe3d6563e7ee5a61a'),
       index: 0,
+      inputSource: Cardano.InputSource.inputs,
       txSize: 100_000,
       witness: {
         signatures: new Map()
@@ -136,6 +138,7 @@ export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
       },
       id: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad'),
       index: 1,
+      inputSource: Cardano.InputSource.inputs,
       txSize: 200_000,
       witness: {
         signatures: new Map()

--- a/packages/wallet/test/services/TransactionReemitter.test.ts
+++ b/packages/wallet/test/services/TransactionReemitter.test.ts
@@ -194,6 +194,12 @@ describe('TransactionReemiter', () => {
     const [outgoingA, _, __, outgoingD] = outgoingTransactions;
     volatileC.body.validityInterval = { invalidHereafter: Cardano.Slot(LAST_TIP_SLOT - 1) };
     const rollbackA: Cardano.HydratedTx = { body: volatileA.body, id: volatileA.id } as Cardano.HydratedTx;
+    // phase2validation failed transactions will not be reemited
+    const rollbackB: Cardano.HydratedTx = {
+      body: volatileB.body,
+      id: volatileB.id,
+      inputSource: Cardano.InputSource.collaterals
+    } as Cardano.HydratedTx;
     const rollbackC: Cardano.HydratedTx = {
       body: volatileC.body,
       id: volatileC.id
@@ -212,7 +218,12 @@ describe('TransactionReemiter', () => {
         c: volatileC,
         d: volatileD
       });
-      const rollback$ = cold<Cardano.HydratedTx>('--a--c--d|', { a: rollbackA, c: rollbackC, d: rollbackD });
+      const rollback$ = cold<Cardano.HydratedTx>('--ab-c--d|', {
+        a: rollbackA,
+        b: rollbackB,
+        c: rollbackC,
+        d: rollbackD
+      });
       const submitting$ = cold<OutgoingTx>('---------|');
       const inFlight$ = cold<TxInFlight[]>('-|');
       const transactionReemiter = createTransactionReemitter({


### PR DESCRIPTION
# Context

In order to distinguish transactions that failed phase 2 validation we need to add a new field: 
inputSource: 'collaterals' | 'inputs'.

A transaction with inputSource 'collaterals' is a transaction that consumed the collateral due to phase2 validation failure.