### PR TITLE
docs: fix broken `web-extension` link

### DIFF
--- a/packages/dapp-connector/README.md
+++ b/packages/dapp-connector/README.md
@@ -5,5 +5,5 @@ persistence and set up web extension messaging.
 
 See [example web extension].
 
-[example web extension]: ../web-extension/e2e/extension
+[example web extension]: ../e2e/test/web-extension/
 [CIP-0030]: https://github.com/cardano-foundation/CIPs/pull/88


### PR DESCRIPTION
# Context

While exploring the code base I noticed there is a broken link to README file so I fixed It.
