### PR TITLE
chore: adjust max-len eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,16 @@ module.exports = {
     'unicorn/no-null': 0,
     'unicorn/prefer-module': 0,
     'unicorn/prefer-node-protocol': 0,
-    'unicorn/prevent-abbreviations': 0
+    'unicorn/prevent-abbreviations': 0,
+    'max-len': [
+      'warn', {
+        "code": 120, // Keep the existing max line length of 120
+        "ignoreComments": true,
+        "ignoreUrls": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true
+      }
+    ]
   },
   settings: {
     'import/resolver': {

--- a/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { logger } from '@cardano-sdk/util-dev';
 import { networkInfoHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';

--- a/packages/cardano-services-client/test/Utxo/utxoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/Utxo/utxoHttpProvider.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano } from '@cardano-sdk/core';
 import { healthCheckResponseWithState } from '../util';
 import { logger } from '@cardano-sdk/util-dev';

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable sonarjs/no-nested-template-literals */
 import * as Queries from './queries';
 import { BlockModel, BlockOutputModel, TipModel, TxModel } from './types';

--- a/packages/cardano-services/src/Program/services/ogmios.ts
+++ b/packages/cardano-services/src/Program/services/ogmios.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable promise/no-nesting */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { DnsResolver } from '../utils';

--- a/packages/cardano-services/src/Program/services/postgres.ts
+++ b/packages/cardano-services/src/Program/services/postgres.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable promise/no-nesting */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable unicorn/no-nested-ternary */

--- a/packages/cardano-services/src/Program/services/rabbitmq.ts
+++ b/packages/cardano-services/src/Program/services/rabbitmq.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable promise/no-nesting */
 /* eslint-disable no-use-before-define */
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/types.ts
@@ -1,5 +1,3 @@
-/* eslint-disable max-len */
-
 import { Cardano, Paginated, QueryStakePoolsArgs } from '@cardano-sdk/core';
 export interface PoolUpdateModel {
   id: string; // pool hash id

--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/util.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/util.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano } from '@cardano-sdk/core';
 import { Cip6ExtMetadataResponse } from './types';
 import { ExtMetadataFormat, StakePoolExtMetadataResponse } from '../types';

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 /* eslint-disable no-console */
-/* eslint-disable max-len */
 /* eslint-disable complexity */
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable unicorn/no-nested-ternary */

--- a/packages/cardano-services/src/util/DbSyncProvider/DbSyncProvider.ts
+++ b/packages/cardano-services/src/util/DbSyncProvider/DbSyncProvider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano, CardanoNode, HealthCheckResponse, Provider, ProviderDependencies } from '@cardano-sdk/core';
 import { DB_BLOCKS_BEHIND_TOLERANCE, DB_MAX_SAFE_INTEGER, LedgerTipModel, findLedgerTip } from './util';
 import { Logger } from 'ts-log';

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable sonarjs/cognitive-complexity */
-/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cardano, ChainHistoryProvider } from '@cardano-sdk/core';
 import { ChainHistoryFixtureBuilder, TxWith } from './fixtures/FixtureBuilder';

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable max-params */
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-empty-function */

--- a/packages/cardano-services/test/Program/programs/httpServer.test.ts
+++ b/packages/cardano-services/test/Program/programs/httpServer.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable sonarjs/no-duplicate-string */
 import { DB_CACHE_TTL_DEFAULT } from '../../../src/InMemoryCache';
 import { EPOCH_POLL_INTERVAL_DEFAULT, listenPromise, serverClosePromise } from '../../../src/util';

--- a/packages/cardano-services/test/Program/services/ogmios.test.ts
+++ b/packages/cardano-services/test/Program/services/ogmios.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
-/* eslint-disable max-len */
 import { CardanoNodeErrors } from '@cardano-sdk/core';
 import { Connection } from '@cardano-ogmios/client';
 import { DbSyncEpochPollService, listenPromise, loadGenesisData, serverClosePromise } from '../../../src/util';

--- a/packages/cardano-services/test/Program/services/postgres.test.ts
+++ b/packages/cardano-services/test/Program/services/postgres.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
-/* eslint-disable max-len */
 import { DbSyncEpochPollService, EpochMonitor, loadGenesisData } from '../../../src/util';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../../src/NetworkInfo';
 import { HttpServer, HttpServerConfig, createDnsResolver, getPool } from '../../../src';

