### PR TITLE
More granularity in metrics buckets

### DIFF
--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -213,7 +213,7 @@ export class HttpServer extends RunnableModule {
     });
     this.app.use(
       expressPromBundle({
-        buckets: [0.003, 0.03, 0.1, 0.3, 1.5, 3, 5, 8, 12, 20, 30],
+        buckets: [0.003, 0.03, 0.1, 0.3, 0.75, 1.5, 3, 5, 8, 12, 20, 30],
         includeMethod: true,
         includePath: true,
         promRegistry,

--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -213,6 +213,7 @@ export class HttpServer extends RunnableModule {
     });
     this.app.use(
       expressPromBundle({
+        buckets: [0.003, 0.03, 0.1, 0.3, 1.5, 3, 5, 8, 12, 20, 30],
         includeMethod: true,
         includePath: true,
         promRegistry,


### PR DESCRIPTION
# Context

The default buckets configuration of [express prometheus bundle](https://www.npmjs.com/package/express-prom-bundle) has not a good granularity.

# Proposed Solution

Provided to the module the option to give buckets the granularity we need.
