### PR TITLE
refactor(cardano-services): changed circulating supply query

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/DbSyncNetworkInfoProvider.ts
@@ -104,7 +104,11 @@ export class DbSyncNetworkInfoProvider extends DbSyncProvider(RunnableModule) im
     const { maxLovelaceSupply } = this.#genesisData;
 
     const [circulatingSupply, totalSupply] = await Promise.all([
-      this.#cache.get(NetworkInfoCacheKey.CIRCULATING_SUPPLY, () => this.#builder.queryCirculatingSupply()),
+      this.#cache.get(
+        NetworkInfoCacheKey.CIRCULATING_SUPPLY,
+        () => this.#builder.queryCirculatingSupply(),
+        UNLIMITED_CACHE_TTL
+      ),
       this.#cache.get(
         NetworkInfoCacheKey.TOTAL_SUPPLY,
         () => this.#builder.queryTotalSupply(maxLovelaceSupply),

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -1,23 +1,5 @@
 export const findCirculatingSupply = `
-    WITH total_rewards AS (
-        SELECT COALESCE(SUM(amount), 0) as rewards_amount
-        FROM reward
-    ),
-    total_withdrawals AS (
-        SELECT COALESCE(SUM(amount), 0) as withdrawals_amount
-        FROM withdrawal
-    ),
-    total_utxo AS (
-        SELECT
-            SUM(tx_out.value) AS utxo_amount
-        FROM tx_out
-        LEFT JOIN tx_in 
-            ON tx_out.tx_id = tx_in.tx_out_id
-            AND tx_out.index = tx_in.tx_out_index
-        WHERE tx_in.id IS NULL    
-    )
-    SELECT CAST(utxo_amount + (rewards_amount - withdrawals_amount) AS BIGINT) as circulating_supply
-    FROM total_rewards, total_withdrawals, total_utxo
+  SELECT ( utxo + rewards ) as circulating_supply FROM ada_pots ORDER BY id DESC LIMIT 1;
 `;
 
 export const findTotalSupply = `


### PR DESCRIPTION
# Context

Getting live circulating supply value from db-sync is very expensive operation.

# Proposed Solution

Get circulating supply from Ada pots to improve performance of the query.

# Notes

Value from Ada pots updated once per epoch, while live circulating supply updating each block, so this change is trading off value accuracy for performance. 