### PR TITLE
feat(core)!: validation tweaks for CIP-25

### DIFF
--- a/packages/core/src/Asset/types/NftMetadata.ts
+++ b/packages/core/src/Asset/types/NftMetadata.ts
@@ -38,9 +38,9 @@ export const MediaType = (mediaType: string) => {
  * https://cips.cardano.org/cips/cip25/
  */
 export interface NftMetadataFile {
-  name: string;
+  name?: string;
   mediaType: MediaType;
-  src: Uri[];
+  src: Uri;
   otherProperties?: Map<string, Metadatum>;
 }
 
@@ -49,10 +49,10 @@ export interface NftMetadataFile {
  */
 export interface NftMetadata {
   name: string;
-  image: Uri[];
+  image: Uri;
   version: string;
   mediaType?: ImageMediaType;
   files?: NftMetadataFile[];
-  description?: string[];
+  description?: string;
   otherProperties?: Map<string, Metadatum>;
 }

--- a/packages/core/test/Asset/util/metadatumToCip25.test.ts
+++ b/packages/core/test/Asset/util/metadatumToCip25.test.ts
@@ -23,7 +23,7 @@ describe('NftMetadata/metadatumToCip25', () => {
   ]);
 
   const minimalConvertedMetadata = {
-    image: ['ipfs://image'],
+    image: 'ipfs://image',
     name: 'test nft',
     version: '1.0'
   };
@@ -85,29 +85,6 @@ describe('NftMetadata/metadatumToCip25', () => {
     });
 
   describe('invalid metadata on optional fields', () => {
-    it('omits files with a missing file name', () => {
-      const metadatum = createMetadatumWithFiles([
-        {
-          __type: 'Map',
-          value: [
-            ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cuf'],
-            ['mediaType', 'image/png']
-          ]
-        },
-        {
-          __type: 'Map',
-          value: [
-            ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cu8'],
-            ['mediaType', 'image/png'],
-            ['name', 'BRAVO']
-          ]
-        }
-      ]);
-      const result = metadatumToCip25(validAsset, metadatum, logger);
-      expect(result).toBeTruthy();
-      expect(result?.files).toHaveLength(1);
-    });
-
     it('omits files with a missing file media type', () => {
       const metadatum = createMetadatumWithFiles([
         {
@@ -177,6 +154,29 @@ describe('NftMetadata/metadatumToCip25', () => {
     expect(metadatumToCip25(validAsset, metadatum, logger)).toBeNull();
   });
 
+  it('returns metadata files with a missing file name', () => {
+    const metadatum = createMetadatumWithFiles([
+      {
+        __type: 'Map',
+        value: [
+          ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cuf'],
+          ['mediaType', 'image/png']
+        ]
+      },
+      {
+        __type: 'Map',
+        value: [
+          ['src', 'ipfs://QmTcKWh95A5fTx1Bbw158cowWysvqLCWTgR9UBiEKD9cu8'],
+          ['mediaType', 'image/png'],
+          ['name', 'BRAVO']
+        ]
+      }
+    ]);
+    const result = metadatumToCip25(validAsset, metadatum, logger);
+    expect(result).toBeTruthy();
+    expect(result?.files).toHaveLength(2);
+  });
+
   it('converts minimal metadata', () => {
     const metadatum: TxMetadata = new Map([
       [721n, new Map([[policyIdString, new Map([[assetNameString, minimalMetadata]])]])]
@@ -191,16 +191,25 @@ describe('NftMetadata/metadatumToCip25', () => {
     expect(metadatumToCip25(asset, metadatum, logger)).toEqual(minimalConvertedMetadata);
   });
 
-  it('supports image with ipfs protocol', () => {
+  it('supports image with ipfs protocol as string', () => {
+    const metadatum = createMetadatumWithFiles(
+      [],
+      ['ipfs://bafybeihtdkq3ntfcewytdaimnrslpxsatsg47e3bqlsgi', '3jkax65pypymi']
+    );
+    const result = metadatumToCip25(validAsset, metadatum, logger);
+    expect(result?.image).toEqual('ipfs://bafybeihtdkq3ntfcewytdaimnrslpxsatsg47e3bqlsgi3jkax65pypymi');
+  });
+
+  it('supports image with ipfs protocol as array', () => {
     const metadatum = createMetadatumWithFiles([], assetImageIPFS);
     const result = metadatumToCip25(validAsset, metadatum, logger);
-    expect(result?.image).toEqual([assetImageIPFS]);
+    expect(result?.image).toEqual(assetImageIPFS);
   });
 
   it('supports image in https protocol', () => {
     const metadatum = createMetadatumWithFiles([], assetImageHTTPS);
     const result = metadatumToCip25(validAsset, metadatum, logger);
-    expect(result?.image).toEqual([assetImageHTTPS]);
+    expect(result?.image).toEqual(assetImageHTTPS);
   });
 
   it('supports bse64 decoded image following data URL scheme standard', () => {
@@ -239,7 +248,7 @@ describe('NftMetadata/metadatumToCip25', () => {
 
     const metadatum = createMetadatumWithFiles([], base64DecodedImage);
     const result = metadatumToCip25(validAsset, metadatum, logger);
-    expect(result?.image).toEqual([base64DecodedImage.join('')]);
+    expect(result?.image).toEqual(base64DecodedImage.join(''));
   });
 
   it('supports CIP-0025 v2', () => {
@@ -297,7 +306,7 @@ describe('NftMetadata/metadatumToCip25', () => {
     ]);
     expect(metadatumToCip25(asset, metadatum, logger)).toEqual({
       ...minimalConvertedMetadata,
-      description: ['description'],
+      description: 'description',
       mediaType: 'image/png',
       otherProperties: new Map([['extraProp', 'extra']])
     });
@@ -410,14 +419,14 @@ describe('NftMetadata/metadatumToCip25', () => {
     expect(metadatumToCip25(asset, metadatum, logger)).toEqual({
       ...minimalConvertedMetadata,
       files: [
-        { mediaType: 'image/jpg', name: 'file1', src: ['https://file1.location'] },
+        { mediaType: 'image/jpg', name: 'file1', src: 'https://file1.location' },
         {
           mediaType: 'image/png',
           name: 'file2',
           otherProperties: new Map([['extraProp', 'extra']]),
-          src: ['ipfs://file2.location']
+          src: 'ipfs://file2.location'
         },
-        { mediaType: 'image/jpg', name: 'file3', src: [base64FileSrc.join('')] }
+        { mediaType: 'image/jpg', name: 'file3', src: base64FileSrc.join('') }
       ]
     });
   });

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -117,12 +117,12 @@ describe('SingleAddressWallet.assets/nft', () => {
             {
               mediaType: 'video/mp4',
               name: 'some name',
-              src: ['file://some_video_file']
+              src: 'ipfs://Qmb78QQ4RXxKQrteRn4X3WaMXXfmi2BU2dLjfWxuJoF2N5'
             },
             {
               mediaType: 'audio/mpeg',
               name: 'some name',
-              src: ['file://some_audio_file', 'file://another_audio_file']
+              src: ['ipfs://Qmb78QQ4RXxKQrteRn4X3WaMXXfmi2', 'BU2dLjfWxuJoF2Ny']
             }
           ],
           id: '1',
@@ -193,7 +193,7 @@ describe('SingleAddressWallet.assets/nft', () => {
       mintOrBurnCount: expect.anything(),
       name: assetNames[TOKEN_METADATA_2_INDEX],
       nftMetadata: {
-        image: ['ipfs://some_hash1'],
+        image: 'ipfs://some_hash1',
         name: 'One',
         otherProperties: new Map([['version', '1.0']]),
         version: '1.0'
@@ -219,20 +219,20 @@ describe('SingleAddressWallet.assets/nft', () => {
       mintOrBurnCount: expect.anything(),
       name: assetNames[TOKEN_METADATA_1_INDEX],
       nftMetadata: {
-        description: ['NFT with different types of files'],
+        description: 'NFT with different types of files',
         files: [
           {
             mediaType: 'video/mp4',
             name: 'some name',
-            src: ['file://some_video_file']
+            src: 'ipfs://Qmb78QQ4RXxKQrteRn4X3WaMXXfmi2BU2dLjfWxuJoF2N5'
           },
           {
             mediaType: 'audio/mpeg',
             name: 'some name',
-            src: ['file://some_audio_file', 'file://another_audio_file']
+            src: 'ipfs://Qmb78QQ4RXxKQrteRn4X3WaMXXfmi2BU2dLjfWxuJoF2Ny'
           }
         ],
-        image: ['ipfs://somehash'],
+        image: 'ipfs://somehash',
         mediaType: 'image/png',
         name: 'NFT with files',
         otherProperties: new Map([
@@ -240,7 +240,7 @@ describe('SingleAddressWallet.assets/nft', () => {
           ['version', '1.0']
         ]),
         version: '1.0'
-      },
+      } as Asset.NftMetadata,
       policyId,
       supply: expect.anything(),
       tokenMetadata: null
@@ -357,7 +357,7 @@ describe('SingleAddressWallet.assets/nft', () => {
           mintOrBurnCount: expect.anything(),
           name: assetNameHex,
           nftMetadata: {
-            image: ['ipfs://some_hash1'],
+            image: 'ipfs://some_hash1',
             name: assetName,
             otherProperties: new Map([['version', '1.0']]),
             version: '1.0'


### PR DESCRIPTION
# Context
Resolve a couple of CIP25-related validation issues, extracted by the logs from the provider server instance on `mainnet`.

# Important Changes Introduced

**BREAKING CHANGES**
- _NftMetadata_
`image`: `Uri[]` -> `Uri`
`description?`: `string[]` -> `string`
- _NftMetadataFile_
`src`: `Uri[]` -> `Uri`

**Other non-breaking changes**

- concatenate all protocols if provided as arrays
- improve logging if any required field is missing
