### PR TITLE
Chore/yarn test flakiness insights

### DIFF
--- a/.github/workflows/continuous-integration-unit-tests.yaml
+++ b/.github/workflows/continuous-integration-unit-tests.yaml
@@ -36,4 +36,4 @@ jobs:
       run: |
         yarn test:build:verify
         yarn test --showConfig
-        yarn test --forceExit --expand --detectOpenHandles
+        TL_LEVEL=debug yarn test --forceExit --expand --detectOpenHandles

--- a/.github/workflows/continuous-integration-unit-tests.yaml
+++ b/.github/workflows/continuous-integration-unit-tests.yaml
@@ -35,4 +35,5 @@ jobs:
     - name: 🔬 Test
       run: |
         yarn test:build:verify
-        yarn test --forceExit
+        yarn test --showConfig
+        yarn test --forceExit --expand --detectOpenHandles

--- a/.github/workflows/continuous-integration-unit-tests.yaml
+++ b/.github/workflows/continuous-integration-unit-tests.yaml
@@ -36,4 +36,4 @@ jobs:
       run: |
         yarn test:build:verify
         yarn test --showConfig
-        TL_LEVEL=debug yarn test --forceExit --expand --detectOpenHandles
+        TL_LEVEL=info yarn test --expand --detectOpenHandles

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: 💽 Install dependencies
       run: |
-        yarn install --immutable --inline-builds --mode=skip-build
+        yarn install --immutable --inline-builds
 
     - name: 🔨 Build
       run: |
@@ -48,4 +48,4 @@ jobs:
       run: |
         yarn test:build:verify
         yarn test --showConfig
-        yarn test --forceExit --expand --detectOpenHandles
+        TL_LEVEL=debug yarn test --forceExit --expand --detectOpenHandles

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -46,6 +46,6 @@ jobs:
 
     - name: 🔬 Test - unit | integration
       run: |
-        yarn lint
         yarn test:build:verify
-        yarn test --forceExit
+        yarn test --showConfig
+        yarn test --forceExit --expand --detectOpenHandles

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -48,4 +48,4 @@ jobs:
       run: |
         yarn test:build:verify
         yarn test --showConfig
-        TL_LEVEL=debug yarn test --forceExit --expand --detectOpenHandles
+        TL_LEVEL=info yarn test --expand --detectOpenHandles


### PR DESCRIPTION
# Context

Add extra jest flags to get more insights in case of hanging/errors in CI.

# Proposed Solution

- fix wong usage of CLI arg in tests
- removed `--forceExit` from CI/CD commands
- `--expand`: Use this flag to show full diffs and errors instead of a patch
- `--detectOpenHandles` logs out errors preventing your tests from exiting clearly and it implies `--runInBand` which ensures your tests run in the same threads so no overlapping. 
-  `--showConfig` print your Jest config and then exits. The reason I call it to print the jest config of the remote CI/CD machine and get more insights such as `maxConcurreny` and `maxWorkers`

# Important Changes Introduced
