### PR TITLE
feat(cardano-services): configurable pgpool size

### DIFF
--- a/packages/cardano-services/src/Program/options/postgres.ts
+++ b/packages/cardano-services/src/Program/options/postgres.ts
@@ -13,6 +13,7 @@ export enum PostgresOptionDescriptions {
   SslCaFile = 'PostgreSQL SSL CA file path',
   Host = 'PostgreSQL host',
   Port = 'PostgreSQL port',
+  PoolMax = 'Maximum number of clients in the PostgreSQL pool',
   ServiceDiscoveryArgs = 'Postgres SRV service name, db, user and password'
 }
 
@@ -26,6 +27,7 @@ export interface PosgresProgramOptions {
   postgresPassword?: string;
   postgresPasswordFile?: string;
   postgresHost?: string;
+  postgresPoolMax?: number;
   postgresPort?: string;
   postgresSslCaFile?: string;
 }
@@ -82,6 +84,11 @@ export const withPostgresOptions = (command: Command) =>
         .argParser(existingFileValidator)
     )
     .addOption(new Option('--postgres-host <postgresHost>', PostgresOptionDescriptions.Host).env('POSTGRES_HOST'))
+    .addOption(
+      new Option('--postgres-pool-max <postgresPoolMax>', PostgresOptionDescriptions.PoolMax)
+        .env('POSTGRES_POOL_MAX')
+        .argParser((max) => Number.parseInt(max, 10))
+    )
     .addOption(new Option('--postgres-port <postgresPort>', PostgresOptionDescriptions.Port).env('POSTGRES_PORT'))
     .addOption(
       new Option('--postgres-ssl-ca-file <postgresSslCaFile>', PostgresOptionDescriptions.SslCaFile).env(

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -683,6 +683,8 @@ describe('CLI', () => {
                   postgresPassword,
                   '--postgres-host',
                   postgresHost,
+                  '--postgres-pool-max',
+                  '50',
                   '--postgres-port',
                   postgresPort,
                   ServiceNames.Utxo
@@ -705,6 +707,7 @@ describe('CLI', () => {
                   POSTGRES_DB: postgresDb,
                   POSTGRES_HOST: postgresHost,
                   POSTGRES_PASSWORD: postgresPassword,
+                  POSTGRES_POOL_MAX: '50',
                   POSTGRES_PORT: postgresPort,
                   POSTGRES_USER: postgresUser,
                   SERVICE_NAMES: ServiceNames.Utxo


### PR DESCRIPTION
# Context
There's no exposed interface to control the pgpool size, which impacts ability to tune the application at runtime.

# Proposed Solution
- Plumb in the `PoolConfig` `max` property, exposed on the CLI. The original type covered the previous options, but it was technically incorrect.