### PR TITLE
Fix stake pools queries fixes

### DIFF
--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
@@ -23,7 +23,6 @@ import {
   RelayModel,
   StakePoolStatsModel,
   SubQuery,
-  TotalAdaModel,
   TotalCountModel
 } from './types';
 import { Logger } from 'ts-log';
@@ -131,7 +130,7 @@ export class StakePoolBuilder {
     return result.rows.length > 0 ? result.rows.map(mapPoolUpdate) : [];
   }
 
-  public async queryPoolMetrics(hashesIds: number[], totalAdaAmount: string, options?: QueryStakePoolsArgs) {
+  public async queryPoolMetrics(hashesIds: number[], totalStake: string, options?: QueryStakePoolsArgs) {
     this.#logger.debug('About to query pool metrics');
     const queryWithSortAndPagination = withPagination(
       withSort(Queries.findPoolsMetrics, options?.sort, [{ field: 'saturation', order: 'desc' }]),
@@ -139,7 +138,7 @@ export class StakePoolBuilder {
     );
     const result: QueryResult<PoolMetricsModel> = await this.#db.query(queryWithSortAndPagination, [
       hashesIds,
-      totalAdaAmount
+      totalStake
     ]);
     return result.rows.length > 0 ? result.rows.map(mapPoolMetrics) : [];
   }
@@ -195,12 +194,6 @@ export class StakePoolBuilder {
     const lastEpoch = result.rows[0];
     if (!lastEpoch) throw new ProviderError(ProviderFailure.Unknown, null, "Couldn't find last epoch");
     return mapEpoch(lastEpoch);
-  }
-
-  public async getTotalAmountOfAda() {
-    this.#logger.debug('About to query total ada amount');
-    const result: QueryResult<TotalAdaModel> = await this.#db.query(Queries.findTotalAda);
-    return result.rows[0].total_ada;
   }
 
   public buildOrQuery(filters: QueryStakePoolsArgs['filters']) {

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -21,19 +21,6 @@ LEFT JOIN epoch_param ep ON
 ORDER BY no DESC
 LIMIT 1`;
 
-export const findTotalAda = `
-SELECT COALESCE(SUM(value)) AS total_ada
-FROM tx_out AS tx_outer WHERE
-NOT exists
-  ( SELECT tx_out.id
-  FROM tx_out
-  JOIN tx_in ON
-  tx_out.tx_id = tx_in.tx_out_id AND
-  tx_out.index = tx_in.tx_out_index
-  WHERE tx_outer.id = tx_out.id
-  );
-`;
-
 export const findPoolsMetrics = `
 WITH current_epoch AS (
   SELECT
@@ -852,8 +839,7 @@ const Queries = {
   findPoolsRegistrations,
   findPoolsRelays,
   findPoolsRetirements,
-  findPoolsWithPledgeMet,
-  findTotalAda
+  findPoolsWithPledgeMet
 };
 
 export default Queries;

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
@@ -124,10 +124,6 @@ export interface SubQuery {
   query: string;
 }
 
-export interface TotalAdaModel {
-  total_ada: string;
-}
-
 export interface PoolMetricsModel {
   blocks_created: number;
   delegators: number;

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/util.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/util.ts
@@ -30,8 +30,8 @@ export enum StakePoolsSubQuery {
   REGISTRATIONS = 'registrations',
   OWNERS = 'owners',
   RETIREMENTS = 'retirements',
-  TOTAL_ADA_AMOUNT = 'total_ada_amount',
   TOTAL_POOLS_COUNT = 'total_stake_pools_count',
+  TOTAL_STAKE = 'total_stake',
   POOL_HASHES = 'pool_hashes',
   POOLS_DATA_ORDERED = 'pools_data_ordered'
 }

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
@@ -186,12 +186,6 @@ describe('StakePoolBuilder', () => {
       });
     });
   });
-  describe('getTotalAmountOfAda', () => {
-    it('getTotalAmountOfAda', async () => {
-      const totalAdaAmount = Number(await builder.getTotalAmountOfAda());
-      expect(totalAdaAmount).toBeGreaterThan(0);
-    });
-  });
   describe('getLastEpoch', () => {
     it('getLastEpoch', async () => {
       const lastEpoch = await builder.getLastEpoch();

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -288,7 +288,7 @@ describe('StakePoolHttpService', () => {
 
       describe('/search', () => {
         const url = '/search';
-        const cachedSubQueriesCount = 11;
+        const cachedSubQueriesCount = 10;
         const cacheKeysCount = 7;
         const nonCacheableSubQueriesCount = 1; // getLastEpoch
         const filerOnePoolOptions: QueryStakePoolsArgs = {

--- a/packages/cardano-services/test/StakePool/fixtures/queries.ts
+++ b/packages/cardano-services/test/StakePool/fixtures/queries.ts
@@ -84,7 +84,6 @@ export const subQueries = `
     FROM
       withdrawal w
       JOIN tx ON tx.id = w.tx_id
-      AND tx.valid_contract = TRUE
       JOIN stake_address sa ON sa.id = w.addr_id
       JOIN pools_delegated pool on pool.stake_address_id = sa.id
     GROUP BY
@@ -116,9 +115,7 @@ export const subQueries = `
       LEFT JOIN tx_in ON tx_out.tx_id = tx_in.tx_out_id
       AND tx_out.index :: smallint = tx_in.tx_out_index :: smallint
       LEFT JOIN tx AS tx_in_tx ON tx_in_tx.id = tx_in.tx_in_id
-      AND tx_in_tx.valid_contract = TRUE
       JOIN tx AS tx_out_tx ON tx_out_tx.id = tx_out.tx_id
-      AND tx_out_tx.valid_contract = TRUE
     WHERE
       tx_in_tx.id IS NULL
   ),


### PR DESCRIPTION
# Context

Due to recent investigations we discovered we have two bugs in stake pools search related queries.

1. In order compute the _saturation_, the total staked amount is required: we are currently using the total UTXOs amount;
2. in case of phase 2 validation fail, **db-sync** stores the collateral inputs and outputs in `tx_in` and `tx_out` as if they were non collateral: we are excluding these UTXOs

# Proposed Solution

1. Replaced the query to get total UTXOs with the call to `OgmiosCardanoNode` to get the required value.
2. Removed the `tx.valid_contract = TRUE` condition from the `WHERE` clauses in stake pools search related queries.