### PR TITLE
refactor(core)!: move parseAssetId and createAssetId from util.assetId

### DIFF
--- a/packages/core/src/Asset/util/assetId.ts
+++ b/packages/core/src/Asset/util/assetId.ts
@@ -1,27 +1,10 @@
 import { AssetId, AssetName, PolicyId } from '../../Cardano/types/Asset';
-import { CML } from '../../CML/CML';
-import { bytesToHex } from '../../util/misc/bytesToHex';
 
 export const policyIdFromAssetId = (assetId: AssetId): PolicyId => PolicyId(assetId.slice(0, 56));
 export const assetNameFromAssetId = (assetId: AssetId): AssetName => AssetName(assetId.slice(56));
-
-/**
- * @returns {string} concatenated hex-encoded policy id and asset name
- */
-export const createAssetId = (scriptHash: CML.ScriptHash, assetName: CML.AssetName): AssetId =>
-  AssetId(bytesToHex(scriptHash.to_bytes()) + bytesToHex(assetName.name()));
 
 /**
  * @returns {AssetId} concatenated policy id and asset name
  */
 export const assetIdFromPolicyAndName = (policyId: PolicyId, assetName: AssetName): AssetId =>
   AssetId(policyId + assetName);
-
-export const parseAssetId = (assetId: AssetId) => {
-  const policyId = policyIdFromAssetId(assetId);
-  const assetName = assetNameFromAssetId(assetId);
-  return {
-    assetName: CML.AssetName.new(Buffer.from(assetName, 'hex')),
-    scriptHash: CML.ScriptHash.from_bytes(Buffer.from(policyId, 'hex'))
-  };
-};

--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -1,13 +1,18 @@
 import * as Cardano from '../../Cardano';
 import * as Crypto from '@cardano-sdk/crypto';
+import { AssetId, PlutusLanguageVersion, ScriptType } from '../../Cardano';
 import { Base64Blob, HexBlob, ManagedFreeableScope, usingAutoFree } from '@cardano-sdk/util';
 import { CML } from '../CML';
-import { PlutusLanguageVersion, ScriptType } from '../../Cardano';
 import { ScriptKind } from '@dcspark/cardano-multiplatform-lib-nodejs';
 import { SerializationError, SerializationFailure } from '../../errors';
 import { bytesToHex } from '../../util/misc';
-import { createAssetId } from '../../Asset/util';
 import { createCertificate } from './certificate';
+
+/**
+ * @returns {string} concatenated hex-encoded policy id and asset name
+ */
+export const createAssetId = (scriptHash: CML.ScriptHash, assetName: CML.AssetName): AssetId =>
+  AssetId(bytesToHex(scriptHash.to_bytes()) + bytesToHex(assetName.name()));
 
 export const txRequiredExtraSignatures = (
   signatures: CML.Ed25519KeyHashes | undefined

--- a/packages/core/src/CML/coreToCml/coreToCml.ts
+++ b/packages/core/src/CML/coreToCml/coreToCml.ts
@@ -65,11 +65,20 @@ import {
 } from '@dcspark/cardano-multiplatform-lib-nodejs';
 
 import * as certificate from './certificate';
+import { AssetId, RedeemerPurpose } from '../../Cardano';
 import { CML } from '../CML';
 import { ManagedFreeableScope } from '@cardano-sdk/util';
-import { RedeemerPurpose } from '../../Cardano';
 import { SerializationError, SerializationFailure } from '../../errors';
-import { assetNameFromAssetId, parseAssetId, policyIdFromAssetId } from '../../Asset/util';
+import { assetNameFromAssetId, policyIdFromAssetId } from '../../Asset/util';
+
+export const parseAssetId = (assetId: AssetId) => {
+  const policyId = policyIdFromAssetId(assetId);
+  const assetName = assetNameFromAssetId(assetId);
+  return {
+    assetName: CML.AssetName.new(Buffer.from(assetName, 'hex')),
+    scriptHash: CML.ScriptHash.from_bytes(Buffer.from(policyId, 'hex'))
+  };
+};
 
 export const tokenMap = (scope: ManagedFreeableScope, map: Cardano.TokenMap) => {
   const multiasset = scope.manage(MultiAsset.new());

--- a/packages/core/test/Asset/util/assetId.test.ts
+++ b/packages/core/test/Asset/util/assetId.test.ts
@@ -1,23 +1,8 @@
 import { AssetId } from '../../../src/Cardano';
-import {
-  assetIdFromPolicyAndName,
-  assetNameFromAssetId,
-  createAssetId,
-  parseAssetId,
-  policyIdFromAssetId
-} from '../../../src/Asset/util';
+import { assetIdFromPolicyAndName, assetNameFromAssetId, policyIdFromAssetId } from '../../../src/Asset/util';
 
 describe('Asset', () => {
   describe('util', () => {
-    it('createAssetId and parseAssetId', async () => {
-      const assetId = AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41');
-      const tsla = parseAssetId(assetId);
-      expect(new TextDecoder().decode(tsla.assetName.name())).toEqual('TSLA');
-      expect(Buffer.from(tsla.scriptHash.to_bytes()).toString('hex')).toEqual(
-        '659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba82'
-      );
-      expect(createAssetId(tsla.scriptHash, tsla.assetName)).toEqual(assetId);
-    });
     it('policyIdFromAssetId, assetNameFromAssetId and assetIdFromPolicyAndName', async () => {
       const assetId = AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41');
       const [policyId, assetName] = [policyIdFromAssetId(assetId), assetNameFromAssetId(assetId)];

--- a/packages/core/test/CML/cmlToCore.test.ts
+++ b/packages/core/test/CML/cmlToCore.test.ts
@@ -1,4 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
+import { AssetId } from '../../src/Cardano';
 import { Base64Blob, HexBlob, ManagedFreeableScope } from '@cardano-sdk/util';
 import { Cardano, cmlToCore, coreToCml } from '../../src';
 import { NativeScript } from '@dcspark/cardano-multiplatform-lib-nodejs';
@@ -17,6 +18,8 @@ import {
   valueCoinOnly,
   valueWithAssets
 } from './testData';
+import { createAssetId } from '../../src/CML/cmlToCore';
+import { parseAssetId } from '../../src/CML/coreToCml';
 
 describe('cmlToCore', () => {
   let scope: ManagedFreeableScope;
@@ -28,6 +31,16 @@ describe('cmlToCore', () => {
   afterEach(() => {
     scope.dispose();
   });
+
+  describe('AssetId', () => {
+    it('createAssetId', async () => {
+      const assetId = AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41');
+      const cmlAssetId = parseAssetId(assetId);
+
+      expect(createAssetId(cmlAssetId.scriptHash, cmlAssetId.assetName)).toEqual(assetId);
+    });
+  });
+
   describe('value', () => {
     it('coin only', () => {
       expect(cmlToCore.value(coreToCml.value(scope, valueCoinOnly))).toEqual(valueCoinOnly);


### PR DESCRIPTION
# Context

The `parseAssetId` and `createAssetId` util are out of place. Their purpose is to convert to/from CML objects from/to the Core type `Cardano.AssetId`

# Proposed Solution

Move both utils to the CML modules `coreToCml` and `cmlToCore`.
