### PR TITLE
feat(cardano-services): ledgerTip query result is now cached with a 1 second TTL

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/keys.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/keys.ts
@@ -3,3 +3,4 @@ export const CIRCULATING_SUPPLY = 'NetworkInfo_circulating_supply';
 export const ACTIVE_STAKE = 'NetworkInfo_active_stake';
 export const LIVE_STAKE = 'NetworkInfo_live_stake';
 export const ERA_SUMMARIES = 'NetworkInfo_era_summaries';
+export const LEDGER_TIP = 'NetworkInfo_ledger_tip';


### PR DESCRIPTION
# Context

The ledger tip API result remains the same for each tick of the chain, so [querying the db ](https://github.com/input-output-hk/cardano-js-sdk/blob/96fabf383b31eafc90f27ada4afaa83d65535af8/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts#L63) for every request places unnecessary load on the DB, and consumes clients from the limited pool, when we could just be caching the value in memory.

# Proposed Solution

add a short-lived cache with a non-configurable TTL of 3 seconds
