### PR TITLE
ci: define merge group as a trigger in the CI workflows

### DIFF
--- a/.github/workflows/continuous-integration-e2e.yaml
+++ b/.github/workflows/continuous-integration-e2e.yaml
@@ -1,6 +1,7 @@
 name: Continuous Integration - E2E
 
 on:
+  merge_group:
   pull_request:
     branches: [ "master" ]
   push:

--- a/.github/workflows/continuous-integration-unit-tests.yaml
+++ b/.github/workflows/continuous-integration-unit-tests.yaml
@@ -1,6 +1,7 @@
 name: Continuous Integration - Unit Tests
 
 on:
+  merge_group:
   pull_request:
     branches: [ "master" ]
   push:


### PR DESCRIPTION
# Context
We've had a couple of cases where PR merges have created an inconsistent state in _master_, which would have been caught with a rebase.

# Proposed Solution
Use the new GitHub [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) feature to add an additional CI run at the point of merging.
