### PR TITLE
feat: Parametrize pagination queries and add support for prepared statements in txs by addresses

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
@@ -187,17 +187,16 @@ export class ChainHistoryBuilder {
     const kind = rangeForQuery ? 'withRange' : 'withoutRange';
     const target = pagination ? 'page' : 'count';
     const q = findTxsByAddresses;
-    const query = `${q.WITH}${q[kind].WITH}${q[target].SELECT}${q[kind].FROM}${q[target].ORDER}`;
-    const args = rangeForQuery ? [addresses, rangeForQuery.lowerBound, rangeForQuery.upperBound] : [addresses];
+    const composedQuery = `${q.WITH}${q[kind].WITH}${q[target].SELECT}${q[kind].FROM}${q[target].ORDER}`;
+    const composedArgs = rangeForQuery ? [addresses, rangeForQuery.lowerBound, rangeForQuery.upperBound] : [addresses];
 
     if (pagination) {
-      const result = await this.#db.query<TxIdModel>(withPagination(query, pagination), args);
-
+      const { query, args } = withPagination(composedQuery, composedArgs, pagination);
+      const result = await this.#db.query<TxIdModel>(query, args);
       return result.rows.map(mapTxId);
     }
 
-    const result = await this.#db.query<CountModel>(query, args);
-
+    const result = await this.#db.query<CountModel>(composedQuery, composedArgs);
     return Number(result.rows[0].count);
   }
 }

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -109,7 +109,11 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
 
   private async transactionsByIds(ids: string[]): Promise<Cardano.HydratedTx[]> {
     this.logger.debug('About to find transactions with ids:', ids);
-    const txResults: QueryResult<TxModel> = await this.dbPools.main.query(Queries.findTransactionsByIds, [ids]);
+    const txResults: QueryResult<TxModel> = await this.dbPools.main.query({
+      name: 'transactions_by_ids',
+      text: Queries.findTransactionsByIds,
+      values: [ids]
+    });
     if (txResults.rows.length === 0) return [];
 
     const [inputs, outputs, mints, withdrawals, redeemers, metadata, collaterals, certificates] = await Promise.all([

--- a/packages/cardano-services/src/Metadata/DbSyncMetadataService.ts
+++ b/packages/cardano-services/src/Metadata/DbSyncMetadataService.ts
@@ -21,7 +21,11 @@ export const createDbSyncMetadataService = (db: Pool, logger: Logger): TxMetadat
   async queryTxMetadataByRecordIds(ids: string[]): Promise<TxMetadataByHashes> {
     logger.debug('About to find metadata for transactions with ids:', ids);
 
-    const result: QueryResult<TxMetadataModel> = await db.query(Queries.findTxMetadataByTxIds, [ids]);
+    const result: QueryResult<TxMetadataModel> = await db.query({
+      name: 'tx_metadata_by_tx_ids',
+      text: Queries.findTxMetadataByTxIds,
+      values: [ids]
+    });
 
     if (result.rows.length === 0) return new Map();
     return mapTxMetadataByHashes(result.rows);

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -140,21 +140,21 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
     switch (sortType) {
       // Add more cases as more sort types are supported
       case 'metrics':
-        return (options?: QueryStakePoolsArgs) =>
+        return (options: QueryStakePoolsArgs) =>
           this.#builder.queryPoolMetrics(hashesIds, totalStake, useBlockfrost, options);
       case 'apy':
         // HACK: If the client request sort by APY default to normal sorting.
         if (this.#responseConfig?.search?.metrics?.apy === false) {
-          return async (options?: QueryStakePoolsArgs) => {
-            if (options) options.sort = undefined;
+          return async (options: QueryStakePoolsArgs) => {
+            options.sort = undefined;
             return await this.#builder.queryPoolData(updatesIds, useBlockfrost, options);
           };
         }
 
-        return (options?: QueryStakePoolsArgs) => this.#builder.queryPoolAPY(hashesIds, this.#epochLength, options);
+        return (options: QueryStakePoolsArgs) => this.#builder.queryPoolAPY(hashesIds, this.#epochLength, options);
       case 'data':
       default:
-        return (options?: QueryStakePoolsArgs) => this.#builder.queryPoolData(updatesIds, useBlockfrost, options);
+        return (options: QueryStakePoolsArgs) => this.#builder.queryPoolData(updatesIds, useBlockfrost, options);
     }
   }
 
@@ -180,12 +180,12 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
     poolUpdates: PoolUpdate[],
     totalStake: string | null,
     useBlockfrost: boolean,
-    options?: QueryStakePoolsArgs
+    options: QueryStakePoolsArgs
   ) {
     const hashesIds = poolUpdates.map(({ id }) => id);
     const updatesIds = poolUpdates.map(({ updateId }) => updateId);
     this.logger.debug(`${hashesIds.length} pools found`);
-    const sortType = options?.sort?.field ? getStakePoolSortType(options.sort.field) : 'data';
+    const sortType = options.sort?.field ? getStakePoolSortType(options.sort.field) : 'data';
 
     const orderedResult = await this.getQueryBySortType(
       sortType,

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -712,9 +712,14 @@ export const getStatusWhereClause = (
   return `(${whereClause.join(' OR ')})`;
 };
 
-export const withPagination = (query: string, pagination?: QueryStakePoolsArgs['pagination']) => {
-  if (pagination) return `${query} LIMIT ${pagination.limit} OFFSET ${pagination.startAt} `;
-  return query;
+export const withPagination = (query: string, args: unknown[], pagination?: QueryStakePoolsArgs['pagination']) => {
+  if (pagination) {
+    return {
+      args: [...args, pagination.limit, pagination.startAt],
+      query: `${query} LIMIT $${++args.length} OFFSET $${++args.length}`
+    };
+  }
+  return { args, query };
 };
 
 const orderBy = (query: string, sort: OrderByOptions[]) =>

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/queries.ts
@@ -716,7 +716,7 @@ export const withPagination = (query: string, args: unknown[], pagination?: Quer
   if (pagination) {
     return {
       args: [...args, pagination.limit, pagination.startAt],
-      query: `${query} LIMIT $${++args.length} OFFSET $${++args.length}`
+      query: `${query} LIMIT $${args.length + 1} OFFSET $${args.length + 2}`
     };
   }
   return { args, query };


### PR DESCRIPTION
# Context

PostgreSQL has the concept of a [prepared statement](https://www.postgresql.org/docs/9.3/static/sql-prepare.html). `node-postgres` supports this by supplying a name parameter to the query config object. If you supply a name parameter the query execution plan will be cached on the PostgreSQL server on a per-connection basis.

We need to optimize the paginated queries and take the advantage of prepared statements.

# Proposed Solution
Check the commit messages

# Important Changes Introduced
- `withPagination()` is refactored to use parametrized queries with `$` signs
- added prepared statements support for `txs-by-addresses` queries
