### PR TITLE
Feat/historical asset info

### DIFF
--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -1,5 +1,10 @@
-import { AssetProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { Asset, AssetProvider } from '@cardano-sdk/core';
+import {
+  CreateHttpProviderConfig,
+  HttpProviderConfig,
+  HttpProviderConfigPaths,
+  createHttpProvider
+} from '../HttpProvider';
 
 /**
  * The AssetProvider endpoint paths.
@@ -10,6 +15,23 @@ const paths: HttpProviderConfigPaths<AssetProvider> = {
   healthCheck: '/health'
 };
 
+const isAssetInfo = (assetInfo: unknown): assetInfo is Asset.AssetInfo => !!(assetInfo as Asset.AssetInfo)?.assetId;
+
+const transformQuantityToSupply = (assetInfo: Asset.AssetInfo | unknown): Asset.AssetInfo | unknown => {
+  if (isAssetInfo(assetInfo) && assetInfo.supply === undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { quantity, ...assetInfoReduced } = assetInfo as any;
+    return { ...assetInfoReduced, supply: quantity } as Asset.AssetInfo;
+  }
+  return assetInfo;
+};
+
+const responseTransformers: HttpProviderConfig<AssetProvider>['responseTransformers'] = {
+  getAsset: (data: unknown): unknown => transformQuantityToSupply(data),
+  getAssets: (data: unknown): unknown =>
+    Array.isArray(data) ? data.map((assetInfo) => transformQuantityToSupply(assetInfo)) : data
+};
+
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
@@ -18,5 +40,6 @@ const paths: HttpProviderConfigPaths<AssetProvider> = {
 export const assetInfoHttpProvider = (config: CreateHttpProviderConfig<AssetProvider>): AssetProvider =>
   createHttpProvider<AssetProvider>({
     ...config,
-    paths
+    paths,
+    responseTransformers
   });

--- a/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
@@ -1,6 +1,7 @@
 import { Cardano } from '@cardano-sdk/core';
 import { assetInfoHttpProvider } from '../../src';
 import { logger } from '@cardano-sdk/util-dev';
+import { toSerializableObject } from '@cardano-sdk/util';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
@@ -40,6 +41,26 @@ describe('assetInfoHttpProvider', () => {
           assetIds: [Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958')]
         })
       ).resolves.toEqual({});
+    });
+
+    test('getAsset maps legacy assetInfo `quantity` as `supply`', async () => {
+      axiosMock.onPost().replyOnce(200, toSerializableObject({ assetId: 'dummy', quantity: 2n }));
+      const provider = assetInfoHttpProvider(config);
+      await expect(
+        provider.getAsset({
+          assetId: Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958')
+        })
+      ).resolves.toEqual({ assetId: 'dummy', supply: 2n });
+    });
+
+    test('getAssets maps legacy assetInfo `quantity` as `supply`', async () => {
+      axiosMock.onPost().replyOnce(200, toSerializableObject([{ assetId: 'dummy', quantity: 2n }]));
+      const provider = assetInfoHttpProvider(config);
+      await expect(
+        provider.getAssets({
+          assetIds: [Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958')]
+        })
+      ).resolves.toEqual([{ assetId: 'dummy', supply: 2n }]);
     });
   });
 });

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -132,9 +132,9 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
 
     const fingerprint = multiAsset.fingerprint as unknown as Cardano.AssetFingerprint;
     const quantities = await this.#builder.queryMultiAssetQuantities(multiAsset.id);
-    const quantity = BigInt(quantities.sum);
+    const supply = BigInt(quantities.sum);
     const mintOrBurnCount = Number(quantities.count);
 
-    return { assetId, fingerprint, mintOrBurnCount, name, policyId, quantity };
+    return { assetId, fingerprint, mintOrBurnCount, name, policyId, supply };
   }
 }

--- a/packages/cardano-services/src/Asset/openApi.json
+++ b/packages/cardano-services/src/Asset/openApi.json
@@ -126,6 +126,22 @@
           },
           "policyId": {
             "type": "string"
+          },
+          "supply": {
+            "$ref": "#/components/schemas/BigInt"
+          }
+        }
+      },
+      "BigInt": {
+        "required": ["value", "__type"],
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "__type": {
+            "type": "string",
+            "enum": ["bigint"]
           }
         }
       },

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -84,7 +84,7 @@ describe('DbSyncAssetProvider', () => {
       mintOrBurnCount: 1,
       name: '6d616361726f6e2d63616b65',
       policyId: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb',
-      quantity: 1n
+      supply: 1n
     });
   });
   it('returns an AssetInfo with extra data', async () => {

--- a/packages/core/src/Asset/types/AssetInfo.ts
+++ b/packages/core/src/Asset/types/AssetInfo.ts
@@ -16,7 +16,7 @@ export interface AssetInfo {
   policyId: PolicyId;
   name: AssetName;
   fingerprint: AssetFingerprint;
-  quantity: bigint;
+  supply: bigint;
   mintOrBurnCount: number;
   /**
    * Sorted by slot

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -154,7 +154,7 @@ describe('SingleAddressWallet.assets/nft', () => {
 
     // Wait until wallet is aware of the minted tokens.
     await firstValueFrom(
-      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
         filter(
           ([assets, balance]) =>
             assets &&
@@ -181,7 +181,7 @@ describe('SingleAddressWallet.assets/nft', () => {
 
   it('supports multiple CIP-25 NFT metadata in one tx', async () => {
     const [nfts, walletAssetBalance] = await firstValueFrom(
-      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
         filter(([assets, balance]) => assets.size === balance.assets?.size),
         filter(([assets]) => [...assets.values()].every((quantity) => !!quantity)),
         map(([assets, balance]) => [[...assets.values()].filter((asset) => !!asset.nftMetadata), balance.assets])
@@ -213,7 +213,7 @@ describe('SingleAddressWallet.assets/nft', () => {
 
   it('parses CIP-25 NFT metadata with files', async () => {
     const [nfts, walletAssetBalance] = await firstValueFrom(
-      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
         filter(([assets, balance]) => assets.size === balance.assets?.size),
         map(([assets, balance]) => [[...assets.values()].filter((asset) => !!asset.nftMetadata), balance.assets])
       )
@@ -297,7 +297,7 @@ describe('SingleAddressWallet.assets/nft', () => {
     );
 
     const nfts = await firstValueFrom(
-      combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
         filter(([assets, balance]) => assets.size === balance.assets?.size),
         map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
       )
@@ -367,7 +367,7 @@ describe('SingleAddressWallet.assets/nft', () => {
 
         // try remove the asset.nftMetadata filter
         const nfts = await firstValueFrom(
-          combineLatest([wallet.assets$, wallet.balance.utxo.total$]).pipe(
+          combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
             filter(([assets, balance]) => assets.size === balance.assets?.size),
             map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
           )

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -203,9 +203,9 @@ describe('SingleAddressWallet.assets/nft', () => {
         version: '1.0'
       },
       policyId,
-      // in case of repeated tests on the same network, total asset quantity is not updated due to
+      // in case of repeated tests on the same network, total asset supply is not updated due to
       // the limitation that asset info is not refreshed on wallet balance changes
-      quantity: expect.anything(),
+      supply: expect.anything(),
       tokenMetadata: null
     });
     expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_1_INDEX])).toBeDefined();
@@ -251,7 +251,7 @@ describe('SingleAddressWallet.assets/nft', () => {
         version: '1.0'
       },
       policyId,
-      quantity: expect.anything(),
+      supply: expect.anything(),
       tokenMetadata: null
     });
   });
@@ -385,7 +385,7 @@ describe('SingleAddressWallet.assets/nft', () => {
             version: '1.0'
           },
           policyId,
-          quantity: expect.anything(),
+          supply: expect.anything(),
           tokenMetadata: null
         });
       });

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -1,14 +1,30 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { Cardano, metadatum, nativeScriptPolicyId } from '@cardano-sdk/core';
-import { FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
+import { Asset, Cardano, metadatum, nativeScriptPolicyId } from '@cardano-sdk/core';
+import { Assets, FinalizeTxProps, InitializeTxProps, SingleAddressWallet } from '@cardano-sdk/wallet';
 import { KeyRole, TransactionSigner, util } from '@cardano-sdk/key-management';
-import { burnTokens, createStandaloneKeyAgent, submitAndConfirm, walletReady } from '../../util';
+import { burnTokens, createStandaloneKeyAgent, firstValueFromTimed, submitAndConfirm, walletReady } from '../../util';
 import { combineLatest, filter, firstValueFrom, map } from 'rxjs';
 import { createLogger } from '@cardano-sdk/util-dev';
 import { getEnv, getWallet, walletVariables } from '../../../src';
 
 const env = getEnv(walletVariables);
 const logger = createLogger();
+
+// Returns [assets in wallet balance, assetInfos with nftMetadata for the assets in the balance]
+const walletBalanceAssetsAndNfts = (wallet: SingleAddressWallet) =>
+  combineLatest([wallet.balance.utxo.total$, wallet.assetInfo$]).pipe(
+    filter(([balance]) => !!balance.assets),
+    map(([balance, assetInfos]): [Cardano.TokenMap, Assets] => [balance.assets!, assetInfos]),
+    // Wait until we have assetInfo for all balance assets
+    filter(([balanceAssets, assetsInfos]) =>
+      [...balanceAssets.keys()].every((balanceAssetId) => !!assetsInfos.get(balanceAssetId))
+    ),
+    // Keep only assetInfos with nftMetadata
+    map(([balanceAssets, assets]): [Cardano.TokenMap, Asset.AssetInfo[]] => [
+      balanceAssets,
+      [...assets.values()].filter((asset) => !!asset.nftMetadata)
+    ])
+  );
 
 describe('SingleAddressWallet.assets/nft', () => {
   const TOKEN_METADATA_1_INDEX = 0;
@@ -153,21 +169,7 @@ describe('SingleAddressWallet.assets/nft', () => {
     await submitAndConfirm(wallet, signedTx);
 
     // Wait until wallet is aware of the minted tokens.
-    await firstValueFrom(
-      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
-        filter(
-          ([assets, balance]) =>
-            assets &&
-            assets.size === balance.assets?.size &&
-            assetIds.every((element) => {
-              const asset = assets.get(element);
-              // asset info with metadata has loaded
-              if (asset?.tokenMetadata === undefined || asset?.nftMetadata === undefined) return false;
-              return true;
-            })
-        )
-      )
-    );
+    await firstValueFromTimed(walletBalanceAssetsAndNfts(wallet), 'Wallet does not have the minted tokens');
   });
 
   afterAll(async () => {
@@ -180,13 +182,7 @@ describe('SingleAddressWallet.assets/nft', () => {
   });
 
   it('supports multiple CIP-25 NFT metadata in one tx', async () => {
-    const [nfts, walletAssetBalance] = await firstValueFrom(
-      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
-        filter(([assets, balance]) => assets.size === balance.assets?.size),
-        filter(([assets]) => [...assets.values()].every((quantity) => !!quantity)),
-        map(([assets, balance]) => [[...assets.values()].filter((asset) => !!asset.nftMetadata), balance.assets])
-      )
-    );
+    const [walletAssetBalance, nfts] = await firstValueFromTimed(walletBalanceAssetsAndNfts(wallet));
 
     // Check balance here because asset info will not be re-fetched when balance changes due to minting and burning
     expect(walletAssetBalance?.get(assetIds[TOKEN_METADATA_2_INDEX])).toBe(1n);
@@ -212,12 +208,7 @@ describe('SingleAddressWallet.assets/nft', () => {
   });
 
   it('parses CIP-25 NFT metadata with files', async () => {
-    const [nfts, walletAssetBalance] = await firstValueFrom(
-      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
-        filter(([assets, balance]) => assets.size === balance.assets?.size),
-        map(([assets, balance]) => [[...assets.values()].filter((asset) => !!asset.nftMetadata), balance.assets])
-      )
-    );
+    const [walletAssetBalance, nfts] = await firstValueFromTimed(walletBalanceAssetsAndNfts(wallet));
 
     // Check balance here because asset info will not be re-fetched when balance changes due to minting and burning
     expect(walletAssetBalance?.get(assetIds[TOKEN_METADATA_1_INDEX])).toBe(1n);
@@ -261,7 +252,7 @@ describe('SingleAddressWallet.assets/nft', () => {
     await walletReady(wallet, coins);
 
     // spend entire balance of test asset
-    const availableBalance = await firstValueFrom(wallet.balance.utxo.available$);
+    const availableBalance = await firstValueFromTimed(wallet.balance.utxo.available$);
     const assetBalance = availableBalance.assets!.get(assetIds[TOKEN_BURN_INDEX])!;
     expect(assetBalance).toBeGreaterThan(0n);
     const txProps: InitializeTxProps = {
@@ -290,20 +281,12 @@ describe('SingleAddressWallet.assets/nft', () => {
     await submitAndConfirm(wallet, signedTx);
 
     // Wait until wallet is aware of the burned token.
-    await firstValueFrom(
+    await firstValueFromTimed(
       wallet.balance.utxo.total$.pipe(
         filter(({ assets }) => (assets ? !assets.has(assetIds[TOKEN_BURN_INDEX]) : false))
-      )
+      ),
+      'Wallet balance should not have the burned asset anymore'
     );
-
-    const nfts = await firstValueFrom(
-      combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
-        filter(([assets, balance]) => assets.size === balance.assets?.size),
-        map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
-      )
-    );
-
-    expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_BURN_INDEX])).toBeUndefined();
   });
 
   describe('CIP-0025 v1 and v2', () => {
@@ -366,12 +349,7 @@ describe('SingleAddressWallet.assets/nft', () => {
         await submitAndConfirm(wallet, signedTx);
 
         // try remove the asset.nftMetadata filter
-        const nfts = await firstValueFrom(
-          combineLatest([wallet.assetInfo$, wallet.balance.utxo.total$]).pipe(
-            filter(([assets, balance]) => assets.size === balance.assets?.size),
-            map(([assets]) => [...assets.values()].filter((asset) => !!asset.nftMetadata))
-          )
-        );
+        const [, nfts] = await firstValueFromTimed(walletBalanceAssetsAndNfts(wallet));
 
         expect(nfts.find((nft) => nft.assetId === assetId)).toMatchObject({
           assetId,

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -424,10 +424,10 @@ export class SingleAddressWallet implements ObservableWallet {
     this.assetInfo$ = new PersistentDocumentTrackerSubject(
       createAssetsTracker({
         assetProvider: this.assetProvider,
-        balanceTracker: this.balance,
         logger: contextLogger(this.#logger, 'assets$'),
         onFatalError,
-        retryBackoffConfig
+        retryBackoffConfig,
+        transactionsTracker: this.transactions
       }),
       stores.assets
     );

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -187,7 +187,7 @@ export class SingleAddressWallet implements ObservableWallet {
   readonly addresses$: TrackerSubject<GroupedAddress[]>;
   readonly protocolParameters$: TrackerSubject<Cardano.ProtocolParameters>;
   readonly genesisParameters$: TrackerSubject<Cardano.CompactGenesis>;
-  readonly assets$: TrackerSubject<Assets>;
+  readonly assetInfo$: TrackerSubject<Assets>;
   readonly fatalError$: Subject<unknown>;
   readonly syncStatus: SyncStatus;
   readonly name: string;
@@ -421,7 +421,7 @@ export class SingleAddressWallet implements ObservableWallet {
     });
 
     this.balance = createBalanceTracker(this.protocolParameters$, this.utxo, this.delegation);
-    this.assets$ = new PersistentDocumentTrackerSubject(
+    this.assetInfo$ = new PersistentDocumentTrackerSubject(
       createAssetsTracker({
         assetProvider: this.assetProvider,
         balanceTracker: this.balance,
@@ -564,7 +564,7 @@ export class SingleAddressWallet implements ObservableWallet {
     this.keyAgent.shutdown();
     this.currentEpoch$.complete();
     this.delegation.shutdown();
-    this.assets$.complete();
+    this.assetInfo$.complete();
     this.fatalError$.complete();
     this.syncStatus.shutdown();
     this.#newTransactions.failedToSubmit$.complete();

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -87,7 +87,8 @@ export interface ObservableWallet {
   readonly currentEpoch$: Observable<EpochInfo>;
   readonly protocolParameters$: Observable<Cardano.ProtocolParameters>;
   readonly addresses$: Observable<GroupedAddress[]>;
-  readonly assets$: Observable<Assets>;
+  /** All owned and historical assets */
+  readonly assetInfo$: Observable<Assets>;
   /**
    * This is the catch all Observable for fatal errors emitted by the Wallet.
    * Once errors are emitted, probably the only available recovery action is to

--- a/packages/wallet/test/SingleAddressWallet/load.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/load.test.ts
@@ -140,7 +140,7 @@ const assertWalletProperties = async (
   expect(addresses[0].address).toEqual(address);
   expect(addresses[0].rewardAccount).toEqual(rewardAccount);
   // assets$
-  expect(await firstValueFrom(wallet.assets$)).toEqual(new Map([[AssetId.TSLA, mocks.asset]]));
+  expect(await firstValueFrom(wallet.assetInfo$)).toEqual(new Map([[AssetId.TSLA, mocks.asset]]));
   // inputAddressResolver
   expect(typeof wallet.util).toBe('object');
 };

--- a/packages/wallet/test/SingleAddressWallet/shutdown.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/shutdown.test.ts
@@ -141,7 +141,7 @@ const assertWalletProperties = async (
   expect(addresses[0].address).toEqual(address);
   expect(addresses[0].rewardAccount).toEqual(rewardAccount);
   // assets$
-  expect(await firstValueFrom(wallet.assets$)).toEqual(new Map([[AssetId.TSLA, mocks.asset]]));
+  expect(await firstValueFrom(wallet.assetInfo$)).toEqual(new Map([[AssetId.TSLA, mocks.asset]]));
   // inputAddressResolver
   expect(typeof wallet.util).toBe('object');
 };
@@ -227,7 +227,7 @@ describe('SingleAddressWallet shutdown', () => {
       }
     });
 
-    wallet1.assets$.subscribe({
+    wallet1.assetInfo$.subscribe({
       complete: () => {
         assets$Completed = true;
       }

--- a/packages/wallet/test/mocks/mockAssetProvider.ts
+++ b/packages/wallet/test/mocks/mockAssetProvider.ts
@@ -12,7 +12,7 @@ export const asset = {
   name: Cardano.AssetName('54534c41'),
   nftMetadata: null,
   policyId: Cardano.PolicyId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373'),
-  quantity: 1000n,
+  supply: 1000n,
   tokenMetadata: null
 } as Asset.AssetInfo;
 

--- a/packages/wallet/test/mocks/mockChainHistoryProvider.ts
+++ b/packages/wallet/test/mocks/mockChainHistoryProvider.ts
@@ -1,6 +1,6 @@
+import { AssetId, somePartialStakePools } from '@cardano-sdk/util-dev';
 import { Cardano, Paginated } from '@cardano-sdk/core';
 import { currentEpoch, ledgerTip, stakeKeyHash } from './mockData';
-import { somePartialStakePools } from '@cardano-sdk/util-dev';
 import delay from 'delay';
 
 export const getRandomTxId = () =>
@@ -128,7 +128,7 @@ export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
             address: Cardano.PaymentAddress(
               'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
             ),
-            value: { coins: 5_000_000n }
+            value: { assets: new Map([[AssetId.TSLA, 1n]]), coins: 5_000_000n }
           }
         ],
         validityInterval: {

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -5,7 +5,7 @@ export const observableWalletChannel = (walletName: string) => `${walletName}$`;
 
 export const observableWalletProperties: RemoteApiProperties<ObservableWallet> = {
   addresses$: RemoteApiPropertyType.HotObservable,
-  assets$: RemoteApiPropertyType.HotObservable,
+  assetInfo$: RemoteApiPropertyType.HotObservable,
   balance: {
     rewardAccounts: {
       deposit$: RemoteApiPropertyType.HotObservable,


### PR DESCRIPTION
# Context

Fetch assetInfo for all assets in the tx history. SingleAddressWallet already provides AssetInfo in assets$ observable, but only for assets that are currently owned by the wallet.

# Proposed Solution
- Rename ObservableWallet.assets$ into ObservableWallet.assetInfo$
- Update it to include all historical assets (tx history as source)
- Rename AssetInfo.quantity → AssetInfo.supply

# Important Changes Introduced
See commits breaking changes