### PR TITLE
feat!: rename confirmed$ to onChain$

### DIFF
--- a/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/delegation.test.ts
@@ -33,10 +33,10 @@ const waitForTx = async (wallet: ObservableWallet, hash: Cardano.TransactionId) 
   await firstValueFromTimed(
     combineLatest([
       wallet.transactions.history$.pipe(filter((txs) => txs.some(({ id }) => id === hash))),
-      // test that confirmed$ works
-      wallet.transactions.outgoing.confirmed$.pipe(filter(({ id }) => id === hash))
+      // test that onChain$ works
+      wallet.transactions.outgoing.onChain$.pipe(filter(({ id }) => id === hash))
     ]),
-    'Tx not confirmed for too long',
+    'Tx not found on-chain for too long',
     TX_TIMEOUT_DEFAULT
   );
   await waitForWalletStateSettle(wallet);
@@ -138,7 +138,7 @@ describe('SingleAddressWallet/delegation', () => {
     await waitForTx(sourceWallet, signedTx.tx.id);
     const tx1ConfirmedState = await getWalletStateSnapshot(sourceWallet);
 
-    // Updates total and available balance after tx is confirmed
+    // Updates total and available balance after tx is on-chain
     expect(tx1ConfirmedState.balance.total.coins).toBe(expectedCoinsAfterTx1);
     expect(tx1ConfirmedState.balance.total).toEqual(tx1ConfirmedState.balance.available);
     expect(tx1PendingState.balance.deposit).toEqual(stakeKeyDeposit);

--- a/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/txChaining.test.ts
@@ -43,7 +43,7 @@ describe('SingleAddressWallet/txChaining', () => {
 
     const finalizedTx2 = await wallet.finalizeTx({ tx: tx2 });
 
-    // 1st tx must also be confirmed because the 2nd one uses output from the 1st one
+    // 1st tx must also be on-chain because the 2nd one uses output from the 1st one
     await submitAndConfirm(wallet, finalizedTx2);
   });
 });

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -1,11 +1,11 @@
 import { Assets } from '../../types';
 import { Cardano, EpochRewards, EraSummary } from '@cardano-sdk/core';
-import { ConfirmedTx, TxInFlight } from '../../services';
 import { EMPTY, combineLatest, map } from 'rxjs';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { InMemoryCollectionStore } from './InMemoryCollectionStore';
 import { InMemoryDocumentStore } from './InMemoryDocumentStore';
 import { InMemoryKeyValueStore } from './InMemoryKeyValueStore';
+import { OutgoingOnChainTx, TxInFlight } from '../../services';
 import { WalletStores } from '../types';
 
 export class InMemoryTipStore extends InMemoryDocumentStore<Cardano.Tip> {}
