### PR TITLE
test(cardano-services): improve CLI test - assertion and logging

### DIFF
--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -117,7 +117,7 @@ const callCliAndAssertExit = (
   proc.stderr!.on('data', (data) => {
     spy();
     if (dataMatchOnError) {
-      expect(data.toString().includes(dataMatchOnError)).toEqual(true);
+      expect(data.toString()).toContain(dataMatchOnError);
     }
   });
   proc.on('exit', (code) => {


### PR DESCRIPTION
# Context
The CLI test is producing hard to debug failures in CI. There's a fragile assertion that swallows the underlying failure, and we're blind to the child process failures since their output is not logged.

# Proposed Solution
- Improve assertion to better reveal failure
- Add a configurable logger to the CLI tests

Not in scope is a way to dynamically set the logger level, so for now, if needing to debug, we can just update the min level in the code. Ideally we should be able to choose this at runtime, or use some other indicator such as commit message content to set it in the workflow.