### PR TITLE
feat: Batch requests to Token Metadata server

### DIFF
--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -6,6 +6,7 @@ import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider }
  */
 const paths: HttpProviderConfigPaths<AssetProvider> = {
   getAsset: '/get-asset',
+  getAssets: '/get-assets',
   healthCheck: '/health'
 };
 

--- a/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
@@ -31,5 +31,15 @@ describe('assetInfoHttpProvider', () => {
         })
       ).resolves.toEqual({});
     });
+
+    test("getAssets doesn't throw", async () => {
+      axiosMock.onPost().replyOnce(200, {});
+      const provider = assetInfoHttpProvider(config);
+      await expect(
+        provider.getAssets({
+          assetIds: [Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958')]
+        })
+      ).resolves.toEqual({});
+    });
   });
 });

--- a/packages/cardano-services/src/Asset/AssetHttpService.ts
+++ b/packages/cardano-services/src/Asset/AssetHttpService.ts
@@ -42,5 +42,10 @@ export class AssetHttpService extends HttpService {
       '/get-asset',
       providerHandler(assetProvider.getAsset.bind(assetProvider))(HttpService.routeHandler(logger), logger)
     );
+
+    router.post(
+      '/get-assets',
+      providerHandler(assetProvider.getAssets.bind(assetProvider))(HttpService.routeHandler(logger), logger)
+    );
   }
 }

--- a/packages/cardano-services/src/Asset/openApi.json
+++ b/packages/cardano-services/src/Asset/openApi.json
@@ -11,6 +11,7 @@
   "paths": {
     "/asset/get-asset": {
       "post": {
+        "deprecated": true,
         "summary": "Get Asset Info",
         "operationId": "getAssetInfo",
         "requestBody": {
@@ -30,6 +31,54 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AssetInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/asset/get-assets": {
+      "post": {
+        "summary": "Get Assets Info",
+        "operationId": "getAssetsInfo",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetAssetsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "success operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetInfoListResponse"
                 }
               }
             }
@@ -94,10 +143,19 @@
           }
         }
       },
+      "ExtraDataAssetIds": {
+        "type": "object",
+        "properties": {
+          "nftMetadata": {
+            "type": "boolean"
+          },
+          "tokenMetadata": {
+            "type": "boolean"
+          }
+        }
+      },
       "GetAssetRequest": {
-        "required": [
-          "assetId"
-        ],
+        "required": ["assetId"],
         "type": "object",
         "properties": {
           "assetId": {
@@ -106,6 +164,27 @@
           "extraData": {
             "$ref": "#/components/schemas/ExtraData"
           }
+        }
+      },
+      "GetAssetsRequest": {
+        "required": ["assetIds"],
+        "type": "object",
+        "properties": {
+          "assetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "extraData": {
+            "$ref": "#/components/schemas/ExtraDataAssetIds"
+          }
+        }
+      },
+      "AssetInfoListResponse": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/AssetInfo"
         }
       }
     }

--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -34,6 +34,7 @@ export const DISABLE_DB_CACHE_DEFAULT = false;
 export const DISABLE_STAKE_POOL_METRIC_APY_DEFAULT = false;
 export const HTTP_SERVER_API_URL_DEFAULT = new URL('http://localhost:3000');
 export const PAGINATION_PAGE_SIZE_LIMIT_DEFAULT = 25;
+export const PAGINATION_PAGE_SIZE_LIMIT_ASSETS = 300;
 export const USE_BLOCKFROST_DEFAULT = false;
 export const USE_QUEUE_DEFAULT = false;
 
@@ -94,16 +95,21 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
       const tokenMetadataService = args.tokenMetadataServerUrl?.startsWith('stub:')
         ? new StubTokenMetadataService()
         : new CardanoTokenRegistry({ logger }, args);