--- a/packages/cardano-services/test/Program/services/rabbitmq.test.ts
+++ b/packages/cardano-services/test/Program/services/rabbitmq.test.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable sonarjs/no-duplicate-string */
-/* eslint-disable max-len */
 import { CardanoNodeErrors, TxSubmitProvider } from '@cardano-sdk/core';
 import { Connection } from '@cardano-ogmios/client';
 import {

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable max-len */
 import { Cardano, RewardsProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, rewardsHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DbSyncRewardsProvider, HttpServer, HttpServerConfig, RewardsHttpService } from '../../src';

--- a/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/HttpMetadataService.test.ts
+++ b/packages/cardano-services/test/StakePool/HttpStakePoolMetadataService/HttpMetadataService.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable prefer-const */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable max-len */
 import { Cardano, QueryStakePoolsArgs, SortField, StakePoolProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, stakePoolHttpProvider } from '../../../cardano-services-client';
 import { DbSyncEpochPollService, loadGenesisData } from '../../src/util';

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable max-len */
 import { APPLICATION_JSON, CONTENT_TYPE, HttpServer, HttpServerConfig, TxSubmitHttpService } from '../../src';
 import { CardanoNodeErrors, ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, txSubmitHttpProvider } from '@cardano-sdk/cardano-services-client';

--- a/packages/cardano-services/test/Utxo/DbUtxoProvider/mappers.test.ts
+++ b/packages/cardano-services/test/Utxo/DbUtxoProvider/mappers.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano } from '@cardano-sdk/core';
 import { UtxoModel, utxosToCore } from '../../../src/Utxo';
 

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { AddressWith, UtxoFixtureBuilder } from './fixtures/FixtureBuilder';
 import { Asset, Cardano, UtxoProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, utxoHttpProvider } from '@cardano-sdk/cardano-services-client';

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable sonarjs/no-identical-functions */
 /* eslint-disable sonarjs/no-duplicate-string */
-/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Asset } from '@cardano-sdk/core';
 import { AssetData, AssetFixtureBuilder, AssetWith } from './Asset/fixtures/FixtureBuilder';

--- a/packages/core/src/Cardano/types/ProtocolParameters.ts
+++ b/packages/core/src/Cardano/types/ProtocolParameters.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Slot } from './Block';
 
 /* eslint-disable no-use-before-define */

--- a/packages/core/src/Cardano/types/StakePool/PoolParameters.ts
+++ b/packages/core/src/Cardano/types/StakePool/PoolParameters.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { ExtendedStakePoolMetadata } from './ExtendedStakePoolMetadata';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { Lovelace } from '../Value';

