### PR TITLE
perf: Optimize transactions by addresses SQL queries

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -7,6 +7,7 @@ import {
   MultiAssetModel,
   RedeemerModel,
   TipModel,
+  TxIdModel,
   TxInput,
   TxInputModel,
   TxModel,
@@ -180,7 +181,7 @@ export const mapTxAlonzo = (
         }
       : undefined,
   blockHeader: {
-    blockNo: Cardano.BlockNo(txModel.block_no),
+    blockNo: Cardano.BlockNo(Number(txModel.block_no)),
     hash: txModel.block_hash.toString('hex') as unknown as Cardano.BlockId,
     slot: Cardano.Slot(Number(txModel.block_slot_no))
   },
@@ -236,3 +237,5 @@ export const mapBlock = (
   txCount: Number(blockModel.tx_count),
   vrf: blockModel.vrf as unknown as Cardano.VrfVkBech32
 });
+
+export const mapTxId = ({ tx_id }: TxIdModel) => tx_id;

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -26,14 +26,14 @@ const selectTxOutput = `
 	FROM tx_out
 	JOIN tx ON tx_out.tx_id = tx.id`;
 
-export const findTxInputsByHashes = `
-  ${selectTxInput()}
-  WHERE tx.hash = ANY($1)
+export const findTxInputsByIds = `
+  	${selectTxInput()}
+  	WHERE tx.id = ANY($1)
 	ORDER BY tx_in.id ASC`;
 
-export const findTxCollateralsByHashes = `
+export const findTxCollateralsByIds = `
 	${selectTxInput(true)}
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx_in.id ASC`;
 
 export const findTxInputsByAddresses = `
@@ -44,9 +44,9 @@ export const findTxInputsByAddresses = `
 	AND block.block_no <= $3
 	ORDER BY tx_in.id ASC`;
 
-export const findTxOutputsByHashes = `
-  ${selectTxOutput}
-  WHERE tx.hash = ANY($1)
+export const findTxOutputsByIds = `
+  	${selectTxOutput}
+  	WHERE tx.id = ANY($1)
 	ORDER BY tx_out.id ASC`;
 
 export const findTxOutputsByAddresses = `
@@ -115,7 +115,7 @@ export const findMultiAssetByTxOut = `
 	WHERE tx_out.id = ANY($1)
 	ORDER BY ma_out.id ASC`;
 
-export const findTxMint = `
+export const findTxMintByIds = `
 	SELECT 
 		mint.quantity AS quantity,
 		ma_id.fingerprint AS fingerprint,
@@ -125,10 +125,10 @@ export const findTxMint = `
 	FROM ma_tx_mint AS mint
 	JOIN multi_asset AS ma_id ON mint.ident = ma_id.id
 	JOIN tx ON tx.id = mint.tx_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY mint.id ASC`;
 
-export const findTransactionsByHashes = `
+export const findTransactionsByIds = `
 	SELECT 
 		tx.hash AS id,
 		tx.block_index AS "index",
@@ -142,10 +142,14 @@ export const findTransactionsByHashes = `
 		block.slot_no AS block_slot_no
 	FROM tx
 	JOIN block ON tx.block_id = block.id
