### PR TITLE
refactor(cardano-services): stop throwing provider unhealthy errors from HttpService init

### DIFF
--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -43,7 +43,7 @@ export abstract class HttpService extends RunnableModule {
 
     const health = await this.healthCheck();
     if (!health.ok) {
-      throw new ProviderError(ProviderFailure.Unhealthy, null, JSON.stringify(health, null, 2));
+      this.logger.warning('Service started in unhealthy state');
     }
   }
 

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -3,7 +3,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Cardano, ChainHistoryProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Cardano, ChainHistoryProvider } from '@cardano-sdk/core';
 import { ChainHistoryFixtureBuilder, TxWith } from './fixtures/FixtureBuilder';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider, HttpServer, HttpServerConfig } from '../../src';
 import { CreateHttpProviderConfig, chainHistoryHttpProvider } from '@cardano-sdk/cardano-services-client';
@@ -50,36 +50,6 @@ describe('ChainHistoryHttpService', () => {
       connectionString: process.env.POSTGRES_CONNECTION_STRING
     });
     fixtureBuilder = new ChainHistoryFixtureBuilder(dbConnection, logger);
-  });
-
-  describe('unhealthy ChainHistoryProvider', () => {
-    beforeEach(async () => {
-      chainHistoryProvider = {
-        blocksByHashes: jest.fn(),
-        healthCheck: jest.fn(() => Promise.resolve({ ok: false })),
-        transactionsByAddresses: jest.fn(),
-        transactionsByHashes: jest.fn()
-      } as unknown as DbSyncChainHistoryProvider;
-    });
-    it('should not throw during service create if the ChainHistoryProvider is unhealthy', () => {
-      expect(() => new ChainHistoryHttpService({ chainHistoryProvider, logger })).not.toThrow(
-        new ProviderError(ProviderFailure.Unhealthy)
-      );
-    });
-
-    it('throws during service initialization if the ChainHistoryProvider is unhealthy', async () => {
-      expect.assertions(2);
-      service = new ChainHistoryHttpService({ chainHistoryProvider, logger });
-      httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      try {
-        await httpServer.initialize();
-      } catch (error: unknown) {
-        if (error instanceof ProviderError) {
-          expect(error.name).toBe('ProviderError');
-          expect(error.reason).toBe('UNHEALTHY');
-        }
-      }
-    });
   });
 
   describe('healthy state', () => {

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
-import { Cardano, ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
+import { Cardano, RewardsProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, rewardsHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DbSyncRewardsProvider, HttpServer, HttpServerConfig, RewardsHttpService } from '../../src';
 import { INFO, createLogger } from 'bunyan';
@@ -39,35 +39,6 @@ describe('RewardsHttpService', () => {
       connectionString: process.env.POSTGRES_CONNECTION_STRING
     });
     fixtureBuilder = new RewardsFixtureBuilder(dbConnection, logger);
-  });
-
-  describe('unhealthy RewardsProvider', () => {
-    beforeEach(async () => {
-      rewardsProvider = {
-        healthCheck: jest.fn(() => Promise.resolve({ ok: false })),
-        rewardAccountBalance: jest.fn(),
-        rewardsHistory: jest.fn()
-      } as unknown as DbSyncRewardsProvider;
-    });
-    it('should not throw during service create if the RewardsProvider is unhealthy', () => {
-      expect(() => new RewardsHttpService({ logger, rewardsProvider })).not.toThrow(
-        new ProviderError(ProviderFailure.Unhealthy)
-      );
-    });
-
-    it('throws during service initialization if the RewardsProvider is unhealthy', async () => {
-      expect.assertions(2);
-      service = new RewardsHttpService({ logger, rewardsProvider });
-      httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      try {
-        await httpServer.initialize();
-      } catch (error: unknown) {
-        if (error instanceof ProviderError) {
-          expect(error.name).toBe('ProviderError');
-          expect(error.reason).toBe('UNHEALTHY');
-        }
-      }
-    });
   });
 
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -1,14 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
-import {
-  Cardano,
-  ProviderError,
-  ProviderFailure,
-  QueryStakePoolsArgs,
-  SortField,
-  StakePoolProvider
-} from '@cardano-sdk/core';
+import { Cardano, ProviderError, QueryStakePoolsArgs, SortField, StakePoolProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, stakePoolHttpProvider } from '../../../cardano-services-client';
 import { DbSyncEpochPollService, loadGenesisData } from '../../src/util';
 import {
@@ -152,36 +145,6 @@ describe('StakePoolHttpService', () => {
       },
       pagination
     };
-  });
-
-  describe('unhealthy StakePoolProvider', () => {
-    beforeEach(async () => {
-      stakePoolProvider = {
-        healthCheck: jest.fn(() => Promise.resolve({ ok: false })),
-        queryStakePools: jest.fn(),
-        stakePoolStats: jest.fn()
-      } as unknown as DbSyncStakePoolProvider;
-    });
-
-    it('should not throw during service create if the StakePoolProvider is unhealthy', () => {
-      expect(() => new StakePoolHttpService({ logger, stakePoolProvider })).not.toThrow(
-        new ProviderError(ProviderFailure.Unhealthy)
-      );
-    });
-
-    it('throws during service initialization if the StakePoolProvider is unhealthy', async () => {
-      expect.assertions(2);
-      service = new StakePoolHttpService({ logger, stakePoolProvider });
-      httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      try {
-        await httpServer.initialize();
-      } catch (error: unknown) {
-        if (error instanceof ProviderError) {
-          expect(error.name).toBe('ProviderError');
-          expect(error.reason).toBe('UNHEALTHY');
-        }
-      }
-    });
   });
 
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
 import { APPLICATION_JSON, CONTENT_TYPE, HttpServer, HttpServerConfig, TxSubmitHttpService } from '../../src';
