### PR TITLE
feat!: upgrade resolveInputAddress to resolveInput

### DIFF
--- a/packages/core/src/Cardano/Address/PaymentAddress.ts
+++ b/packages/core/src/Cardano/Address/PaymentAddress.ts
@@ -6,7 +6,7 @@ import {
   assertIsBech32WithPrefix,
   assertIsHexString
 } from '@cardano-sdk/util';
-import { HydratedTx, HydratedTxIn, TxIn } from '../types';
+import { HydratedTx, HydratedTxIn, TxIn, TxOut } from '../types';
 import { NetworkId } from '../ChainId';
 import { RewardAccount } from './RewardAccount';
 
@@ -72,13 +72,13 @@ export const inputsWithAddresses = (tx: HydratedTx, ownAddresses: PaymentAddress
   tx.body.inputs.filter(isAddressWithin(ownAddresses));
 
 /**
- * @param txIn transaction input to resolve address from
- * @returns input owner address
+ * @param txIn transaction input to resolve associated txOut from
+ * @returns txOut
  */
-export type ResolveInputAddress = (txIn: TxIn) => Promise<PaymentAddress | null>;
+export type ResolveInput = (txIn: TxIn) => Promise<TxOut | null>;
 
 export interface InputResolver {
-  resolveInputAddress: ResolveInputAddress;
+  resolveInput: ResolveInput;
 }
 
 /**

--- a/packages/e2e/src/scripts/mnemonic.ts
+++ b/packages/e2e/src/scripts/mnemonic.ts
@@ -21,7 +21,7 @@ import { localNetworkChainId } from '../util';
     },
     {
       bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
-      inputResolver: { resolveInputAddress: async () => null },
+      inputResolver: { resolveInput: async () => null },
       logger: console
     }
   );

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -259,5 +259,5 @@ export const createStandaloneKeyAgent = async (
       getPassphrase: async () => Buffer.from(''),
       mnemonicWords: mnemonics
     },
-    { bip32Ed25519, inputResolver: { resolveInputAddress: async () => null }, logger }
+    { bip32Ed25519, inputResolver: { resolveInput: async () => null }, logger }
   );

--- a/packages/key-management/src/util/mapHardwareSigningData.ts
+++ b/packages/key-management/src/util/mapHardwareSigningData.ts
@@ -91,7 +91,7 @@ const prepareTrezorInputs = async (
     const input = scope.manage(inputs.get(i));
     const inputTxId = scope.manage(input.transaction_id());
     const coreInput = cmlToCore.txIn(input);
-    const paymentAddress = await inputResolver.resolveInputAddress(coreInput);
+    const resolution = await inputResolver.resolveInput(coreInput);
 
     let trezorInput = {
       prev_hash: Buffer.from(inputTxId.to_bytes()).toString('hex'),
@@ -99,8 +99,8 @@ const prepareTrezorInputs = async (
     } as trezor.CardanoInput;
 
     let paymentKeyPath = null;
-    if (paymentAddress) {
-      const knownAddress = knownAddresses.find(({ address }) => address === paymentAddress);
+    if (resolution?.address) {
+      const knownAddress = knownAddresses.find(({ address }) => address === resolution.address);
       if (knownAddress) {
         paymentKeyPath = [
           harden(CardanoKeyConst.PURPOSE),
@@ -420,11 +420,11 @@ const prepareLedgerInputs = async (
   for (let i = 0; i < inputs.len(); i++) {
     const input = scope.manage(inputs.get(i));
     const coreInput = cmlToCore.txIn(input);
-    const paymentAddress = await inputResolver.resolveInputAddress(coreInput);
+    const resolution = await inputResolver.resolveInput(coreInput);
 
     let paymentKeyPath = null;
-    if (paymentAddress) {
-      const knownAddress = knownAddresses.find(({ address }) => address === paymentAddress);
+    if (resolution?.address) {
+      const knownAddress = knownAddresses.find(({ address }) => address === resolution.address);
       if (knownAddress) {
         paymentKeyPath = [
           harden(CardanoKeyConst.PURPOSE),

--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -74,9 +74,9 @@ export const ownSignatureKeyPaths = async (
     (
       await Promise.all(
         txInputs.map(async (input) => {
-          const ownAddress = await inputResolver.resolveInputAddress(input);
-          if (!ownAddress) return null;
-          return knownAddresses.find(({ address }) => address === ownAddress);
+          const resolution = await inputResolver.resolveInput(input);
+          if (!resolution) return null;
+          return knownAddresses.find(({ address }) => address === resolution.address);
         })
       )
     ).filter(isNotNil)

--- a/packages/key-management/test/InMemoryKeyAgent.test.ts
+++ b/packages/key-management/test/InMemoryKeyAgent.test.ts
@@ -17,7 +17,7 @@ describe('InMemoryKeyAgent', () => {
   beforeEach(async () => {
     mnemonicWords = util.generateMnemonicWords();
     getPassphrase = jest.fn().mockResolvedValue(Buffer.from('password'));
-    inputResolver = { resolveInputAddress: jest.fn() };
+    inputResolver = { resolveInput: jest.fn() };
     keyAgent = await InMemoryKeyAgent.fromBip39MnemonicWords(
       {
         chainId: Cardano.ChainIds.Preview,

--- a/packages/key-management/test/KeyAgentBase.test.ts
+++ b/packages/key-management/test/KeyAgentBase.test.ts
@@ -11,7 +11,7 @@ class MockKeyAgent extends KeyAgentBase {
   constructor(data: SerializableInMemoryKeyAgentData) {
     super(data, {
       bip32Ed25519,
-      inputResolver: { resolveInputAddress: () => Promise.resolve(null) },
+      inputResolver: { resolveInput: () => Promise.resolve(null) },
       logger: dummyLogger
     });
   }

--- a/packages/key-management/test/mocks/mockKeyAgentDependencies.ts
+++ b/packages/key-management/test/mocks/mockKeyAgentDependencies.ts
@@ -6,7 +6,7 @@ import { dummyLogger } from 'ts-log';
 export const mockKeyAgentDependencies = (): jest.Mocked<KeyAgentDependencies> => ({
   bip32Ed25519: new CmlBip32Ed25519(CML),
   inputResolver: {
-    resolveInputAddress: jest.fn().mockResolvedValue(null)
+    resolveInput: jest.fn().mockResolvedValue(null)
   },
   logger: dummyLogger
 });

--- a/packages/key-management/test/restoreKeyAgent.test.ts
+++ b/packages/key-management/test/restoreKeyAgent.test.ts
@@ -18,7 +18,7 @@ import { dummyLogger } from 'ts-log';
 describe('KeyManagement/restoreKeyAgent', () => {
   const dependencies: KeyAgentDependencies = {
     bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
-    inputResolver: { resolveInputAddress: jest.fn() },
+    inputResolver: { resolveInput: jest.fn() },
     logger: dummyLogger
   };
 

--- a/packages/key-management/test/tsconfig.json
+++ b/packages/key-management/test/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "baseUrl": "."
   },
+  "include": [
+    "../../tx-construction/test/testData"
+  ],
   "references": [
     {
       "path": "../src"

--- a/packages/key-management/test/util/createAsyncKeyAgent.test.ts
+++ b/packages/key-management/test/util/createAsyncKeyAgent.test.ts
@@ -14,7 +14,7 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
   beforeEach(async () => {
     const mnemonicWords = util.generateMnemonicWords();
     const getPassphrase = jest.fn().mockResolvedValue(Buffer.from('password'));
-    inputResolver = { resolveInputAddress: jest.fn() };
+    inputResolver = { resolveInput: jest.fn() };
     keyAgent = await InMemoryKeyAgent.fromBip39MnemonicWords(
       {
         chainId: Cardano.ChainIds.Preview,
@@ -37,7 +37,7 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
     await expect(asyncKeyAgent.signBlob(keyDerivationPath, blob)).resolves.toEqual(
       await keyAgent.signBlob(keyDerivationPath, blob)
     );
-    inputResolver.resolveInputAddress.mockResolvedValue(null);
+    inputResolver.resolveInput.mockResolvedValue(null);
     const txInternals = {
       body: { fee: 20_000n, inputs: [], outputs: [], validityInterval: {} } as Cardano.HydratedTxBody,
       hash: Cardano.TransactionId('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec')

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { AccountKeyDerivationPath, AddressType, GroupedAddress, KeyRole, util } from '../../src';
 import { Cardano } from '@cardano-sdk/core';
+import { txOut } from '../../../tx-construction/test/testData';
 
 export const stakeKeyPath = {
   index: 0,
@@ -45,12 +46,12 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     const knownAddresses = [address1, address2].map((address, index) =>
       createGroupedAddress(address, ownRewardAccount, AddressType.External, index, stakeKeyPath)
     );
-    const resolveInputAddress = jest
+    const resolveInput = jest
       .fn()
-      .mockReturnValueOnce(address1)
-      .mockReturnValueOnce(address2)
-      .mockReturnValueOnce(address1);
-    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInputAddress })).toEqual([
+      .mockReturnValueOnce({ ...txOut, address: address1 })
+      .mockReturnValueOnce({ ...txOut, address: address2 })
+      .mockReturnValueOnce({ ...txOut, address: address1 });
+    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInput })).toEqual([
       {
         index: 0,
         role: KeyRole.External
@@ -70,8 +71,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash: ownStakeKeyHash }],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
-      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      const resolveInput = jest
+        .fn()
+        .mockReturnValueOnce({ ...txOut, address: address1 })
+        .mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
         {
           index: 0,
           role: KeyRole.External
@@ -88,8 +92,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         certificates: [{ __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash: ownStakeKeyHash }],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
-      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      const resolveInput = jest
+        .fn()
+        .mockReturnValueOnce({ ...txOut, address: address1 })
+        .mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
         {
           index: 0,
           role: KeyRole.External
@@ -110,8 +117,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         certificates: [{ __typename: Cardano.CertificateType.StakeDelegation, stakeKeyHash: ownStakeKeyHash }],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
-      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      const resolveInput = jest
+        .fn()
+        .mockReturnValueOnce({ ...txOut, address: address1 })
+        .mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
         {
           index: 0,
           role: KeyRole.External
@@ -133,8 +143,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       ],
       inputs: [{}, {}, {}]
     } as Cardano.TxBody;
-    const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+    const resolveInput = jest
+      .fn()
+      .mockReturnValueOnce({ ...txOut, address: address1 })
+      .mockReturnValueOnce(address1);
+    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
       {
         index: 0,
         role: KeyRole.External
@@ -160,8 +173,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         ],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
-      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      const resolveInput = jest
+        .fn()
+        .mockReturnValueOnce({ ...txOut, address: address1 })
+        .mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
         {
           index: 0,
           role: KeyRole.External
@@ -204,8 +220,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         ],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
-      const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+      const resolveInput = jest
+        .fn()
+        .mockReturnValueOnce({ ...txOut, address: address1 })
+        .mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
         {
           index: 0,
           role: KeyRole.External
@@ -223,8 +242,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       certificates: [{ __typename: Cardano.CertificateType.MIR, rewardAccount: ownRewardAccount }],
       inputs: [{}, {}, {}]
     } as Cardano.TxBody;
-    const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+    const resolveInput = jest
+      .fn()
+      .mockReturnValueOnce({ ...txOut, address: address1 })
+      .mockReturnValueOnce(address1);
+    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
       {
         index: 0,
         role: KeyRole.External
@@ -242,8 +264,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash: otherStakeKeyHash }],
       inputs: [{}, {}, {}]
     } as Cardano.TxBody;
-    const resolveInputAddress = jest.fn().mockReturnValueOnce(address1).mockReturnValueOnce(address1);
-    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInputAddress })).toEqual([
+    const resolveInput = jest
+      .fn()
+      .mockReturnValueOnce({ ...txOut, address: address1 })
+      .mockReturnValueOnce(address1);
+    expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
       {
         index: 0,
         role: KeyRole.External
@@ -257,8 +282,8 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       withdrawals: [{ quantity: 1n, stakeAddress: ownRewardAccount }]
     } as Cardano.TxBody;
     const knownAddresses = [createGroupedAddress(address1, ownRewardAccount, AddressType.External, 0, stakeKeyPath)];
-    const resolveInputAddress = jest.fn().mockReturnValue(address1);
-    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInputAddress })).toEqual([
+    const resolveInput = jest.fn().mockReturnValue({ ...txOut, address: address1 });
+    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInput })).toEqual([
       {
         index: 0,
         role: KeyRole.External
@@ -276,8 +301,8 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       withdrawals: [{ quantity: 1n, stakeAddress: otherRewardAccount }]
     } as Cardano.TxBody;
     const knownAddresses = [createGroupedAddress(address1, ownRewardAccount, AddressType.External, 0, stakeKeyPath)];
-    const resolveInputAddress = jest.fn().mockReturnValue(address1);
-    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInputAddress })).toEqual([
+    const resolveInput = jest.fn().mockReturnValue({ ...txOut, address: address1 });
+    expect(await util.ownSignatureKeyPaths(txBody, knownAddresses, { resolveInput })).toEqual([
       {
         index: 0,
         role: KeyRole.External

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -108,9 +108,11 @@ export const createOutputValidator = ({ protocolParameters$ }: OutputValidatorCo
 };
 
 export const createInputResolver = ({ utxo }: InputResolverContext): Cardano.InputResolver => ({
-  async resolveInputAddress(input: Cardano.TxIn) {
+  async resolveInput(input: Cardano.TxIn) {
     const utxoAvailable = await firstValueFrom(utxo.available$);
-    return utxoAvailable?.find(([txIn]) => txInEquals(txIn, input))?.[1].address || null;
+    const availableUtxo = utxoAvailable?.find(([txIn]) => txInEquals(txIn, input));
+    if (!availableUtxo) return null;
+    return availableUtxo[1];
   }
 });
 
@@ -137,9 +139,9 @@ export const createLazyWalletUtil = (): WalletUtil & { initialize: SetWalletUtil
   const resolverReady = new Promise((resolve: SetWalletUtilContext) => (initialize = resolve)).then(createWalletUtil);
   return {
     initialize: initialize!,
-    async resolveInputAddress(input) {
+    async resolveInput(input) {
       const resolver = await resolverReady;
-      return resolver.resolveInputAddress(input);
+      return resolver.resolveInput(input);
     },
     async validateOutput(output) {
       const resolver = await resolverReady;

--- a/packages/wallet/test/SingleAddressWallet/methods.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/methods.test.ts
@@ -138,16 +138,17 @@ describe('SingleAddressWallet methods', () => {
       });
     });
 
-    describe('resolveInputAddress', () => {
-      it('returns input address for wallet-owned utxo', async () => {
+    describe('resolveInput', () => {
+      it('returns the txOut associated with the input for wallet-owned UTxO', async () => {
         const utxoSet = await firstValueFrom(wallet.utxo.available$);
-        const resolveInputAddressResult = await wallet.util.resolveInputAddress(utxoSet[0][0]);
-        expect(typeof resolveInputAddressResult).toBe('string');
+        const resolveInputAddressResult = await wallet.util.resolveInput(utxoSet[0][0]);
+        expect(typeof resolveInputAddressResult!.address).toBe('string');
+        expect(typeof resolveInputAddressResult!.value).toBe('object');
       });
 
       it('returns null for non-wallet-owned utxo', async () => {
         expect(
-          await wallet.util.resolveInputAddress({
+          await wallet.util.resolveInput({
             index: 9,
             txId: Cardano.TransactionId('6804edf9712d2b619edb6ac86861fe93a730693183a262b165fcc1ba1bc99cad')
           })

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -65,7 +65,7 @@ describe('WalletUtil', () => {
   });
 
   describe('createInputResolver', () => {
-    it('resolveInputAddress resolves inputs from provided utxo set', async () => {
+    it('resolveInput resolves inputs from provided utxo set', async () => {
       const utxo: Cardano.Utxo[] = [
         [
           {
@@ -83,13 +83,16 @@ describe('WalletUtil', () => {
       ];
       const resolver = createInputResolver({ utxo: { available$: of(utxo) } });
       expect(
-        await resolver.resolveInputAddress({
+        await resolver.resolveInput({
           index: 0,
           txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
         })
-      ).toBe('addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg');
+      ).toEqual({
+        address: 'addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg',
+        value: { coins: 50_000_000n }
+      });
       expect(
-        await resolver.resolveInputAddress({
+        await resolver.resolveInput({
           index: 0,
           txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d4')
         })


### PR DESCRIPTION
# Context
Applications wishing to display Values relating to the resolved input need to independently fetch the entire transaction to resolve every input. This is sub-optimal in both needing to remotely fetch transactions already present in the wallet, and that most of the data is not needed, so the we’re placing significant unnecessary load on the provider backend. As a result, the UX is impacted as a result of network latency.

# Proposed Solution
Rename the function and return `{address, value}` instead of just the address.

