### PR TITLE
refactor: exclude collaterals from HydratedTx

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -163,13 +163,12 @@ interface TxAlonzoData {
   withdrawals?: Cardano.Withdrawal[];
   redeemers?: Cardano.Redeemer[];
   metadata?: Cardano.TxMetadata;
-  collaterals?: Cardano.HydratedTxIn[];
   certificates?: Cardano.Certificate[];
 }
 
 export const mapTxAlonzo = (
   txModel: TxModel,
-  { inputSource, inputs, outputs, mint, withdrawals, redeemers, metadata, collaterals, certificates }: TxAlonzoData
+  { inputSource, inputs, outputs, mint, withdrawals, redeemers, metadata, certificates }: TxAlonzoData
 ): Cardano.HydratedTx => ({
   auxiliaryData:
     metadata && metadata.size > 0
@@ -186,7 +185,6 @@ export const mapTxAlonzo = (
   },
   body: {
     certificates,
-    collaterals,
     fee: BigInt(txModel.fee),
     inputs,
     mint,

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -326,16 +326,16 @@ describe('ChainHistoryHttpService', () => {
           expect(tx.auxiliaryData).toBeDefined();
         });
 
-        it('has collateral inputs', async () => {
-          const response = await provider.transactionsByHashes({
-            ids: await fixtureBuilder.getTxHashes(1, { with: [TxWith.CollateralInput] })
-          });
-          const tx: Cardano.HydratedTx = response[0];
-          expect(response.length).toEqual(1);
+        // it('has collateral inputs', async () => {
+        //   const response = await provider.transactionsByHashes({
+        //     ids: await fixtureBuilder.getTxHashes(1, { with: [TxWith.CollateralInput] })
+        //   });
+        //   const tx: Cardano.HydratedTx = response[0];
+        //   expect(response.length).toEqual(1);
 
-          expect(tx.body.collaterals).toMatchShapeOf(DataMocks.Tx.collateralInputs);
-          expect(tx.body.collaterals?.length).toEqual(1);
-        });
+        //   expect(tx.body.collaterals).toMatchShapeOf(DataMocks.Tx.collateralInputs);
+        //   expect(tx.body.collaterals?.length).toEqual(1);
+        // });
 
         it('has certificates', async () => {
           const response = await provider.transactionsByHashes({

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -353,7 +353,6 @@ describe('chain history mappers', () => {
     test('map TxModel to Cardano.HydratedTx with extra data', () => {
       const result = mappers.mapTxAlonzo(txModel, {
         certificates,
-        collaterals: inputs,
         inputSource,
         inputs,
         metadata,
@@ -365,7 +364,7 @@ describe('chain history mappers', () => {
       expect(result).toEqual<Cardano.HydratedTx>({
         ...expected,
         auxiliaryData: { body: { blob: metadata } },
-        body: { ...expected.body, certificates, collaterals: inputs, mint: assets, withdrawals },
+        body: { ...expected.body, certificates, mint: assets, withdrawals },
         witness: { ...expected.witness, redeemers }
       });
     });

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -40,7 +40,6 @@ export interface Withdrawal {
 
 export interface HydratedTxBody {
   inputs: HydratedTxIn[];
-  collaterals?: HydratedTxIn[];
   outputs: TxOut[];
   fee: Lovelace;
   validityInterval?: ValidityInterval;

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -77,7 +77,6 @@ export const normalizeTxBody = (body: Cardano.HydratedTxBody | Cardano.TxBody) =
   // TODO: inputs should be a Set since they're unordered.
   // Then Jest should correctly compare it with toEqual.
   body.inputs = sortTxIn(body.inputs);
-  body.collaterals = sortTxIn(body.collaterals);
   body.referenceInputs = sortTxIn(body.referenceInputs);
   return body;
 };


### PR DESCRIPTION
collaterals field in HydratedTxBody is present only if the transaction was successful, so it is not consumed. In case transaction has phase 2 validation failure, collaterals are consumed and they will not be part of the
`HydratedTxBody.collaterals` field, but will be part of `inputs`. Optimized queries by not including collaterals as they have not been consumed and only have historical purpose.

# Context

`DbSyncChainHistoryProvider.transactionsByHashes` performs two queries:
1. Get the inputs: `this.#builder.queryTransactionInputsByHashes(ids)` - these will always be the consumed inputs:
  - collaterals in case of phase 2 validation failure
  - inputs in case of a successful transaction
1. Get the collaterals: `this.#builder.queryTransactionInputsByHashes(ids, true)` - these will be populated only in case the transaction was successful, but they are NOT consumed. -- this step could be skipped altogether, excluding collaterals from  `OnChainTx` type.

# Proposed Solution

Remove collaterals from HydratedTxBody and skip making the extra query to get it in `DbSyncChainHistoryProvider.transactionsByHashes`

# Important Changes Introduced
