### PR TITLE
fix(cardano-services)!: remove duplicate protocolParams operation id

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
+++ b/packages/cardano-services/src/NetworkInfo/NetworkInfoHttpService.ts
@@ -59,13 +59,6 @@ export class NetworkInfoHttpService extends HttpService {
       )
     );
     router.post(
-      '/current-wallet-protocol-parameters',
-      providerHandler(networkInfoProvider.protocolParameters.bind(networkInfoProvider))(
-        HttpService.routeHandler(logger),
-        logger
-      )
-    );
-    router.post(
       '/genesis-parameters',
       providerHandler(networkInfoProvider.genesisParameters.bind(networkInfoProvider))(
         HttpService.routeHandler(logger),

--- a/packages/cardano-services/src/NetworkInfo/openApi.json
+++ b/packages/cardano-services/src/NetworkInfo/openApi.json
@@ -147,33 +147,6 @@
         }
       }
     },
-    "/network-info/current-wallet-protocol-parameters": {
-      "post": {
-        "summary": "fetch current wallet protocol params",
-        "description": "Fetch current Wallet Protocol Params",
-        "operationId": "protocolParams",
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "current wallet protocol params fetched",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProtocolParametersResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid request"
-          }
-        }
-      }
-    },
     "/network-info/genesis-parameters": {
       "post": {
         "summary": "fetch genesis params",
@@ -205,10 +178,7 @@
   "components": {
     "schemas": {
       "Stake": {
-        "required": [
-          "active",
-          "live"
-        ],
+        "required": ["active", "live"],
         "type": "object",
         "properties": {
           "live": {
@@ -220,10 +190,7 @@
         }
       },
       "LovelaceSupply": {
-        "required": [
-          "circulating",
-          "total"
-        ],
+        "required": ["circulating", "total"],
         "type": "object",
         "properties": {
           "circulating": {
@@ -235,17 +202,11 @@
         }
       },
       "EraSummary": {
-        "required": [
-          "parameters",
-          "start"
-        ],
+        "required": ["parameters", "start"],
         "type": "object",
         "properties": {
           "parameters": {
-            "required": [
-              "epochLength",
-              "slotLength"
-            ],
+            "required": ["epochLength", "slotLength"],
             "type": "object",
             "properties": {
               "epochLength": {
@@ -259,10 +220,7 @@
             }
           },
           "start": {
-            "required": [
-              "slot",
-              "time"
-            ],
+            "required": ["slot", "time"],
             "type": "object",
             "properties": {
               "slot": {
@@ -277,10 +235,7 @@
         }
       },
       "Date": {
-        "required": [
-          "__type",
-          "value"
-        ],
+        "required": ["__type", "value"],
         "type": "object",
         "properties": {
           "value": {
@@ -288,17 +243,12 @@
           },
           "__type": {
             "type": "string",
-            "enum": [
-              "Date"
-            ]
+            "enum": ["Date"]
           }
         }
       },
       "BigInt": {
-        "required": [
-          "__type",
-          "value"
-        ],
+        "required": ["__type", "value"],
         "type": "object",
         "properties": {
           "value": {
@@ -307,19 +257,13 @@
           },
           "__type": {
             "type": "string",
-            "enum": [
-              "bigint"
-            ]
+            "enum": ["bigint"]
           }
         }
       },
       "LedgerTipResponse": {
         "type": "object",
-        "required": [
-          "blockNo",
-          "slot",
-          "hash"
-        ],
+        "required": ["blockNo", "slot", "hash"],
         "properties": {
           "blockNo": {
             "type": "number",

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -372,28 +372,6 @@ describe('NetworkInfoHttpService', () => {
       });
     });
 
-    describe('/current-wallet-protocol-parameters', () => {
-      describe('with Http Server', () => {
-        it('returns a 200 coded response with a well formed HTTP request', async () => {
-          expect((await axios.post(`${baseUrl}/current-wallet-protocol-parameters`, {})).status).toEqual(200);
-        });
-
-        it('returns a 415 coded response if the wrong content type header is used', async () => {
-          expect.assertions(2);
-          try {
-            await axios.post(
-              `${baseUrl}/current-wallet-protocol-parameters`,
-              {},
-              { headers: { 'Content-Type': APPLICATION_CBOR } }
-            );
-          } catch (error: any) {
-            expect(error.response.status).toBe(415);
-            expect(error.message).toBe(UNSUPPORTED_MEDIA_STRING);
-          }
-        });
-      });
-    });
-
     describe('/genesis-parameters', () => {
       describe('with Http Server', () => {
         it('returns a 200 coded response with a well formed HTTP request', async () => {


### PR DESCRIPTION
# Context
Two NetworkInfo openApi paths point to the same operationId, `protocolParams`.

# Important Changes Introduced
BREAKING CHANGE: remove obsolete NetworkInfo openApi path
	/network-info/current-wallet-protocol-parameters.

