### PR TITLE
Feat/stake pool metadata fetcher

### DIFF
--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -19,7 +19,7 @@ import {
 import { DbSyncEpochPollService, loadGenesisData } from '../../util';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../NetworkInfo';
 import { DbSyncRewardsProvider, RewardsHttpService } from '../../Rewards';
-import { DbSyncStakePoolProvider, StakePoolHttpService, createHttpStakePoolExtMetadataService } from '../../StakePool';
+import { DbSyncStakePoolProvider, StakePoolHttpService, createHttpStakePoolMetadataService } from '../../StakePool';
 import { DbSyncUtxoProvider, UtxoHttpService } from '../../Utxo';
 import { DnsResolver, createDnsResolver, serviceSetHas } from '../utils';
 import { GenesisData } from '../../types';
@@ -168,7 +168,7 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
           epochMonitor: getEpochMonitor(db),
           genesisData,
           logger,
-          metadataService: createHttpStakePoolExtMetadataService(logger)
+          metadataService: createHttpStakePoolMetadataService(logger)
         }
       );
       return new StakePoolHttpService({ logger, stakePoolProvider });

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -9,7 +9,7 @@ import {
 } from '@cardano-sdk/core';
 import { CommonPoolInfo, OrderedResult, PoolAPY, PoolData, PoolMetrics, PoolSortType, PoolUpdate } from './types';
 import { DbSyncProvider, DbSyncProviderDependencies, Disposer, EpochMonitor } from '../../util';
