### PR TITLE
feat(cardano-services): optimizes the query to get the ledger tip

### DIFF
--- a/packages/cardano-services/src/util/DbSyncProvider/util.ts
+++ b/packages/cardano-services/src/util/DbSyncProvider/util.ts
@@ -8,9 +8,8 @@ export const DB_MAX_SAFE_INTEGER = 2_147_483_647;
 export const DB_BLOCKS_BEHIND_TOLERANCE = 5;
 
 export const findLedgerTip = `
-    SELECT 
-    block_no, slot_no, hash
-    FROM block
-    ORDER BY block_no DESC 
-    NULLS LAST
-    LIMIT 1`;
+SELECT
+  block_no, slot_no, hash
+FROM block
+WHERE
+  block_no = (SELECT MAX(block_no) FROM block)`;


### PR DESCRIPTION
# Context

The query executed on polling by wallets to get the ledger tip takes about 500ms on _mainnet_.

# Proposed Solution

Rewrote the query in a more optimized way.