### PR TITLE
refactor(cardano-services): aggregates the first two queries of txs/b…

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -85,10 +85,9 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
       } ${blockRange?.upperBound ? `and before ${upperBound}` : ''}`
     );
 
-    const [totalResultCount, ids] = await Promise.all([
-      this.#builder.queryTxIdsByAddresses(addresses, blockRange),
-      this.#builder.queryTxIdsByAddresses(addresses, blockRange, pagination)
-    ]);
+    const allIds = await this.#builder.queryTxIdsByAddresses(addresses, blockRange);
+    const totalResultCount = allIds.length;
+    const ids = allIds.splice(pagination.startAt, pagination.limit);
 
     return { pageResults: totalResultCount ? await this.transactionsByIds(ids) : [], totalResultCount };
   }

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -258,6 +258,11 @@ export const findDelegationCertsByTxIds = `
 	ORDER BY tx.id ASC`;
 
 export const findTxsByAddresses = {
+  ORDER: `
+ORDER BY tx_id`,
+  SELECT: `
+SELECT
+  DISTINCT tx_id`,
   WITH: `
 WITH source AS (
   SELECT tx_id, tx_in_id FROM tx_out
@@ -269,19 +274,6 @@ combined AS (
   UNION ALL
   SELECT tx_in_id AS tx_id FROM source WHERE tx_in_id IS NOT NULL
 )`,
-  count: {
-    ORDER: '',
-    SELECT: `
-SELECT
-  COUNT(DISTINCT tx_id) AS count`
-  },
-  page: {
-    ORDER: `
-ORDER BY tx_id`,
-    SELECT: `
-SELECT
-  DISTINCT tx_id`
-  },
   withRange: {
     FROM: `
 FROM partial
@@ -295,7 +287,6 @@ partial AS (
   SELECT
     DISTINCT tx_id
   FROM combined
-  ORDER BY tx_id
 )`
   },
   withoutRange: {

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -134,10 +134,6 @@ export interface DelegationCertModel extends CertificateModel {
   pool_id: string;
 }
 
-export interface CountModel {
-  count: string;
-}
-
 export interface TxIdModel {
   tx_id: string;
 }


### PR DESCRIPTION
# Context

At its beginning, the `txs/by-addresses` endpoint performs two similar queries to get the total number of transactions and the `tx.id`s of the requested page.

# Proposed Solution

Merged the two queries in a single one to get the entire list of `tx.id`s and performed the _count_ and the _pagination_ at TypeScript level.
This should reduce the DB server workload, but simultaneously increases the amount of data transferred from the DB server to the SDK.
We need to measure the impact of this change, moreover on the restoration of wallets with high number of transactions, before taking a decision on merging this or not.

The increased workload on SDK side shouldn't be a big problem as SDK servers can be simply scaled adding more sibling servers while scaling the DB server would require much more expensive actions: the reduction of the DB server workload (to be measured) should be another aspect to take care while taking the final decision about this branch.

# QA request

Hi @iadmytro , could you please perform load tests on wallet restoration procedure to verify this change yields better performance?

It would be useful to perform load tests on a set of wallets with high number of transactions and on a set of wallets with low number of transactions; following the expected result

- restoration of wallets with low number of transaction is expected to have benefit: please verify this
- restoration of wallets with high number of transaction unknown: the main reason of this QA request.