-import { CardanoNodeErrors, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
+import { CardanoNodeErrors, ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, txSubmitHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { FATAL, createLogger } from 'bunyan';
 import { OgmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
@@ -46,18 +46,6 @@ describe('TxSubmitHttpService', () => {
 
   afterEach(async () => {
     jest.clearAllMocks();
-  });
-
-  describe('unhealthy TxSubmitProvider', () => {
-    beforeAll(async () => {
-      txSubmitProvider = txSubmitProviderMock(() => Promise.resolve({ ok: false }));
-    });
-
-    it('should not throw during initialization if the TxSubmitProvider is unhealthy', () => {
-      expect(() => new TxSubmitHttpService({ logger, txSubmitProvider })).not.toThrow(
-        new ProviderError(ProviderFailure.Unhealthy)
-      );
-    });
   });
 
   describe('healthy TxSubmitProvider on startup, unhealthy at request time', () => {

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import { AddressWith, UtxoFixtureBuilder } from './fixtures/FixtureBuilder';
-import { Asset, Cardano, ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
+import { Asset, Cardano, UtxoProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, utxoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DataMocks } from '../data-mocks';
 import { DbSyncUtxoProvider, HttpServer, HttpServerConfig, UtxoHttpService } from '../../src';
@@ -43,34 +43,6 @@ describe('UtxoHttpService', () => {
       connectionString: process.env.POSTGRES_CONNECTION_STRING
     });
     fixtureBuilder = new UtxoFixtureBuilder(dbConnection, logger);
-  });
-
-  describe('unhealthy UtxoProvider', () => {
-    beforeEach(async () => {
-      utxoProvider = {
-        healthCheck: jest.fn(() => Promise.resolve({ ok: false })),
-        utxoByAddresses: jest.fn()
-      } as unknown as DbSyncUtxoProvider;
-    });
-    it('should not throw during service create if the UtxoProvider is unhealthy', () => {
-      expect(() => new UtxoHttpService({ logger, utxoProvider })).not.toThrow(
-        new ProviderError(ProviderFailure.Unhealthy)
-      );
-    });
-
-    it('throws during service initialization if the UtxoProvider is unhealthy', async () => {
-      expect.assertions(2);
-      service = new UtxoHttpService({ logger, utxoProvider });
-      httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });
-      try {
-        await httpServer.initialize();
-      } catch (error: unknown) {
-        if (error instanceof ProviderError) {
-          expect(error.name).toBe('ProviderError');
-          expect(error.reason).toBe('UNHEALTHY');
-        }
-      }
-    });
   });
 
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -1663,45 +1663,6 @@ describe('CLI', () => {
             });
           });
 
-          describe('with RabbitMQ and default URL', () => {
-            it('throws a provider unhealthy error when using CLI options', (done) => {
-              expect.assertions(2);
-
-              proc = fork(exePath, [...baseArgs, '--api-url', apiUrl, '--use-queue', 'true', ServiceNames.TxSubmit], {
-                env: {},
-                stdio: 'pipe'
-              });
-
-              proc.stderr!.on('data', (data) => expect(data.toString()).toMatch('ProviderError: UNHEALTHY'));
-
-              proc.on('exit', (code) => {
-                expect(code).toBe(1);
-                done();
-              });
-            });
-
-            it('throws a provider unhealthy error when using env variables', (done) => {
-              expect.assertions(2);
-
-              proc = fork(exePath, ['start-provider-server'], {
-                env: {
-                  API_URL: apiUrl,
-                  LOGGER_MIN_SEVERITY: 'error',
-                  SERVICE_NAMES: ServiceNames.TxSubmit,
-                  USE_QUEUE: 'true'
-                },
-                stdio: 'pipe'
-              });
-
-              proc.stderr!.on('data', (data) => expect(data.toString()).toMatch('ProviderError: UNHEALTHY'));
-
-              proc.on('exit', (code) => {
-                expect(code).toBe(1);
-                done();
-              });
-            });
-          });
-
           describe('with service discovery', () => {
             it('tx-submit throws DNS SRV error and exits with code 1 when using CLI options', (done) => {
               callCliAndAssertExit(


### PR DESCRIPTION
# Context
Change from throwing an error to logging a warning if the `HttpService` provider health is
not ok on init, to ensure it always starts, facilitating improved metrics and usability.
The original intent was that we could have assurance at startup that the service is "ready",
but that's a fairly weak situation, since the provider health could immediately revert, so
the client just gets a false sense of security. Administrators will get a warning in the logs,
and clients will now be able to use the /health endpoint to make the correct decision for
their context, with a single approach to dealing with unhealthy provider exceptions.

# Proposed Solution
Log a warning instead of throwing an error in the `HttpService` initialisation method.