-import { GenesisData, InMemoryCache, StakePoolExtMetadataService, UNLIMITED_CACHE_TTL } from '../..';
+import { GenesisData, InMemoryCache, StakePoolMetadataService, UNLIMITED_CACHE_TTL } from '../..';
 import {
   IDS_NAMESPACE,
   REWARDS_HISTORY_LIMIT_DEFAULT,
@@ -71,7 +71,7 @@ export interface StakePoolProviderDependencies extends DbSyncProviderDependencie
   /**
    * The Stake Pool extended metadata service.
    */
-  metadataService: StakePoolExtMetadataService;
+  metadataService: StakePoolMetadataService;
 }
 
 export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) implements StakePoolProvider {
@@ -80,7 +80,7 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
   #epochLength: number;
   #epochMonitor: EpochMonitor;
   #epochRolloverDisposer: Disposer;
-  #metadataService: StakePoolExtMetadataService;
+  #metadataService: StakePoolMetadataService;
   #paginationPageSizeLimit: number;
   #responseConfig: StakePoolProviderProps['responseConfig'];
   #useBlockfrost: boolean;

--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
@@ -1,6 +1,6 @@
 import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
-import { StakePoolExtMetadataResponse, StakePoolExtMetadataService } from '../types';
+import { StakePoolExtMetadataResponse, StakePoolMetadataService } from '../types';
 import { ValidationError, validate } from 'jsonschema';
 import { getExtMetadataUrl, getSchemaFormat, loadJsonSchema } from './util';
 import { mapToExtendedMetadata } from './mappers';
@@ -9,13 +9,13 @@ import axios, { AxiosInstance } from 'axios';
 const HTTP_CLIENT_TIMEOUT = 1 * 1000;
 const HTTP_CLIENT_MAX_CONTENT_LENGTH = 5000;
 
-export const createHttpStakePoolExtMetadataService = (
+export const createHttpStakePoolMetadataService = (
   logger: Logger,
   axiosClient: AxiosInstance = axios.create({
     maxContentLength: HTTP_CLIENT_MAX_CONTENT_LENGTH,
     timeout: HTTP_CLIENT_TIMEOUT
   })
-): StakePoolExtMetadataService => ({
+): StakePoolMetadataService => ({
   async getStakePoolExtendedMetadata(metadata: Cardano.StakePoolMetadata): Promise<Cardano.ExtendedStakePoolMetadata> {
     const url = getExtMetadataUrl(metadata);
     try {
@@ -30,14 +30,14 @@ export const createHttpStakePoolExtMetadataService = (
           throw new ProviderError(
             ProviderFailure.NotFound,
             error,
-            `StakePoolExtMetadataService failed to fetch extended metadata from ${url} due to resource not found`
+            `StakePoolMetadataService failed to fetch extended metadata from ${url} due to resource not found`
           );
         }
 
         throw new ProviderError(
           ProviderFailure.ConnectionFailure,
           error,
-          `StakePoolExtMetadataService failed to fetch extended metadata from ${url} due to connection error`
+          `StakePoolMetadataService failed to fetch extended metadata from ${url} due to connection error`
         );
       }
       if (error instanceof ValidationError) {

--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
@@ -1,13 +1,23 @@
-import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+/* eslint-disable max-len */
+/* eslint-disable complexity */
+/* eslint-disable sonarjs/cognitive-complexity */
+/* eslint-disable max-depth */
+
+import * as Crypto from '@cardano-sdk/crypto';
+import { CML, Cardano } from '@cardano-sdk/core';
+import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
+import { HexBlob } from '@cardano-sdk/util';
 import { Logger } from 'ts-log';
 import { StakePoolExtMetadataResponse, StakePoolMetadataService } from '../types';
+import { StakePoolMetadataResponse, StakePoolMetadataServiceError, StakePoolMetadataServiceFailure } from '../..';
 import { ValidationError, validate } from 'jsonschema';
 import { getExtMetadataUrl, getSchemaFormat, loadJsonSchema } from './util';
 import { mapToExtendedMetadata } from './mappers';
-import axios, { AxiosInstance } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
-const HTTP_CLIENT_TIMEOUT = 1 * 1000;
+const HTTP_CLIENT_TIMEOUT = 2 * 1000;
 const HTTP_CLIENT_MAX_CONTENT_LENGTH = 5000;
+const SERVICE_NAME = 'StakePoolMetadataService';
 
 export const createHttpStakePoolMetadataService = (
   logger: Logger,
@@ -16,38 +26,145 @@ export const createHttpStakePoolMetadataService = (
     timeout: HTTP_CLIENT_TIMEOUT
   })
 ): StakePoolMetadataService => ({
-  async getStakePoolExtendedMetadata(metadata: Cardano.StakePoolMetadata): Promise<Cardano.ExtendedStakePoolMetadata> {
+  async getStakePoolExtendedMetadata(
+    metadata: Cardano.StakePoolMetadata,
+    config: AxiosRequestConfig = {}
+  ): Promise<Cardano.ExtendedStakePoolMetadata> {
     const url = getExtMetadataUrl(metadata);
     try {
       logger.debug('About to fetch stake pool extended metadata');
-      const { data } = await axiosClient.get<StakePoolExtMetadataResponse>(url);
+      const { data } = await axiosClient.get<StakePoolExtMetadataResponse>(url, config);
       const schema = loadJsonSchema(getSchemaFormat(metadata));
       validate(data, schema, { throwError: true });
       return mapToExtendedMetadata(data);
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 404) {
-          throw new ProviderError(
-            ProviderFailure.NotFound,
+          throw new StakePoolMetadataServiceError(
+            StakePoolMetadataServiceFailure.FailedToFetchExtendedMetadata,
             error,
-            `StakePoolMetadataService failed to fetch extended metadata from ${url} due to resource not found`
+            `${SERVICE_NAME} failed to fetch extended metadata from ${url} due to resource not found`
           );
         }
 
-        throw new ProviderError(
-          ProviderFailure.ConnectionFailure,
+        throw new StakePoolMetadataServiceError(
+          StakePoolMetadataServiceFailure.FailedToFetchExtendedMetadata,
           error,
-          `StakePoolMetadataService failed to fetch extended metadata from ${url} due to connection error`
+          `${SERVICE_NAME} failed to fetch extended metadata from ${url} due to connection error`
         );
       }
+
       if (error instanceof ValidationError) {
-        throw new ProviderError(
-          ProviderFailure.InvalidResponse,
+        throw new StakePoolMetadataServiceError(
+          StakePoolMetadataServiceFailure.InvalidExtendedMetadataFormat,
           error,
           'Extended metadata JSON format validation failed against the corresponding schema for correctness'
         );
       }
+
       throw error;
     }
+  },
+  async getStakePoolMetadata(hash: Hash32ByteBase16, url: string): Promise<StakePoolMetadataResponse> {
+    const errors = [];
+    let metadata: Cardano.StakePoolMetadata | undefined;
+    let extMetadata: Cardano.ExtendedStakePoolMetadata | undefined;
+
+    try {
+      logger.debug(`About to fetch stake pool metadata JSON from ${url}`);
+
+      // Fetch metadata as byte array
+      const { data } = await axiosClient.get<Uint8Array>(url, { responseType: 'arraybuffer' });
+
+      // Produce metadata hash
+      const metadataHash = Crypto.blake2b(Crypto.blake2b.BYTES).update(data).digest('hex');
+
+      // Verify base hashes
+      if (metadataHash !== hash) {
+        return {
+          errors: [
+            new StakePoolMetadataServiceError(
+              StakePoolMetadataServiceFailure.InvalidStakePoolHash,
+              null,
+              `Invalid stake pool hash. Computed '${metadataHash}', expected '${hash}'`
+            )
+          ],
+          metadata
+        };
+      }
+
+      // Transform fetched metadata from bytes array to JSON
+      metadata = JSON.parse(data.toString());
+
+      if (metadata?.extDataUrl || metadata?.extended) {
+        // Validate CIP-6 ext metadata fields
+        if (metadata.extDataUrl && (!metadata.extSigUrl || !metadata.extVkey)) {
+          return {
+            errors: [
+              new StakePoolMetadataServiceError(
+                StakePoolMetadataServiceFailure.InvalidMetadata,
+                null,
+                'Missing ext signature or public key'
+              )
+            ],
+            metadata
+          };
+        }
+
+        // Fetch extended metadata (supports both cip-6 and ada pools formats already)
+        extMetadata = await this.getStakePoolExtendedMetadata(metadata);
+
+        // In case of CIP-6 standard -> perform signature verification
+        if (metadata.extDataUrl && metadata.extSigUrl && metadata.extVkey) {
+          // Based on the CIP-6, we have `extSigUrl` (A URL with the extended metadata signature), so we need to make another HTTP request to get the actual signature
+          try {
+            const signature = (await axiosClient.get<Crypto.Ed25519SignatureHex>(metadata.extSigUrl)).data;
+            const message = HexBlob.fromBytes(Buffer.from(JSON.stringify(extMetadata)));
+            const publicKey = Crypto.Ed25519PublicKeyHex(metadata.extVkey);
+            const bip32Ed25519 = new Crypto.CmlBip32Ed25519(CML);
+
+            // Verify the signature
+            const isSignatureValid = await bip32Ed25519.verify(signature, message, publicKey);
+
+            // If not valid -> omit extended metadata from response and add specific error
+            if (!isSignatureValid) {
+              extMetadata = undefined;
+              errors.push(
+                new StakePoolMetadataServiceError(
+                  StakePoolMetadataServiceFailure.InvalidExtendedMetadataSignature,
+                  null,
+                  'Invalid extended metadata signature'
+                )
+              );
+            }
+
+            // If signature url failed -> omit extended metadata from response and add specific error
+          } catch (error) {
+            extMetadata = undefined;
+            errors.push(
+              new StakePoolMetadataServiceError(
+                StakePoolMetadataServiceFailure.FailedToFetchExtendedSignature,
+                error,
+                `${SERVICE_NAME} failed to fetch extended signature from ${metadata.extSigUrl} due to connection error`
+              )
+            );
+          }
+        }
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        errors.push(
+          new StakePoolMetadataServiceError(
+            StakePoolMetadataServiceFailure.FailedToFetchMetadata,
+            error.toJSON(),
+            `${SERVICE_NAME} failed to fetch metadata JSON from ${url} due to ${error.message}`
+          )
+        );
+      } else if (error instanceof StakePoolMetadataServiceError) {
+        errors.push(error);
+      }
+    }
+
+    return { errors, metadata: { ...metadata!, ext: extMetadata } };
   }
 });

--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/errors.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/errors.ts
@@ -1,0 +1,17 @@
+import { ComposableError, formatErrorMessage } from '@cardano-sdk/util';
+
+export enum StakePoolMetadataServiceFailure {
+  FailedToFetchExtendedMetadata = 'FAILED_TO_FETCH_EXTENDED_METADATA',
+  FailedToFetchMetadata = 'FAILED_TO_FETCH_METADATA',
+  FailedToFetchExtendedSignature = 'FAILED_TO_FETCH_EXTENDED_SIGNATURE',
+  InvalidExtendedMetadataFormat = 'INVALID_EXTENDED_METADATA_FORMAT',
+  InvalidExtendedMetadataSignature = 'INVALID_EXTENDED_METADATA_SIGNATURE',
+  InvalidStakePoolHash = 'INVALID_STAKE_POOL_HASH',
+  InvalidMetadata = 'INVALID_METADATA'
+}
+
+export class StakePoolMetadataServiceError<InnerError = unknown> extends ComposableError<InnerError> {
+  constructor(public reason: StakePoolMetadataServiceFailure, innerError?: InnerError, public detail?: string) {
+    super(formatErrorMessage(reason, detail), innerError);
+  }
+}

--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/index.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/index.ts
@@ -2,3 +2,4 @@ export * from './HttpStakePoolMetadataService';
 export * from './types';
 export * from './util';
 export * from './mappers';
+export * from './errors';

--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/index.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/index.ts
@@ -1,4 +1,4 @@
-export * from './HttpStakePoolExtMetadataService';
+export * from './HttpStakePoolMetadataService';
 export * from './types';
 export * from './util';
 export * from './mappers';

--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/types.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/types.ts
@@ -1,3 +1,6 @@
+import { Cardano } from '@cardano-sdk/core';
+import { CustomError } from 'ts-custom-error';
+
 /**
  * AdaPools format response types
  * Based on: https://a.adapools.org/extended-example
@@ -88,4 +91,9 @@ export type Cip6ExtendedStakePoolMetadataFields = {
 export type Cip6ExtMetadataResponse = {
   serial: number;
   pool: Cip6ExtendedStakePoolMetadataFields;
+};
+
+export type StakePoolMetadataResponse = {
+  metadata: Cardano.StakePoolMetadata | undefined;
+  errors: CustomError[];
 };

--- a/packages/cardano-services/src/StakePool/types.ts
+++ b/packages/cardano-services/src/StakePool/types.ts
@@ -1,10 +1,10 @@
-import { APExtMetadataResponse, Cip6ExtMetadataResponse } from './HttpStakePoolMetadata';
+import { APExtMetadataResponse, Cip6ExtMetadataResponse, StakePoolMetadataResponse } from './HttpStakePoolMetadata';
 import { Cardano } from '@cardano-sdk/core';
+import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 
 export interface StakePoolMetadataService {
-  getStakePoolExtendedMetadata(
-    poolMetadata: Cardano.StakePoolMetadata
-  ): Promise<Cardano.ExtendedStakePoolMetadata | null>;
+  getStakePoolMetadata(hash: Hash32ByteBase16, url: string): Promise<StakePoolMetadataResponse>;
+  getStakePoolExtendedMetadata(poolMetadata: Cardano.StakePoolMetadata): Promise<Cardano.ExtendedStakePoolMetadata>;
 }
 
 export enum ExtMetadataFormat {

--- a/packages/cardano-services/src/StakePool/types.ts
+++ b/packages/cardano-services/src/StakePool/types.ts
@@ -1,7 +1,7 @@
 import { APExtMetadataResponse, Cip6ExtMetadataResponse } from './HttpStakePoolMetadata';
 import { Cardano } from '@cardano-sdk/core';
 
-export interface StakePoolExtMetadataService {
+export interface StakePoolMetadataService {
   getStakePoolExtendedMetadata(
     poolMetadata: Cardano.StakePoolMetadata
   ): Promise<Cardano.ExtendedStakePoolMetadata | null>;

--- a/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/HttpMetadataService.test.ts
+++ b/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/HttpMetadataService.test.ts
@@ -4,7 +4,7 @@ import { DataMocks } from '../../data-mocks';
 import { ExtMetadataFormat } from '../../../src/StakePool/types';
 import { adaPoolsExtMetadataMock, cip6ExtMetadataMock, mainExtMetadataMock } from './mocks';
 import { createGenericMockServer, logger } from '@cardano-sdk/util-dev';
-import { createHttpStakePoolExtMetadataService } from '../../../src';
+import { createHttpStakePoolMetadataService } from '../../../src';
 import url from 'url';
 
 export const mockPoolExtMetadataServer = createGenericMockServer((handler) => async (req, res) => {
@@ -28,11 +28,11 @@ export const mockPoolExtMetadataServer = createGenericMockServer((handler) => as
   return res.end(JSON.stringify(adaPoolsExtMetadataMock));
 });
 
-describe('StakePoolExtMetadataService', () => {
+describe('StakePoolMetadataService', () => {
   describe('healthy state', () => {
     let closeMock: () => Promise<void> = jest.fn();
     let serverUrl = '';
-    const extendedMetadataService = createHttpStakePoolExtMetadataService(logger);
+    const extendedMetadataService = createHttpStakePoolMetadataService(logger);
 
     beforeAll(async () => {
       ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({})));
@@ -78,7 +78,7 @@ describe('StakePoolExtMetadataService', () => {
   });
 
   describe('error cases are correctly handled', () => {
-    const extendedMetadataService = createHttpStakePoolExtMetadataService(logger);
+    const extendedMetadataService = createHttpStakePoolMetadataService(logger);
     let closeMock: () => Promise<void> = jest.fn();
     let serverUrl: string;
 
@@ -147,7 +147,7 @@ describe('StakePoolExtMetadataService', () => {
         new ProviderError(
           ProviderFailure.ConnectionFailure,
           null,
-          `StakePoolExtMetadataService failed to fetch extended metadata from ${serverUrl}/${ExtMetadataFormat.CIP6} due to connection error`
+          `StakePoolMetadataService failed to fetch extended metadata from ${serverUrl}/${ExtMetadataFormat.CIP6} due to connection error`
         )
       );
     });
@@ -177,7 +177,7 @@ describe('StakePoolExtMetadataService', () => {
         new ProviderError(
           ProviderFailure.NotFound,
           null,
-          `StakePoolExtMetadataService failed to fetch extended metadata from ${serverUrl}/${ExtMetadataFormat.CIP6} due to resource not found`
+          `StakePoolMetadataService failed to fetch extended metadata from ${serverUrl}/${ExtMetadataFormat.CIP6} due to resource not found`
         )
       );
     });

--- a/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/mocks.ts
+++ b/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/mocks.ts
@@ -66,3 +66,11 @@ export const cip6ExtMetadataMock: Cip6ExtMetadataResponse = {
   },
   serial: 2_020_072_001
 };
+
+export const stakePoolMetadata: Cardano.StakePoolMetadata = {
+  description: 'Stakepool - Your reliable & trustworthy stakepool',
+  extended: 'http://localhost/extendedMetadata',
+  homepage: 'https://www.home-page.com',
+  name: 'Stakepool #1',
+  ticker: 'STKP'
+};

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -19,7 +19,7 @@ import {
   InMemoryCache,
   StakePoolHttpService,
   UNLIMITED_CACHE_TTL,
-  createHttpStakePoolExtMetadataService
+  createHttpStakePoolMetadataService
 } from '../../src';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { INFO, createLogger } from 'bunyan';
@@ -189,7 +189,7 @@ describe('StakePoolHttpService', () => {
     const dbConnectionQuerySpy = jest.spyOn(db, 'query');
     const clearCacheSpy = jest.spyOn(cache, 'clear');
     let genesisData: GenesisData;
-    const metadataService = createHttpStakePoolExtMetadataService(logger);
+    const metadataService = createHttpStakePoolMetadataService(logger);
 
     beforeAll(async () => {
       genesisData = await loadGenesisData(cardanoNodeConfigPath);
@@ -207,7 +207,12 @@ describe('StakePoolHttpService', () => {
           withTip: true
         })
       ) as unknown as OgmiosCardanoNode;
-
+      stakePoolProvider = new DbSyncStakePoolProvider(
+        { paginationPageSizeLimit: pagination.limit, useBlockfrost: false },
+        { cache, cardanoNode, db, epochMonitor, genesisData, logger, metadataService }
+      );
+      service = new StakePoolHttpService({ logger, stakePoolProvider });
+      httpServer = new HttpServer(config, { logger, runnableDependencies: [cardanoNode], services: [service] });
       provider = stakePoolHttpProvider(clientConfig);
     });
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,4 +1,4 @@
-import { ComposableError } from '@cardano-sdk/util';
+import { ComposableError, formatErrorMessage } from '@cardano-sdk/util';
 import { CustomError } from 'ts-custom-error';
 
 export enum ProviderFailure {
@@ -21,11 +21,9 @@ export const providerFailureToStatusCodeMap: { [key in ProviderFailure]: number 
   [ProviderFailure.ConnectionFailure]: 500
 };
 
-const formatMessage = (reason: string, detail?: string) => reason + (detail ? ` (${detail})` : '');
-
 export class ProviderError<InnerError = unknown> extends ComposableError<InnerError> {
   constructor(public reason: ProviderFailure, innerError?: InnerError, public detail?: string) {
-    super(formatMessage(reason, detail), innerError);
+    super(formatErrorMessage(reason, detail), innerError);
   }
 }
 
@@ -42,7 +40,7 @@ export enum SerializationFailure {
 
 export class SerializationError<InnerError = unknown> extends ComposableError<InnerError> {
   constructor(public reason: SerializationFailure, public detail?: string, innerError?: InnerError) {
-    super(formatMessage(reason, detail), innerError);
+    super(formatErrorMessage(reason, detail), innerError);
   }
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,7 +8,8 @@ export enum ProviderFailure {
   NotImplemented = 'NOT_IMPLEMENTED',
   Unhealthy = 'UNHEALTHY',
   ConnectionFailure = 'CONNECTION_FAILURE',
-  BadRequest = 'BAD_REQUEST'
+  BadRequest = 'BAD_REQUEST',
+  ServerUnavailable = 'SERVER_UNAVAILABLE'
 }
 
 export const providerFailureToStatusCodeMap: { [key in ProviderFailure]: number } = {
@@ -18,7 +19,8 @@ export const providerFailureToStatusCodeMap: { [key in ProviderFailure]: number 
   [ProviderFailure.Unknown]: 500,
   [ProviderFailure.InvalidResponse]: 500,
   [ProviderFailure.NotImplemented]: 500,
-  [ProviderFailure.ConnectionFailure]: 500
+  [ProviderFailure.ConnectionFailure]: 500,
+  [ProviderFailure.ServerUnavailable]: 500
 };
 
 export class ProviderError<InnerError = unknown> extends ComposableError<InnerError> {

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -1,5 +1,7 @@
 import { CustomError } from 'ts-custom-error';
 
+export const formatErrorMessage = (reason: string, detail?: string) => reason + (detail ? ` (${detail})` : '');
+
 interface ErrorLike {
   message: string;
   stack: string;


### PR DESCRIPTION
# Context

We must be able to fetch the off-chain pool metadata, verify the base hash, and extended stake pool metadata signature using the extSigUrl (A URL with the extended metadata signature) and extVkey (the public key for verification) as specified in [CIP-6](https://cips.cardano.org/cips/cip6/).

We also want to add support for AdaPools extended metadata. (make use of extended property if presented within JSON response)

# Proposed Solution

Implement a new StakePoolMetadataService that can fetch the metadata and perform the proper validations

