### PR TITLE
Test/stake pool search load test review

### DIFF
--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -114,10 +114,12 @@ services:
     environment:
       - DB_CACHE_TTL=${DB_CACHE_TTL:-120}
       - DISABLE_DB_CACHE=${DISABLE_DB_CACHE:-false}
+      - DISABLE_STAKE_POOL_METRIC_APY=${DISABLE_STAKE_POOL_METRIC_APY:-false}
       - ENABLE_METRICS=${ENABLE_METRICS:-false}
       - EPOCH_POLL_INTERVAL=${EPOCH_POLL_INTERVAL:-10000}
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}
       - OGMIOS_URL=ws://cardano-node-ogmios:1337
+      - POSTGRES_POOL_MAX=${POSTGRES_POOL_MAX:-10}
       - RABBITMQ_URL=amqp://rabbitmq:5672
       - SERVICE_NAMES=${SERVICE_NAMES:-asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo}
       - USE_BLOCKFROST=${USE_BLOCKFROST:-false}

--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -175,7 +175,7 @@ services:
       - NETWORK=${NETWORK:-mainnet}
       - SCAN_INTERVAL=${SCAN_INTERVAL:-60}
     ports:
-      - 3000:3000
+      - ${API_PORT:-4001}:3000
     restart: on-failure
     secrets:
       - blockfrost_key

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -269,7 +269,7 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
     const totalCount = poolUpdates.length;
     // Get last epoch data
     const lastEpoch = await this.#builder.getLastEpochWithData();
-    const { optimalPoolCount, no: lastEpochNo } = lastEpoch;
+    const { no: lastEpochNo } = lastEpoch;
     // Get stake pools data cached
     const { orderedResultHashIds, orderedResultUpdateIds, orderedResult, poolDatas, hashesIds, sortType } =
       await this.#cache.get(queryCacheKey(StakePoolsSubQuery.POOLS_DATA_ORDERED, options), () =>
