### PR TITLE
refactor(cardano-services): tx.valid_contract filter is not needed to…

### DIFF
--- a/packages/cardano-services/src/Rewards/DbSyncRewardProvider/queries.ts
+++ b/packages/cardano-services/src/Rewards/DbSyncRewardProvider/queries.ts
@@ -19,8 +19,6 @@ export const findAccountBalance = `
     ) - (
         SELECT COALESCE(SUM(w.amount),0) 
         FROM withdrawal w
-        JOIN tx ON tx.id = w.tx_id AND 
-            tx.valid_contract = TRUE
         JOIN stake_address ON stake_address.id = w.addr_id
         WHERE stake_address.view = $1
     ) AS balance


### PR DESCRIPTION
… calculate withdrawals

Withdrawals are ignored for in phase 2 validation failed transactions. No need to join and filter withdrawal table by transaction valid_contract.

# Context

see commits
