### PR TITLE
test: concurrent users metrics

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -21,6 +21,7 @@
     "artillery:wallet-restoration": "WORKERS=1 node -r ts-node/register ../../node_modules/.bin/artillery run --dotenv ./.env test/artillery/wallet-restoration/WalletRestoration.yml",
     "load-test-custom:stake-pool-query": "ts-node test/load-test-custom/stake-pool-search/stake-pool-search.test.ts",
     "load-test-custom:wallet-init": "ts-node test/load-test-custom/wallet-init/wallet-init.test.ts",
+    "load-test-custom:wallet-restoration": "ts-node test/load-test-custom/wallet-restoration/wallet-restoration.test.ts",
     "test": "shx echo 'test' command not implemented yet",
     "test:blockfrost": "jest -c jest.config.js --forceExit --selectProjects blockfrost --runInBand --verbose",
     "test:utils": "jest -c jest.config.js --forceExit --selectProjects utils --verbose",

--- a/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.ts
+++ b/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.ts
@@ -1,4 +1,3 @@
-import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { AddressesModel, WalletVars } from './types';
 import { Cardano } from '@cardano-sdk/core';
 import { FunctionHook } from '../artillery';
@@ -6,7 +5,8 @@ import { Pool } from 'pg';
 import { StubKeyAgent, getEnv, getWallet, walletVariables } from '../../../src';
 import { findAddressesWithRegisteredStakeKey } from './queries';
 import { logger } from '@cardano-sdk/util-dev';