-      const assetProvider = new DbSyncAssetProvider({
-        cache: {
-          healthCheck: healthCheckCache
+      const assetProvider = new DbSyncAssetProvider(
+        {
+          paginationPageSizeLimit: Math.min(args.paginationPageSizeLimit! * 10, PAGINATION_PAGE_SIZE_LIMIT_ASSETS)
         },
-        cardanoNode,
-        dbPools,
-        logger,
-        ntfMetadataService,
-        tokenMetadataService
-      });
+        {
+          cache: {
+            healthCheck: healthCheckCache
+          },
+          cardanoNode,
+          dbPools,
+          logger,
+          ntfMetadataService,
+          tokenMetadataService
+        }
+      );
 
       return new AssetHttpService({ assetProvider, logger });
     }, ServiceNames.Asset),

--- a/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
+++ b/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
@@ -8,6 +8,7 @@ import { sleep } from '../util';
 
 const testDescription = 'test description';
 const testName = 'test name';
+const testSubject = 'test id';
 
 describe('CardanoTokenRegistry', () => {
   const invalidAssetId = Cardano.AssetId('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
@@ -22,11 +23,12 @@ describe('CardanoTokenRegistry', () => {
           description: { value: testDescription },
           logo: { value: 'test logo' },
           name: { value: testName },
-          subject: 'test',
+          subject: testSubject,
           ticker: { value: 'test ticker' },
           url: { value: 'test url' }
         })
       ).toStrictEqual({
+        assetId: testSubject,
         decimals: 23,
         desc: testDescription,
         icon: 'test logo',
@@ -40,9 +42,9 @@ describe('CardanoTokenRegistry', () => {
         toCoreTokenMetadata({
           description: { value: testDescription },
           name: { value: testName },
-          subject: 'test'
+          subject: testSubject
         })
-      ).toStrictEqual({ desc: testDescription, name: testName }));
+      ).toStrictEqual({ assetId: testSubject, desc: testDescription, name: testName }));
   });
 
   describe('return value', () => {
@@ -70,6 +72,7 @@ describe('CardanoTokenRegistry', () => {
       expect(metadata![0]).not.toBeNull();
 
       const result = {
+        assetId: validAssetId,
         decimals: 8,
         desc: 'SingularityNET',
         icon: 'testLogo',
@@ -122,7 +125,7 @@ describe('CardanoTokenRegistry', () => {
       await closeMock();
     });
 
-    it('metadata are cached', async () => {
+    it('metadata is cached', async () => {
       const firstResult = await tokenRegistry.getTokenMetadata([validAssetId]);
       const secondResult = await tokenRegistry.getTokenMetadata([validAssetId]);
 
@@ -175,7 +178,7 @@ describe('CardanoTokenRegistry', () => {
 
     it('internal server error', async () => {
       const failedMetadata = null;
-      const succeededMetadata = { name: 'test' };
+      const succeededMetadata = { assetId: validAssetId, name: 'test' };
 
       let alreadyCalled = false;
       const record = async () => {
@@ -185,9 +188,7 @@ describe('CardanoTokenRegistry', () => {
 
         return {
           body: {
-            subjects: [
-              { name: { value: 'test' }, subject: 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958' }
-            ]
+            subjects: [{ name: { value: 'test' }, subject: validAssetId }]
           }
         };
       };
@@ -216,9 +217,7 @@ describe('CardanoTokenRegistry', () => {
 
         return {
           body: {
-            subjects: [
-              { name: { value: 'test' }, subject: 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958' }
-            ]
+            subjects: [{ name: { value: 'test' }, subject: validAssetId }]
           }
         };
       };

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -9,6 +9,7 @@ import {
   DbSyncNftMetadataService,
   InMemoryCache,
   NftMetadataService,
+  PAGINATION_PAGE_SIZE_LIMIT_ASSETS,
   TokenMetadataService,
   UNLIMITED_CACHE_TTL
 } from '../../src';
@@ -51,14 +52,17 @@ describe('DbSyncAssetProvider', () => {
       { logger },
       { tokenMetadataRequestTimeout: defaultTimeout, tokenMetadataServerUrl: serverUrl }
     );
-    provider = new DbSyncAssetProvider({
-      cache,
-      cardanoNode,
-      dbPools,
-      logger,
-      ntfMetadataService,
-      tokenMetadataService
-    });
+    provider = new DbSyncAssetProvider(
+      { paginationPageSizeLimit: PAGINATION_PAGE_SIZE_LIMIT_ASSETS },
+      {
+        cache,
+        cardanoNode,
+        dbPools,
+        logger,
+        ntfMetadataService,
+        tokenMetadataService
+      }
+    );
     fixtureBuilder = new AssetFixtureBuilder(dbPools.main, logger);
   });
 
@@ -94,6 +98,7 @@ describe('DbSyncAssetProvider', () => {
     expect(asset.history).toEqual(history);
     expect(asset.nftMetadata).toStrictEqual(assets[0].metadata);
     expect(asset.tokenMetadata).toStrictEqual({
+      assetId: '728847c7898b06f180de05c80b37d38bf77a9ea22bd1e222b8014d964e46542d66696c6573',
       desc: 'This is my second NFT',
       name: 'Bored Ape'
     });
@@ -105,14 +110,17 @@ describe('DbSyncAssetProvider', () => {
       { tokenMetadataRequestTimeout: defaultTimeout, tokenMetadataServerUrl: serverUrl }
     );
 
-    provider = new DbSyncAssetProvider({
-      cache,
-      cardanoNode,
-      dbPools,
-      logger,
-      ntfMetadataService,
-      tokenMetadataService
-    });
+    provider = new DbSyncAssetProvider(
+      { paginationPageSizeLimit: PAGINATION_PAGE_SIZE_LIMIT_ASSETS },
+      {
+        cache,
+        cardanoNode,
+        dbPools,
+        logger,
+        ntfMetadataService,
+        tokenMetadataService
+      }
+    );
 
     const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
     const asset = await provider.getAsset({
@@ -136,14 +144,17 @@ describe('DbSyncAssetProvider', () => {
       { logger },
       { tokenMetadataRequestTimeout: defaultTimeout, tokenMetadataServerUrl: serverUrl }
     );
-    provider = new DbSyncAssetProvider({
-      cache,
-      cardanoNode,
-      dbPools,
-      logger,
-      ntfMetadataService,
-      tokenMetadataService
-    });
+    provider = new DbSyncAssetProvider(
+      { paginationPageSizeLimit: PAGINATION_PAGE_SIZE_LIMIT_ASSETS },
+      {
+        cache,
+        cardanoNode,
+        dbPools,
+        logger,
+        ntfMetadataService,
+        tokenMetadataService
+      }
+    );
 
     const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
     const asset = await provider.getAsset({

--- a/packages/core/src/Asset/types/TokenMetadata.ts
+++ b/packages/core/src/Asset/types/TokenMetadata.ts
@@ -1,3 +1,5 @@
+import { Cardano } from '../..';
+
 export interface TokenMetadataSizedIcon {
   /**
    * Most likely one of 16, 32, 64, 96, 128
@@ -17,6 +19,10 @@ export interface TokenMetadataSizedIcon {
  * https://github.com/cardano-foundation/CIPs/pull/137
  */
 export interface TokenMetadata {
+  /**
+   * Associated asset id (concatenated hex values of policyId + assetName)
+   */
+  assetId: Cardano.AssetId;
   /**
    * Asset name
    */

--- a/packages/core/src/Provider/AssetProvider/types.ts
+++ b/packages/core/src/Provider/AssetProvider/types.ts
@@ -5,15 +5,28 @@ interface AssetExtraData {
   tokenMetadata?: boolean;
   history?: boolean;
 }
+
 export interface GetAssetArgs {
   assetId: Cardano.AssetId;
   extraData?: AssetExtraData;
 }
 
+export interface GetAssetsArgs {
+  assetIds: Cardano.AssetId[];
+  extraData?: Omit<AssetExtraData, 'history'>;
+}
+
 export interface AssetProvider extends Provider {
   /**
-   * @param id asset ID (concatenated hex values of policyId + assetName)
+   * @param assetId asset ID (concatenated hex values of policyId + assetName)
+   * @param extraData optional extra data to be provided - nftMetadata, tokenMetadata or history
    * @throws ProviderError
    */
   getAsset: (args: GetAssetArgs) => Promise<Asset.AssetInfo>;
+  /**
+   * @param assetIds asset IDs (concatenated hex values of policyId + assetName)
+   * @param extraData optional extra data to be provided - nftMetadata, tokenMetadata or history
+   * @throws ProviderError
+   */
+  getAssets: (args: GetAssetsArgs) => Promise<Asset.AssetInfo[]>;
 }

--- a/packages/util-rxjs/src/concatAndCombineLatest.ts
+++ b/packages/util-rxjs/src/concatAndCombineLatest.ts
@@ -1,0 +1,32 @@
+import { Observable, combineLatest, concat, ignoreElements, of, share, take } from 'rxjs';
+
+/** Subscribe to o$ after trigger$ emits its first value */
+const startOnTrigger = <A, B>(trigger$: Observable<A>, o$: Observable<B>) =>
+  concat(trigger$.pipe(take(1), ignoreElements()), o$);
+
+/**
+ * Creates a new observable that:
+ *   - acts like `combineLatest` for the input `args` observables
+ *   - unlike `combineLatest` it starts the observables in a sequence, like concat
+ *   - unlike `concat`, it does not wait for the previous one to complete,
+ *     instead it starts the next observable when the previous one emits the first value
+ */
+export const concatAndCombineLatest = <T>(obsArray: Observable<T>[]): Observable<T[]> => {
+  if (obsArray.length === 0) {
+    return of([]);
+  }
+
+  // Build an array of observables, where each item in the array starts only when the previous one emitted the first value
+  const observableCascadeArray: Observable<T>[] = [];
+  // Share the observable to be used as source and as trigger
+  let sharedTrigger$ = obsArray[0].pipe(share());
+  observableCascadeArray.push(sharedTrigger$);
+  for (const o$ of obsArray.slice(1)) {
+    // next o$ starts only after sharedTrigger$ emitted once
+    const triggeredO$ = startOnTrigger(sharedTrigger$, o$);
+    // triggerO$ will be a source and a trigger for the next one, thus cascading the observables
+    sharedTrigger$ = triggeredO$.pipe(share());
+    observableCascadeArray.push(sharedTrigger$);
+  }
+  return combineLatest(observableCascadeArray);
+};

--- a/packages/util-rxjs/src/index.ts
+++ b/packages/util-rxjs/src/index.ts
@@ -3,4 +3,5 @@ export * from './blockingWithLatestFrom';
 export * from './toEmpty';
 export * from './passthrough';
 export * from './finalizeWithLatest';
+export * from './concatAndCombineLatest';
 export * from './types';

--- a/packages/util-rxjs/test/concatAndCombineLatest.test.ts
+++ b/packages/util-rxjs/test/concatAndCombineLatest.test.ts
@@ -1,0 +1,48 @@
+import { concatAndCombineLatest } from '../src';
+import { createTestScheduler } from '@cardano-sdk/util-dev';
+
+describe('concatAndCombineLatest', () => {
+  it('emits an empty array if the source is an empty array', () => {
+    createTestScheduler().run(({ expectObservable }) => {
+      expectObservable(concatAndCombineLatest([])).toBe('(a|)', { a: [] });
+    });
+  });
+
+  it('mirrors the values wrapped in array, given an array with a single observable', () => {
+    createTestScheduler().run(({ cold, expectObservable }) => {
+      const o$ = cold('xy|');
+      expectObservable(concatAndCombineLatest([o$])).toBe('ab|', { a: ['x'], b: ['y'] });
+    });
+  });
+
+  it('concats the emitted values for two observables', () => {
+    createTestScheduler().run(({ cold, expectObservable }) => {
+      const o1$ = cold('x|');
+      const o2$ = cold('y|');
+      expectObservable(concatAndCombineLatest([o1$, o2$])).toBe('a|', { a: ['x', 'y'] });
+    });
+  });
+
+  it(`for multiple observables,
+      subscribes sequentially like concat,
+      based on prev emitting at least once, instead of complete event,
+      and combines them like combineLatest
+      `, () => {
+    createTestScheduler().run(({ cold, expectObservable, expectSubscriptions }) => {
+      const o1$ = cold('-a--b--c|');
+      const o2$ = cold(' ---x-y--z|');
+      const o3$ = cold('    -m|');
+
+      expectObservable(concatAndCombineLatest([o1$, o2$, o3$])).toBe('-----abc-d|', {
+        a: ['b', 'x', 'm'],
+        b: ['b', 'y', 'm'],
+        c: ['c', 'y', 'm'],
+        d: ['c', 'z', 'm']
+      });
+
+      expectSubscriptions(o1$.subscriptions).toBe('^-------!');
+      expectSubscriptions(o2$.subscriptions).toBe('-^--------!');
+      expectSubscriptions(o3$.subscriptions).toBe('----^-!');
+    });
+  });
+});

--- a/packages/wallet/src/services/ProviderTracker/TrackedAssetProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedAssetProvider.ts
@@ -24,6 +24,7 @@ export class TrackedAssetProvider extends ProviderTracker implements AssetProvid
   readonly stats = new AssetProviderStats();
   readonly healthCheck: AssetProvider['healthCheck'];
   readonly getAsset: AssetProvider['getAsset'];
+  readonly getAssets: AssetProvider['getAssets'];
 
   constructor(assetProvider: AssetProvider) {
     super();
@@ -33,5 +34,8 @@ export class TrackedAssetProvider extends ProviderTracker implements AssetProvid
 
     this.getAsset = ({ assetId, extraData }) =>
       this.trackedCall(() => assetProvider.getAsset({ assetId, extraData }), this.stats.getAsset$);
+
+    this.getAssets = ({ assetIds, extraData }) =>
+      this.trackedCall(() => assetProvider.getAssets({ assetIds, extraData }), this.stats.getAsset$);
   }
 }

--- a/packages/wallet/test/mocks/mockAssetProvider.ts
+++ b/packages/wallet/test/mocks/mockAssetProvider.ts
@@ -18,6 +18,7 @@ export const asset = {
 
 export const mockAssetProvider = () => ({
   getAsset: jest.fn().mockResolvedValue(asset),
+  getAssets: jest.fn().mockResolvedValue([asset]),
   healthCheck: jest.fn().mockResolvedValue({ ok: true })
 });
 


### PR DESCRIPTION
# Context
A good optimization would be to batch the requests - perform from the wallet just 1 request `provider.getAssets(ids)` instead of `N` requests by single id (could be more than `1k` per wallet, for instance, a random wallet I picked `has got metadata for` `263` assets which mean `263` HTTP requests for a single wallet, without retried ones).
That’s a lot and the improvement also would drastically reduce the produced load to the Token Metadata server.
Also, the rate-limiting issue would be resolved by batching the requests against Token Metadata Server.

# Proposed Solution
Create a new endpoint on the backend `/get-assets` which returns all assets with their nft and token metadata.
Use that new provider method in the wallet and reduce the number of requests significantly.

# Important Changes Introduced
- create new HTTP endpoint /get-assets
- extend Asset HTTP service and provider to support fetching by ids
- add open API spec for the new endpoint
- extend asset info provider client
- refactor AssetTracker in wallet package to use fetching by ids by chunks 