--- a/packages/core/src/Provider/ChainHistoryProvider/types.ts
+++ b/packages/core/src/Provider/ChainHistoryProvider/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano, Paginated, PaginationArgs, Provider, Range } from '../..';
 
 export type TransactionsByAddressesArgs = {

--- a/packages/core/test/CML/coreToCml.test.ts
+++ b/packages/core/test/CML/coreToCml.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { AssetId } from '../../src/Cardano';
 import { BigNum } from '@dcspark/cardano-multiplatform-lib-nodejs';
 import { CML, Cardano, SerializationFailure, coreToCml } from '../../src';

--- a/packages/core/test/CML/reserialization.test.ts
+++ b/packages/core/test/CML/reserialization.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { CML, cmlToCore, coreToCml } from '../../src';
 import { ManagedFreeableScope } from '@cardano-sdk/util';
 

--- a/packages/core/test/Cardano/Address/Address.test.ts
+++ b/packages/core/test/Cardano/Address/Address.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as cip19TestVectors from './Cip19TestVectors';
 import { ByronAddressType } from '../../../src/Cardano';
 import { Cardano } from '../../../src';

--- a/packages/core/test/Cardano/Address/BaseAddress.test.ts
+++ b/packages/core/test/Cardano/Address/BaseAddress.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as cip19TestVectors from './Cip19TestVectors';
 import { Cardano } from '../../../src';
 

--- a/packages/crypto/test/hexType.test.ts
+++ b/packages/crypto/test/hexType.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as Crypto from '../src';
 import { HexBlob, InvalidStringError } from '@cardano-sdk/util';
 

--- a/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.ts
+++ b/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { AddressesModel, WalletVars } from './types';
 import { Cardano } from '@cardano-sdk/core';

--- a/packages/e2e/test/providers/StakePoolProvider.test.ts
+++ b/packages/e2e/test/providers/StakePoolProvider.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-/* eslint-disable max-len */
 /* eslint-disable sonarjs/cognitive-complexity */
 import * as envalid from 'envalid';
 import { Cardano, QueryStakePoolsArgs, StakePoolProvider } from '@cardano-sdk/core';

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChainHistory.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChainHistory.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { SingleAddressWallet, buildTx } from '@cardano-sdk/wallet';
 import { assertTxIsValid } from '../../../../wallet/test/util';
 import { filter, firstValueFrom, map, take } from 'rxjs';

--- a/packages/governance/test/cip36.test.ts
+++ b/packages/governance/test/cip36.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as Crypto from '@cardano-sdk/crypto';
 import { CML, Cardano, coreToCml } from '@cardano-sdk/core';
 import { cip36 } from '../src';

--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as Crypto from '@cardano-sdk/crypto';
 import {
   BYRON_TX_FEE_COEFFICIENT,

--- a/packages/ogmios/test/ogmiosToCore/testData.ts
+++ b/packages/ogmios/test/ogmiosToCore/testData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano } from '@cardano-sdk/core';
 import { Ogmios } from '../../src';
 

--- a/packages/projection/src/projectIntoSink.ts
+++ b/packages/projection/src/projectIntoSink.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable jsdoc/valid-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {

--- a/packages/util-dev/src/docker.ts
+++ b/packages/util-dev/src/docker.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { containerExec, imageExists, pullImageAsync } from 'dockerode-utils';
 import Docker from 'dockerode';
 

--- a/packages/util/test/primitives.test.ts
+++ b/packages/util/test/primitives.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable sonarjs/no-duplicate-string */
 import { Base64Blob, HexBlob, InvalidStringError, castHexBlob, typedBech32, typedHex } from '../src';
 

--- a/packages/wallet/src/TxBuilder/buildTx.ts
+++ b/packages/wallet/src/TxBuilder/buildTx.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { FinalizeTxProps, InitializeTxProps, InitializeTxResult, ObservableWallet } from '../types';

--- a/packages/wallet/src/TxBuilder/types.ts
+++ b/packages/wallet/src/TxBuilder/types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 

--- a/packages/wallet/src/services/AssetsTracker.ts
+++ b/packages/wallet/src/services/AssetsTracker.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Asset, Cardano } from '@cardano-sdk/core';
 import { BalanceTracker } from './types';
 import { Logger } from 'ts-log';

--- a/packages/wallet/test/SingleAddressWallet/methods.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/methods.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as Crypto from '@cardano-sdk/crypto';
 import * as mocks from '../mocks';
 import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';

--- a/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
 import * as mocks from '../mocks';

--- a/packages/wallet/test/mocks/mockChainHistoryProvider.ts
+++ b/packages/wallet/test/mocks/mockChainHistoryProvider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { Cardano, Paginated } from '@cardano-sdk/core';
 import { currentEpoch, ledgerTip, stakeKeyHash } from './mockData';
 import { somePartialStakePools } from '@cardano-sdk/util-dev';

--- a/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
+++ b/packages/wallet/test/mocks/mockNetworkInfoProvider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { genesisParameters, ledgerTip, protocolParameters } from './mockData';
 import { testnetEraSummaries } from '@cardano-sdk/util-dev';
 

--- a/packages/wallet/test/services/BalanceTracker.test.ts
+++ b/packages/wallet/test/services/BalanceTracker.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable prettier/prettier */
 /* eslint-disable no-multi-spaces */
 /* eslint-disable space-in-parens */

--- a/packages/wallet/test/services/TransactionsTracker.test.ts
+++ b/packages/wallet/test/services/TransactionsTracker.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable space-in-parens */
 /* eslint-disable no-multi-spaces */
 /* eslint-disable prettier/prettier */

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import * as Crypto from '@cardano-sdk/crypto';
 import * as mocks from '../mocks';
 import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';


### PR DESCRIPTION
# Context
Very often we have to ignore some rules which is quite annoying.
The most ignored is `max-len` rule which we just ignore with `/* eslint-disable max-len */` in top line of the file.

# Proposed Solution
Adjust `max-len` `eslint` rule:
- keep the existing max line length of `120` for the code
- ignore comments, URLs, strings, and template literals
- update all files

# Important Changes Introduced
