### PR TITLE
feat: Make request timeout to external services configurable

### DIFF
--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -55,7 +55,8 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
       try {
         assetInfo.tokenMetadata = (await this.#dependencies.tokenMetadataService.getTokenMetadata([assetId]))[0];
       } catch (error) {
-        if (error instanceof ProviderError && error.reason === ProviderFailure.ConnectionFailure) {
+        if (error instanceof ProviderError && error.reason === ProviderFailure.Unhealthy) {
+          this.logger.error(`Failed to fetch token metadata for asset with ${assetId} due to: ${error.message}`);
           assetInfo.tokenMetadata = undefined;
         } else {
           throw error;

--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -90,6 +90,7 @@ export type ProviderServerArgs = CommonProgramOptions &
     disableStakePoolMetricApy?: boolean;
     tokenMetadataCacheTTL?: number;
     tokenMetadataServerUrl?: string;
+    tokenMetadataRequestTimeout?: number;
     epochPollInterval: number;
     dbCacheTtl: number;
     useBlockfrost?: boolean;

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -40,7 +40,11 @@ import {
 } from './Program';
 import { Command, Option } from 'commander';
 import { DB_CACHE_TTL_DEFAULT } from './InMemoryCache';
-import { DEFAULT_TOKEN_METADATA_CACHE_TTL, DEFAULT_TOKEN_METADATA_SERVER_URL } from './Asset';
+import {
+  DEFAULT_TOKEN_METADATA_CACHE_TTL,
+  DEFAULT_TOKEN_METADATA_REQUEST_TIMEOUT,
+  DEFAULT_TOKEN_METADATA_SERVER_URL
+} from './Asset';
 import { EPOCH_POLL_INTERVAL_DEFAULT } from './util';
 import { HttpServer } from './Http';
 import { URL } from 'url';
@@ -167,6 +171,15 @@ withCommonOptions(
       .env('TOKEN_METADATA_CACHE_TTL')
       .default(DEFAULT_TOKEN_METADATA_CACHE_TTL)
       .argParser(cacheTtlValidator)
+  )
+  .addOption(
+    new Option(
+      '--token-metadata-request-timeout <tokenMetadataRequestTimeout>',
+      ProviderServerOptionDescriptions.PaginationPageSizeLimit
+    )
+      .env('TOKEN_METADATA_REQUEST_TIMEOUT')
+      .default(DEFAULT_TOKEN_METADATA_REQUEST_TIMEOUT)
+      .argParser((interval) => Number.parseInt(interval, 10))
   )
   .addOption(
     new Option('--use-blockfrost <true/false>', ProviderServerOptionDescriptions.UseBlockfrost)

--- a/packages/cardano-services/test/Asset/AssetHttpService.test.ts
+++ b/packages/cardano-services/test/Asset/AssetHttpService.test.ts
@@ -53,7 +53,7 @@ describe('AssetHttpService', () => {
 
   describe('healthy state', () => {
     beforeAll(async () => {
-      ({ closeMock, serverUrl } = await mockTokenRegistry(() => ({})));
+      ({ closeMock, serverUrl } = await mockTokenRegistry(async () => ({})));
       db = new Pool({ connectionString: process.env.POSTGRES_CONNECTION_STRING });
       ntfMetadataService = new DbSyncNftMetadataService({
         db,

--- a/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/HttpMetadataService.test.ts
+++ b/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/HttpMetadataService.test.ts
@@ -19,7 +19,7 @@ const UNFETCHABLE = 'http://some_url/unfetchable';
 const INVALID_KEY = 'd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a';
 
 export const mockPoolExtMetadataServer = createGenericMockServer((handler) => async (req, res) => {
-  const result = handler(req);
+  const result = await handler(req);
 
   res.setHeader('Content-Type', 'application/json');
 
@@ -54,7 +54,10 @@ describe('StakePoolMetadataService', () => {
 
   describe('getStakePoolMetadata', () => {
     it('fetch stake pool JSON metadata without extended data', async () => {
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({ body: mainExtMetadataMock, code: 200 })));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({
+        body: mainExtMetadataMock,
+        code: 200
+      })));
 
       const result = await metadataService.getStakePoolMetadata(
         '0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8' as Hash32ByteBase16,
@@ -72,7 +75,7 @@ describe('StakePoolMetadataService', () => {
 
       // First fetch returns the metadata, second fetch return the extended metadata.
       let alreadyCalled = false;
-      const handler = () => {
+      const handler = async () => {
         if (alreadyCalled) return { body: adaPoolsExtMetadataMock, code: 200 };
         alreadyCalled = true;
 
@@ -103,7 +106,7 @@ describe('StakePoolMetadataService', () => {
     });
 
     it('returns StakePoolMetadataServiceError with FailedToFetchMetadata error code when it gets resource not found server error', async () => {
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({ body: {}, code: 500 })));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({ body: {}, code: 500 })));
 
       const result = await metadataService.getStakePoolMetadata(
         '4781fffc4cc4a0d6074ae905869e8596f13246b79888af5a8d9580d3a372729a' as Hash32ByteBase16,
@@ -123,7 +126,10 @@ describe('StakePoolMetadataService', () => {
     });
 
     it('returns StakePoolMetadataServiceError with InvalidStakePoolHash error code when the hash doesnt match', async () => {
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({ body: mainExtMetadataMock, code: 200 })));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({
+        body: mainExtMetadataMock,
+        code: 200
+      })));
 
       const result = await metadataService.getStakePoolMetadata(
         '0000000000000000000000000000000000000000000000000000000000000000' as Hash32ByteBase16,
@@ -144,7 +150,7 @@ describe('StakePoolMetadataService', () => {
 
     it('returns StakePoolMetadataServiceError with InvalidMetadata error code when metadata has extDataUrl but is missing extSigUrl', async () => {
       const metadata = { ...mainExtMetadataMock, extDataUrl: UNFETCHABLE };
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({
         body: metadata,
         code: 200
       })));
@@ -172,7 +178,7 @@ describe('StakePoolMetadataService', () => {
         extDataUrl: UNFETCHABLE,
         extSigUrl: UNFETCHABLE
       };
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({
         body: metadata,
         code: 200
       })));
@@ -198,7 +204,7 @@ describe('StakePoolMetadataService', () => {
       let metadata: any;
 
       let alreadyCalled = false;
-      const handler = () => {
+      const handler = async () => {
         if (alreadyCalled) return { body: cip6ExtMetadataMock, code: 200 };
         alreadyCalled = true;
 
@@ -242,7 +248,7 @@ describe('StakePoolMetadataService', () => {
       let metadata: any;
 
       let numFetch = 0;
-      const handler = () => {
+      const handler = async () => {
         if (numFetch === 0) {
           ++numFetch;
           return {
@@ -297,7 +303,7 @@ describe('StakePoolMetadataService', () => {
 
   describe('getStakePoolExtendedMetadata', () => {
     it('returns ada pools format when extended key is present in the metadata', async () => {
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({})));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({})));
 
       const extMetadata: Cardano.StakePoolMetadata = {
         ...mainExtMetadataMock(),
@@ -310,7 +316,7 @@ describe('StakePoolMetadataService', () => {
     });
 
     it('returns CIP-6 format when extDataUrl is present in the metadata', async () => {
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({})));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({})));
 
       const extMetadata: Cardano.StakePoolMetadata = {
         ...mainExtMetadataMock(),
@@ -323,7 +329,7 @@ describe('StakePoolMetadataService', () => {
     });
 
     it('returns CIP-6 format with priority when the metadata including both extended properties', async () => {
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({})));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({})));
 
       const extMetadata: Cardano.StakePoolMetadata = {
         ...mainExtMetadataMock(),
@@ -338,7 +344,7 @@ describe('StakePoolMetadataService', () => {
 
     it('throws StakePoolMetadataServiceError with InvalidExtendedMetadataFormat error code when it gets an invalid CIP-6 response format', async () => {
       const invalidCip6ResponseFormat = { pool1: { ...cip6ExtMetadataMock.pool }, serial: 12_345 };
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({ body: invalidCip6ResponseFormat })));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({ body: invalidCip6ResponseFormat })));
 
       const extMetadata: Cardano.StakePoolMetadata = {
         ...mainExtMetadataMock(),
@@ -356,7 +362,9 @@ describe('StakePoolMetadataService', () => {
 
     it('throws StakePoolMetadataServiceError with InvalidExtendedMetadataFormat error code when it gets an invalid AP response format', async () => {
       const invalidAdaPoolsResponseFormat = { info1: { ...adaPoolsExtMetadataMock.info } };
-      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(() => ({ body: invalidAdaPoolsResponseFormat })));
+      ({ closeMock, serverUrl } = await mockPoolExtMetadataServer(async () => ({
+        body: invalidAdaPoolsResponseFormat
+      })));
 
       const extMetadata: Cardano.StakePoolMetadata = {
         ...mainExtMetadataMock(),
@@ -374,7 +382,7 @@ describe('StakePoolMetadataService', () => {
 
     it('throws StakePoolMetadataServiceError with FailedToFetchExtendedMetadata error code when it gets internal server error response', async () => {
       let alreadyCalled = false;
-      const handler = () => {
+      const handler = async () => {
         if (alreadyCalled) return { body: {}, code: 500 };
         alreadyCalled = true;
 
@@ -404,7 +412,7 @@ describe('StakePoolMetadataService', () => {
 
     it('throws StakePoolMetadataServiceError with FailedToFetchExtendedMetadata error code when it gets resource not found server error', async () => {
       let alreadyCalled = false;
-      const handler = () => {
+      const handler = async () => {
         if (alreadyCalled) return { body: {}, code: 404 };
         alreadyCalled = true;
 

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -18,7 +18,7 @@ import { fromSerializableObject } from '@cardano-sdk/util';
 import { getRandomPort } from 'get-port-please';
 import { healthCheckResponseMock } from '../../core/test/CardanoNode/mocks';
 import { listenPromise, serverClosePromise } from '../src/util';
-import { mockTokenRegistry } from './Asset/CardanoTokenRegistry.test';
+import { mockTokenRegistry } from './Asset/fixtures/mocks';
 import axios, { AxiosError } from 'axios';
 import http from 'http';
 import path from 'path';
@@ -1596,6 +1596,7 @@ describe('CLI', () => {
           });
 
           describe('specifying a Token-Registry-dependent service', () => {
+            const tokenMetadataRequestTimeout = '3000';
             let closeMock: () => Promise<void> = jest.fn();
             let tokenMetadataServerUrl = '';
             let serverUrl = ';';
@@ -1609,7 +1610,7 @@ describe('CLI', () => {
                 subject: asset.id
               };
 
-              ({ closeMock, serverUrl } = await mockTokenRegistry(() => ({
+              ({ closeMock, serverUrl } = await mockTokenRegistry(async () => ({
                 body: { subjects: [record] }
               })));
               tokenMetadataServerUrl = serverUrl;
@@ -1631,6 +1632,8 @@ describe('CLI', () => {
                     postgresConnectionString,
                     '--token-metadata-server-url',
                     tokenMetadataServerUrl,
+                    '--token-metadata-request-timeout',
+                    tokenMetadataRequestTimeout,
                     ServiceNames.Asset
                   ],
                   { env: {}, stdio: 'pipe' }
@@ -1656,6 +1659,7 @@ describe('CLI', () => {
                     OGMIOS_URL: ogmiosConnection.address.webSocket,
                     POSTGRES_CONNECTION_STRING: postgresConnectionString,
                     SERVICE_NAMES: ServiceNames.Asset,
+                    TOKEN_METADATA_REQUEST_TIMEOUT: tokenMetadataRequestTimeout,
                     TOKEN_METADATA_SERVER_URL: tokenMetadataServerUrl
                   },
                   stdio: 'pipe'

--- a/packages/util-dev/src/createGenericMockServer.ts
+++ b/packages/util-dev/src/createGenericMockServer.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, RequestListener, createServer } from 'http';
 import { getRandomPort } from 'get-port-please';
 
-export type MockHandler = (req?: IncomingMessage) => { body?: unknown; code?: number };
+export type MockHandler = (req?: IncomingMessage) => Promise<{ body?: unknown; code?: number }>;
 export type ListenerGenerator = (handler: MockHandler) => RequestListener;
 
 /**
@@ -14,7 +14,7 @@ export type ListenerGenerator = (handler: MockHandler) => RequestListener;
  */
 export const createGenericMockServer =
   (listenerGenerator: ListenerGenerator, serverPort?: number) =>
-  (handler: MockHandler = () => ({})) =>
+  (handler: MockHandler = async () => ({})) =>
     // eslint-disable-next-line func-call-spacing
     new Promise<{ closeMock: () => Promise<void>; serverUrl: string }>(async (resolve, reject) => {
       try {


### PR DESCRIPTION
# Context

We need to expose an interface for request timeouts to external sources such as the TokenMetadata registry, so it’s configurable while performing fetching through HTTP.

# Proposed Solution

Logged variation of internal network errors related to the Token Metadata Server
![Screenshot 2023-03-21 at 17 17 31](https://user-images.githubusercontent.com/10476819/226668064-ad4bd577-30a2-4cbc-af52-a67e6423ee6a.png)


# Important Changes Introduced
- expose `TOKEN_METADATA_REQUEST_TIMEOUT` env var
- expose `--token-metadata-request-timeout` CLI arg
- use default request timeout of `3` seconds for the token metadata registry
- log corresponding extended error message when the client doesn't get the actual error
- refactor `mockTokenRegistry()` with async handler
