### PR TITLE
fix(cardano-service): fixes a log called method

### DIFF
--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -43,7 +43,7 @@ export abstract class HttpService extends RunnableModule {
 
     const health = await this.healthCheck();
     if (!health.ok) {
-      this.logger.warning('Service started in unhealthy state');
+      this.logger.warn('Service started in unhealthy state');
     }
   }
 


### PR DESCRIPTION
# Context

```
export interface Logger {
    trace(message?: any, ...optionalParams: any[]): void;
    debug(message?: any, ...optionalParams: any[]): void;
    info(message?: any, ...optionalParams: any[]): void;
    warn(message?: any, ...optionalParams: any[]): void;
    error(message?: any, ...optionalParams: any[]): void;
    [x: string]: any;
}
```

This is the interface from `ts-log` which makes us prone to the error fixed in this PR.

# Proposed Solution

Just emergency fixed the effect problem, not the source problem.