### PR TITLE
Feat/adp 2627 cip30 sign tx should throw

### DIFF
--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -32,7 +32,6 @@ const getStakingKeyPaths = (
 
     for (const certificate of txBody.certificates) {
       switch (certificate.__typename) {
-        case Cardano.CertificateType.StakeKeyRegistration:
         case Cardano.CertificateType.StakeKeyDeregistration:
         case Cardano.CertificateType.StakeDelegation:
           if (certificate.stakeKeyHash === stakeKeyHash) paths.add(account.stakeKeyDerivationPath);
@@ -49,6 +48,7 @@ const getStakingKeyPaths = (
         case Cardano.CertificateType.MIR:
           if (certificate.rewardAccount === account.rewardAccount) paths.add(account.stakeKeyDerivationPath);
           break;
+        case Cardano.CertificateType.StakeKeyRegistration:
         case Cardano.CertificateType.GenesisKeyDelegation:
         default:
         // Nothing to do.

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import { AccountKeyDerivationPath, AddressType, GroupedAddress, KeyRole, util } from '../../src';
 import { Cardano } from '@cardano-sdk/core';
 
@@ -62,8 +63,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   });
 
   it(
-    'doesnt returns stake key derivation path when a StakeKeyRegistration' +
-      // eslint-disable-next-line sonarjs/no-duplicate-string
+    'does not return stake key derivation path when a StakeKeyRegistration' +
       ' certificate with the wallet stake key hash is present',
     async () => {
       const txBody = {

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -62,7 +62,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   });
 
   it(
-    'returns stake key derivation path when a StakeKeyRegistration' +
+    'doesnt returns stake key derivation path when a StakeKeyRegistration' +
       // eslint-disable-next-line sonarjs/no-duplicate-string
       ' certificate with the wallet stake key hash is present',
     async () => {
@@ -75,10 +75,6 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         {
           index: 0,
           role: KeyRole.External
-        },
-        {
-          index: 0,
-          role: KeyRole.Stake
         }
       ]);
     }

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -1,9 +1,11 @@
+/* eslint-disable no-bitwise */
 import { BigIntMath } from '@cardano-sdk/util';
 import { Cardano } from '@cardano-sdk/core';
 import { Observable, firstValueFrom } from 'rxjs';
-import { OutputValidation } from '../types';
+import { ObservableWallet, OutputValidation } from '../types';
 import { computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit } from '@cardano-sdk/tx-construction';
 import { txInEquals } from './util';
+import uniqBy from 'lodash/uniqBy';
 
 export type ProtocolParametersRequiredByOutputValidator = Pick<
   Cardano.ProtocolParameters,
@@ -156,4 +158,83 @@ export const createLazyWalletUtil = (): WalletUtil & { initialize: SetWalletUtil
       return resolver.validateValues(values);
     }
   };
+};
+
+/**
+ * Gets whether the given TX requires signatures that can not be provided by the given wallet.
+ *
+ * @param tx The transaction to inspect.
+ * @param wallet The wallet that will provide the signatures.
+ * @returns true if the wallet can not sign all inputs/certificates; otherwise; false.
+ */
+// eslint-disable-next-line complexity, sonarjs/cognitive-complexity
+export const requiresForeignSignatures = async (tx: Cardano.Tx, wallet: ObservableWallet): Promise<boolean> => {
+  const utxoSet = await firstValueFrom(wallet.utxo.total$);
+  const knownAddresses = await firstValueFrom(wallet.addresses$);
+  const uniqueAccounts = uniqBy(knownAddresses, 'rewardAccount').map((groupedAddress) => {
+    const stakeKeyHash = Cardano.RewardAccount.toHash(groupedAddress.rewardAccount);
+    return {
+      poolId: Cardano.PoolId.fromKeyHash(stakeKeyHash),
+      rewardAccount: groupedAddress.rewardAccount,
+      stakeKeyHash
+    };
+  });
+
+  // Iterate over the inputs and see if all of them are present in our UTXO set.
+  for (const input of tx.body.inputs) {
+    const ownsInput = utxoSet.find(
+      (utxo: Cardano.Utxo) => input.txId === utxo[0].txId && input.index === utxo[0].index
+    );
+
+    if (!ownsInput) return true;
+  }
+
+  // Iterate over the collateral inputs and see if all of them are present in our UTXO set.
+  if (tx.body.collaterals) {
+    for (const input of tx.body.collaterals) {
+      const ownsInput = utxoSet.find(
+        (utxo: Cardano.Utxo) => input.txId === utxo[0].txId && input.index === utxo[0].index
+      );
+
+      if (!ownsInput) return true;
+    }
+  }
+
+  // If all inputs are accounted for, see if all certificates belong to any of our reward accounts.
+  if (!tx.body.certificates) return false;
+
+  for (const certificate of tx.body.certificates) {
+    let matchesOneAccount = false;
+
+    for (const account of uniqueAccounts) {
+      switch (certificate.__typename) {
+        case Cardano.CertificateType.StakeKeyDeregistration:
+        case Cardano.CertificateType.StakeDelegation:
+          if (certificate.stakeKeyHash === account.stakeKeyHash) matchesOneAccount = true;
+          break;
+        case Cardano.CertificateType.PoolRegistration:
+          for (const owner of certificate.poolParameters.owners) {
+            // eslint-disable-next-line max-depth
+            if (owner === account.rewardAccount) matchesOneAccount = true;
+          }
+          break;
+        case Cardano.CertificateType.PoolRetirement:
+          if (certificate.poolId === account.poolId) matchesOneAccount = true;
+          break;
+        case Cardano.CertificateType.MIR:
+          if (certificate.rewardAccount === account.rewardAccount) matchesOneAccount = true;
+          break;
+        case Cardano.CertificateType.StakeKeyRegistration:
+        case Cardano.CertificateType.GenesisKeyDelegation:
+        default:
+          // These certificates don't require our signature, so we will map them as 'accounted for'.
+          matchesOneAccount = true;
+      }
+    }
+
+    // If it doesn't match at least one account, then it requires a foreign signature.
+    if (!matchesOneAccount) return true;
+  }
+
+  return false;
 };

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -1,14 +1,25 @@
 /* eslint-disable max-len */
