### PR TITLE
feat(ogmios): log successful transaction submission with info level

### DIFF
--- a/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
@@ -68,7 +68,8 @@ export class OgmiosTxSubmitProvider extends RunnableModule implements TxSubmitPr
       throw new CardanoNodeErrors.NotInitializedError('submitTx', this.name);
     }
     try {
-      await this.#txSubmissionClient.submitTx(signedTransaction);
+      const id = await this.#txSubmissionClient.submitTx(signedTransaction);
+      this.#logger.info(`Submitted ${id}`);
     } catch (error) {
       throw Cardano.util.asTxSubmissionError(error) || new CardanoNodeErrors.UnknownTxSubmissionError(error);
     }


### PR DESCRIPTION
# Context
We're currently not logging successful tx submissions, so can only rely on requests for gathering metrics on system metrics.

# Proposed Solution
Log the tx hash returned by Ogmios.

# Important Changes Introduced
The default logging level will now include a log of all submitted transactions. This may appear to be a bit noisy but can be reworked with a more sophisticated metrics solution in future. For now it's not too impactful, and does fit within the "info" category IMO.
