### PR TITLE
Fix/failed tx undetected when undefined invalid hereafter

### DIFF
--- a/packages/wallet/src/services/TransactionsTracker.ts
+++ b/packages/wallet/src/services/TransactionsTracker.ts
@@ -3,6 +3,7 @@ import { ConfirmedTx, FailedTx, OutgoingTx, TransactionFailure, TransactionsTrac
 import { DocumentStore, OrderedCollectionStore } from '../persistence';
 import {
   EMPTY,
+  NEVER,
   Observable,
   Subject,
   combineLatest,
@@ -282,7 +283,7 @@ export const createTransactionsTracker = (
                     filter(({ slot }) => slot > invalidHereafter),
                     map(() => ({ reason: TransactionFailure.Timeout, ...tx }))
                   )
-                : EMPTY
+                : NEVER
             ).pipe(take(1), takeUntil(txConfirmed$(tx)));
           })
         )

--- a/packages/wallet/test/services/TransactionsTracker.test.ts
+++ b/packages/wallet/test/services/TransactionsTracker.test.ts
@@ -338,7 +338,9 @@ describe('TransactionsTracker', () => {
         const failedToSubmit$ = hot<FailedTx>('---a|', {
           a: { reason: TransactionFailure.FailedToSubmit, ...outgoingTx }
         });
-        const failedFromReemitter$ = cold<FailedTx>('-a|', { a: { reason: TransactionFailure.Timeout, ...outgoingTxReemit } });
+        const failedFromReemitter$ = cold<FailedTx>('-a|', {
+          a: { reason: TransactionFailure.Timeout, ...outgoingTxReemit }
+        });
         const transactionsTracker = createTransactionsTracker(
           {
             addresses$,
@@ -462,7 +464,11 @@ describe('TransactionsTracker', () => {
           }
         );
         expectObservable(transactionsTracker.outgoing.submitting$).toBe('-a-b--|', { a: outgoingTx, b: outgoingTx });
-        expectObservable(transactionsTracker.outgoing.inFlight$).toBe('ab-c-a|', { a: [], b: [outgoingTx], c: [outgoingTx] });
+        expectObservable(transactionsTracker.outgoing.inFlight$).toBe('ab-c-a|', {
+          a: [],
+          b: [outgoingTx],
+          c: [outgoingTx]
+        });
         expectObservable(transactionsTracker.outgoing.failed$).toBe('-----a|', {
           a: { reason: TransactionFailure.FailedToSubmit, ...outgoingTx }
         });


### PR DESCRIPTION
# Context

In case of undefined invalidHereafter in transaction, failed transactions rxjs pipe
used an EMPTY observable, which completed immediately, causing the whole
observable to close before detecting the failed transaction.

# Proposed Solution
Use NEVER observable since it waits for other conditions (completed, rollback, failed).

# Important Changes Introduced
None
