### PR TITLE
getAssets queries optimization - parallel execution

### DIFF
--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -84,10 +84,9 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
       );
     }
 
-    const assetList: Asset.AssetInfo[] = [];
-    let tokenMetadataList: (Asset.TokenMetadata | null | undefined)[] = [];
+    const fetchTokenMetadataList = async () => {
+      let tokenMetadataList: (Asset.TokenMetadata | null | undefined)[] = [];
 
-    if (extraData?.tokenMetadata) {
       try {
         tokenMetadataList = await this.#dependencies.tokenMetadataService.getTokenMetadata(assetIds);
       } catch (error) {
@@ -98,19 +97,24 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
           throw error;
         }
       }
-    }
 
-    for (const assetId of assetIds) {
+      return tokenMetadataList;
+    };
+
+    const tokenMetadataListPromise = extraData?.tokenMetadata ? fetchTokenMetadataList() : undefined;
+
+    const getAssetInfo = async (assetId: Cardano.AssetId) => {
       const assetInfo = await this.getAssetInfo(assetId);
 
       if (extraData?.nftMetadata)
         assetInfo.nftMetadata = await this.#dependencies.ntfMetadataService.getNftMetadata(assetInfo);
-      if (extraData?.tokenMetadata) assetInfo.tokenMetadata = tokenMetadataList[assetIds.indexOf(assetId)];
+      if (tokenMetadataListPromise)
+        assetInfo.tokenMetadata = (await tokenMetadataListPromise)[assetIds.indexOf(assetId)];
 
-      assetList.push(assetInfo);
-    }
+      return assetInfo;
+    };
 
-    return assetList;
+    return Promise.all(assetIds.map((_) => getAssetInfo(_)));
   }
 
   private async loadHistory(assetInfo: Asset.AssetInfo) {


### PR DESCRIPTION
# Context

After [getAssets queries optimization](https://github.com/input-output-hk/cardano-js-sdk/pull/697) another optiomization action could be to execute the queries in parallel.
On the other hand this could have the drawback to make the server unresponsive (making busy all the DB connections of the pool).

# Proposed Solution

Execute the `getAssets` queries in parallel.

# Important Changes Introduced

The queries are parallelized to the HTTP request to get token metadata as well.

@iadmytro can you perform some comparison tests to verify this change yields better performance and acceptable resource demand?