### PR TITLE
yarn test flakiness

### DIFF
--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -125,17 +125,20 @@ const callCliAndAssertExit = (
     }),
     true
   );
-  proc.stderr!.on('data', spy);
+  const chunks: string[] = [];
   proc.stderr!.on('data', (data) => {
     spy();
-    if (dataMatchOnError) {
-      expect(data.toString()).toContain(dataMatchOnError);
-    }
+    chunks.push(data.toString());
   });
   proc.on('exit', (code) => {
-    expect(code).toBe(1);
-    expect(spy).toHaveBeenCalled();
-    done();
+    try {
+      expect(code).toBe(1);
+      expect(spy).toHaveBeenCalled();
+      if (dataMatchOnError) expect(chunks.join('')).toContain(dataMatchOnError);
+      done();
+    } catch (error) {
+      done(error);
+    }
   });
 };
 

--- a/packages/cardano-services/test/jest-setup/jest-setup.ts
+++ b/packages/cardano-services/test/jest-setup/jest-setup.ts
@@ -25,7 +25,14 @@ const databaseConfigs = {
 const setupDBData = async (databaseConfig: DatabaseConfig, user: string, container: DockerUtil.Docker.Container) => {
   const { database, snapshot, fixture } = databaseConfig;
 
-  await DockerUtil.containerExec(container, ['bash', '-c', `psql -U ${user} -c "CREATE DATABASE ${database}"`]);
+  const create = await DockerUtil.containerExec(container, [
+    'bash',
+    '-c',
+    `psql -U ${user} -c "CREATE DATABASE ${database}"`
+  ]);
+
+  if (create.length !== 1 || !create[0].match('CREATE DATABASE'))
+    throw new Error(`Error while creating the DB ${JSON.stringify(create)}`);
 
   if (snapshot) {
     await container.putArchive(path.join(__dirname, `${database}-db-snapshot.tar`), {


### PR DESCRIPTION
# Context

`yarn workspace @cardano-sdk/cardano-services test` suffers some flakiness.

# Proposed solution

Handling the output chunks should resolve one source of flakiness.

# Important Changes Introduced

- The change to `jest-setup.ts` does not actually addresses the other source of flakiness, but at least makes the not yet identified error to immediately throw rather than making the test hanging silently. Hopefully this can give us some more info to address the root cause.
- Fixed 4 occurrences of the typo `--service_names` instead of `--service-names`
- `dataMatchOnError` is now required to be sure the got error is the expected one.