### PR TITLE
build(core): rm util-dev circular devDependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,6 @@
     "prepack": "yarn build"
   },
   "devDependencies": {
-    "@cardano-sdk/util-dev": "^0.8.0",
     "@types/lodash": "^4.14.182",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",

--- a/packages/core/test/Asset/util/metadatumToCip25.test.ts
+++ b/packages/core/test/Asset/util/metadatumToCip25.test.ts
@@ -1,9 +1,11 @@
 import { AssetInfo } from '../../../src/Asset';
 import { AssetName, Metadatum, PolicyId, TxMetadata } from '../../../src/Cardano';
 import { Cardano } from '../../../src';
+import { dummyLogger } from 'ts-log';
 import { fromSerializableObject } from '@cardano-sdk/util';
-import { logger } from '@cardano-sdk/util-dev';
 import { metadatumToCip25 } from '../../../src/Asset/util';
+
+const logger = dummyLogger;
 
 describe('NftMetadata/metadatumToCip25', () => {
   const assetNameStringUtf8 = 'CIP0025-v2';

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -8,9 +8,6 @@
       "path": "../src"
     },
     {
-      "path": "../../util-dev/src"
-    },
-    {
       "path": "../../crypto/src"
     }
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2440,7 +2440,6 @@ __metadata:
     "@cardano-ogmios/schema": 5.6.0
     "@cardano-sdk/crypto": ^0.1.3
     "@cardano-sdk/util": ^0.8.2
-    "@cardano-sdk/util-dev": ^0.8.0
     "@dcspark/cardano-multiplatform-lib-nodejs": ^3.1.1
     "@foxglove/crc": ^0.0.3
     "@scure/base": ^1.1.1


### PR DESCRIPTION
# Context

There is a circular dependency that `lerna` complains about

```
lerna WARN ECYCLE Dependency cycles detected, you should fix these!
lerna WARN ECYCLE @cardano-sdk/core -> @cardano-sdk/util-dev -> @cardano-sdk/core
```

# Proposed Solution

Remove `util-dev` dependency from `core` pacakge.json
