### PR TITLE
fix: tx metadata memory leak

### DIFF
--- a/packages/cardano-services/src/Metadata/mappers.ts
+++ b/packages/cardano-services/src/Metadata/mappers.ts
@@ -8,7 +8,9 @@ export const mapTxMetadata = (metadataModel: Pick<TxMetadataModel, 'bytes' | 'ke
 
     if (bytes && key) {
       const biKey = BigInt(key);
-      const metadata = usingAutoFree((_) => cmlToCore.txMetadata(CML.GeneralTransactionMetadata.from_bytes(bytes)));
+      const metadata = usingAutoFree((scope) =>
+        cmlToCore.txMetadata(scope.manage(CML.GeneralTransactionMetadata.from_bytes(bytes)))
+      );
 
       if (metadata) {
         const datum = metadata.get(biKey);

--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -453,7 +453,7 @@ export const txMetadata = (auxiliaryMetadata?: CML.GeneralTransactionMetadata): 
   usingAutoFree((scope) => {
     if (!auxiliaryMetadata) return;
     const auxiliaryMetadataMap: Cardano.TxMetadata = new Map();
-    const metadataKeys = auxiliaryMetadata.keys();
+    const metadataKeys = scope.manage(auxiliaryMetadata.keys());
     for (let i = 0; i < metadataKeys.len(); i++) {
       const key = scope.manage(metadataKeys.get(i));
       const transactionMetadatum = scope.manage(auxiliaryMetadata.get(key));


### PR DESCRIPTION
# Context
We observe many `RangeError: offset is out of bounds` errors related to Tx Metadata mappings.

# Proposed Solution
Add missed Managed freeable scope in a few places.

