### PR TITLE
fix(wallet): map tx submission errors to TxSendError in cip30 submitTx

### DIFF
--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -349,7 +349,8 @@ export const createWalletApi = (
         return tx.id;
       } catch (error) {
         logger.error(error);
-        throw error;
+        const info = error instanceof Error ? error.message : 'unknown';
+        throw new TxSendError(TxSendErrorCode.Failure, info);
       }
     } else {
       logger.debug('transaction refused');


### PR DESCRIPTION
# Context

cip30 submitTx can throw an error that is uncompliant with the spec
