### PR TITLE
fix(e2e): wallet restoration scenario

### DIFF
--- a/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.yml
+++ b/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.yml
@@ -15,6 +15,9 @@ before:
     flow:
       - log: "Find distinct addresses from DB"
       - function: "findAddresses"
+after:
+    flow:
+      - log: "Load test scenario completed"
 scenarios:
   - name: "Wallet restoration"
     afterScenario: "shutdownWallet"


### PR DESCRIPTION
# Context
I found one issue in debug log severity while performing a bunch of load test executions - the wallet restoration scenario uses one and the same fetched address from DB as the exposed [walletRestoration](https://github.com/input-output-hk/cardano-js-sdk/blob/90de06309ddccd971c8ba5c95e1ee23761891f31/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.ts#L54-L87) function doesn’t iterate over all fetched addresses. 

The issue is caused due to the index variable which tracks the current address from the addresses found list. The walletRestoration function is invoked for each new virtual user, so the index should be located in the global scope rather than the function scope, and then incremented accordingly by each invocation.


# Important Changes Introduced
- fix DB addresses traversing, move current address index to global scope
- added more logs 

Note: verified against `local-network`