-  WHERE tx.hash = ANY($1)
+  WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC`;
 
-export const findWithdrawal = `
+export const findTxRecordIdsByTxHashes = `
+	SELECT id FROM tx WHERE hash = ANY($1)	
+`;
+
+export const findWithdrawalsByTxIds = `
 	SELECT
 		withdrawal.amount AS quantity,
 		tx.hash AS tx_id,
@@ -153,10 +157,10 @@ export const findWithdrawal = `
 	FROM withdrawal
 	JOIN tx ON tx.id = withdrawal.tx_id
 	JOIN stake_address AS stk_addr ON stk_addr.id = withdrawal.addr_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY withdrawal.id ASC`;
 
-export const findRedeemer = `
+export const findRedeemersByTxIds = `
 	SELECT
 		redeemer."index" AS "index",
 		redeemer.purpose AS purpose,
@@ -166,10 +170,10 @@ export const findRedeemer = `
 		tx.hash AS tx_id
 	FROM redeemer
 	JOIN tx ON tx.id = redeemer.tx_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY redeemer.id ASC`;
 
-export const findPoolRetireCerts = `
+export const findPoolRetireCertsTxIds = `
 	SELECT 
 		cert.cert_index AS cert_index,
 		cert.retiring_epoch AS retiring_epoch,
@@ -178,10 +182,10 @@ export const findPoolRetireCerts = `
 	FROM tx 
 	JOIN pool_retire AS cert ON cert.announced_tx_id = tx.id
 	JOIN pool_hash AS pool ON pool.id = cert.hash_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC`;
 
-export const findPoolRegisterCerts = `
+export const findPoolRegisterCertsByTxIds = `
 	SELECT	
 		cert.cert_index AS cert_index,
 		pool."view" AS pool_id,
@@ -189,10 +193,10 @@ export const findPoolRegisterCerts = `
 	FROM tx
 	JOIN pool_update AS cert ON cert.registered_tx_id = tx.id
 	JOIN pool_hash AS pool ON pool.id = cert.hash_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC`;
 
-export const findMirCerts = `
+export const findMirCertsByTxIds = `
 	(SELECT
 		cert.cert_index AS cert_index,
 		cert.amount AS amount,
@@ -202,7 +206,7 @@ export const findMirCerts = `
 	FROM tx
 	JOIN reserve AS cert ON cert.tx_id = tx.id
 	JOIN stake_address AS addr ON cert.addr_id = addr.id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC)
 	UNION
 	(SELECT
@@ -214,10 +218,10 @@ export const findMirCerts = `
 	FROM tx
 	JOIN treasury AS cert ON cert.tx_id = tx.id
 	JOIN stake_address AS addr ON cert.addr_id = addr.id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC)`;
 
-export const findStakeCerts = `
+export const findStakeCertsByTxIds = `
 	(SELECT 
 		cert.cert_index AS cert_index,
 		addr."view" AS address,
@@ -226,7 +230,7 @@ export const findStakeCerts = `
 	FROM tx
 	JOIN stake_registration AS cert ON cert.tx_id = tx.id
 	JOIN stake_address AS addr ON addr.id = cert.addr_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC)
 	UNION
 	(SELECT 
@@ -237,10 +241,10 @@ export const findStakeCerts = `
 	FROM tx
 	JOIN stake_deregistration AS cert ON cert.tx_id = tx.id
 	JOIN stake_address AS addr ON addr.id = cert.addr_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC)`;
 
-export const findDelegationCerts = `
+export const findDelegationCertsByTxIds = `
 	SELECT 
 		cert.cert_index AS cert_index,
 		tx.hash AS tx_id,
@@ -250,5 +254,53 @@ export const findDelegationCerts = `
 	JOIN delegation AS cert ON cert.tx_id = tx.id
 	JOIN pool_hash AS pool ON pool.id = cert.pool_hash_id
 	JOIN stake_address AS addr ON addr.id = cert.addr_id
-	WHERE tx.hash = ANY($1)
+	WHERE tx.id = ANY($1)
 	ORDER BY tx.id ASC`;
+
+export const findTxsByAddresses = {
+  WITH: `
+WITH source AS (
+  SELECT tx_id, tx_in_id FROM tx_out
+  LEFT JOIN tx_in ON tx_out_id = tx_id AND tx_out_index = index
+  WHERE address = ANY($1)
+),
+combined AS (
+  SELECT tx_id FROM source
+  UNION ALL
+  SELECT tx_in_id AS tx_id FROM source WHERE tx_in_id IS NOT NULL
+)`,
+  count: {
+    ORDER: '',
+    SELECT: `
+SELECT
+  COUNT(DISTINCT tx_id) AS count`
+  },
+  page: {
+    ORDER: `
+ORDER BY tx_id`,
+    SELECT: `
+SELECT
+  DISTINCT tx_id`
+  },
+  withRange: {
+    FROM: `
+FROM partial
+JOIN tx ON
+  tx.id = tx_id
+JOIN block ON
+  block.id = block_id AND
+  block_no BETWEEN $2 AND $3`,
+    WITH: `,
+partial AS (
+  SELECT
+    DISTINCT tx_id
+  FROM combined
+  ORDER BY tx_id
+)`
+  },
+  withoutRange: {
+    FROM: `
+FROM combined`,
+    WITH: ''
+  }
+} as const;

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -133,3 +133,11 @@ export interface DelegationCertModel extends CertificateModel {
   address: string;
   pool_id: string;
 }
+
+export interface CountModel {
+  count: string;
+}
+
+export interface TxIdModel {
+  tx_id: string;
+}

--- a/packages/cardano-services/src/Metadata/queries.ts
+++ b/packages/cardano-services/src/Metadata/queries.ts
@@ -1,4 +1,4 @@
-export const findTxMetadata = `
+export const findTxMetadataByTxHashes = `
 SELECT
   key,
   bytes,
@@ -6,4 +6,14 @@ SELECT
 FROM tx_metadata AS meta
 JOIN tx ON tx_id = tx.id
 WHERE hash = ANY($1)
+ORDER BY meta.id ASC`;
+
+export const findTxMetadataByTxIds = `
+SELECT
+  key,
+  bytes,
+  hash AS tx_id
+FROM tx_metadata AS meta
+JOIN tx ON tx_id = tx.id
+WHERE tx.id = ANY($1)
 ORDER BY meta.id ASC`;

--- a/packages/cardano-services/src/Metadata/types.ts
+++ b/packages/cardano-services/src/Metadata/types.ts
@@ -2,6 +2,7 @@ import { Cardano } from '@cardano-sdk/core';
 
 export interface TxMetadataService {
   queryTxMetadataByHashes(hashes: Cardano.TransactionId[]): Promise<Map<Cardano.TransactionId, Cardano.TxMetadata>>;
+  queryTxMetadataByRecordIds(ids: string[]): Promise<Map<string, Cardano.TxMetadata>>;
 }
 
 export interface TxMetadataModel {

--- a/packages/cardano-services/src/Metadata/util.ts
+++ b/packages/cardano-services/src/Metadata/util.ts
@@ -1,0 +1,16 @@
+import { Cardano } from '@cardano-sdk/core';
+import { TxMetadataByHashes } from './DbSyncMetadataService';
+import { TxMetadataModel } from './types';
+import { mapTxMetadata } from './mappers';
+
+export const mapTxMetadataByHashes = (listOfMetadata: TxMetadataModel[]): TxMetadataByHashes => {
+  const metadataMap: Map<Cardano.TransactionId, TxMetadataModel[]> = new Map();
+
+  for (const metadata of listOfMetadata) {
+    const txId = metadata.tx_id.toString('hex') as Cardano.TransactionId;
+    const currentMetadata: TxMetadataModel[] = metadataMap.get(txId) ?? [];
+    metadataMap.set(txId, [...currentMetadata, metadata]);
+  }
+
+  return new Map([...metadataMap].map(([id, metadata]) => [id, mapTxMetadata(metadata)]));
+};

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -512,7 +512,7 @@ describe('ChainHistoryHttpService', () => {
           const response = await provider.transactionsByAddresses({ addresses, pagination: { limit: 5, startAt: 0 } });
           expect(response.pageResults.length).toBeGreaterThan(0);
           expect(
-            response.pageResults[0].body.inputs.find((txIn) => txIn.address === genesisAddresses[0])
+            response.pageResults[1].body.inputs.find((txIn) => txIn.address === genesisAddresses[0])
           ).toBeDefined();
           expect(response.pageResults[0].body.inputs).toMatchShapeOf(DataMocks.Tx.inputs);
         });

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/ChainHistoryBuilder.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/ChainHistoryBuilder.test.ts
@@ -4,15 +4,16 @@ import { ChainHistoryFixtureBuilder, TxWith } from '../fixtures/FixtureBuilder';
 import { DataMocks } from '../../data-mocks';
 import { Pool } from 'pg';
 import { createLogger } from '@cardano-sdk/util-dev';
+import { hexStringToBuffer } from '@cardano-sdk/util';
 
 const logger = createLogger({ record: true });
 
 /**
  * Checks tx_ids are logged as hex strings
  *
- * @param text the text of the loggd message containing tx_ids
+ * @param text the text of the logged message containing tx_ids
  */
-const checkLoggedTxids = (text: string): void => {
+const checkLoggedTxIds = (text: string, tx_id?: boolean): void => {
   //
   const messages = logger.messages.filter(
     (_) => _.level === 'debug' && typeof _.message[0] === 'string' && _.message[0].match(text)
@@ -24,6 +25,8 @@ const checkLoggedTxids = (text: string): void => {
   const tx_ids = message[1] as unknown[];
   expect(tx_ids.length).toBeGreaterThan(0);
   expect(typeof tx_ids[0]).toBe('string');
+  // If this line throws, the logged string is not a record id
+  if (tx_id) return expect(tx_ids[0]).toBe(Number(tx_ids[0]).toString());
   // If this line throws, the logged string is not a formally valid tx_id
   Cardano.TransactionId(tx_ids[0] as string);
 };
@@ -47,61 +50,65 @@ describe('ChainHistoryBuilder', () => {
 
   beforeEach(() => logger.reset());
 
-  describe('queryTransactionInputsByHashes', () => {
+  const getTxId = async (hash: Cardano.TransactionId) => {
+    const query = 'SELECT id FROM tx WHERE hash = $1';
+    const res = await dbConnection.query<{ id: string }>(query, [hexStringToBuffer(hash)]);
+
+    return res.rowCount ? res.rows[0].id : '0';
+  };
+
+  const getTxIds = (hashes: Cardano.TransactionId[]) => Promise.all(hashes.map((_) => getTxId(_)));
+
+  describe('queryTransactionInputsByIds', () => {
     test('query transaction inputs by tx hashes', async () => {
-      const txHashes = await fixtureBuilder.getTxHashes(1);
-      const result = await builder.queryTransactionInputsByHashes(txHashes);
+      const ids = await getTxIds(await fixtureBuilder.getTxHashes(1));
+      const result = await builder.queryTransactionInputsByIds(ids);
       expect(result.length).toBeGreaterThanOrEqual(1);
       expect(result[0]).toMatchShapeOf(DataMocks.Tx.txInput);
-      checkLoggedTxids('About to find inputs \\(collateral');
+      checkLoggedTxIds('About to find inputs \\(collateral', true);
     });
     test('query transaction inputs with empty array', async () => {
-      const result = await builder.queryTransactionInputsByHashes([]);
+      const result = await builder.queryTransactionInputsByIds([]);
       expect(result).toHaveLength(0);
     });
     test('query transaction inputs when tx hashes not found', async () => {
-      const result = await builder.queryTransactionInputsByHashes([
-        Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
-      ]);
+      const result = await builder.queryTransactionInputsByIds(['0']);
       expect(result).toHaveLength(0);
     });
 
     describe('with collateral true', () => {
       test('query transaction collateral inputs by tx hashes', async () => {
         const txHashes = await fixtureBuilder.getTxHashes(1, { with: [TxWith.CollateralInput] });
-        const result = await builder.queryTransactionInputsByHashes(txHashes, true);
+        const ids = await getTxIds(txHashes);
+        const result = await builder.queryTransactionInputsByIds(ids, true);
         expect(result).toHaveLength(1);
         expect(result).toMatchShapeOf(DataMocks.Tx.txInput);
       });
       test('query transaction collateral inputs when tx not found or does not have any ', async () => {
-        const result = await builder.queryTransactionInputsByHashes(
-          [
-            Cardano.TransactionId('295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7'),
-            Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
-          ],
-          true
-        );
+        const ids = await getTxIds([
+          Cardano.TransactionId('295d5e0f7ee182426eaeda8c9f1c63502c72cdf4afd6e0ee0f209adf94a614e7')
+        ]);
+        const result = await builder.queryTransactionInputsByIds(['0', ...ids], true);
         expect(result).toHaveLength(0);
       });
     });
   });
 
-  describe('queryTransactionOutputsByHashes', () => {
+  describe('queryTransactionOutputsByIds', () => {
     test('query transaction outputs by tx hashes', async () => {
       const txHashes = await fixtureBuilder.getTxHashes(2);
-      const result = await builder.queryTransactionOutputsByHashes(txHashes);
+      const ids = await getTxIds(txHashes);
+      const result = await builder.queryTransactionOutputsByIds(ids);
       expect(result.length).toBeGreaterThanOrEqual(2);
       expect(result[0]).toMatchShapeOf(DataMocks.Tx.txOut);
-      checkLoggedTxids('About to find outputs for transactions');
+      checkLoggedTxIds('About to find outputs for transactions with ids', true);
     });
     test('query transaction outputs with empty array', async () => {
-      const result = await builder.queryTransactionOutputsByHashes([]);
+      const result = await builder.queryTransactionOutputsByIds([]);
       expect(result).toHaveLength(0);
     });
     test('query transaction outputs when tx hashes not found', async () => {
-      const result = await builder.queryTransactionOutputsByHashes([
-        Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
-      ]);
+      const result = await builder.queryTransactionOutputsByIds(['0']);
       expect(result).toHaveLength(0);
     });
   });
@@ -125,73 +132,77 @@ describe('ChainHistoryBuilder', () => {
     });
   });
 
-  describe('queryTxMintByHashes', () => {
+  describe('queryTxMintByIds', () => {
     test('query transaction mint by tx hashes', async () => {
       const txHashes = await fixtureBuilder.getTxHashes(2, { with: [TxWith.Mint] });
-      const result = await builder.queryTxMintByHashes(txHashes);
+      const ids = await getTxIds(txHashes);
+      const result = await builder.queryTxMintByIds(ids);
       expect(result.size).toEqual(2);
       expect(result.get(txHashes[0])).toMatchShapeOf(DataMocks.Tx.txTokenMap);
-      checkLoggedTxids('About to find tx mint for txs');
+      checkLoggedTxIds('About to find tx mint for transactions with ids', true);
     });
     test('query transaction mint with empty array', async () => {
-      const result = await builder.queryTxMintByHashes([]);
+      const result = await builder.queryTxMintByIds([]);
       expect(result.size).toEqual(0);
     });
     test('query transaction mint when tx not found or has no mint operations', async () => {
-      const result = await builder.queryTxMintByHashes([
-        Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000'),
+      const ids = await getTxIds([
         Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819')
       ]);
+      const result = await builder.queryTxMintByIds(['0', ...ids]);
       expect(result.size).toEqual(0);
     });
   });
 
-  describe('queryWithdrawalsByHashes', () => {
+  describe('queryWithdrawalsByTxIds', () => {
     test('query transaction withdrawals by tx hashes', async () => {
       const txHashes = await fixtureBuilder.getTxHashes(1, { with: [TxWith.Withdrawal] });
-      const result = await builder.queryWithdrawalsByHashes(txHashes);
+      const ids = await getTxIds(txHashes);
+      const result = await builder.queryWithdrawalsByTxIds(ids);
       expect(result.size).toEqual(1);
       expect(result.get(txHashes[0])).toMatchShapeOf(DataMocks.Tx.withdrawal);
-      checkLoggedTxids('About to find withdrawals for txs');
+      checkLoggedTxIds('About to find withdrawals for transactions with ids', true);
     });
     test('query transaction withdrawals with empty array', async () => {
-      const result = await builder.queryWithdrawalsByHashes([]);
+      const result = await builder.queryWithdrawalsByTxIds([]);
       expect(result.size).toEqual(0);
     });
     test('query transaction withdrawals when tx not found or has no withdrawals', async () => {
-      const result = await builder.queryWithdrawalsByHashes([
-        Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000'),
+      const ids = await getTxIds([
         Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819')
       ]);
+      const result = await builder.queryWithdrawalsByTxIds(['0', ...ids]);
       expect(result.size).toEqual(0);
     });
   });
 
-  describe('queryRedeemersByHashes', () => {
+  describe('queryRedeemersByIds', () => {
     test('query transaction redeemers by tx hashes', async () => {
       const txHashes = await fixtureBuilder.getTxHashes(1, { with: [TxWith.Redeemer] });
-      const result = await builder.queryRedeemersByHashes(txHashes);
+      const ids = await getTxIds(txHashes);
+      const result = await builder.queryRedeemersByIds(ids);
       expect(result.size).toEqual(1);
       expect(result.get(txHashes[0])![0]).toMatchShapeOf(DataMocks.Tx.redeemer);
-      checkLoggedTxids('About to find redeemers for txs');
+      checkLoggedTxIds('About to find redeemers for transactions with ids', true);
     });
     test('query transaction redeemers with empty array', async () => {
-      const result = await builder.queryRedeemersByHashes([]);
+      const result = await builder.queryRedeemersByIds([]);
       expect(result.size).toEqual(0);
     });
     test('query transaction redeemers when tx not found or has no redeemers', async () => {
-      const result = await builder.queryRedeemersByHashes([
-        Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000'),
+      const ids = await getTxIds([
         Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819')
       ]);
+      const result = await builder.queryRedeemersByIds(['0', ...ids]);
       expect(result.size).toEqual(0);
     });
   });
 
-  describe('queryCertificatesByHashes', () => {
+  describe('queryCertificatesByIds', () => {
     test('query certificates by tx hashes', async () => {
       const txHashes = await fixtureBuilder.getTxHashes(2, { with: [TxWith.DelegationCertificate] });
-      const result = await builder.queryCertificatesByHashes(txHashes);
+      const ids = await getTxIds(txHashes);
+      const result = await builder.queryCertificatesByIds(ids);
       expect(result.size).toBeGreaterThanOrEqual(2);
       const certificates = result.get(txHashes[0]);
       let delegationCertificate;
@@ -200,17 +211,17 @@ describe('ChainHistoryBuilder', () => {
       }
       expect(delegationCertificate).toBeDefined();
       expect(delegationCertificate).toMatchShapeOf(DataMocks.Tx.certificate);
-      checkLoggedTxids('About to find certificates for txs');
+      checkLoggedTxIds('About to find certificates for transactions with ids', true);
     });
     test('query certificates with empty array', async () => {
-      const result = await builder.queryCertificatesByHashes([]);
+      const result = await builder.queryCertificatesByIds([]);
       expect(result.size).toEqual(0);
     });
     test('query certificates when tx not found or has not certificates', async () => {
-      const result = await builder.queryCertificatesByHashes([
-        Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000'),
+      const ids = await getTxIds([
         Cardano.TransactionId('cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819')
       ]);
+      const result = await builder.queryCertificatesByIds(['0', ...ids]);
       expect(result.size).toEqual(0);
     });
   });


### PR DESCRIPTION
# Context

The `/chain-history/txs/by-addresses` endpoint (called by wallet restoration procedure) may take a long time depending on the number of the transactions affecting the addresses.

# Proposed Solution

The `transactionsByAddresses` exposed function takes advantage from `transactionsByHashes` exposed function.

- Added a new `transactionsByIds` internal function.
- Changed the two previously said function to call the new one.

This let to change the main query performed by `transactionsByAddresses` to return the `tx.id` rather than `tx.hash` optimizing it.

# Important Changes Introduced

Changed all the `ChainHistoryBuilder` methods called by `transactionsByHashes` to accept `tx.id` rather than `tx.hash`.