@@ -317,10 +317,6 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
     );
     const { results, poolsToCache } = toStakePoolResults(orderedResultHashIds, fromCache, useBlockfrost, {
       lastEpochNo: Cardano.EpochNo(lastEpochNo),
-      nodeMetricsDependencies: {
-        optimalPoolCount,
-        totalAdaAmount: BigInt(totalStake)
-      },
       poolAPYs,
       poolDatas,
       poolMetrics,

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -7,7 +7,16 @@ import {
   StakePoolProvider,
   StakePoolStats
 } from '@cardano-sdk/core';
-import { CommonPoolInfo, OrderedResult, PoolAPY, PoolData, PoolMetrics, PoolSortType, PoolUpdate } from './types';
+import {
+  CommonPoolInfo,
+  OrderedResult,
+  PoolAPY,
+  PoolData,
+  PoolMetrics,
+  PoolSortType,
+  PoolUpdate,
+  StakePoolResults
+} from './types';
 import { DbSyncProvider, DbSyncProviderDependencies, Disposer, EpochMonitor } from '../../util';
 import { GenesisData, InMemoryCache, StakePoolMetadataService, UNLIMITED_CACHE_TTL } from '../..';
 import {
@@ -18,7 +27,7 @@ import {
   getStakePoolSortType,
   queryCacheKey
 } from './util';
-import { RunnableModule, isNotNil } from '@cardano-sdk/util';
+import { PromiseOrValue, RunnableModule, isNotNil, resolveObjectValues } from '@cardano-sdk/util';
 import { StakePoolBuilder } from './StakePoolBuilder';
 import { toStakePoolResults } from './mappers';
 import merge from 'lodash/merge';
@@ -192,9 +201,40 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
     return { hashesIds, orderedResult, orderedResultHashIds, orderedResultUpdateIds, poolDatas, sortType };
   }
 
-  private cacheStakePools(itemsToCache: { [hashId: number]: Cardano.StakePool }, rewardsHistoryKey: string) {
-    for (const [hashId, pool] of Object.entries(itemsToCache))
-      this.#cache.set(`${IDS_NAMESPACE}/${rewardsHistoryKey}/${hashId}`, pool, UNLIMITED_CACHE_TTL);
+  private cacheStakePools(
+    cachedPromises: { [k: string]: PromiseOrValue<Cardano.StakePool | undefined> },
+    resultPromise: Promise<StakePoolResults>,
+    rewardsHistoryKey: string
+  ) {
+    for (const [hashId, promise] of Object.entries(cachedPromises)) {
+      // If the pool was already cached, there is nothing to do
+      if (promise) continue;
+
+      const cacheKey = `${IDS_NAMESPACE}/${rewardsHistoryKey}/${hashId}`;
+
+      // Cache a promise which will resolve with the pool when resultPromise will be resolved
+      this.#cache.set(
+        cacheKey,
+        resultPromise.then(
+          ({ poolsToCache }) => {
+            // Once the resultPromise is resolved, pick the right pool from it
+            const pool = poolsToCache[hashId as unknown as number];
+
+            // Replace the cached promise with the pool
+            this.#cache.set(cacheKey, pool, UNLIMITED_CACHE_TTL);
+
+            return pool;
+          },
+          (error) => {
+            // In case of error, reset the cached value to let next request to start a new query
+            this.#cache.set(cacheKey, undefined, UNLIMITED_CACHE_TTL);
+
+            throw error;
+          }
+        ),
+        UNLIMITED_CACHE_TTL
+      );
+    }
   }
 
   private async queryExtraPoolsData(
@@ -300,38 +340,45 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
     );
     // Create a lookup table with cached pools: (hashId:Cardano.StakePool)
     const rewardsHistoryKey = JSON.stringify(rewardsHistoryLimit);
-    const fromCache = Object.fromEntries(
+    const cachedPromises = Object.fromEntries(
       orderedResultHashIds.map((hashId) => [
         hashId,
-        this.#cache.getVal<Cardano.StakePool>(`${IDS_NAMESPACE}/${rewardsHistoryKey}/${hashId}`)
+        this.#cache.getVal<PromiseOrValue<Cardano.StakePool | undefined>>(
+          `${IDS_NAMESPACE}/${rewardsHistoryKey}/${hashId}`
+        )
       ])
     );
-    // Compute ids to fetch from db
-    const idsToFetch = Object.entries(fromCache)
-      .filter(([_, pool]) => pool === undefined)
-      .map(([hashId, _]) => ({ id: Number(hashId), updateId: hashIdsMap[hashId] }));
-    // Get stake pools extra information
-    const { poolRelays, poolOwners, poolRegistrations, poolRetirements, poolMetrics } = await this.queryExtraPoolsData(
-      idsToFetch,
-      sortType,
-      totalStake,
-      orderedResult,
-      useBlockfrost
-    );
-    const { results, poolsToCache } = toStakePoolResults(orderedResultHashIds, fromCache, useBlockfrost, {
-      lastEpochNo: Cardano.EpochNo(lastEpochNo),
-      poolAPYs,
-      poolDatas,
-      poolMetrics,
-      poolOwners,
-      poolRegistrations,
-      poolRelays,
-      poolRetirements,
-      poolRewards: poolRewards.filter(isNotNil),
-      totalCount
-    });
-    // Cache stake pools core objects
-    this.cacheStakePools(poolsToCache, rewardsHistoryKey);
+
+    const queryExtraPoolsDataMissingFromCacheAndMap = async () => {
+      const fromCache = await resolveObjectValues(cachedPromises);
+      // Compute ids to fetch from db
+      const idsToFetch = Object.entries(fromCache)
+        .filter(([_, pool]) => pool === undefined)
+        .map(([hashId, _]) => ({ id: Number(hashId), updateId: hashIdsMap[hashId] }));
+      // Get stake pools extra information
+      const { poolRelays, poolOwners, poolRegistrations, poolRetirements, poolMetrics } =
+        await this.queryExtraPoolsData(idsToFetch, sortType, totalStake, orderedResult, useBlockfrost);
+
+      return toStakePoolResults(orderedResultHashIds, fromCache, useBlockfrost, {
+        lastEpochNo: Cardano.EpochNo(lastEpochNo),
+        poolAPYs,
+        poolDatas,
+        poolMetrics,
+        poolOwners,
+        poolRegistrations,
+        poolRelays,
+        poolRetirements,
+        poolRewards: poolRewards.filter(isNotNil),
+        totalCount
+      });
+    };
+
+    const resultPromise = queryExtraPoolsDataMissingFromCacheAndMap();
+
+    this.cacheStakePools(cachedPromises, resultPromise, rewardsHistoryKey);
+
+    const { results } = await resultPromise;
+
     return results;
   }
 

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.ts
@@ -133,7 +133,7 @@ export class StakePoolBuilder {
 
   public async queryPoolMetrics(
     hashesIds: number[],
-    totalStake: string,
+    totalStake: string | null,
     useBlockfrost: boolean,
     options?: QueryStakePoolsArgs
   ) {

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/mappers.ts
@@ -45,11 +45,6 @@ const getPoolStatus = (
   return Cardano.StakePoolStatus.Retired;
 };
 
-interface NodeMetricsDependencies {
-  totalAdaAmount: Cardano.Lovelace;
-  optimalPoolCount?: number;
-}
-
 interface ToCoreStakePoolInput {
   poolOwners: PoolOwner[];
   poolDatas: PoolData[];
@@ -61,7 +56,6 @@ interface ToCoreStakePoolInput {
   poolMetrics: PoolMetrics[];
   totalCount: number;
   poolAPYs: PoolAPY[];
-  nodeMetricsDependencies: NodeMetricsDependencies;
 }
 
 /**

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/mappers.test.ts
@@ -16,7 +16,6 @@ import {
   toStakePoolResults
 } from '../../../src';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
-import { mockStakeDistribution } from '../../../../core/test/CardanoNode/mocks';
 
 // eslint-disable-next-line max-statements
 describe('mappers', () => {
@@ -108,11 +107,6 @@ describe('mappers', () => {
   const poolAPYModel = {
     apy: 0.015,
     hash_id
-  };
-  const nodeMetricsDependencies = {
-    optimalPoolCount: 10,
-    stakeDistribution: mockStakeDistribution,
-    totalAdaAmount: BigInt('42000004107749657')
   };
   it('mapPoolRetirement', () => {
     expect(mapPoolRetirement(poolRetirementModel)).toEqual({
@@ -265,7 +259,6 @@ describe('mappers', () => {
       expect(
         toStakePoolResults([hashId], fromCache, false, {
           lastEpochNo: Cardano.EpochNo(poolRetirementModel.retiring_epoch - 1),
-          nodeMetricsDependencies,
           poolAPYs,
           poolDatas,
           poolMetrics: partialMetrics,
@@ -288,7 +281,6 @@ describe('mappers', () => {
       expect(
         toStakePoolResults([hashId], fromCache, false, {
           lastEpochNo: Cardano.EpochNo(poolRetirementModel.retiring_epoch + 1),
-          nodeMetricsDependencies,
           poolAPYs,
           poolDatas,
           poolMetrics: partialMetrics,
@@ -323,7 +315,6 @@ describe('mappers', () => {
       expect(
         toStakePoolResults([hashId], fromCache, false, {
           lastEpochNo: Cardano.EpochNo(poolRegistrationModel.active_epoch_no - 1),
-          nodeMetricsDependencies,
           poolAPYs,
           poolDatas,
           poolMetrics: partialMetrics,
@@ -358,7 +349,6 @@ describe('mappers', () => {
       expect(
         toStakePoolResults([hashId], fromCache, false, {
           lastEpochNo: Cardano.EpochNo(poolRegistrationModel.active_epoch_no),
-          nodeMetricsDependencies,
           poolAPYs,
           poolDatas,
           poolMetrics: partialMetrics,
@@ -382,7 +372,6 @@ describe('mappers', () => {
       expect(
         toStakePoolResults([hashId], { [hashId]: stakePool }, false, {
           lastEpochNo: Cardano.EpochNo(poolRetirementModel.retiring_epoch - 1),
-          nodeMetricsDependencies,
           poolAPYs,
           poolDatas,
           poolMetrics: partialMetrics,

--- a/packages/e2e/test/artillery/StakePoolSearch.ts
+++ b/packages/e2e/test/artillery/StakePoolSearch.ts
@@ -59,11 +59,13 @@ const getStatName = (ctx: ArtilleryContext<StakePoolSearchVars>) => {
   return `query.${nameStatId}_${statusStatName}`;
 };
 
-const randomizeFilter = () => {
-  const filters: NonNullable<QueryStakePoolsArgs['filters']> = {};
+type Filters = NonNullable<QueryStakePoolsArgs['filters']>;
 
-  // Apply a random filter to 80% of the remaining users in the list, or if it's empty.
-  if (poolIds.length === 0 || Math.random() > 0.2) {
+const randomizeFilter = (): Filters => {
+  const filters: Filters = {};
+
+  // Apply a random filter to 80% of the users
+  if (Math.random() > 0.2) {
     filters.status = [
       [
         Cardano.StakePoolStatus.Activating,
@@ -132,7 +134,7 @@ export const performQuery: FunctionHook<StakePoolSearchVars> = async (ctx, ee, d
     const result = await provider.queryStakePools(args);
 
     // Take ids to randomize next requests
-    for (const pool of result.pageResults) poolIds.push(pool.id);
+    for (const pool of result.pageResults) if (!poolIds.includes(pool.id)) poolIds.push(pool.id);
 
     // Store the result in the context
     vars.pageResults = result.pageResults;

--- a/packages/e2e/test/artillery/StakePoolSearch.yml
+++ b/packages/e2e/test/artillery/StakePoolSearch.yml
@@ -6,12 +6,11 @@ config:
     timeout: 180
   phases:
     - name: 'Stake Pool Search'
-      duration: 10
-      arrivalRate: 1
+      duration: 1
+      arrivalCount: 1
     - name: 'Stake Pool Search Queries'
-      duration: 90
-      arrivalRate: 1
-      rampTo: 100
+      duration: '{{$processEnvironment.TEST_DURATION_IN_SECS}}'
+      arrivalCount: '{{$processEnvironment.VIRTUAL_USERS_COUNT}}'
   processor: './StakePoolSearch.ts'
 
 scenarios:

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -13,3 +13,5 @@ export * from './logging';
 export * from './RunnableModule';
 export * from './opaqueTypes';
 export * from './environment';
+
+export { PromiseOrValue, resolveObjectValues } from './util';

--- a/packages/util/src/util.ts
+++ b/packages/util/src/util.ts
@@ -1,0 +1,8 @@
+export type PromiseOrValue<T> = Promise<T> | T;
+
+export const resolveObjectValues = async <T>(obj: { [k: string]: PromiseOrValue<T> }): Promise<{ [k: string]: T }> =>
+  Object.fromEntries(
+    await Promise.all(
+      Object.entries(obj).map(([key, promise]) => Promise.resolve(promise).then((value) => [key, value]))
+    )
+  );

--- a/packages/util/test/util.test.ts
+++ b/packages/util/test/util.test.ts
@@ -1,0 +1,15 @@
+import { resolveObjectValues } from '../src';
+
+describe('util', () => {
+  describe('resolveObjectValues', () => {
+    it('resolves all object values which are promises', async () => {
+      const result = await resolveObjectValues({
+        first: 1,
+        second: Promise.resolve(2),
+        third: new Promise<number>((resolve) => setTimeout(() => resolve(3), 10))
+      });
+
+      expect(result).toEqual({ first: 1, second: 2, third: 3 });
+    });
+  });
+});


### PR DESCRIPTION
# Context

The stake pool search load test as was born is not configurable, making it configurable will let us to perform different load test scenarios.

While working on it I identified some actions, from minor to major, and I tried to address them as well.

# Proposed Solution

- Changed the stake pool search load test to accept configuration variables
- Changed the `DbSyncStakePoolProvider` to skip the query for stake distribution when configured to use Blockfrost hybrid solution: the total stake amount is required to compute the `saturation` which is a value cached from Blockfrost.
- Changed the `DbSyncStakePoolProvider` to not repeat the same on going queries.

# Important Changes Introduced

- Removed a few lines of unused code
- Applied some minor improvements to the `docker-compose.yml` file.