-import { Cardano } from '@cardano-sdk/core';
+import * as Crypto from '@cardano-sdk/crypto';
+import * as mocks from '../mocks';
+import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';
+import { CML, Cardano } from '@cardano-sdk/core';
 import {
   OutputValidator,
   ProtocolParametersRequiredByOutputValidator,
+  SingleAddressWallet,
   WalletUtilContext,
   createInputResolver,
   createLazyWalletUtil,
-  createOutputValidator
+  createOutputValidator,
+  requiresForeignSignatures,
+  setupWallet
 } from '../../src';
+import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
+import { dummyLogger as logger } from 'ts-log';
+import { mockChainHistoryProvider, mockRewardsProvider, utxo as mockUtxo } from '../mocks';
 import { of } from 'rxjs';
+import { testAsyncKeyAgent } from '../../../key-management/test/mocks';
+import { waitForWalletStateSettle } from '../util';
 
 describe('WalletUtil', () => {
   describe('createOutputValidator', () => {
@@ -98,6 +109,260 @@ describe('WalletUtil', () => {
       } as WalletUtilContext);
       const result = await resultPromise;
       expect(result.coinMissing).toBe(0n);
+    });
+  });
+
+  describe('requiresForeignSignatures', () => {
+    const address = mocks.utxo[0][0].address!;
+    let txSubmitProvider: mocks.TxSubmitProviderStub;
+    let networkInfoProvider: mocks.NetworkInfoProviderStub;
+    let wallet: SingleAddressWallet;
+    let utxoProvider: mocks.UtxoProviderStub;
+    let tx: Cardano.Tx;
+
+    beforeEach(async () => {
+      txSubmitProvider = mocks.mockTxSubmitProvider();
+      networkInfoProvider = mocks.mockNetworkInfoProvider();
+      utxoProvider = mocks.mockUtxoProvider();
+      const assetProvider = mocks.mockAssetProvider();
+      const stakePoolProvider = createStubStakePoolProvider();
+      const rewardsProvider = mockRewardsProvider();
+      const chainHistoryProvider = mockChainHistoryProvider();
+      const groupedAddress: GroupedAddress = {
+        accountIndex: 0,
+        address,
+        index: 0,
+        networkId: Cardano.NetworkId.Testnet,
+        rewardAccount: mocks.rewardAccount,
+        stakeKeyDerivationPath: mocks.stakeKeyDerivationPath,
+        type: AddressType.External
+      };
+      ({ wallet } = await setupWallet({
+        bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+        createKeyAgent: async (dependencies) => {
+          const asyncKeyAgent = await testAsyncKeyAgent([groupedAddress], dependencies);
+          asyncKeyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);
+          return asyncKeyAgent;
+        },
+        createWallet: async (keyAgent) =>
+          new SingleAddressWallet(
+            { name: 'Test Wallet' },
+            {
+              assetProvider,
+              chainHistoryProvider,
+              keyAgent,
+              logger,
+              networkInfoProvider,
+              rewardsProvider,
+              stakePoolProvider,
+              txSubmitProvider,
+              utxoProvider
+            }
+          ),
+        logger
+      }));
+
+      await waitForWalletStateSettle(wallet);
+
+      const props = {
+        certificates: [
+          {
+            __typename: Cardano.CertificateType.StakeKeyDeregistration,
+            stakeKeyHash: mocks.stakeKeyHash
+          } as Cardano.StakeAddressCertificate
+        ],
+        collaterals: new Set([mockUtxo[2][0]]),
+        outputs: new Set([
+          {
+            address: Cardano.Address(
+              'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w'
+            ),
+            value: { coins: 11_111_111n }
+          }
+        ])
+      };
+
+      tx = await wallet.finalizeTx({ tx: await wallet.initializeTx(props) });
+    });
+
+    afterEach(() => {
+      wallet.shutdown();
+    });
+
+    it('returns false when all inputs and certificates are accounted for ', async () => {
+      // Inputs are selected by input selection algorithm
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(1);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeFalsy();
+    });
+
+    it('returns true when at least one certificate can not be accounted for - StakeKeyDeregistration ', async () => {
+      const foreignRewardAccountHash = Cardano.RewardAccount.toHash(
+        Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')
+      );
+
+      tx.body.certificates = [
+        {
+          __typename: Cardano.CertificateType.StakeKeyDeregistration,
+          stakeKeyHash: foreignRewardAccountHash
+        } as Cardano.StakeAddressCertificate,
+        ...tx.body.certificates!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(2);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+    });
+
+    it('returns true when at least one certificate can not be accounted for - StakeDelegation ', async () => {
+      const foreignRewardAccountHash = Cardano.RewardAccount.toHash(
+        Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')
+      );
+
+      tx.body.certificates = [
+        {
+          __typename: Cardano.CertificateType.StakeDelegation,
+          poolId: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash),
+          stakeKeyHash: foreignRewardAccountHash
+        } as Cardano.StakeDelegationCertificate,
+        ...tx.body.certificates!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(2);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+    });
+
+    it('returns true when at least one certificate can not be accounted for - PoolRegistration ', async () => {
+      const foreignRewardAccountHash = Cardano.RewardAccount.toHash(
+        Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')
+      );
+
+      tx.body.certificates = [
+        {
+          __typename: Cardano.CertificateType.PoolRegistration,
+          poolParameters: {
+            cost: 340n,
+            id: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash),
+            margin: {
+              denominator: 50,
+              numerator: 10
+            },
+            owners: [Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')],
+            pledge: 10_000n,
+            relays: [
+              {
+                __typename: 'RelayByName',
+                hostname: 'localhost'
+              }
+            ],
+            rewardAccount: Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27'),
+            vrf: Cardano.VrfVkHex('641d042ed39c2c258d381060c1424f40ef8abfe25ef566f4cb22477c42b2a014')
+          }
+        } as Cardano.PoolRegistrationCertificate,
+        ...tx.body.certificates!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(2);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+    });
+
+    it('returns true when at least one certificate can not be accounted for - PoolRetirement ', async () => {
+      const foreignRewardAccountHash = Cardano.RewardAccount.toHash(
+        Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')
+      );
+
+      tx.body.certificates = [
+        {
+          __typename: Cardano.CertificateType.PoolRetirement,
+          epoch: Cardano.EpochNo(100),
+          poolId: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash)
+        } as Cardano.PoolRetirementCertificate,
+        ...tx.body.certificates!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(2);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+    });
+
+    it('returns true when at least one certificate can not be accounted for - MIR ', async () => {
+      tx.body.certificates = [
+        {
+          __typename: Cardano.CertificateType.MIR,
+          pot: Cardano.MirCertificatePot.Treasury,
+          quantity: 100n,
+          rewardAccount: Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')
+        } as Cardano.MirCertificate,
+        ...tx.body.certificates!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(2);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+    });
+
+    it('returns false when a StakeKeyRegistration certificate can not be accounted for ', async () => {
+      const foreignRewardAccountHash = Cardano.RewardAccount.toHash(
+        Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')
+      );
+
+      tx.body.certificates = [
+        {
+          __typename: Cardano.CertificateType.StakeKeyRegistration,
+          stakeKeyHash: foreignRewardAccountHash
+        } as Cardano.StakeAddressCertificate,
+        ...tx.body.certificates!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(2);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeFalsy();
+    });
+
+    it('returns false when a GenesisKeyDelegation certificate can not be accounted for ', async () => {
+      tx.body.certificates = [
+        {
+          __typename: Cardano.CertificateType.GenesisKeyDelegation,
+          genesisDelegateHash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+          genesisHash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+          vrfKeyHash: Crypto.Hash32ByteBase16('0000000000000000000000000000000000000000000000000000000000000000')
+        } as Cardano.GenesisKeyDelegationCertificate,
+        ...tx.body.certificates!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(2);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeFalsy();
+    });
+
+    it('returns true when at least one input from collateral is not accounted for ', async () => {
+      tx.body.collaterals = [
+        {
+          index: 0,
+          txId: Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
+        },
+        ...tx.body.collaterals!
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+      expect(tx.body.certificates!.length).toBe(1);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+    });
+
+    it('returns true when at least one input is not accounted for ', async () => {
+      tx.body.inputs = [
+        {
+          index: 0,
+          txId: Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
+        },
+        ...tx.body.inputs
+      ];
+
+      expect(tx.body.inputs.length).toBeGreaterThanOrEqual(2);
+      expect(tx.body.certificates!.length).toBe(1);
+      expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
# Context

cip30 signTx should throw (reject) when it doesn't find any keys to sign with.

if partialSign=true and returned signatures length is 0 then throw (not explicit in cip, so not 100% sure about this)

if partialSign=false and not ALL inputs of the tx can be signed by the wallet then throw

From the cip:

```
If partialSign is true, the wallet only tries to sign what it can.
If partialSign is false and the wallet could not sign the entire transaction,
```
DataSignErrorCode shall be returned with the ProofGeneration code.

# Proposed Solution

- add a new wallet util 'requiresForeignSignatures' to check if the wallet can account for all inputs/certificates in the transaciton.
- check in the signTx function if all inputs/certs are accounted for, and throw depending on the value of the partialSign param. 
