### PR TITLE
feat(cardano-services): add path metrics on provider server

### DIFF
--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -214,6 +214,7 @@ export class HttpServer extends RunnableModule {
     this.app.use(
       expressPromBundle({
         includeMethod: true,
+        includePath: true,
         promRegistry,
         ...this.#config.metrics?.options
       })

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -27,7 +27,8 @@ jest.setTimeout(90_000);
 const DNS_SERVER_NOT_REACHABLE_ERROR = 'querySrv ENOTFOUND';
 const CLI_CONFLICTING_OPTIONS_ERROR_MESSAGE = 'cannot be used with option';
 const CLI_CONFLICTING_ENV_VARS_ERROR_MESSAGE = 'cannot be used with environment variable';
-const METRICS_ENDPOINT_LABEL_RESPONSE = 'http_request_duration_seconds duration histogram of http responses';
+const METRICS_ENDPOINT_LABEL_RESPONSE =
+  'http_request_duration_seconds duration histogram of http responses labeled with: status_code, method, path';
 const REQUIRES_PG_CONNECTION = 'requires the PostgreSQL Connection string or Postgres SRV service name';
 
 const exePath = path.join(__dirname, '..', 'dist', 'cjs', 'cli.js');


### PR DESCRIPTION
# Context
The current metrics exposed by[npm: express-prom-bundle](https://www.npmjs.com/package/express-prom-bundle) has no granular metrics per route.
We need to enable it and check if a prom client needs an additional path normalization function.

# Proposed Solution
![Screenshot 2023-03-31 at 12 54 48](https://user-images.githubusercontent.com/10476819/229131867-7d340b08-23b1-4544-b2ca-0cf6cd08d118.png)

