### PR TITLE
ci: build Dockerfile in CI without cache

### DIFF
--- a/.github/workflows/continuous-integration-e2e.yaml
+++ b/.github/workflows/continuous-integration-e2e.yaml
@@ -26,6 +26,7 @@ jobs:
       run: |
         yarn install --immutable --inline-builds
         yarn build
+        docker build --no-cache .
 
     - name: 🌐 Setup local test network
       working-directory: packages/e2e


### PR DESCRIPTION
# Context
It's possible for changes in package dependencies to remove the need for a local `node_modules` directory in `cardano-services`, but our existing workflows will use available cache, which are not invalidated by this scenario. 

# Proposed Solution
This change ensure at least one build in CI checks we can reliably build the image. Note that omitting the `target` tells the Docker engine to build each stage.

# Important Changes Introduced
