### PR TITLE
feat(ogmios): ogmios TxSubmit client now uses a long-running ws connection

### DIFF
--- a/packages/cardano-services/test/Program/services/ogmios.test.ts
+++ b/packages/cardano-services/test/Program/services/ogmios.test.ts
@@ -328,7 +328,7 @@ describe('Service dependency abstractions', () => {
       }
     });
 
-    it('should resolve initialize without reconnection logic with one time ws connection type', async () => {
+    it('should resolve DNS twice during initialization without reconnection logic with long ws connection type', async () => {
       const srvRecord = { name: 'localhost', port: ogmiosPortDefault, priority: 1, weight: 1 };
       const failingOgmiosMockPort = await getRandomPort();
       let resolverAlreadyCalled = false;
@@ -347,10 +347,7 @@ describe('Service dependency abstractions', () => {
       });
 
       await expect(provider.initialize()).resolves.toBeUndefined();
-      // This test should fail once we switch to a long-running ws connection
-      // dnsResolverMock should be called twice and try to dns resolve
-      // while init the txSubmitClient within `provider.initialize()`
-      expect(dnsResolverMock).toBeCalledTimes(1);
+      expect(dnsResolverMock).toBeCalledTimes(2);
       await provider.start();
       await provider.shutdown();
     });

--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@cardano-ogmios/client": "5.6.0",
+    "@cardano-ogmios/schema": "5.6.0",
     "@cardano-sdk/core": "^0.10.0",
     "@cardano-sdk/crypto": "^0.1.3",
     "@cardano-sdk/util": "^0.8.2",

--- a/packages/ogmios/src/Ogmios/TxSubmissionClient.ts
+++ b/packages/ogmios/src/Ogmios/TxSubmissionClient.ts
@@ -1,0 +1,81 @@
+import { InteractionContext, TxSubmission, ensureSocketIsOpen, safeJSON } from '@cardano-ogmios/client';
+import { Ogmios, TxId } from '@cardano-ogmios/schema';
+import { WebSocket } from '@cardano-ogmios/client/dist/IsomorphicWebSocket';
+import { baseRequest } from '@cardano-ogmios/client/dist/Request';
+import { nanoid } from 'nanoid';
+
+/**
+ * See also {@link createTxSubmissionClient} for creating a client.
+ */
+export interface TxSubmissionClient {
+  context: InteractionContext;
+  submitTx: (bytes: string) => Promise<TxId>;
+  shutdown: () => Promise<void>;
+}
+
+/**
+ * Waits for a response with the reflection property requestId matching the one we send in the mirror
+ * property of the request.
+ *
+ * @param socket The websocket object.
+ * @param requestId The requestId, this will be used to filter our response.
+ * @param resolve The original promise resolve callback.
+ * @param reject The original promise reject callback.
+ */
+const waitForResponse =
+  (
+    socket: WebSocket,
+    requestId: string,
+    resolve: { (value: string | PromiseLike<string>): void; (arg0: string): void },
+    reject: { (reason?: never): void; (arg0: Error[]): void }
+  ) =>
+  (message: string) => {
+    const submitTxRes: Ogmios['SubmitTxResponse'] = safeJSON.parse(message);
+
+    if ((submitTxRes.type as string) !== 'jsonwsp/fault' && submitTxRes.methodname !== 'SubmitTx') {
+      return;
+    }
+
+    if (!submitTxRes.reflection || submitTxRes.reflection.requestId !== requestId) return;
+
+    // This is the response we are waiting for, we can unregister our callback from the socket.
+    socket.removeListener('message', waitForResponse(socket, requestId, resolve, reject));
+
+    const response = TxSubmission.handleSubmitTxResponse(submitTxRes);
+
+    if (TxSubmission.isTxId(response)) {
+      resolve(response);
+    } else {
+      reject(response);
+    }
+  };
+
+/**
+ * Create a client for submitting signed transactions to underlying Cardano chain.
+ */
+export const createTxSubmissionClient = async (context: InteractionContext): Promise<TxSubmissionClient> =>
+  Promise.resolve({
+    context,
+    shutdown: () =>
+      new Promise((resolve) => {
+        ensureSocketIsOpen(context.socket);
+        context.socket.once('close', resolve);
+        context.socket.close();
+      }),
+    submitTx: async (bytes) => {
+      ensureSocketIsOpen(context.socket);
+      const requestId = nanoid(5);
+      return new Promise<string>((resolve, reject) => {
+        context.socket.on('message', waitForResponse(context.socket, requestId, resolve, reject));
+
+        context.socket.send(
+          safeJSON.stringify({
+            ...baseRequest,
+            args: { submit: bytes },
+            methodname: 'SubmitTx',
+            mirror: { requestId }
+          } as Ogmios['SubmitTx'])
+        );
+      });
+    }
+  } as TxSubmissionClient);


### PR DESCRIPTION
# Context

We discovered an ogmios client bug affecting the submission of multiple transactions through a single long lasting WebSocket connection.

Basically the transaction submission client needs to implement the mirror/reflection feature as the [query client](https://github.com/CardanoSolutions/ogmios/blob/31a2d6e8ca17e1e6e7eb4bf72a041bece49ec80e/clients/TypeScript/packages/client/src/StateQuery/Query.ts#L28) does.

# Proposed Solution

 Implement the mirror/reflection feature from the StateQuery client in the TxSubmit client.