@@ -16,7 +16,7 @@ export class InMemoryEraSummariesStore extends InMemoryDocumentStore<EraSummary[
 export class InMemoryAssetsStore extends InMemoryDocumentStore<Assets> {}
 export class InMemoryAddressesStore extends InMemoryDocumentStore<GroupedAddress[]> {}
 export class InMemoryInFlightTransactionsStore extends InMemoryDocumentStore<TxInFlight[]> {}
-export class InMemoryVolatileTransactionsStore extends InMemoryDocumentStore<ConfirmedTx[]> {}
+export class InMemoryVolatileTransactionsStore extends InMemoryDocumentStore<OutgoingOnChainTx[]> {}
 
 export class InMemoryTransactionsStore extends InMemoryCollectionStore<Cardano.HydratedTx> {}
 export class InMemoryUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -1,9 +1,9 @@
 import { Assets } from '../../types';
 import { Cardano, EpochRewards, EraSummary } from '@cardano-sdk/core';
-import { ConfirmedTx, TxInFlight } from '../../services';
 import { CreatePouchDbStoresDependencies } from './types';
 import { EMPTY, combineLatest, map } from 'rxjs';
 import { GroupedAddress } from '@cardano-sdk/key-management';
+import { OutgoingOnChainTx, TxInFlight } from '../../services';
 import { PouchDbCollectionStore } from './PouchDbCollectionStore';
 import { PouchDbDocumentStore } from './PouchDbDocumentStore';
 import { PouchDbKeyValueStore } from './PouchDbKeyValueStore';
@@ -17,7 +17,7 @@ export class PouchDbEraSummariesStore extends PouchDbDocumentStore<EraSummary[]>
 export class PouchDbAssetsStore extends PouchDbDocumentStore<Assets> {}
 export class PouchDbAddressesStore extends PouchDbDocumentStore<GroupedAddress[]> {}
 export class PouchDbInFlightTransactionsStore extends PouchDbDocumentStore<TxInFlight[]> {}
-export class PouchDbVolatileTransactionsStore extends PouchDbDocumentStore<ConfirmedTx[]> {}
+export class PouchDbVolatileTransactionsStore extends PouchDbDocumentStore<OutgoingOnChainTx[]> {}
 
 export class PouchDbTransactionsStore extends PouchDbCollectionStore<Cardano.HydratedTx> {}
 export class PouchDbUtxoStore extends PouchDbCollectionStore<Cardano.Utxo> {}

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -1,8 +1,8 @@
 import { Assets } from '../types';
 import { Cardano, EpochRewards, EraSummary, StakeSummary, SupplySummary } from '@cardano-sdk/core';
-import { ConfirmedTx, TxInFlight } from '../services';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { Observable } from 'rxjs';
+import { OutgoingOnChainTx, TxInFlight } from '../services';
 
 export interface Destroyable {
   destroyed: boolean;
@@ -75,7 +75,7 @@ export interface WalletStores extends Destroyable {
   unspendableUtxo: CollectionStore<Cardano.Utxo>;
   transactions: OrderedCollectionStore<Cardano.HydratedTx>;
   inFlightTransactions: DocumentStore<TxInFlight[]>;
-  volatileTransactions: DocumentStore<ConfirmedTx[]>;
+  volatileTransactions: DocumentStore<OutgoingOnChainTx[]>;
   rewardsHistory: KeyValueStore<Cardano.RewardAccount, EpochRewards[]>;
   rewardsBalances: KeyValueStore<Cardano.RewardAccount, Cardano.Lovelace>;
   stakePools: KeyValueStore<Cardano.PoolId, Cardano.StakePool>;

--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -89,7 +89,7 @@ export const createDelegationTracker = ({
     rewardsHistoryProvider = createRewardsHistoryProvider(rewardsTracker, retryBackoffConfig),
     rewardsProvider = createRewardsProvider(
       epoch$,
-      transactionsTracker.outgoing.confirmed$,
+      transactionsTracker.outgoing.onChain$,
       rewardsTracker,
       retryBackoffConfig,
       onFatalError

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -57,8 +57,8 @@ export interface FailedTx extends OutgoingTx {
   error?: CardanoNodeErrors.TxSubmissionError;
 }
 
-export interface ConfirmedTx extends OutgoingTx {
-  confirmedAt: Cardano.PartialBlockHeader['slot'];
+export interface OutgoingOnChainTx extends OutgoingTx {
+  slot: Cardano.PartialBlockHeader['slot'];
 }
 
 export interface TxInFlight extends OutgoingTx {
@@ -73,7 +73,7 @@ export interface TransactionsTracker {
     readonly submitting$: Observable<OutgoingTx>;
     readonly pending$: Observable<OutgoingTx>;
     readonly failed$: Observable<FailedTx>;
-    readonly confirmed$: Observable<ConfirmedTx>;
+    readonly onChain$: Observable<OutgoingOnChainTx>;
   };
 }
 

--- a/packages/wallet/test/SingleAddressWallet/rollback.test.ts
+++ b/packages/wallet/test/SingleAddressWallet/rollback.test.ts
@@ -153,7 +153,7 @@ describe('SingleAddressWallet rollback', () => {
 
     stores.volatileTransactions.set([
       {
-        confirmedAt: rollBackTx.blockHeader.slot,
+        slot: rollBackTx.blockHeader.slot,
         ...toOutgoingTx(tx)
       }
     ]);

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -98,7 +98,7 @@ describe('integration/withdrawal', () => {
 
     expect(tx.body.withdrawals).toEqual([{ quantity: availableRewards, stakeAddress: rewardAccount }]);
 
-    const confirmedSubscription = wallet.transactions.outgoing.confirmed$.subscribe(({ id }) => {
+    const onChainSubscription = wallet.transactions.outgoing.onChain$.subscribe(({ id }) => {
       if (id === tx.id) {
         // Transaction successful
       }
@@ -118,7 +118,7 @@ describe('integration/withdrawal', () => {
     }
 
     // Cleanup
-    confirmedSubscription.unsubscribe();
+    onChainSubscription.unsubscribe();
     failedSubscription.unsubscribe();
     wallet.shutdown();
   });

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -40,9 +40,9 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
   transactions: {
     history$: RemoteApiPropertyType.HotObservable,
     outgoing: {
-      confirmed$: RemoteApiPropertyType.HotObservable,
       failed$: RemoteApiPropertyType.HotObservable,
       inFlight$: RemoteApiPropertyType.HotObservable,
+      onChain$: RemoteApiPropertyType.HotObservable,
       pending$: RemoteApiPropertyType.HotObservable,
       submitting$: RemoteApiPropertyType.HotObservable
     },


### PR DESCRIPTION
# Context

The transactions tracker confirmed$ observable name is a bit misleading. The transactions emitted by this observable are transactions that have been submitted with the SingleAddressWallet that were confirmed to be on the chain.

But these transactions are not confirmed as they could be rolled back.

A better name would be onChain$.

# Proposed Solution
The transactions emitted by this observable are transactions that have been submitted with the SingleAddressWallet that were confirmed to be on the chain.
But these transactions are not confirmed as they could be rolled back, so a more suitable name is onChain$ instead of confirmed$

# Important Changes Introduced
BREAKING CHANGE:
- renamed `TransactionsTracker.outgoing.confirmed$` to `onChain$`
- renamed `TransactionReemitterProps.transactions.outgoing.confirmed$` to `onChain$`
- renamed web-extension `observableWalletProperties.transactions.outgoing.confirmed$` to `onChain$`
- rename ConfirmedTx to OutgoingOnChainTx
- renamed OutgoingOnChainTx.confirmedAt to `slot`