### PR TITLE
build: correct invalid production dependencies

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -50,6 +50,8 @@
     "@cardano-ogmios/schema": "5.6.0",
     "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1",
     "@types/blake2b": "^2.1.0",
+    "@types/bn.js": "^5.1.1",
+    "@types/libsodium-wrappers-sumo": "^0.7.5",
     "@types/lodash": "^4.14.182",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",
@@ -77,8 +79,6 @@
   },
   "dependencies": {
     "@cardano-sdk/util": "^0.8.1",
-    "@types/bn.js": "^5.1.1",
-    "@types/libsodium-wrappers-sumo": "^0.7.5",
     "blake2b": "^2.1.4",
     "bn.js": "^5.2.1",
     "i": "^0.3.7",

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -54,6 +54,7 @@
     "test:e2e": "shx echo 'test:e2e' command not implemented yet"
   },
   "devDependencies": {
+    "@types/dockerode": "^3.3.8",
     "@types/jest": "^26.0.24",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",
@@ -66,7 +67,6 @@
   "dependencies": {
     "@cardano-sdk/core": "^0.9.0",
     "@cardano-sdk/util": "^0.8.1",
-    "@types/dockerode": "^3.3.8",
     "delay": "^5.0.0",
     "dockerode": "^3.3.1",
     "dockerode-utils": "^0.0.7",


### PR DESCRIPTION
# Context
A couple of packages have `@types/*` packages listed as `dependencies`, rather than `devDependencies`. This causes complexities when consuming the package in some environments.

# Proposed Solution
Move them to `devDependencies`