-import { waitForWalletStateSettle } from '../../util';
+import { mapToGroupedAddress, waitForWalletStateSettle } from '../../util';
+import { util } from '@cardano-sdk/key-management';
 
 const env = getEnv([
   ...walletVariables,
@@ -63,15 +63,6 @@ const extractAddresses = async (count: number): Promise<AddressesModel[]> => {
   }
   return result;
 };
-
-const mapToGroupedAddress = (addrModel: AddressesModel): GroupedAddress => ({
-  accountIndex: 0,
-  address: Cardano.PaymentAddress(addrModel.address),
-  index: 0,
-  networkId: addrModel.address.startsWith('addr_test') ? Cardano.NetworkId.Testnet : Cardano.NetworkId.Mainnet,
-  rewardAccount: Cardano.RewardAccount(addrModel.stake_address),
-  type: AddressType.External
-});
 
 export const getAddresses: FunctionHook<WalletVars> = async ({ vars }, _, done) => {
   vars.walletLoads = Number(env.VIRTUAL_USERS_COUNT);

--- a/packages/e2e/test/load-test-custom/wallet-restoration/wallet-restoration.test.ts
+++ b/packages/e2e/test/load-test-custom/wallet-restoration/wallet-restoration.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable import/imports-first */
+// This line must come before loading the env, to configure the location of the .env file
+import * as dotenv from 'dotenv';
+import path from 'path';
+dotenv.config({ path: path.join(__dirname, '../../../.env') });
+import { Cardano } from '@cardano-sdk/core/dist/esm';
+import { GroupedAddress, util } from '@cardano-sdk/key-management';
+import { Logger } from 'ts-log';
+import { MINUTE, StubKeyAgent, getEnv, getWallet, walletVariables } from '../../../src';
+import { SingleAddressWallet } from '@cardano-sdk/wallet';
+import { logger } from '@cardano-sdk/util-dev';
+import { mapToGroupedAddress, waitForWalletStateSettle } from '../../util';
+
+/**
+ * Env var MAX_USERS sets the maximum number of concurrent users to measure
+ * default value 100
+ */
+const RESTORATION_TIMEOUT = process.env.RESTORATION_TIMEOUT
+  ? Number.parseInt(process.env.RESTORATION_TIMEOUT)
+  : 5 * MINUTE;
+const resultsFilePrefix = 'restoration'; // group suffix and extension will be added to file name
+// user groups with different numbers of tx in wallet
+const groups = [
+  [1, 10],
+  [10, 100],
+  [100, 1000]
+];
+const fs = require('fs');
+const env = getEnv([...walletVariables, 'DB_SYNC_CONNECTION_STRING']);
+const testLogger: Logger = console;
+const formattedDate = new Date().toISOString().split('T')[0];
+const dirName = `./${formattedDate}/`;
+const range = (toNum: number) => {
+  // [1 ... toNum]
+  const resArr = [...Array.from({ length: toNum + 1 }).keys()];
+  resArr.shift();
+  return resArr;
+};
+
+const initWallets = async (walletsNum: number, addresses: GroupedAddress[]): Promise<SingleAddressWallet[]> => {
+  testLogger.info('Number of concurrent users: ', walletsNum);
+  let currentAddress;
+  const wallets = [];
+  for (let i = 0; i < walletsNum; i++) {
+    currentAddress = addresses[i];
+    testLogger.info('  address:', currentAddress.address);
+    const keyAgent = util.createAsyncKeyAgent(new StubKeyAgent(currentAddress));
+    const { wallet } = await getWallet({
+      env,
+      idx: 0,
+      keyAgent,
+      logger,
+      name: 'Test Wallet',
+      polling: { interval: 50 }
+    });
+    wallets.push(wallet);
+  }
+  return wallets;
+};
+
+const measureRestorationTime = async (maxUsers: number, addresses: GroupedAddress[], resultsFile: string) => {
+  for (let users = 1; users <= maxUsers; users++) {
+    const wallets = await initWallets(users, addresses.slice(0, maxUsers));
+    addresses.splice(0, maxUsers);
+    try {
+      const start = Date.now();
+      const resp = await Promise.all(wallets.map(async (w) => await waitForWalletStateSettle(w, RESTORATION_TIMEOUT)));
+      if (resp.some((r) => !r)) testLogger.error('Restoration failed');
+      const stop = Date.now();
+      const time = (stop - start) / 1000;
+      testLogger.info('Restoration time - ', time);
+      await fs.appendFile(resultsFile, `${wallets.length},${time}\n`, { flag: 'a' }, (err: never) => {
+        if (err) {
+          testLogger.error(err);
+        }
+      });
+      for (const w of wallets) w.shutdown();
+    } catch (error) {
+      testLogger.error(error);
+    }
+  }
+};
+
+type TestData = {
+  tx_count: number;
+  address: Cardano.PaymentAddress;
+  stake_address: Cardano.RewardAddress;
+};
+
+// Test measures response time for increasing number of concurrent users up to MAX-USERS
+const runTest = async () => {
+  if (!fs.existsSync(dirName)) {
+    fs.mkdirSync(dirName);
+  }
+  const maxUsers = process.env.MAX_USERS ? Number.parseInt(process.env.MAX_USERS) : 100;
+  // calculate number of addresses needed for `maxUsers` measurements
+  const numAddresses = range(maxUsers).reduce((a, b) => a + b);
+  const result = require('../../dump/addresses/mainnet.json');
+  for (const group of groups) {
+    testLogger.info(`Measurements or addresses with ${group[0]} to ${group[1]} txs`);
+    const filteredAddr = result.filter((e: TestData) => e.tx_count > group[0] && e.tx_count < group[1]);
+    if (filteredAddr < numAddresses) throw new Error('Not enough addresses!');
+    const addresses: GroupedAddress[] = filteredAddr.map(mapToGroupedAddress);
+    const creationTime = new Date().toISOString().split('T')[1];
+    const resultsFile = `${dirName}${resultsFilePrefix}-${group[0]}-${group[1]}-${creationTime}.csv`;
+    await measureRestorationTime(maxUsers, addresses, resultsFile);
+    testLogger.info('Results appended to file - ', resultsFile);
+  }
+};
+runTest().catch(() => {
+  testLogger.error('Execution failed');
+});

--- a/packages/e2e/test/util.ts
+++ b/packages/e2e/test/util.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
 import * as envalid from 'envalid';
+import { AddressType, GroupedAddress, InMemoryKeyAgent, TransactionSigner } from '@cardano-sdk/key-management';
+import { AddressesModel } from './artillery/wallet-restoration/types';
 import { Cardano, createSlotEpochCalc } from '@cardano-sdk/core';
 import {
   EMPTY,
@@ -35,7 +37,6 @@ import {
   SingleAddressWallet,
   buildTx
 } from '@cardano-sdk/wallet';
-import { InMemoryKeyAgent, TransactionSigner } from '@cardano-sdk/key-management';
 import { assertTxIsValid } from '../../wallet/test/util';
 import { logger } from '@cardano-sdk/util-dev';
 import sortBy from 'lodash/sortBy';
@@ -339,3 +340,12 @@ export const burnTokens = async ({
     FAST_OPERATION_TIMEOUT_DEFAULT
   );
 };
+
+export const mapToGroupedAddress = (addrModel: AddressesModel): GroupedAddress => ({
+  accountIndex: 0,
+  address: Cardano.PaymentAddress(addrModel.address),
+  index: 0,
+  networkId: addrModel.address.startsWith('addr_test') ? Cardano.NetworkId.Testnet : Cardano.NetworkId.Mainnet,
+  rewardAccount: Cardano.RewardAccount(addrModel.stake_address),
+  type: AddressType.External
+});


### PR DESCRIPTION
# Context

Test for simulation of concurrent wallet restoration workload from specified number of users.

Process
   Test gradually increase load from 1 user to specified number of users
   Time measured till last wallet in the batch restored

Parameters
  MAX_USERS - max number of concurrent wallet restorations in the batch
  RESTORATION_TIMEOUT -  max wait time in milliseconds 
  Groups - (currently hardcoded) users divided by number of tx in wallet to restore

Output written to csv file with 2 columns number of concurrent users and restoration time
