### PR TITLE
getAssets queries optimization

### DIFF
--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/AssetBuilder.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/AssetBuilder.ts
@@ -1,7 +1,7 @@
 import { Cardano } from '@cardano-sdk/core';
-import { LastMintTxModel, MultiAssetHistoryModel, MultiAssetModel, MultiAssetQuantitiesModel } from './types';
+import { LastMintTxModel, MultiAssetHistoryModel, MultiAssetModel } from './types';
 import { Logger } from 'ts-log';
-import { Pool, QueryResult } from 'pg';
+import { Pool } from 'pg';
 import Queries from './queries';
 
 export class AssetBuilder {
@@ -15,34 +15,31 @@ export class AssetBuilder {
 
   public async queryLastMintTx(policyId: Cardano.PolicyId, name: Cardano.AssetName) {
     this.#logger.debug('About to query last nft mint tx for asset', { name, policyId });
-    const result: QueryResult<LastMintTxModel> = await this.#db.query(Queries.findLastNftMintTx, [
-      Buffer.from(policyId, 'hex'),
-      Buffer.from(name, 'hex')
-    ]);
+    const result = await this.#db.query<LastMintTxModel>({
+      name: 'nft_last_mint_tx',
+      text: Queries.findLastNftMintTx,
+      values: [Buffer.from(policyId, 'hex'), Buffer.from(name, 'hex')]
+    });
     return result.rows[0];
   }
 
   public async queryMultiAsset(policyId: Cardano.PolicyId, name: Cardano.AssetName) {
     this.#logger.debug('About to query multi asset', { name, policyId });
-    const result: QueryResult<MultiAssetModel> = await this.#db.query(Queries.findMultiAsset, [
-      Buffer.from(policyId, 'hex'),
-      Buffer.from(name, 'hex')
-    ]);
+    const result = await this.#db.query<MultiAssetModel>({
+      name: 'find_multi_asset',
+      text: Queries.findMultiAsset,
+      values: [Buffer.from(policyId, 'hex'), Buffer.from(name, 'hex')]
+    });
     return result.rows[0];
   }
 
   public async queryMultiAssetHistory(policyId: Cardano.PolicyId, name: Cardano.AssetName) {
     this.#logger.debug('About to query multi asset history', { name, policyId });
-    const result: QueryResult<MultiAssetHistoryModel> = await this.#db.query(Queries.findMultiAssetHistory, [
-      Buffer.from(policyId, 'hex'),
-      Buffer.from(name, 'hex')
-    ]);
+    const result = await this.#db.query<MultiAssetHistoryModel>({
+      name: 'find_multi_asset_history',
+      text: Queries.findMultiAssetHistory,
+      values: [Buffer.from(policyId, 'hex'), Buffer.from(name, 'hex')]
+    });
     return result.rows;
-  }
-
-  public async queryMultiAssetQuantities(id: string) {
-    this.#logger.debug('About to query multi asset quantities', { id });
-    const result: QueryResult<MultiAssetQuantitiesModel> = await this.#db.query(Queries.findMultiAssetQuantities, [id]);
-    return result.rows[0];
   }
 }

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -131,9 +131,8 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
       throw new ProviderError(ProviderFailure.NotFound, undefined, 'No entries found in multi_asset table');
 
     const fingerprint = multiAsset.fingerprint as unknown as Cardano.AssetFingerprint;
