### PR TITLE
refactor!: the TxSubmit endpoint no longer adds the stack trace when …

### DIFF
--- a/packages/core/src/Cardano/util/txSubmissionErrors.ts
+++ b/packages/core/src/Cardano/util/txSubmissionErrors.ts
@@ -1,4 +1,5 @@
 import { CardanoNodeErrors } from '../../CardanoNode';
+import { isProductionEnvironment, stripStackTrace } from '@cardano-sdk/util';
 
 /**
  * Tests the provided error for an instanceof match in the TxSubmissionErrors object
@@ -17,10 +18,19 @@ export const asTxSubmissionError = (error: unknown): CardanoNodeErrors.TxSubmiss
   if (Array.isArray(error)) {
     for (const err of error) {
       if (isTxSubmissionError(err)) {
+        if (isProductionEnvironment()) stripStackTrace(err);
+
         return err;
       }
     }
     return null;
   }
-  return isTxSubmissionError(error) ? error : null;
+
+  if (isTxSubmissionError(error)) {
+    if (isProductionEnvironment()) stripStackTrace(error);
+
+    return error;
+  }
+
+  return null;
 };

--- a/packages/util/src/environment.ts
+++ b/packages/util/src/environment.ts
@@ -1,0 +1,22 @@
+/**
+ * Node.js environment configurations.
+ */
+export enum Environment {
+  /**
+   * Production environment.
+   *
+   * Node.js assumes it's always running in a development environment. You can signal Node.js that you are running
+   * in production by setting the NODE_ENV=production environment variable.
+   */
+  Production = 'production',
+
+  /**
+   * Development environment.
+   */
+  Development = 'development'
+}
+
+export const isProductionEnvironment = (): boolean => process.env.NODE_ENV === Environment.Production;
+
+export const getEnvironmentConfiguration = (): Environment =>
+  isProductionEnvironment() ? Environment.Production : Environment.Development;

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -12,3 +12,4 @@ export * from './network';
 export * from './logging';
 export * from './RunnableModule';
 export * from './opaqueTypes';
+export * from './environment';

--- a/packages/util/test/errors.test.ts
+++ b/packages/util/test/errors.test.ts
@@ -1,0 +1,68 @@
+import { ComposableError } from '../';
+import { stripStackTrace } from '../src';
+
+class TestError<InnerError = unknown> extends ComposableError<InnerError> {
+  constructor(innerError: InnerError) {
+    super('Test error', innerError);
+  }
+}
+
+const throwsError = () => {
+  throw new Error('a');
+};
+
+const throwsComposableError = () => {
+  try {
+    throwsError();
+  } catch (error) {
+    throw new TestError(error);
+  }
+};
+
+describe('stripStackTrace', () => {
+  it('doesnt throw if given undefined', () => {
+    const error = undefined;
+    expect(() => stripStackTrace(error)).not.toThrow();
+  });
+
+  it('doesnt throw if given null', () => {
+    const error = null;
+    expect(() => stripStackTrace(error)).not.toThrow();
+  });
+
+  it('doesnt throw if a non Error object', () => {
+    const error = { a: 'a' };
+    expect(() => stripStackTrace(error)).not.toThrow();
+    expect(() => stripStackTrace(10)).not.toThrow();
+    expect(() => stripStackTrace('some error')).not.toThrow();
+  });
+
+  it('removes the stack field from the Error object', () => {
+    try {
+      throwsError();
+    } catch (error) {
+      stripStackTrace(error);
+      expect((error as Error).stack).toBeUndefined();
+    }
+  });
+
+  it('removes the stack field from the Error object and inner errors', () => {
+    try {
+      throwsComposableError();
+    } catch (error) {
+      let testError = error as TestError;
+      let innerError = testError.innerError as Error;
+
+      expect(testError.stack).toBeDefined();
+      expect(innerError.stack).toBeDefined();
+
+      stripStackTrace(error);
+
+      testError = error as TestError;
+      innerError = testError.innerError as Error;
+
+      expect(testError.stack).toBeUndefined();
+      expect(innerError.stack).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
# Context

We need to strip the stack trace from domain error at the HTTP API when running in a production env.

# Proposed Solution
 - Strip the stack trace from domain error at the HTTP API

