### PR TITLE
Test/prepare tests for mainnet

### DIFF
--- a/packages/e2e/jest.config.js
+++ b/packages/e2e/jest.config.js
@@ -1,9 +1,13 @@
-const project = (displayName) => ({
-  displayName,
+const commonProjectProps = {
   preset: 'ts-jest',
   setupFiles: ['dotenv/config'],
-  testMatch: [`<rootDir>/test/${displayName}/**/*.test.ts`],
   transform: { '^.+\\.test.ts?$': 'ts-jest' }
+};
+
+const project = (displayName) => ({
+  displayName,
+  testMatch: [`<rootDir>/test/${displayName}/**/*.test.ts`],
+  ...commonProjectProps
 });
 
 // jest tests suitable to run in an environment with real ADA (not tADA)
@@ -25,17 +29,19 @@ module.exports = {
     project('load-testing'),
     project('local-network'),
     project('long-running'),
-    project('measurement-util'),
     project('ogmios'),
     project('projection'),
     project('providers'),
     project('wallet'),
     {
+      ...commonProjectProps,
       displayName: 'wallet-real-ada',
-      preset: 'ts-jest',
-      setupFiles: ['dotenv/config'],
-      testMatch: [`<rootDir>/test/wallet/SingleAddressWallet/(${realAdaTestFileNames.join('|')}).test.ts`],
-      transform: { '^.+\\.test.ts?$': 'ts-jest' }
+      testMatch: [`<rootDir>/test/wallet/SingleAddressWallet/(${realAdaTestFileNames.join('|')}).test.ts`]
+    },
+    {
+      ...commonProjectProps,
+      displayName: 'utils',
+      testMatch: ['<rootDir>/test/measurement-util/*.test.ts', '<rootDir>/test/util.test.ts']
     }
   ],
   testTimeout: 1000 * 60 * 25

--- a/packages/e2e/jest.config.js
+++ b/packages/e2e/jest.config.js
@@ -6,6 +6,19 @@ const project = (displayName) => ({
   transform: { '^.+\\.test.ts?$': 'ts-jest' }
 });
 
+// jest tests suitable to run in an environment with real ADA (not tADA)
+const realAdaTestFileNames = [
+  'delegation',
+  'metadata',
+  'mint',
+  'multisignature',
+  'nft',
+  'pouchDbWalletStores',
+  'txChainHistory',
+  'txChaining',
+  'unspendableUtxos'
+];
+
 module.exports = {
   projects: [
     { ...project('blockfrost'), globalSetup: './test/blockfrost/setup.ts' },
@@ -16,7 +29,14 @@ module.exports = {
     project('ogmios'),
     project('projection'),
     project('providers'),
-    project('wallet')
+    project('wallet'),
+    {
+      displayName: 'wallet-real-ada',
+      preset: 'ts-jest',
+      setupFiles: ['dotenv/config'],
+      testMatch: [`<rootDir>/test/wallet/SingleAddressWallet/(${realAdaTestFileNames.join('|')}).test.ts`],
+      transform: { '^.+\\.test.ts?$': 'ts-jest' }
+    }
   ],
   testTimeout: 1000 * 60 * 25
 };

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -23,7 +23,7 @@
     "load-test-custom:wallet-init": "ts-node test/load-test-custom/wallet-init/wallet-init.test.ts",
     "test": "shx echo 'test' command not implemented yet",
     "test:blockfrost": "jest -c jest.config.js --forceExit --selectProjects blockfrost --runInBand --verbose",
-    "test:measurement-util": "jest -c jest.config.js --forceExit --selectProjects measurement-util --verbose",
+    "test:utils": "jest -c jest.config.js --forceExit --selectProjects utils --verbose",
     "test:load-testing": "jest -c jest.config.js --forceExit --selectProjects load-testing --runInBand --verbose",
     "test:long-running": "jest -c jest.config.js --forceExit --selectProjects long-running --runInBand --verbose",
     "test:local-network": "jest -c jest.config.js --forceExit --selectProjects local-network --runInBand --verbose",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -31,6 +31,7 @@
     "test:ogmios": "jest -c jest.config.js --forceExit --selectProjects ogmios --runInBand --verbose",
     "test:providers": "jest -c jest.config.js --forceExit --selectProjects providers --runInBand --verbose",
     "test:wallet": "jest -c jest.config.js --forceExit --selectProjects wallet --runInBand --verbose",
+    "test:wallet-real-ada": "jest -c jest.config.js --forceExit --selectProjects wallet-real-ada --runInBand --verbose",
     "test:web-extension:build:sw": "tsc --build ./test && tsc --build ./test/web-extension && webpack -c test/web-extension/webpack.config.sw.js",
     "test:web-extension:build:other": "tsc --build ./test && tsc --build ./test/web-extension && webpack -c test/web-extension/webpack.config.js",
     "test:web-extension:build:sw:watch": "yarn test:web-extension:build:sw --watch",

--- a/packages/e2e/test/util.test.ts
+++ b/packages/e2e/test/util.test.ts
@@ -1,0 +1,84 @@
+import { BehaviorSubject, NEVER, of } from 'rxjs';
+import { Cardano } from '@cardano-sdk/core';
+import { ObservableWallet } from '@cardano-sdk/wallet';
+import { insufficientFundsMessage, walletReady } from './util';
+
+describe('util for e2e tests', () => {
+  describe('walletReady', () => {
+    const address = Cardano.PaymentAddress(
+      'addr_test1qpcncempf4svkpw0salztrsxzrfpr5ll323q5whw7lv94vyw0kz5rxvdaq6u6tslwfrrgz6l4n4lpcpnawn87yl9k6dsu4hhg2'
+    );
+
+    const timeoutErrStr = 'Took too long to be ready';
+
+    let wallet: ObservableWallet;
+    let total$: BehaviorSubject<Cardano.Value>;
+    let isSettled$: BehaviorSubject<boolean>;
+
+    beforeEach(() => {
+      total$ = new BehaviorSubject<Cardano.Value>({ coins: 1n });
+      isSettled$ = new BehaviorSubject<boolean>(true);
+      wallet = {
+        addresses$: of([{ address }]),
+        balance: { utxo: { total$ } },
+        syncStatus: { isSettled$ }
+      } as unknown as ObservableWallet;
+    });
+
+    it('uses 1 lovelace as minimum required balance', async () => {
+      const [_, { coins }] = await walletReady(wallet);
+
+      expect(coins).toEqual(1n);
+    });
+
+    it('returns the balance when it is equal to the required minimum', async () => {
+      const coins = 1_000_000n;
+      total$.next({ coins });
+      const [_, balance] = await walletReady(wallet, coins);
+      expect(balance.coins).toEqual(coins);
+    });
+
+    it('returns the balance when it is greater than the required minimum', async () => {
+      const coins = 1_000_001n;
+      total$.next({ coins });
+      const [_, balance] = await walletReady(wallet, coins - 1n);
+
+      expect(balance.coins).toEqual(coins);
+    });
+
+    it('fails with timeout if wallet is not ready', async () => {
+      const minCoinBalance = 0n;
+      isSettled$.next(false);
+      await expect(walletReady(wallet, minCoinBalance, 0)).rejects.toThrow(timeoutErrStr);
+    });
+
+    it('fails with timeout if wallet balance never resolves', async () => {
+      const minCoinBalance = 0n;
+      wallet = {
+        addresses$: of([{ address }]),
+        balance: { utxo: { total$: NEVER } },
+        syncStatus: { isSettled$ }
+      } as unknown as ObservableWallet;
+      await expect(walletReady(wallet, minCoinBalance, 0)).rejects.toThrow(timeoutErrStr);
+    });
+
+    it('fails with timeout if wallet address never resolves', async () => {
+      const minCoinBalance = 0n;
+      wallet = {
+        addresses$: NEVER,
+        balance: { utxo: { total$ } },
+        syncStatus: { isSettled$ }
+      } as unknown as ObservableWallet;
+      await expect(walletReady(wallet, minCoinBalance, 0)).rejects.toThrow(timeoutErrStr);
+    });
+
+    it('fails with insufficient funds if balance minimum not met', async () => {
+      const coins = 10n;
+      const minCoinBalance = coins + 1n;
+      total$.next({ coins });
+      await expect(walletReady(wallet, minCoinBalance)).rejects.toThrow(
+        insufficientFundsMessage(address, minCoinBalance, coins)
+      );
+    });
+  });
+});

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -28,8 +28,15 @@ import {
   throwError,
   timeout
 } from 'rxjs';
-import { InMemoryKeyAgent } from '@cardano-sdk/key-management';
-import { InitializeTxProps, ObservableWallet, SignedTx, SingleAddressWallet, buildTx } from '@cardano-sdk/wallet';
+import {
+  FinalizeTxProps,
+  InitializeTxProps,
+  ObservableWallet,
+  SignedTx,
+  SingleAddressWallet,
+  buildTx
+} from '@cardano-sdk/wallet';
+import { InMemoryKeyAgent, TransactionSigner } from '@cardano-sdk/key-management';
 import { assertTxIsValid } from '../../wallet/test/util';
 import { logger } from '@cardano-sdk/util-dev';
 import sortBy from 'lodash/sortBy';
@@ -262,3 +269,61 @@ export const createStandaloneKeyAgent = async (
     },
     { bip32Ed25519, inputResolver: { resolveInput: async () => null }, logger }
   );
+
+/**
+ * Create burn transaction to cleanup minted assets in tests.
+ * Each test or test suite should call this function to remove any minted assets.
+ * Pass `tokens` with positive value. This method will negate them.
+ * In case `tokens` is undefined, all wallet tokens will be burned.
+ */
+export const burnTokens = async ({
+  wallet,
+  tokens,
+  scripts,
+  policySigners: extraSigners
+}: {
+  wallet: SingleAddressWallet;
+  tokens?: Cardano.TokenMap;
+  scripts: Cardano.Script[];
+  policySigners: TransactionSigner[];
+}) => {
+  if (!tokens) {
+    tokens = (await firstValueFrom(wallet.balance.utxo.available$)).assets;
+  }
+
+  if (!tokens?.size) {
+    return; // nothing to burn
+  }
+
+  const negativeTokens = new Map([...tokens].map(([assetId, value]) => [assetId, -value]));
+  const txProps: InitializeTxProps = {
+    mint: negativeTokens,
+    scripts,
+    witness: { extraSigners }
+  };
+
+  const unsignedTx = await wallet.initializeTx(txProps);
+
+  const finalizeProps: FinalizeTxProps = {
+    scripts,
+    tx: unsignedTx,
+    witness: { extraSigners }
+  };
+
+  const signedTx = await wallet.finalizeTx(finalizeProps);
+  await submitAndConfirm(wallet, signedTx);
+
+  // Wait until all assets are burned
+  await firstValueFromTimed(
+    wallet.balance.utxo.available$.pipe(
+      map(({ assets: availableAssets }) => availableAssets),
+      filter(
+        (availableAssets) =>
+          !availableAssets?.size ||
+          ![...tokens!].some(([id]) => [...availableAssets].some(([assetId]) => assetId === id))
+      )
+    ),
+    'Not all assets were burned',
+    FAST_OPERATION_TIMEOUT_DEFAULT
+  );
+};

--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -87,14 +87,13 @@ describe('SingleAddressWallet/delegation', () => {
     // source wallet has the highest balance to begin with
     const [sourceWallet, destWallet] = await chooseWallets();
 
-    await walletReady(sourceWallet);
+    const tx1OutputCoins = 1_000_000n;
+    await walletReady(sourceWallet, tx1OutputCoins);
 
     const protocolParameters = await firstValueFrom(sourceWallet.protocolParameters$);
     const stakeKeyDeposit = BigInt(protocolParameters.stakeKeyDeposit);
     const initialState = await getWalletStateSnapshot(sourceWallet);
-    expect(initialState.balance.total.coins).toBeGreaterThan(0n);
     expect(initialState.balance.total.coins).toBe(initialState.balance.available.coins);
-    const tx1OutputCoins = 1_000_000n;
     const poolId = await chooseDifferentPoolIdRandomly(initialState.rewardAccount.delegatee?.nextNextEpoch?.id);
     expect(poolId).toBeDefined();
     const initialDeposit = initialState.isStakeKeyRegistered ? stakeKeyDeposit : 0n;

--- a/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
@@ -26,6 +26,9 @@ describe('SingleAddressWallet/metadata', () => {
     const walletUtil = createWalletUtil(wallet);
     const { minimumCoin } = await walletUtil.validateValue({ coins: 0n });
 
+    // Make sure the wallet has sufficient funds to run this test
+    await walletReady(wallet, minimumCoin);
+
     const builtTx = await buildTx({ logger, observableWallet: wallet })
       .addOutput({ address: ownAddress, value: { coins: minimumCoin } })
       .setMetadata(metadata)

--- a/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
@@ -73,7 +73,7 @@ describe('SingleAddressWallet/mint', () => {
   });
 
   it('can mint a token with no asset name', async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
     await walletReady(wallet);
 
@@ -162,7 +162,7 @@ describe('SingleAddressWallet/mint', () => {
   });
 
   it('can detect a phase2 validation failure and emit the transaction as failed', async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
     // Plutus script that always returns false.
     const alwaysFailScript: Cardano.PlutusScript = {

--- a/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
@@ -25,13 +25,13 @@ describe('SingleAddressWallet/mint', () => {
     const genesis = await firstValueFrom(wallet.genesisParameters$);
 
     const aliceKeyAgent = await createStandaloneKeyAgent(
-      util.generateMnemonicWords(),
+      env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
       await wallet.keyAgent.getBip32Ed25519()
     );
 
     const derivationPath = {
-      index: 0,
+      index: 2,
       role: KeyRole.External
     };
 

--- a/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
@@ -20,7 +20,8 @@ describe('SingleAddressWallet/mint', () => {
   it('can mint a token with no asset name', async () => {
     wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
-    await walletReady(wallet);
+    const coins = 3_000_000n;
+    await walletReady(wallet, coins);
 
     const genesis = await firstValueFrom(wallet.genesisParameters$);
 
@@ -65,7 +66,7 @@ describe('SingleAddressWallet/mint', () => {
           address: walletAddress,
           value: {
             assets: tokens,
-            coins: 3_000_000n
+            coins
           }
         }
       ]),

--- a/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
@@ -1,8 +1,8 @@
 import { Cardano, nativeScriptPolicyId } from '@cardano-sdk/core';
 import { FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
 import { KeyRole, util } from '@cardano-sdk/key-management';
+import { burnTokens, createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { createLogger } from '@cardano-sdk/util-dev';
-import { createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { filter, firstValueFrom, map, take } from 'rxjs';
 import { getEnv, getWallet, walletVariables } from '../../../src';
 import { isNotNil } from '@cardano-sdk/util';
@@ -104,5 +104,7 @@ describe('SingleAddressWallet/mint', () => {
     expect(value!.assets!.has(assetId)).toBeTruthy();
     expect(value!.assets!.get(assetId)).toBe(1n);
     expect(txFoundInHistory.inputSource).toBe(Cardano.InputSource.inputs);
+
+    await burnTokens({ policySigners: [alicePolicySigner], scripts: [policyScript], wallet });
   });
 });

--- a/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/mint.test.ts
@@ -1,69 +1,14 @@
-/* eslint-disable sonarjs/no-duplicate-string */
 import { Cardano, nativeScriptPolicyId } from '@cardano-sdk/core';
-import {
-  FinalizeTxProps,
-  InitializeTxProps,
-  SingleAddressWallet,
-  TransactionFailure,
-  buildTx
-} from '@cardano-sdk/wallet';
-import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
-import { HexBlob, isNotNil } from '@cardano-sdk/util';
+import { FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
 import { KeyRole, util } from '@cardano-sdk/key-management';
-import { assertTxIsValid } from '../../../../wallet/test/util';
 import { createLogger } from '@cardano-sdk/util-dev';
-import { createStandaloneKeyAgent, firstValueFromTimed, submitAndConfirm, walletReady } from '../../util';
+import { createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { filter, firstValueFrom, map, take } from 'rxjs';
 import { getEnv, getWallet, walletVariables } from '../../../src';
+import { isNotNil } from '@cardano-sdk/util';
 
 const env = getEnv(walletVariables);
 const logger = createLogger();
-
-/**
- * Creates an output suitable legacy collateral.
- *
- * @param wallet The wallet which will set the collateral.
- */
-const createCollateral = async (
-  wallet: SingleAddressWallet
-): Promise<{ collateralInput: Cardano.TxIn; collateralCoinValue: bigint }> => {
-  const txBuilder = buildTx({ logger, observableWallet: wallet });
-
-  const address = (await firstValueFrom(wallet.addresses$))[0].address;
-
-  // Create a new UTxO to be use as collateral.
-  const txOutput = txBuilder.buildOutput().address(address).coin(5_000_000n).toTxOut();
-
-  const unsignedTx = await txBuilder.addOutput(txOutput).build();
-
-  assertTxIsValid(unsignedTx);
-
-  const signedTx = await unsignedTx.sign();
-  await signedTx.submit();
-
-  // Wait for transaction to be on chain.
-  await firstValueFrom(
-    wallet.transactions.history$.pipe(
-      map((txs) => txs.find((tx) => tx.id === signedTx.tx.id)),
-      filter(isNotNil),
-      take(1)
-    )
-  );
-
-  // Find the collateral UTxO in the UTxO set.
-  const utxo = await firstValueFrom(
-    wallet.utxo.available$.pipe(
-      map((utxos) => utxos.find((o) => o[0].txId === signedTx.tx.id && o[1].value.coins === 5_000_000n)),
-      filter(isNotNil),
-      take(1)
-    )
-  );
-
-  // Set UTxO as unspendable.
-  await wallet.utxo.setUnspendable([utxo]);
-
-  return { collateralCoinValue: utxo[1].value.coins, collateralInput: utxo[0] };
-};
 
 describe('SingleAddressWallet/mint', () => {
   let wallet: SingleAddressWallet;
@@ -159,97 +104,5 @@ describe('SingleAddressWallet/mint', () => {
     expect(value!.assets!.has(assetId)).toBeTruthy();
     expect(value!.assets!.get(assetId)).toBe(1n);
     expect(txFoundInHistory.inputSource).toBe(Cardano.InputSource.inputs);
-  });
-
-  it('can detect a phase2 validation failure and emit the transaction as failed', async () => {
-    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
-
-    // Plutus script that always returns false.
-    const alwaysFailScript: Cardano.PlutusScript = {
-      __type: Cardano.ScriptType.Plutus,
-      bytes: HexBlob(
-        // eslint-disable-next-line max-len
-        '5907620100003232323232323232323232323232332232323232322232325335320193333573466e1cd55cea80124000466442466002006004646464646464646464646464646666ae68cdc39aab9d500c480008cccccccccccc88888888888848cccccccccccc00403403002c02802402001c01801401000c008cd4050054d5d0a80619a80a00a9aba1500b33501401635742a014666aa030eb9405cd5d0a804999aa80c3ae501735742a01066a02803e6ae85401cccd54060081d69aba150063232323333573466e1cd55cea801240004664424660020060046464646666ae68cdc39aab9d5002480008cc8848cc00400c008cd40a9d69aba15002302b357426ae8940088c98c80b4cd5ce01701681589aab9e5001137540026ae854008c8c8c8cccd5cd19b8735573aa004900011991091980080180119a8153ad35742a00460566ae84d5d1280111931901699ab9c02e02d02b135573ca00226ea8004d5d09aba2500223263202933573805405204e26aae7940044dd50009aba1500533501475c6ae854010ccd540600708004d5d0a801999aa80c3ae200135742a004603c6ae84d5d1280111931901299ab9c026025023135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d55cf280089baa00135742a004601c6ae84d5d1280111931900b99ab9c018017015101613263201633573892010350543500016135573ca00226ea800448c88c008dd6000990009aa80a911999aab9f0012500a233500930043574200460066ae880080508c8c8cccd5cd19b8735573aa004900011991091980080180118061aba150023005357426ae8940088c98c8050cd5ce00a80a00909aab9e5001137540024646464646666ae68cdc39aab9d5004480008cccc888848cccc00401401000c008c8c8c8cccd5cd19b8735573aa0049000119910919800801801180a9aba1500233500f014357426ae8940088c98c8064cd5ce00d00c80b89aab9e5001137540026ae854010ccd54021d728039aba150033232323333573466e1d4005200423212223002004357426aae79400c8cccd5cd19b875002480088c84888c004010dd71aba135573ca00846666ae68cdc3a801a400042444006464c6403666ae7007006c06406005c4d55cea80089baa00135742a00466a016eb8d5d09aba2500223263201533573802c02a02626ae8940044d5d1280089aab9e500113754002266aa002eb9d6889119118011bab00132001355012223233335573e0044a010466a00e66442466002006004600c6aae754008c014d55cf280118021aba200301213574200222440042442446600200800624464646666ae68cdc3a800a40004642446004006600a6ae84d55cf280191999ab9a3370ea0049001109100091931900819ab9c01101000e00d135573aa00226ea80048c8c8cccd5cd19b875001480188c848888c010014c01cd5d09aab9e500323333573466e1d400920042321222230020053009357426aae7940108cccd5cd19b875003480088c848888c004014c01cd5d09aab9e500523333573466e1d40112000232122223003005375c6ae84d55cf280311931900819ab9c01101000e00d00c00b135573aa00226ea80048c8c8cccd5cd19b8735573aa004900011991091980080180118029aba15002375a6ae84d5d1280111931900619ab9c00d00c00a135573ca00226ea80048c8cccd5cd19b8735573aa002900011bae357426aae7940088c98c8028cd5ce00580500409baa001232323232323333573466e1d4005200c21222222200323333573466e1d4009200a21222222200423333573466e1d400d2008233221222222233001009008375c6ae854014dd69aba135744a00a46666ae68cdc3a8022400c4664424444444660040120106eb8d5d0a8039bae357426ae89401c8cccd5cd19b875005480108cc8848888888cc018024020c030d5d0a8049bae357426ae8940248cccd5cd19b875006480088c848888888c01c020c034d5d09aab9e500b23333573466e1d401d2000232122222223005008300e357426aae7940308c98c804ccd5ce00a00980880800780700680600589aab9d5004135573ca00626aae7940084d55cf280089baa0012323232323333573466e1d400520022333222122333001005004003375a6ae854010dd69aba15003375a6ae84d5d1280191999ab9a3370ea0049000119091180100198041aba135573ca00c464c6401866ae700340300280244d55cea80189aba25001135573ca00226ea80048c8c8cccd5cd19b875001480088c8488c00400cdd71aba135573ca00646666ae68cdc3a8012400046424460040066eb8d5d09aab9e500423263200933573801401200e00c26aae7540044dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6401466ae7002c02802001c0184d55cea80089baa0012323333573466e1d40052002212200223333573466e1d40092000200823263200633573800e00c00800626aae74dd5000a4c2400292010350543100122001112323001001223300330020020011'
-      ),
-      version: Cardano.PlutusLanguageVersion.V2
-    };
-
-    // Script minting policy id.
-    const policyId = Cardano.PolicyId('38299ce86f8cbef9ebeecc2e94370cb49196d60c93797fffb71d3932');
-    const scriptRedeemer: Cardano.Redeemer = {
-      // CBOR for Void redeemer.
-      data: HexBlob('d8799fff'),
-      executionUnits: {
-        memory: 13_421_562,
-        steps: 9_818_438_928
-      },
-      // Hardcoded to 0 since we only have one script
-      index: 0,
-      purpose: Cardano.RedeemerPurpose.mint
-    };
-
-    // Script data hash was precomputed with the CML (hash of datums, redeemers and language views).
-    const scriptDataHash = Hash32ByteBase16('b6eb57092c330973b23784ac39426921eebd8376343409c03f613fa1a2017126');
-
-    await walletReady(wallet);
-
-    const { collateralInput, collateralCoinValue } = await createCollateral(wallet);
-    const assetId = Cardano.AssetId(`${policyId}707572706C65`);
-    const tokens = new Map([[assetId, 1n]]);
-
-    const walletAddress = (await firstValueFrom(wallet.addresses$))[0].address;
-
-    const txProps: InitializeTxProps = {
-      collaterals: new Set([collateralInput]),
-      mint: tokens,
-      options: {
-        validityInterval: {
-          invalidBefore: undefined,
-          // eslint-disable-next-line max-len
-          invalidHereafter: undefined // HACK: setting any valid interval cause an error in the node: Uncomputable slot arithmetic; transaction's validity bounds go beyond the foreseeable end of the current era
-        }
-      },
-      outputs: new Set([
-        {
-          address: walletAddress,
-          value: {
-            assets: tokens,
-            coins: 3_000_000n
-          }
-        }
-      ]),
-      scriptIntegrityHash: scriptDataHash,
-      scripts: [alwaysFailScript],
-      witness: { redeemers: [scriptRedeemer] }
-    };
-
-    const unsignedTx = await wallet.initializeTx(txProps);
-    const finalizeProps: FinalizeTxProps = {
-      isValid: false,
-      scripts: [alwaysFailScript],
-      tx: unsignedTx,
-      witness: { redeemers: [scriptRedeemer] }
-    };
-
-    const signedTx = await wallet.finalizeTx(finalizeProps);
-
-    const [, failedTx, txFoundInHistory] = await Promise.all([
-      wallet.submitTx(signedTx),
-      firstValueFromTimed(wallet.transactions.outgoing.failed$),
-      firstValueFromTimed(
-        wallet.transactions.history$.pipe(
-          map((txs) => txs.find((tx) => tx.id === signedTx.id)),
-          filter(isNotNil),
-          take(1)
-        )
-      )
-    ]);
-
-    // Transaction should be part of the history
-    expect(txFoundInHistory).toBeTruthy();
-    // But it should also be failed since it failed the phase2 validation
-    expect(failedTx.id).toEqual(signedTx.id);
-    expect(failedTx.reason).toBe(TransactionFailure.Phase2Validation);
-    expect(txFoundInHistory.body.fee).toEqual(collateralCoinValue);
   });
 });

--- a/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
@@ -19,7 +19,7 @@ describe('SingleAddressWallet/multisignature', () => {
   });
 
   it('can create a transaction with multiple signatures to mint an asset', async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
     await walletReady(wallet);
 

--- a/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
@@ -26,29 +26,34 @@ describe('SingleAddressWallet/multisignature', () => {
     const genesis = await firstValueFrom(wallet.genesisParameters$);
 
     const aliceKeyAgent = await createStandaloneKeyAgent(
-      util.generateMnemonicWords(),
+      env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
       await wallet.keyAgent.getBip32Ed25519()
     );
     const bobKeyAgent = await createStandaloneKeyAgent(
-      util.generateMnemonicWords(),
+      env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
       await wallet.keyAgent.getBip32Ed25519()
     );
 
-    const derivationPath = {
-      index: 0,
+    const aliceDerivationPath = {
+      index: 2,
       role: KeyRole.External
     };
 
-    const alicePubKey = await aliceKeyAgent.derivePublicKey(derivationPath);
+    const bobDerivationPath = {
+      index: 3,
+      role: KeyRole.External
+    };
+
+    const alicePubKey = await aliceKeyAgent.derivePublicKey(aliceDerivationPath);
     const aliceKeyHash = await aliceKeyAgent.bip32Ed25519.getPubKeyHash(alicePubKey);
 
-    const bobPubKey = await bobKeyAgent.derivePublicKey(derivationPath);
+    const bobPubKey = await bobKeyAgent.derivePublicKey(bobDerivationPath);
     const bobKeyHash = await bobKeyAgent.bip32Ed25519.getPubKeyHash(bobPubKey);
 
-    const alicePolicySigner = new util.KeyAgentTransactionSigner(aliceKeyAgent, derivationPath);
-    const bobPolicySigner = new util.KeyAgentTransactionSigner(bobKeyAgent, derivationPath);
+    const alicePolicySigner = new util.KeyAgentTransactionSigner(aliceKeyAgent, aliceDerivationPath);
+    const bobPolicySigner = new util.KeyAgentTransactionSigner(bobKeyAgent, bobDerivationPath);
 
     const policyScript: Cardano.NativeScript = {
       __type: Cardano.ScriptType.Native,

--- a/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
@@ -21,7 +21,8 @@ describe('SingleAddressWallet/multisignature', () => {
   it('can create a transaction with multiple signatures to mint an asset', async () => {
     wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
-    await walletReady(wallet);
+    const coins = 3_000_000n;
+    await walletReady(wallet, coins);
 
     const genesis = await firstValueFrom(wallet.genesisParameters$);
 
@@ -85,7 +86,7 @@ describe('SingleAddressWallet/multisignature', () => {
           address: walletAddress,
           value: {
             assets: tokens,
-            coins: 3_000_000n
+            coins
           }
         }
       ]),

--- a/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/multisignature.test.ts
@@ -2,8 +2,8 @@
 import { Cardano, nativeScriptPolicyId } from '@cardano-sdk/core';
 import { FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
 import { KeyRole, util } from '@cardano-sdk/key-management';
+import { burnTokens, createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { createLogger } from '@cardano-sdk/util-dev';
-import { createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { filter, firstValueFrom } from 'rxjs';
 import { getEnv, getWallet, walletVariables } from '../../../src';
 
@@ -112,5 +112,11 @@ describe('SingleAddressWallet/multisignature', () => {
     expect(value).toBeDefined();
     expect(value!.assets!.has(assetId)).toBeTruthy();
     expect(value!.assets!.get(assetId)).toBe(10n);
+
+    await burnTokens({
+      policySigners: [alicePolicySigner, bobPolicySigner],
+      scripts: [policyScript],
+      wallet
+    });
   });
 });

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -25,7 +25,7 @@ describe('SingleAddressWallet.assets/nft', () => {
   let walletAddress: Cardano.PaymentAddress;
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
     await walletReady(wallet);
 

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -32,22 +32,21 @@ describe('SingleAddressWallet.assets/nft', () => {
     const genesis = await firstValueFrom(wallet.genesisParameters$);
 
     const keyAgent = await createStandaloneKeyAgent(
-      util.generateMnemonicWords(),
+      env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
       await wallet.keyAgent.getBip32Ed25519()
     );
 
-    const pubKey = await keyAgent.derivePublicKey({
-      index: 0,
+    const derivationPath = {
+      index: 2,
       role: KeyRole.External
-    });
+    };
+
+    const pubKey = await keyAgent.derivePublicKey(derivationPath);
 
     const keyHash = await keyAgent.bip32Ed25519.getPubKeyHash(pubKey);
 
-    policySigner = new util.KeyAgentTransactionSigner(keyAgent, {
-      index: 0,
-      role: KeyRole.External
-    });
+    policySigner = new util.KeyAgentTransactionSigner(keyAgent, derivationPath);
 
     policyScript = {
       __type: Cardano.ScriptType.Native,

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -2,9 +2,9 @@
 import { Cardano, metadatum, nativeScriptPolicyId } from '@cardano-sdk/core';
 import { FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
 import { KeyRole, TransactionSigner, util } from '@cardano-sdk/key-management';
+import { burnTokens, createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
 import { createLogger } from '@cardano-sdk/util-dev';
-import { createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
 import { getEnv, getWallet, walletVariables } from '../../../src';
 
 const env = getEnv(walletVariables);
@@ -169,22 +169,31 @@ describe('SingleAddressWallet.assets/nft', () => {
     );
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    await burnTokens({
+      policySigners: [policySigner],
+      scripts: [policyScript],
+      wallet
+    });
     wallet.shutdown();
   });
 
   it('supports multiple CIP-25 NFT metadata in one tx', async () => {
-    const nfts = await firstValueFrom(
+    const [nfts, walletAssetBalance] = await firstValueFrom(
       combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
         filter(([assets, balance]) => assets.size === balance.assets?.size),
-        map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
+        filter(([assets]) => [...assets.values()].every((quantity) => !!quantity)),
+        map(([assets, balance]) => [[...assets.values()].filter((asset) => !!asset.nftMetadata), balance.assets])
       )
     );
+
+    // Check balance here because asset info will not be re-fetched when balance changes due to minting and burning
+    expect(walletAssetBalance?.get(assetIds[TOKEN_METADATA_2_INDEX])).toBe(1n);
 
     expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_2_INDEX])).toMatchObject({
       assetId: assetIds[TOKEN_METADATA_2_INDEX],
       fingerprint: fingerprints[TOKEN_METADATA_2_INDEX],
-      mintOrBurnCount: 1,
+      mintOrBurnCount: expect.anything(),
       name: assetNames[TOKEN_METADATA_2_INDEX],
       nftMetadata: {
         image: ['ipfs://some_hash1'],
@@ -193,23 +202,29 @@ describe('SingleAddressWallet.assets/nft', () => {
         version: '1.0'
       },
       policyId,
-      quantity: 1n,
+      // in case of repeated tests on the same network, total asset quantity is not updated due to
+      // the limitation that asset info is not refreshed on wallet balance changes
+      quantity: expect.anything(),
       tokenMetadata: null
     });
     expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_1_INDEX])).toBeDefined();
   });
 
   it('parses CIP-25 NFT metadata with files', async () => {
-    const nfts = await firstValueFrom(
+    const [nfts, walletAssetBalance] = await firstValueFrom(
       combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
         filter(([assets, balance]) => assets.size === balance.assets?.size),
-        map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
+        map(([assets, balance]) => [[...assets.values()].filter((asset) => !!asset.nftMetadata), balance.assets])
       )
     );
+
+    // Check balance here because asset info will not be re-fetched when balance changes due to minting and burning
+    expect(walletAssetBalance?.get(assetIds[TOKEN_METADATA_1_INDEX])).toBe(1n);
+
     expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_1_INDEX])).toMatchObject({
       assetId: assetIds[TOKEN_METADATA_1_INDEX],
       fingerprint: fingerprints[TOKEN_METADATA_1_INDEX],
-      mintOrBurnCount: 1,
+      mintOrBurnCount: expect.anything(),
       name: assetNames[TOKEN_METADATA_1_INDEX],
       nftMetadata: {
         description: ['NFT with different types of files'],
@@ -235,7 +250,7 @@ describe('SingleAddressWallet.assets/nft', () => {
         version: '1.0'
       },
       policyId,
-      quantity: 1n,
+      quantity: expect.anything(),
       tokenMetadata: null
     });
   });
@@ -354,7 +369,7 @@ describe('SingleAddressWallet.assets/nft', () => {
         expect(nfts.find((nft) => nft.assetId === assetId)).toMatchObject({
           assetId,
           fingerprint,
-          mintOrBurnCount: 1,
+          mintOrBurnCount: expect.anything(),
           name: assetNameHex,
           nftMetadata: {
             image: ['ipfs://some_hash1'],
@@ -363,7 +378,7 @@ describe('SingleAddressWallet.assets/nft', () => {
             version: '1.0'
           },
           policyId,
-          quantity: 1n,
+          quantity: expect.anything(),
           tokenMetadata: null
         });
       });

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -23,11 +23,12 @@ describe('SingleAddressWallet.assets/nft', () => {
   let fingerprints: Cardano.AssetFingerprint[];
   const assetNames = ['4e46542d66696c6573', '4e46542d303031', '4e46542d303032'];
   let walletAddress: Cardano.PaymentAddress;
+  const coins = 10_000_000n; // number of coins to use in each transaction
 
   beforeAll(async () => {
     wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
 
-    await walletReady(wallet);
+    await walletReady(wallet, coins);
 
     const genesis = await firstValueFrom(wallet.genesisParameters$);
 
@@ -131,7 +132,7 @@ describe('SingleAddressWallet.assets/nft', () => {
           address: walletAddress,
           value: {
             assets: tokens,
-            coins: 50_000_000n
+            coins
           }
         }
       ]),
@@ -256,6 +257,9 @@ describe('SingleAddressWallet.assets/nft', () => {
   });
 
   it('supports burning tokens', async () => {
+    // Make sure the wallet has sufficient funds to run this test
+    await walletReady(wallet, coins);
+
     // spend entire balance of test asset
     const availableBalance = await firstValueFrom(wallet.balance.utxo.available$);
     const assetBalance = availableBalance.assets!.get(assetIds[TOKEN_BURN_INDEX])!;
@@ -266,7 +270,7 @@ describe('SingleAddressWallet.assets/nft', () => {
         {
           address: walletAddress,
           value: {
-            coins: 50_000_000n
+            coins
           }
         }
       ]),
@@ -306,6 +310,9 @@ describe('SingleAddressWallet.assets/nft', () => {
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const CIP0025Test = (testName: string, assetName: string, version: 1 | 2, encoding?: 'hex' | 'utf8') =>
       it(testName, async () => {
+        // Make sure the wallet has sufficient funds to run this test
+        await walletReady(wallet, coins);
+
         const assetNameHex = Buffer.from(assetName).toString('hex');
         const assetId = Cardano.AssetId(`${policyId}${assetNameHex}`);
         const fingerprint = Cardano.AssetFingerprint.fromParts(policyId, Cardano.AssetName(assetNameHex));
@@ -337,7 +344,7 @@ describe('SingleAddressWallet.assets/nft', () => {
               address: walletAddress,
               value: {
                 assets: tokens,
-                coins: 50_000_000n
+                coins
               }
             }
           ]),

--- a/packages/e2e/test/wallet/SingleAddressWallet/phase2validation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/phase2validation.test.ts
@@ -1,0 +1,164 @@
+import { Cardano } from '@cardano-sdk/core';
+import {
+  FinalizeTxProps,
+  InitializeTxProps,
+  SingleAddressWallet,
+  TransactionFailure,
+  buildTx
+} from '@cardano-sdk/wallet';
+import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
+import { HexBlob, isNotNil } from '@cardano-sdk/util';
+import { assertTxIsValid } from '../../../../wallet/test/util';
+import { createLogger } from '@cardano-sdk/util-dev';
+import { filter, firstValueFrom, map, take } from 'rxjs';
+import { firstValueFromTimed, walletReady } from '../../util';
+import { getEnv, getWallet, walletVariables } from '../../../src';
+
+const env = getEnv(walletVariables);
+const logger = createLogger();
+
+/**
+ * Creates an output suitable legacy collateral.
+ *
+ * @param wallet The wallet which will set the collateral.
+ */
+const createCollateral = async (
+  wallet: SingleAddressWallet
+): Promise<{ collateralInput: Cardano.TxIn; collateralCoinValue: bigint }> => {
+  const txBuilder = buildTx({ logger, observableWallet: wallet });
+
+  const address = (await firstValueFrom(wallet.addresses$))[0].address;
+
+  // Create a new UTxO to be use as collateral.
+  const txOutput = txBuilder.buildOutput().address(address).coin(5_000_000n).toTxOut();
+
+  const unsignedTx = await txBuilder.addOutput(txOutput).build();
+
+  assertTxIsValid(unsignedTx);
+
+  const signedTx = await unsignedTx.sign();
+  await signedTx.submit();
+
+  // Wait for transaction to be on chain.
+  await firstValueFrom(
+    wallet.transactions.history$.pipe(
+      map((txs) => txs.find((tx) => tx.id === signedTx.tx.id)),
+      filter(isNotNil),
+      take(1)
+    )
+  );
+
+  // Find the collateral UTxO in the UTxO set.
+  const utxo = await firstValueFrom(
+    wallet.utxo.available$.pipe(
+      map((utxos) => utxos.find((o) => o[0].txId === signedTx.tx.id && o[1].value.coins === 5_000_000n)),
+      filter(isNotNil),
+      take(1)
+    )
+  );
+
+  // Set UTxO as unspendable.
+  await wallet.utxo.setUnspendable([utxo]);
+
+  return { collateralCoinValue: utxo[1].value.coins, collateralInput: utxo[0] };
+};
+
+describe('SingleAddressWallet/phase2validation', () => {
+  let wallet: SingleAddressWallet;
+
+  afterAll(() => {
+    wallet.shutdown();
+  });
+
+  it('can detect a phase2 validation failure and emit the transaction as failed', async () => {
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+
+    // Plutus script that always returns false.
+    const alwaysFailScript: Cardano.PlutusScript = {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob(
+        // eslint-disable-next-line max-len
+        '5907620100003232323232323232323232323232332232323232322232325335320193333573466e1cd55cea80124000466442466002006004646464646464646464646464646666ae68cdc39aab9d500c480008cccccccccccc88888888888848cccccccccccc00403403002c02802402001c01801401000c008cd4050054d5d0a80619a80a00a9aba1500b33501401635742a014666aa030eb9405cd5d0a804999aa80c3ae501735742a01066a02803e6ae85401cccd54060081d69aba150063232323333573466e1cd55cea801240004664424660020060046464646666ae68cdc39aab9d5002480008cc8848cc00400c008cd40a9d69aba15002302b357426ae8940088c98c80b4cd5ce01701681589aab9e5001137540026ae854008c8c8c8cccd5cd19b8735573aa004900011991091980080180119a8153ad35742a00460566ae84d5d1280111931901699ab9c02e02d02b135573ca00226ea8004d5d09aba2500223263202933573805405204e26aae7940044dd50009aba1500533501475c6ae854010ccd540600708004d5d0a801999aa80c3ae200135742a004603c6ae84d5d1280111931901299ab9c026025023135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d55cf280089baa00135742a004601c6ae84d5d1280111931900b99ab9c018017015101613263201633573892010350543500016135573ca00226ea800448c88c008dd6000990009aa80a911999aab9f0012500a233500930043574200460066ae880080508c8c8cccd5cd19b8735573aa004900011991091980080180118061aba150023005357426ae8940088c98c8050cd5ce00a80a00909aab9e5001137540024646464646666ae68cdc39aab9d5004480008cccc888848cccc00401401000c008c8c8c8cccd5cd19b8735573aa0049000119910919800801801180a9aba1500233500f014357426ae8940088c98c8064cd5ce00d00c80b89aab9e5001137540026ae854010ccd54021d728039aba150033232323333573466e1d4005200423212223002004357426aae79400c8cccd5cd19b875002480088c84888c004010dd71aba135573ca00846666ae68cdc3a801a400042444006464c6403666ae7007006c06406005c4d55cea80089baa00135742a00466a016eb8d5d09aba2500223263201533573802c02a02626ae8940044d5d1280089aab9e500113754002266aa002eb9d6889119118011bab00132001355012223233335573e0044a010466a00e66442466002006004600c6aae754008c014d55cf280118021aba200301213574200222440042442446600200800624464646666ae68cdc3a800a40004642446004006600a6ae84d55cf280191999ab9a3370ea0049001109100091931900819ab9c01101000e00d135573aa00226ea80048c8c8cccd5cd19b875001480188c848888c010014c01cd5d09aab9e500323333573466e1d400920042321222230020053009357426aae7940108cccd5cd19b875003480088c848888c004014c01cd5d09aab9e500523333573466e1d40112000232122223003005375c6ae84d55cf280311931900819ab9c01101000e00d00c00b135573aa00226ea80048c8c8cccd5cd19b8735573aa004900011991091980080180118029aba15002375a6ae84d5d1280111931900619ab9c00d00c00a135573ca00226ea80048c8cccd5cd19b8735573aa002900011bae357426aae7940088c98c8028cd5ce00580500409baa001232323232323333573466e1d4005200c21222222200323333573466e1d4009200a21222222200423333573466e1d400d2008233221222222233001009008375c6ae854014dd69aba135744a00a46666ae68cdc3a8022400c4664424444444660040120106eb8d5d0a8039bae357426ae89401c8cccd5cd19b875005480108cc8848888888cc018024020c030d5d0a8049bae357426ae8940248cccd5cd19b875006480088c848888888c01c020c034d5d09aab9e500b23333573466e1d401d2000232122222223005008300e357426aae7940308c98c804ccd5ce00a00980880800780700680600589aab9d5004135573ca00626aae7940084d55cf280089baa0012323232323333573466e1d400520022333222122333001005004003375a6ae854010dd69aba15003375a6ae84d5d1280191999ab9a3370ea0049000119091180100198041aba135573ca00c464c6401866ae700340300280244d55cea80189aba25001135573ca00226ea80048c8c8cccd5cd19b875001480088c8488c00400cdd71aba135573ca00646666ae68cdc3a8012400046424460040066eb8d5d09aab9e500423263200933573801401200e00c26aae7540044dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6401466ae7002c02802001c0184d55cea80089baa0012323333573466e1d40052002212200223333573466e1d40092000200823263200633573800e00c00800626aae74dd5000a4c2400292010350543100122001112323001001223300330020020011'
+      ),
+      version: Cardano.PlutusLanguageVersion.V2
+    };
+
+    // Script minting policy id.
+    const policyId = Cardano.PolicyId('38299ce86f8cbef9ebeecc2e94370cb49196d60c93797fffb71d3932');
+    const scriptRedeemer: Cardano.Redeemer = {
+      // CBOR for Void redeemer.
+      data: HexBlob('d8799fff'),
+      executionUnits: {
+        memory: 13_421_562,
+        steps: 9_818_438_928
+      },
+      // Hardcoded to 0 since we only have one script
+      index: 0,
+      purpose: Cardano.RedeemerPurpose.mint
+    };
+
+    // Script data hash was precomputed with the CML (hash of datums, redeemers and language views).
+    const scriptDataHash = Hash32ByteBase16('b6eb57092c330973b23784ac39426921eebd8376343409c03f613fa1a2017126');
+
+    await walletReady(wallet);
+
+    const { collateralInput, collateralCoinValue } = await createCollateral(wallet);
+    const assetId = Cardano.AssetId(`${policyId}707572706C65`);
+    const tokens = new Map([[assetId, 1n]]);
+
+    const walletAddress = (await firstValueFrom(wallet.addresses$))[0].address;
+
+    const txProps: InitializeTxProps = {
+      collaterals: new Set([collateralInput]),
+      mint: tokens,
+      options: {
+        validityInterval: {
+          invalidBefore: undefined,
+          // eslint-disable-next-line max-len
+          invalidHereafter: undefined // HACK: setting any valid interval cause an error in the node: Uncomputable slot arithmetic; transaction's validity bounds go beyond the foreseeable end of the current era
+        }
+      },
+      outputs: new Set([
+        {
+          address: walletAddress,
+          value: {
+            assets: tokens,
+            coins: 3_000_000n
+          }
+        }
+      ]),
+      scriptIntegrityHash: scriptDataHash,
+      scripts: [alwaysFailScript],
+      witness: { redeemers: [scriptRedeemer] }
+    };
+
+    const unsignedTx = await wallet.initializeTx(txProps);
+    const finalizeProps: FinalizeTxProps = {
+      isValid: false,
+      scripts: [alwaysFailScript],
+      tx: unsignedTx,
+      witness: { redeemers: [scriptRedeemer] }
+    };
+
+    const signedTx = await wallet.finalizeTx(finalizeProps);
+
+    const [, failedTx, txFoundInHistory] = await Promise.all([
+      wallet.submitTx(signedTx),
+      firstValueFromTimed(wallet.transactions.outgoing.failed$),
+      firstValueFromTimed(
+        wallet.transactions.history$.pipe(
+          map((txs) => txs.find((tx) => tx.id === signedTx.id)),
+          filter(isNotNil),
+          take(1)
+        )
+      )
+    ]);
+
+    // Transaction should be part of the history
+    expect(txFoundInHistory).toBeTruthy();
+    // But it should also be failed since it failed the phase2 validation
+    expect(failedTx.id).toEqual(signedTx.id);
+    expect(failedTx.reason).toBe(TransactionFailure.Phase2Validation);
+    expect(txFoundInHistory.body.fee).toEqual(collateralCoinValue);
+  });
+});

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChainHistory.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChainHistory.test.ts
@@ -9,7 +9,7 @@ import { normalizeTxBody } from '../../util';
 
 const env = getEnv(walletVariables);
 
-describe('tx chain history', () => {
+describe('SingleAddressWallet/txChainHistory', () => {
   let wallet: SingleAddressWallet;
 
   beforeEach(async () => {

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChainHistory.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChainHistory.test.ts
@@ -5,7 +5,7 @@ import { filter, firstValueFrom, map, take } from 'rxjs';
 import { getEnv, getWallet, walletVariables } from '../../../src';
 import { isNotNil } from '@cardano-sdk/util';
 import { logger } from '@cardano-sdk/util-dev';
-import { normalizeTxBody } from '../../util';
+import { normalizeTxBody, walletReady } from '../../util';
 
 const env = getEnv(walletVariables);
 
@@ -22,6 +22,8 @@ describe('SingleAddressWallet/txChainHistory', () => {
 
   it('submit a transaction and find it in chain history', async () => {
     const tAdaToSend = 10_000_000n;
+    // Make sure the wallet has sufficient funds to run this test
+    await walletReady(wallet, tAdaToSend);
 
     await firstValueFrom(wallet.syncStatus.isSettled$.pipe(filter((isSettled) => isSettled)));
 

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
@@ -13,7 +13,7 @@ describe('SingleAddressWallet/txChaining', () => {
     jest.setTimeout(180_000);
     wallet = (await getWallet({ env, logger, name: 'Test Wallet' })).wallet;
 
-    await walletReady(wallet);
+    await walletReady(wallet, 1_000_000n);
   });
 
   afterAll(() => {

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
@@ -6,7 +6,7 @@ import { submitAndConfirm, walletReady } from '../../util';
 
 const env = getEnv(walletVariables);
 
-describe('SingleAddressWallet', () => {
+describe('SingleAddressWallet/txChaining', () => {
   let wallet: ObservableWallet;
 
   beforeAll(async () => {

--- a/packages/e2e/test/wallet/SingleAddressWallet/unspendableUtxos.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/unspendableUtxos.test.ts
@@ -25,8 +25,9 @@ describe('SingleAddressWallet/unspendableUtxos', () => {
     wallet1 = (await getWallet({ env, logger, name: 'Wallet 1', polling: { interval: 50 } })).wallet;
     wallet2 = (await getWallet({ env, logger, name: 'Wallet 2', polling: { interval: 50 } })).wallet;
 
-    await walletReady(wallet1);
-    await walletReady(wallet2);
+    const coins = 5_000_000n;
+    await walletReady(wallet1, coins);
+    await walletReady(wallet2, coins);
 
     const txBuilder1 = buildTx({ logger, observableWallet: wallet1 });
     const txBuilder2 = buildTx({ logger, observableWallet: wallet2 });

--- a/packages/e2e/test/wallet/SingleAddressWallet/unspendableUtxos.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/unspendableUtxos.test.ts
@@ -22,8 +22,8 @@ describe('SingleAddressWallet/unspendableUtxos', () => {
   // eslint-disable-next-line max-statements
   it('unsets unspendable UTxOs when no longer in the wallets UTxO set', async () => {
     // Here we will simulate the scenario of collateral consumption by spending it from another wallet instance.
-    wallet1 = (await getWallet({ env, idx: 0, logger, name: 'Wallet 1', polling: { interval: 50 } })).wallet;
-    wallet2 = (await getWallet({ env, idx: 0, logger, name: 'Wallet 2', polling: { interval: 50 } })).wallet;
+    wallet1 = (await getWallet({ env, logger, name: 'Wallet 1', polling: { interval: 50 } })).wallet;
+    wallet2 = (await getWallet({ env, logger, name: 'Wallet 2', polling: { interval: 50 } })).wallet;
 
     await walletReady(wallet1);
     await walletReady(wallet2);


### PR DESCRIPTION
# Context
Review and configure tests to be ran on Mainnet

# Proposed Solution
1. `yarn test:mainnet-real-ada` picks only the tests suitable for a network with real ada
2. Added a `KEY_MANAGEMENT_PARAMS_PEER` env to be used in tests with two wallets.
3. Added `MINT_POLICY_SIGNER_MNEMONICS1` and `...2` to be used for minting tests to avoid losing the keys previously generated randomly in tests.
4. Added burn tokens step to cleanup after minting tests.
 
# Important Changes Introduced