-    const quantities = await this.#builder.queryMultiAssetQuantities(multiAsset.id);
-    const supply = BigInt(quantities.sum);
-    const mintOrBurnCount = Number(quantities.count);
+    const supply = BigInt(multiAsset.sum);
+    const mintOrBurnCount = Number(multiAsset.count);
 
     return { assetId, fingerprint, mintOrBurnCount, name, policyId, supply };
   }

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/queries.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/queries.ts
@@ -10,9 +10,17 @@ export const findLastNftMintTx = `
 `;
 
 export const findMultiAsset = `
-	SELECT id, fingerprint
-	FROM multi_asset
-	WHERE policy = $1 AND name = $2
+SELECT
+  fingerprint,
+  COUNT(*) AS count,
+  SUM(quantity) AS sum
+FROM multi_asset
+JOIN ma_tx_mint
+  ON ident = multi_asset.id
+WHERE
+  policy = $1 AND name = $2
+GROUP BY
+  fingerprint
 `;
 
 export const findMultiAssetHistory = `
@@ -23,17 +31,10 @@ export const findMultiAssetHistory = `
 	WHERE ma.policy = $1 AND ma.name = $2
 `;
 
-export const findMultiAssetQuantities = `
-	SELECT COUNT(*) AS count, SUM(quantity) AS sum
-	FROM ma_tx_mint
-	WHERE ident = $1
-`;
-
 const Queries = {
   findLastNftMintTx,
   findMultiAsset,
-  findMultiAssetHistory,
-  findMultiAssetQuantities
+  findMultiAssetHistory
 };
 
 export default Queries;

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/types.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/types.ts
@@ -3,16 +3,12 @@ export interface LastMintTxModel {
 }
 
 export interface MultiAssetModel {
+  count: string;
   fingerprint: string;
-  id: string;
+  sum: string;
 }
 
 export interface MultiAssetHistoryModel {
   hash: Buffer;
   quantity: string;
-}
-
-export interface MultiAssetQuantitiesModel {
-  count: string;
-  sum: string;
 }

--- a/packages/cardano-services/src/Metadata/DbSyncMetadataService.ts
+++ b/packages/cardano-services/src/Metadata/DbSyncMetadataService.ts
@@ -13,11 +13,16 @@ export const createDbSyncMetadataService = (db: Pool, logger: Logger): TxMetadat
     const byteHashes = hashes.map((hash) => hexStringToBuffer(hash));
     logger.debug('About to find metadata for txs:', hashes);
 
-    const result: QueryResult<TxMetadataModel> = await db.query(Queries.findTxMetadataByTxHashes, [byteHashes]);
+    const result = await db.query<TxMetadataModel>({
+      name: 'tx_metadata',
+      text: Queries.findTxMetadataByTxHashes,
+      values: [byteHashes]
+    });
 
     if (result.rows.length === 0) return new Map();
     return mapTxMetadataByHashes(result.rows);
   },
+
   async queryTxMetadataByRecordIds(ids: string[]): Promise<TxMetadataByHashes> {
     logger.debug('About to find metadata for transactions with ids:', ids);
 

--- a/packages/cardano-services/test/Asset/AssetBuilder.test.ts
+++ b/packages/cardano-services/test/Asset/AssetBuilder.test.ts
@@ -45,8 +45,9 @@ describe('AssetBuilder', () => {
       expect(() => Cardano.AssetFingerprint(ma.fingerprint)).not.toThrow();
       expect(ma.fingerprint).toEqual(Cardano.AssetFingerprint.fromParts(assets[0].policyId, assets[0].name));
       expect(ma).toMatchShapeOf({
+        count: '123',
         fingerprint: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65',
-        id: '590675'
+        sum: '42'
       });
     });
     test('return undefined when not found', async () => {
@@ -67,17 +68,6 @@ describe('AssetBuilder', () => {
     test('return empty array when not found', async () => {
       const result = await builder.queryMultiAssetHistory(notValidPolicyId, notValidAssetName);
       expect(result).toStrictEqual([]);
-    });
-  });
-
-  describe('queryMultiAssetQuantities', () => {
-    test('query multi_asset', async () => {
-      const result = await builder.queryMultiAssetQuantities('1');
-      expect(result).toMatchShapeOf({ count: '1', sum: '1' });
-    });
-    test('return the record with empty data when not found', async () => {
-      const result = await builder.queryMultiAssetQuantities('9999999');
-      expect(result).toMatchShapeOf({ count: '0', sum: null });
     });
   });
 });

--- a/packages/core/src/Provider/AssetProvider/types.ts
+++ b/packages/core/src/Provider/AssetProvider/types.ts
@@ -1,11 +1,20 @@
 import { Asset, Cardano, Provider } from '../..';
 
-interface AssetExtraData {
+export interface AssetsExtraData {
   nftMetadata?: boolean;
   tokenMetadata?: boolean;
+}
+
+/**
+ * @deprecated Use `AssetsExtraData` with `getAssets` instead
+ */
+export interface AssetExtraData extends AssetsExtraData {
   history?: boolean;
 }
 
+/**
+ * @deprecated Use `GetAssetsArgs` with `getAssets` instead
+ */
 export interface GetAssetArgs {
   assetId: Cardano.AssetId;
   extraData?: AssetExtraData;
@@ -13,16 +22,18 @@ export interface GetAssetArgs {
 
 export interface GetAssetsArgs {
   assetIds: Cardano.AssetId[];
-  extraData?: Omit<AssetExtraData, 'history'>;
+  extraData?: AssetsExtraData;
 }
 
 export interface AssetProvider extends Provider {
   /**
+   * @deprecated Use `getAssets` instead
    * @param assetId asset ID (concatenated hex values of policyId + assetName)
    * @param extraData optional extra data to be provided - nftMetadata, tokenMetadata or history
    * @throws ProviderError
    */
   getAsset: (args: GetAssetArgs) => Promise<Asset.AssetInfo>;
+
   /**
    * @param assetIds asset IDs (concatenated hex values of policyId + assetName)
    * @param extraData optional extra data to be provided - nftMetadata, tokenMetadata or history


### PR DESCRIPTION
# Context

After [feat: Batch requests to Token Metadata server](https://github.com/input-output-hk/cardano-js-sdk/pull/691), some more optimization about DB queries can be done.

# Proposed Solution

- Used prepared statement to perform queries;
- Aggregated the `getAssetInfo` two queries in a single one.

# Important Changes Introduced

Deprecated `getAsset` and its interface