### PR TITLE
fix: always return a healthcheck response, logging errors instead of throwing

### DIFF
--- a/packages/cardano-services/test/util/DbSyncProvider/DbSyncProvider.test.ts
+++ b/packages/cardano-services/test/util/DbSyncProvider/DbSyncProvider.test.ts
@@ -1,0 +1,139 @@
+import { Connection, createConnectionObject } from '@cardano-ogmios/client';
+import { DbSyncProvider, DbSyncProviderDependencies } from '../../../src/util';
+import { HEALTH_RESPONSE_BODY } from '../../../../ogmios/test/mocks/util';
+import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
+import { Pool, QueryResult } from 'pg';
+import { Provider } from '@cardano-sdk/core';
+import {
+  createMockOgmiosServer,
+  listenPromise,
+  serverClosePromise
+} from '../../../../ogmios/test/mocks/mockOgmiosServer';
+import { getRandomPort } from 'get-port-please';
+import { dummyLogger as logger } from 'ts-log';
+import http from 'http';
+
+const someError = new Error('Some error');
+
+const healthyMockOgmios = () =>
+  createMockOgmiosServer({
+    healthCheck: { response: { success: true } }
+  });
+
+const unhealthyMockOgmios = () =>
+  createMockOgmiosServer({
+    healthCheck: {
+      response: {
+        failWith: someError,
+        success: false
+      }
+    }
+  });
+
+export interface SomeProvider extends Provider {
+  getData: () => Promise<QueryResult>;
+}
+
+class DbSyncSomeProvider extends DbSyncProvider() implements SomeProvider {
+  constructor(dependencies: DbSyncProviderDependencies) {
+    super(dependencies);
+  }
+
+  async getData() {
+    return this.db.query('SELECT * from a');
+  }
+}
+
+jest.mock('pg', () => ({
+  Pool: jest.fn(() => ({
+    connect: jest.fn(),
+    end: jest.fn(),
+    query: jest.fn()
+  }))
+}));
+
+describe('DbSyncProvider', () => {
+  describe('healthCheck', () => {
+    let cardanoNode: OgmiosCardanoNode;
+    let connection: Connection;
+    let mockServer: http.Server;
+    let db: Pool;
+    let provider: DbSyncSomeProvider;
+
+    beforeEach(async () => {
+      connection = createConnectionObject({ port: await getRandomPort() });
+      db = new Pool();
+    });
+
+    afterEach(async () => {
+      await serverClosePromise(mockServer);
+      jest.clearAllMocks();
+    });
+
+    describe('healthy database', () => {
+      beforeEach(async () => {
+        // Mock the database query with the same tip as the Ogmios mock,
+        // to ensure the sync percentage is 100
+        (db.query as jest.Mock).mockResolvedValue({
+          rows: [
+            {
+              block_no: HEALTH_RESPONSE_BODY.lastKnownTip.blockNo,
+              hash: HEALTH_RESPONSE_BODY.lastKnownTip.hash,
+              slot_no: HEALTH_RESPONSE_BODY.lastKnownTip.slot.toString()
+            }
+          ]
+        });
+        cardanoNode = new OgmiosCardanoNode(connection, logger);
+      });
+
+      it('is ok when node is healthy', async () => {
+        mockServer = healthyMockOgmios();
+        await listenPromise(mockServer, connection.port);
+        provider = new DbSyncSomeProvider({ cardanoNode, db, logger });
+        const res = await provider.healthCheck();
+        expect(res.ok).toEqual(true);
+        expect(res.localNode).toBeDefined();
+        expect(res.projectedTip).toBeDefined();
+      });
+
+      it('is not ok when node is unhealthy', async () => {
+        mockServer = unhealthyMockOgmios();
+        await listenPromise(mockServer, connection.port);
+        cardanoNode = new OgmiosCardanoNode(connection, logger);
+        provider = new DbSyncSomeProvider({ cardanoNode, db, logger });
+        const res = await provider.healthCheck();
+        expect(res.ok).toEqual(false);
+        expect(res.localNode).toBeUndefined();
+        expect(res.projectedTip).toBeDefined();
+      });
+    });
+
+    describe('unhealthy database', () => {
+      beforeEach(async () => {
+        (db.query as jest.Mock).mockRejectedValue(someError);
+      });
+
+      it('is not ok when the node is healthy', async () => {
+        mockServer = healthyMockOgmios();
+        await listenPromise(mockServer, connection.port);
+        cardanoNode = new OgmiosCardanoNode(connection, logger);
+        provider = new DbSyncSomeProvider({ cardanoNode, db, logger });
+        const res = await provider.healthCheck();
+        expect(res.ok).toEqual(false);
+        expect(res.localNode).toBeDefined();
+        expect(res.projectedTip).toBeUndefined();
+      });
+
+      it('is not ok when the node is unhealthy', async () => {
+        mockServer = unhealthyMockOgmios();
+        await listenPromise(mockServer, connection.port);
+        cardanoNode = new OgmiosCardanoNode(connection, logger);
+        provider = new DbSyncSomeProvider({ cardanoNode, db, logger });
+        const res = await provider.healthCheck();
+        expect(res.ok).toEqual(false);
+        expect(res.localNode).toBeUndefined();
+        expect(res.projectedTip).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/ogmios/src/CardanoNode/OgmiosCardanoNode.ts
+++ b/packages/ogmios/src/CardanoNode/OgmiosCardanoNode.ts
@@ -89,10 +89,14 @@ export class OgmiosCardanoNode extends RunnableModule implements CardanoNode {
     }
   }
 
-  async healthCheck(): Promise<HealthCheckResponse> {
+  healthCheck(): Promise<HealthCheckResponse> {
+    return OgmiosCardanoNode.healthCheck(this.#connectionConfig);
+  }
+
+  static async healthCheck(connectionConfig: ConnectionConfig): Promise<HealthCheckResponse> {
     try {
       const { networkSynchronization, lastKnownTip } = await getServerHealth({
-        connection: createConnectionObject(this.#connectionConfig)
+        connection: createConnectionObject(connectionConfig)
       });
       return {
         localNode: {

--- a/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
@@ -77,7 +77,7 @@ export class OgmiosTxSubmitProvider extends RunnableModule implements TxSubmitPr
   }
 
   async healthCheck(): Promise<HealthCheckResponse> {
-    return OgmiosCardanoNode.healthCheck(this.#connectionConfig);
+    return OgmiosCardanoNode.healthCheck(this.#connectionConfig, this.logger);
   }
 
   async startImpl(): Promise<void> {

--- a/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
@@ -4,8 +4,6 @@ import {
   CardanoNodeErrors,
   HealthCheckResponse,
   ProviderDependencies,
-  ProviderError,
-  ProviderFailure,
   SubmitTxArgs,
   TxSubmitProvider
 } from '@cardano-sdk/core';
@@ -14,11 +12,10 @@ import {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   TxSubmission,
-  createConnectionObject,
-  createTxSubmissionClient,
-  getServerHealth
+  createTxSubmissionClient
 } from '@cardano-ogmios/client';
 import { Logger } from 'ts-log';
+import { OgmiosCardanoNode } from '../../CardanoNode';
 import { RunnableModule, contextLogger, isNotNil } from '@cardano-sdk/util';
 import { createInteractionContextWithLogger } from '../../util';
 
@@ -80,24 +77,7 @@ export class OgmiosTxSubmitProvider extends RunnableModule implements TxSubmitPr
   }
 
   async healthCheck(): Promise<HealthCheckResponse> {
-    try {
-      const { networkSynchronization, lastKnownTip } = await getServerHealth({
-        connection: createConnectionObject(this.#connectionConfig)
-      });
-      return {
-        localNode: {
-          ledgerTip: lastKnownTip,
-          networkSync: Cardano.Percent(networkSynchronization)
-        },
-        ok: networkSynchronization > 0.99
-      };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      if (error.name === 'FetchError') {
-        return { ok: false };
-      }
-      throw new ProviderError(ProviderFailure.Unknown, error);
-    }
+    return OgmiosCardanoNode.healthCheck(this.#connectionConfig);
   }
 
   async startImpl(): Promise<void> {

--- a/packages/ogmios/test/CardanoNode/OgmiosCardanoNode.test.ts
+++ b/packages/ogmios/test/CardanoNode/OgmiosCardanoNode.test.ts
@@ -133,6 +133,53 @@ describe('OgmiosCardanoNode', () => {
         });
       });
     });
+    describe('healthCheck', () => {
+      describe('success', () => {
+        beforeAll(async () => {
+          mockServer = createMockOgmiosServer({
+            healthCheck: { response: { success: true } }
+          });
+          await listenPromise(mockServer, connection.port);
+          node = new OgmiosCardanoNode(connection, logger);
+          await node.initialize();
+          await node.start();
+        });
+        afterAll(async () => {
+          await node.shutdown();
+          await serverClosePromise(mockServer);
+        });
+        it('returns ok if successful', async () => {
+          const res = await node.healthCheck();
+          expect(res.ok).toBe(true);
+        });
+      });
+      describe('failure', () => {
+        beforeAll(async () => {
+          mockServer = createMockOgmiosServer({
+            healthCheck: {
+              response: {
+                failWith: new Error('Some error'),
+                success: false
+              },
+              skipInvocations: 1
+            }
+          });
+          await listenPromise(mockServer, connection.port);
+          node = new OgmiosCardanoNode(connection, logger);
+          await node.initialize();
+          await node.start();
+        });
+        afterAll(async () => {
+          await node.shutdown();
+          await serverClosePromise(mockServer);
+        });
+
+        it('returns not ok if the Ogmios server throws an error', async () => {
+          const res = await node.healthCheck();
+          expect(res.ok).toBe(false);
+        });
+      });
+    });
     describe('stakeDistribution', () => {
       describe('success', () => {
         beforeAll(async () => {

--- a/packages/ogmios/test/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.test.ts
+++ b/packages/ogmios/test/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.test.ts
@@ -1,4 +1,4 @@
-import { CardanoNodeErrors, ProviderError } from '@cardano-sdk/core';
+import { CardanoNodeErrors } from '@cardano-sdk/core';
 import { Connection, createConnectionObject } from '@cardano-ogmios/client';
 import { OgmiosTxSubmitProvider } from '../../../src';
 import { bufferToHexString } from '@cardano-sdk/util';
@@ -60,14 +60,15 @@ describe('OgmiosTxSubmitProvider', () => {
       });
     });
 
-    it('throws a typed error if caught during the service interaction', async () => {
+    it('returns not ok if the Ogmios server throws an error', async () => {
       mockServer = createMockOgmiosServer({
         healthCheck: { response: { failWith: new Error('Some error'), success: false } },
         submitTx: { response: { success: true } }
       });
       await listenPromise(mockServer, connection.port);
       provider = new OgmiosTxSubmitProvider(connection, { logger });
-      await expect(provider.healthCheck()).rejects.toThrowError(ProviderError);
+      const health = await provider.healthCheck();
+      expect(health.ok).toBe(false);
     });
   });
 

--- a/packages/ogmios/test/mocks/types.ts
+++ b/packages/ogmios/test/mocks/types.ts
@@ -44,5 +44,6 @@ export type StakeDistributionResponse = {
 };
 
 export type InvocationState = {
+  health: number;
   txSubmit: number;
 };


### PR DESCRIPTION
# Context
The current health check functions have the potential to throw, which is invalid behaviour given an internal error should be interpreted as unhealthy state.

# Proposed Solution
- This fix improves: `DbSyncProvider`, `OgmiosCardanoNode`, and `OgmiosTxSubmitProvider`.
- Catch all errors, log instead of throw, report the state as unhealthy
- Add missing tests to cover the desired behaviour
- Move Ogmios health check logic and mapping to static method, to reduce duplication in other modules.