### PR TITLE
feat!: transaction body core type now includes all fields

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -175,9 +175,7 @@ export const mapTxAlonzo = (
   auxiliaryData:
     metadata && metadata.size > 0
       ? {
-          body: {
-            blob: metadata
-          }
+          blob: metadata
         }
       : undefined,
   blockHeader: {

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -364,7 +364,7 @@ describe('chain history mappers', () => {
       });
       expect(result).toEqual<Cardano.HydratedTx>({
         ...expected,
-        auxiliaryData: { body: { blob: metadata } },
+        auxiliaryData: { blob: metadata },
         body: { ...expected.body, certificates, collaterals: inputs, mint: assets, withdrawals },
         witness: { ...expected.witness, redeemers }
       });

--- a/packages/cardano-services/test/data-mocks/tx.ts
+++ b/packages/cardano-services/test/data-mocks/tx.ts
@@ -35,9 +35,7 @@ export const txIn: Cardano.HydratedTxIn = {
 
 export const base = {
   auxiliaryData: {
-    body: {
-      blob: new Map()
-    }
+    blob: new Map()
   },
   blockHeader: {
     blockNo: Cardano.BlockNo(3_157_934),

--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -275,14 +275,18 @@ export const txBody = (body: CML.TransactionBody): Cardano.TxBody =>
     const cslReferenceInputs = scope.manage(body.reference_inputs());
     const cslCollateralReturn = scope.manage(body.collateral_return());
     const cslTotalCollateral = scope.manage(body.total_collateral());
+    const cslAuxiliaryDataHash = scope.manage(body.auxiliary_data_hash());
+    const cslNetworkId = scope.manage(body.network_id());
 
     return {
+      auxiliaryDataHash: cslAuxiliaryDataHash ? Crypto.Hash32ByteBase16(cslAuxiliaryDataHash.to_hex()) : undefined,
       certificates: txCertificates(scope.manage(body.certs())),
       collateralReturn: cslCollateralReturn ? txOut(cslCollateralReturn) : undefined,
       collaterals: cslCollaterals && txInputs(cslCollaterals),
       fee: BigInt(scope.manage(body.fee()).to_str()),
       inputs: txInputs(scope.manage(body.inputs())),
       mint: txMint(scope.manage(body.multiassets())),
+      networkId: cslNetworkId ? cslNetworkId.kind() : undefined,
       outputs: txOutputs(scope.manage(body.outputs())),
       referenceInputs: cslReferenceInputs ? txInputs(cslReferenceInputs) : undefined,
       requiredExtraSignatures: txRequiredExtraSignatures(scope.manage(body.required_signers())),
@@ -468,12 +472,9 @@ export const txMetadata = (auxiliaryMetadata?: CML.GeneralTransactionMetadata): 
 export const txAuxiliaryData = (auxiliaryData?: CML.AuxiliaryData): Cardano.AuxiliaryData | undefined =>
   usingAutoFree((scope) => {
     if (!auxiliaryData) return;
-    // TODO: create hash
     const auxiliaryMetadata = scope.manage(auxiliaryData.metadata());
     return {
-      body: {
-        blob: txMetadata(auxiliaryMetadata)
-      }
+      blob: txMetadata(auxiliaryMetadata)
     };
   });
 

--- a/packages/core/src/CML/coreToCml/coreToCml.ts
+++ b/packages/core/src/CML/coreToCml/coreToCml.ts
@@ -6,6 +6,7 @@ import {
   AssetName,
   Assets,
   AuxiliaryData,
+  AuxiliaryDataHash,
   BigNum,
   BootstrapWitness,
   BootstrapWitnesses,
@@ -59,12 +60,11 @@ import {
   Vkey,
   Vkeywitness,
   Vkeywitnesses,
-  Withdrawals,
-  hash_auxiliary_data
+  Withdrawals
 } from '@dcspark/cardano-multiplatform-lib-nodejs';
+import { AssetId, NetworkId, RedeemerPurpose } from '../../Cardano';
 
 import * as certificate from './certificate';
-import { AssetId, RedeemerPurpose } from '../../Cardano';
 import { CML } from '../CML';
 import { ManagedFreeableScope } from '@cardano-sdk/util';
 import { SerializationError, SerializationFailure } from '../../errors';
@@ -368,7 +368,7 @@ export const txAuxiliaryData = (
   if (!auxiliaryData) return;
   const result = scope.manage(AuxiliaryData.new());
 
-  const { blob, scripts } = auxiliaryData.body;
+  const { blob, scripts } = auxiliaryData;
   if (blob) {
     result.set_metadata(txMetadata(scope, blob));
   }
@@ -422,16 +422,18 @@ export const txBody = (
     validityInterval,
     certificates,
     withdrawals,
+    auxiliaryDataHash,
     mint,
     collaterals,
     requiredExtraSignatures,
     scriptIntegrityHash,
     totalCollateral,
     collateralReturn,
-    referenceInputs
-  }: Cardano.TxBody,
-  auxiliaryData?: Cardano.AuxiliaryData
-): TransactionBody => {
+    referenceInputs,
+    networkId
+  }: Cardano.TxBody
+): // eslint-disable-next-line sonarjs/cognitive-complexity
+TransactionBody => {
   const cslOutputs = scope.manage(TransactionOutputs.new());
   for (const output of outputs) {
     cslOutputs.add(txOut(scope, output));
@@ -473,6 +475,17 @@ export const txBody = (
   if (scriptIntegrityHash) {
     cslBody.set_script_data_hash(scope.manage(ScriptDataHash.from_bytes(Buffer.from(scriptIntegrityHash, 'hex'))));
   }
+
+  if (auxiliaryDataHash) {
+    cslBody.set_auxiliary_data_hash(scope.manage(AuxiliaryDataHash.from_hex(auxiliaryDataHash)));
+  }
+
+  if (networkId) {
+    const id =
+      networkId === NetworkId.Mainnet ? scope.manage(CML.NetworkId.mainnet()) : scope.manage(CML.NetworkId.testnet());
+    cslBody.set_network_id(id);
+  }
+
   if (certificates?.length) {
     const certs = scope.manage(Certificates.new());
     for (const cert of certificates) {
@@ -482,10 +495,6 @@ export const txBody = (
   }
   if (withdrawals?.length) {
     cslBody.set_withdrawals(txWithdrawals(scope, withdrawals));
-  }
-  const cslAuxiliaryData = txAuxiliaryData(scope, auxiliaryData);
-  if (cslAuxiliaryData) {
-    cslBody.set_auxiliary_data_hash(scope.manage(hash_auxiliary_data(cslAuxiliaryData)));
   }
 
   return cslBody;

--- a/packages/core/src/Cardano/types/AuxiliaryData.ts
+++ b/packages/core/src/Cardano/types/AuxiliaryData.ts
@@ -1,5 +1,8 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { Script } from './Script';
+import { coreToCml } from '../../CML';
+import { usingAutoFree } from '@cardano-sdk/util';
 
 // eslint-disable-next-line no-use-before-define
 export type MetadatumMap = Map<Metadatum, Metadatum>;
@@ -8,12 +11,14 @@ export type Metadatum = bigint | MetadatumMap | string | Uint8Array | Metadatum[
 
 export type TxMetadata = Map<bigint, Metadatum>;
 
-export interface AuxiliaryDataBody {
+export interface AuxiliaryData {
   blob?: TxMetadata;
   scripts?: Script[];
 }
 
-export interface AuxiliaryData {
-  hash?: Hash32ByteBase16;
-  body: AuxiliaryDataBody;
-}
+export const computeAuxiliaryDataHash = (data: AuxiliaryData | undefined): Hash32ByteBase16 | undefined =>
+  usingAutoFree((scope) => {
+    if (!data) return;
+    const cmlData = coreToCml.txAuxiliaryData(scope, data);
+    return Hash32ByteBase16(Crypto.blake2b(Crypto.blake2b.BYTES).update(cmlData!.to_bytes()).digest('hex'));
+  });

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -7,6 +7,7 @@ import { Datum, Script } from './Script';
 import { ExUnits, ValidityInterval } from './ProtocolParameters';
 import { HydratedTxIn, TxIn, TxOut } from './Utxo';
 import { Lovelace, TokenMap } from './Value';
+import { NetworkId } from '../ChainId';
 import { PartialBlockHeader } from './Block';
 import { RewardAccount } from '../Address';
 import { TxBodyCBOR } from '../../CBOR/TxBodyCBOR';
@@ -49,6 +50,8 @@ export interface HydratedTxBody {
   mint?: TokenMap;
   scriptIntegrityHash?: Crypto.Hash32ByteBase16;
   requiredExtraSignatures?: Crypto.Ed25519KeyHashHex[];
+  networkId?: NetworkId;
+  auxiliaryDataHash?: Crypto.Hash32ByteBase16;
 
   /**
    * The total collateral field lets users write transactions whose collateral is evident by just looking at the

--- a/packages/core/src/Serialization/Transaction.ts
+++ b/packages/core/src/Serialization/Transaction.ts
@@ -153,7 +153,7 @@ export class Transaction {
 
     const transaction = scope.manage(
       new Transaction(
-        CoreToCml.txBody(scope, tx.body, tx.auxiliaryData),
+        CoreToCml.txBody(scope, tx.body),
         txWitnessSet,
         CoreToCml.txAuxiliaryData(scope, tx.auxiliaryData)
       )

--- a/packages/core/src/util/txInspector.ts
+++ b/packages/core/src/util/txInspector.ts
@@ -290,7 +290,7 @@ export const mintInspector =
     // was built by this client the script will be present in the witness set, however, if this transaction was
     // queried from a remote repository that doesn't fetch the witness data of the transaction we can still check
     // if the script is present in the auxiliary data.
-    const scripts = [...(tx.auxiliaryData?.body?.scripts || []), ...(tx.witness?.scripts || [])];
+    const scripts = [...(tx.auxiliaryData?.scripts || []), ...(tx.witness?.scripts || [])];
 
     for (const script of scripts) {
       switch (script.__type) {
@@ -338,7 +338,7 @@ export const assetsBurnedInspector: AssetsMintedInspector = mintInspector((quant
  *
  * @param {HydratedTx} tx transaction to inspect.
  */
-export const metadataInspector: MetadataInspector = (tx) => tx.auxiliaryData?.body?.blob ?? new Map();
+export const metadataInspector: MetadataInspector = (tx) => tx.auxiliaryData?.blob ?? new Map();
 
 /**
  * Returns a function to convert lower level transaction data to a higher level object, using the provided inspectors.

--- a/packages/core/test/CML/coreToCml.test.ts
+++ b/packages/core/test/CML/coreToCml.test.ts
@@ -256,7 +256,7 @@ describe('coreToCml', () => {
       // eslint-disable-next-line unicorn/consistent-function-scoping, @typescript-eslint/no-explicit-any
       const convertMetadatum = (metadatum: any) => {
         const label = 123n;
-        const auxiliaryData = coreToCml.txAuxiliaryData(scope, { body: { blob: new Map([[label, metadatum]]) } });
+        const auxiliaryData = coreToCml.txAuxiliaryData(scope, { blob: new Map([[label, metadatum]]) });
         const metadata = scope.manage(auxiliaryData?.metadata());
         return scope.manage(metadata?.get(scope.manage(BigNum.from_str(label.toString()))));
       };

--- a/packages/core/test/CML/testData.ts
+++ b/packages/core/test/CML/testData.ts
@@ -143,6 +143,7 @@ export const txOutWithDatum: Cardano.TxOut = {
 };
 
 export const txBody: Cardano.TxBody = {
+  auxiliaryDataHash: Crypto.Hash32ByteBase16('2ceb364d93225b4a0f004a0975a13eb50c3cc6348474b4fe9121f8dc72ca0cfa'),
   certificates: [
     {
       __typename: Cardano.CertificateType.PoolRetirement,
@@ -188,22 +189,20 @@ export const signature =
   'bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755';
 export const tx: Cardano.Tx = {
   auxiliaryData: {
-    body: {
-      blob: new Map<bigint, Cardano.Metadatum>([
-        [1n, 1234n],
-        [2n, 'str'],
-        [3n, [1234n, 'str']],
-        [4n, new Uint8Array(Buffer.from('bytes'))],
-        [
-          5n,
-          new Map<Cardano.Metadatum, Cardano.Metadatum>([
-            ['strkey', 123n],
-            [['listkey'], 'strvalue']
-          ])
-        ],
-        [6n, -7n]
-      ])
-    }
+    blob: new Map<bigint, Cardano.Metadatum>([
+      [1n, 1234n],
+      [2n, 'str'],
+      [3n, [1234n, 'str']],
+      [4n, new Uint8Array(Buffer.from('bytes'))],
+      [
+        5n,
+        new Map<Cardano.Metadatum, Cardano.Metadatum>([
+          ['strkey', 123n],
+          [['listkey'], 'strvalue']
+        ])
+      ],
+      [6n, -7n]
+    ])
   },
   body: txBody,
   id: Cardano.TransactionId('8d2feeab1087e0aa4ad06e878c5269eaa2edcef5264bcc97542a28c189b2cbc5'),

--- a/packages/core/test/Cardano/types/AuxiliaryData.test.ts
+++ b/packages/core/test/Cardano/types/AuxiliaryData.test.ts
@@ -1,0 +1,35 @@
+import { Metadatum, computeAuxiliaryDataHash } from '../../../src/Cardano';
+
+describe('Cardano/types/AuxiliaryData', () => {
+  describe('computeAuxiliaryDataHash', () => {
+    it('can compute the correct auxiliary data hash', () => {
+      const auxiliaryData = {
+        blob: new Map<bigint, Metadatum>([
+          [1n, 1234n],
+          [2n, 'str'],
+          [3n, [1234n, 'str']],
+          [4n, new Uint8Array(Buffer.from('bytes'))],
+          [
+            5n,
+            new Map<Metadatum, Metadatum>([
+              ['strkey', 123n],
+              [['listkey'], 'strvalue']
+            ])
+          ],
+          [6n, -7n]
+        ])
+      };
+
+      expect(computeAuxiliaryDataHash(auxiliaryData)).toEqual(
+        '2ceb364d93225b4a0f004a0975a13eb50c3cc6348474b4fe9121f8dc72ca0cfa'
+      );
+    });
+
+    it('returns undefined when given an undefined auxiliary data', () => {
+      const auxiliaryData = undefined;
+
+      expect(() => computeAuxiliaryDataHash(auxiliaryData)).not.toThrow();
+      expect(computeAuxiliaryDataHash(auxiliaryData)).toEqual(undefined);
+    });
+  });
+});

--- a/packages/core/test/Serialization/Transaction.test.ts
+++ b/packages/core/test/Serialization/Transaction.test.ts
@@ -40,9 +40,9 @@ describe('Transaction', () => {
   it('correctly converts from a Babbage Core transaction', () => {
     const scope = new ManagedFreeableScope();
     const tx = Transaction.fromCore(scope, babbageTx);
+
     expect(tx.toCore()).toEqual(babbageTx);
   });
-
   it('calling free several times doesnt throw an error', () => {
     const tx = Transaction.fromCbor(HexBlob(TX));
     expect(() => tx.free()).not.toThrow();
@@ -59,7 +59,6 @@ describe('Transaction', () => {
 
     // Perform a round trip serialization.
     const tx2 = Transaction.fromCbor(tx.toCbor());
-
     expect(tx2.isValid()).toEqual(false);
   });
 

--- a/packages/core/test/util/txInspector.test.ts
+++ b/packages/core/test/util/txInspector.test.ts
@@ -190,10 +190,8 @@ describe('txInspector', () => {
   };
 
   const auxiliaryData = {
-    body: {
-      blob: txMetadatum,
-      scripts: [mockScript2]
-    }
+    blob: txMetadatum,
+    scripts: [mockScript2]
   };
 
   const buildMockTx = (

--- a/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/metadata.test.ts
@@ -48,6 +48,6 @@ describe('SingleAddressWallet/metadata', () => {
         filter(isNotNil)
       )
     );
-    expect(loadedTx.auxiliaryData?.body.blob).toEqual(metadata);
+    expect(loadedTx.auxiliaryData?.blob).toEqual(metadata);
   });
 });

--- a/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/SingleAddressWallet/nft.test.ts
@@ -135,9 +135,7 @@ describe('SingleAddressWallet.assets/nft', () => {
     });
 
     const auxiliaryData = {
-      body: {
-        blob: new Map([[721n, txMetadatum]])
-      }
+      blob: new Map([[721n, txMetadatum]])
     };
 
     const txProps: InitializeTxProps = {
@@ -317,7 +315,7 @@ describe('SingleAddressWallet.assets/nft', () => {
           ]
         ]);
 
-        const auxiliaryData = { body: { blob: new Map([[721n, txDataMetadatum]]) } };
+        const auxiliaryData = { blob: new Map([[721n, txDataMetadatum]]) };
 
         const txProps: InitializeTxProps = {
           auxiliaryData,

--- a/packages/ogmios/test/CardanoNode/__snapshots__/ObservableOgmiosCardanoNode.test.ts.snap
+++ b/packages/ogmios/test/CardanoNode/__snapshots__/ObservableOgmiosCardanoNode.test.ts.snap
@@ -44,6 +44,7 @@ Array [
         Object {
           "auxiliaryData": undefined,
           "body": Object {
+            "auxiliaryDataHash": undefined,
             "certificates": Array [],
             "collaterals": Array [
               Object {

--- a/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
+++ b/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
@@ -5,72 +5,70 @@ Object {
   "body": Array [
     Object {
       "auxiliaryData": Object {
-        "body": Object {
-          "blob": Map {
-            2n => Map {
-              "list" => Array [
-                Map {
-                  "int" => 9798604473814314674n,
-                },
-                Map {
-                  "bytes" => "7a43",
-                },
-              ],
-            },
+        "blob": Map {
+          2n => Map {
+            "list" => Array [
+              Map {
+                "int" => 9798604473814314674n,
+              },
+              Map {
+                "bytes" => "7a43",
+              },
+            ],
           },
-          "scripts": Array [
-            Object {
-              "__type": "native",
-              "keyHash": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
-              "kind": 0,
-            },
-            Object {
-              "__type": "native",
-              "keyHash": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
-              "kind": 0,
-            },
-            Object {
-              "__type": "native",
-              "kind": 1,
-              "scripts": Array [
-                Object {
-                  "__type": "native",
-                  "kind": 2,
-                  "scripts": Array [],
-                },
-                Object {
-                  "__type": "native",
-                  "keyHash": "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7",
-                  "kind": 0,
-                },
-                Object {
-                  "__type": "native",
-                  "kind": 2,
-                  "scripts": Array [
-                    Object {
-                      "__type": "native",
-                      "kind": 5,
-                      "slot": 15272,
-                    },
-                  ],
-                },
-                Object {
-                  "__type": "native",
-                  "kind": 4,
-                  "slot": 44521,
-                },
-                Object {
-                  "__type": "native",
-                  "kind": 4,
-                  "slot": 91998,
-                },
-              ],
-            },
-          ],
         },
-        "hash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
+        "scripts": Array [
+          Object {
+            "__type": "native",
+            "keyHash": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
+            "kind": 0,
+          },
+          Object {
+            "__type": "native",
+            "keyHash": "a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+            "kind": 0,
+          },
+          Object {
+            "__type": "native",
+            "kind": 1,
+            "scripts": Array [
+              Object {
+                "__type": "native",
+                "kind": 2,
+                "scripts": Array [],
+              },
+              Object {
+                "__type": "native",
+                "keyHash": "58e1b65718531b42494610c506cef10ff031fa817a8ff75c0ab180e7",
+                "kind": 0,
+              },
+              Object {
+                "__type": "native",
+                "kind": 2,
+                "scripts": Array [
+                  Object {
+                    "__type": "native",
+                    "kind": 5,
+                    "slot": 15272,
+                  },
+                ],
+              },
+              Object {
+                "__type": "native",
+                "kind": 4,
+                "slot": 44521,
+              },
+              Object {
+                "__type": "native",
+                "kind": 4,
+                "slot": 91998,
+              },
+            ],
+          },
+        ],
       },
       "body": Object {
+        "auxiliaryDataHash": "ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25",
         "certificates": Array [],
         "collaterals": undefined,
         "fee": 724n,
@@ -155,72 +153,70 @@ Object {
   "body": Array [
     Object {
       "auxiliaryData": Object {
-        "body": Object {
-          "blob": Map {
-            674n => Map {
-              "map" => Array [
-                Map {
-                  "k" => Map {
-                    "string" => "msg",
-                  },
-                  "v" => Map {
-                    "list" => Array [
-                      Map {
-                        "string" => "Auto-Loop-Transaction #338666 by ATADA",
-                      },
-                      Map {
-                        "string" => "",
-                      },
-                      Map {
-                        "string" => "Live Epoch 16, we have 061h 17m 32s left until the next one",
-                      },
-                      Map {
-                        "string" => "It's Montag - 22 August 2022 - 12:42:28 in Austria",
-                      },
-                      Map {
-                        "string" => "",
-                      },
-                      Map {
-                        "string" => "📈 The current ADA Price on Kraken is: $0.451502 / ADA",
-                      },
-                      Map {
-                        "string" => "",
-                      },
-                      Map {
-                        "string" => "A random Zen-Quote for you: 🙏",
-                      },
-                      Map {
-                        "string" => "There are three classes of people: those who see. Those who see",
-                      },
-                      Map {
-                        "string" => "when they are shown. Those who do not see. - Leonardo da Vinci",
-                      },
-                      Map {
-                        "string" => "",
-                      },
-                      Map {
-                        "string" => "Node-Revision: 950c4e222086fed5ca53564e642434ce9307b0b9",
-                      },
-                      Map {
-                        "string" => "",
-                      },
-                      Map {
-                        "string" => "PreProd-Chain is awesome, have some fun! 😍",
-                      },
-                      Map {
-                        "string" => " Best regards, Martin :-)",
-                      },
-                    ],
-                  },
+        "blob": Map {
+          674n => Map {
+            "map" => Array [
+              Map {
+                "k" => Map {
+                  "string" => "msg",
                 },
-              ],
-            },
+                "v" => Map {
+                  "list" => Array [
+                    Map {
+                      "string" => "Auto-Loop-Transaction #338666 by ATADA",
+                    },
+                    Map {
+                      "string" => "",
+                    },
+                    Map {
+                      "string" => "Live Epoch 16, we have 061h 17m 32s left until the next one",
+                    },
+                    Map {
+                      "string" => "It's Montag - 22 August 2022 - 12:42:28 in Austria",
+                    },
+                    Map {
+                      "string" => "",
+                    },
+                    Map {
+                      "string" => "📈 The current ADA Price on Kraken is: $0.451502 / ADA",
+                    },
+                    Map {
+                      "string" => "",
+                    },
+                    Map {
+                      "string" => "A random Zen-Quote for you: 🙏",
+                    },
+                    Map {
+                      "string" => "There are three classes of people: those who see. Those who see",
+                    },
+                    Map {
+                      "string" => "when they are shown. Those who do not see. - Leonardo da Vinci",
+                    },
+                    Map {
+                      "string" => "",
+                    },
+                    Map {
+                      "string" => "Node-Revision: 950c4e222086fed5ca53564e642434ce9307b0b9",
+                    },
+                    Map {
+                      "string" => "",
+                    },
+                    Map {
+                      "string" => "PreProd-Chain is awesome, have some fun! 😍",
+                    },
+                    Map {
+                      "string" => " Best regards, Martin :-)",
+                    },
+                  ],
+                },
+              },
+            ],
           },
-          "scripts": Array [],
         },
-        "hash": "0ad6d4a6e10182157142994b2cce2aebee9406e3e2be31bfb1574ed2409a71dc",
+        "scripts": Array [],
       },
       "body": Object {
+        "auxiliaryDataHash": "0ad6d4a6e10182157142994b2cce2aebee9406e3e2be31bfb1574ed2409a71dc",
         "certificates": Array [
           Object {
             "__typename": "StakeDelegationCertificate",
@@ -319,23 +315,21 @@ Object {
   "body": Array [
     Object {
       "auxiliaryData": Object {
-        "body": Object {
-          "blob": Map {
-            2n => Map {
-              "string" => "",
-            },
+        "blob": Map {
+          2n => Map {
+            "string" => "",
           },
-          "scripts": Array [
-            Object {
-              "__type": "native",
-              "kind": 4,
-              "slot": 63725,
-            },
-          ],
         },
-        "hash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
+        "scripts": Array [
+          Object {
+            "__type": "native",
+            "kind": 4,
+            "slot": 63725,
+          },
+        ],
       },
       "body": Object {
+        "auxiliaryDataHash": "bb30a42c1e62f0afda5f0a4e8a562f7a13a24cea00ee81917b86b89e801314aa",
         "certificates": Array [
           Object {
             "__typename": "MirCertificate",
@@ -515,6 +509,7 @@ Object {
     Object {
       "auxiliaryData": undefined,
       "body": Object {
+        "auxiliaryDataHash": undefined,
         "certificates": Array [
           Object {
             "__typename": "StakeKeyRegistrationCertificate",
@@ -617,20 +612,18 @@ Object {
     },
     Object {
       "auxiliaryData": Object {
-        "body": Object {
-          "blob": Map {
-            1n => Map {
-              "int" => -16613019303347710699n,
-            },
-            2n => Map {
-              "bytes" => "6573",
-            },
+        "blob": Map {
+          1n => Map {
+            "int" => -16613019303347710699n,
           },
-          "scripts": Array [],
+          2n => Map {
+            "bytes" => "6573",
+          },
         },
-        "hash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
+        "scripts": Array [],
       },
       "body": Object {
+        "auxiliaryDataHash": "ae85d245a3d00bfde01f59f3c4fe0b4bfae1cb37e9cf91929eadcea4985711de",
         "certificates": Array [
           Object {
             "__typename": "PoolRegistrationCertificate",

--- a/packages/tx-construction/test/testData.ts
+++ b/packages/tx-construction/test/testData.ts
@@ -74,6 +74,7 @@ export const txOut: Cardano.TxOut = {
 };
 
 export const txBody: Cardano.TxBody = {
+  auxiliaryDataHash: Crypto.Hash32ByteBase16('2ceb364d93225b4a0f004a0975a13eb50c3cc6348474b4fe9121f8dc72ca0cfa'),
   certificates: [
     {
       __typename: Cardano.CertificateType.PoolRetirement,
@@ -129,22 +130,20 @@ export const signature =
   'bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755bdea87fca1b4b4df8a9b8fb4183c0fab2f8261eb6c5e4bc42c800bb9c8918755';
 export const tx: Cardano.Tx = {
   auxiliaryData: {
-    body: {
-      blob: new Map<bigint, Cardano.Metadatum>([
-        [1n, 1234n],
-        [2n, 'str'],
-        [3n, [1234n, 'str']],
-        [4n, new Uint8Array(Buffer.from('bytes'))],
-        [
-          5n,
-          new Map<Cardano.Metadatum, Cardano.Metadatum>([
-            ['strkey', 123n],
-            [['listkey'], 'strvalue']
-          ])
-        ],
-        [6n, -7n]
-      ])
-    }
+    blob: new Map<bigint, Cardano.Metadatum>([
+      [1n, 1234n],
+      [2n, 'str'],
+      [3n, [1234n, 'str']],
+      [4n, new Uint8Array(Buffer.from('bytes'))],
+      [
+        5n,
+        new Map<Cardano.Metadatum, Cardano.Metadatum>([
+          ['strkey', 123n],
+          [['listkey'], 'strvalue']
+        ])
+      ],
+      [6n, -7n]
+    ])
   },
   body: txBody,
   id: Cardano.TransactionId('8d2feeab1087e0aa4ad06e878c5269eaa2edcef5264bcc97542a28c189b2cbc5'),

--- a/packages/wallet/src/Transaction/createTransactionInternals.ts
+++ b/packages/wallet/src/Transaction/createTransactionInternals.ts
@@ -37,6 +37,7 @@ export const createTransactionInternals = async ({
       });
     }
     const body: Cardano.TxBody = {
+      auxiliaryDataHash: auxiliaryData ? Cardano.computeAuxiliaryDataHash(auxiliaryData) : undefined,
       certificates,
       fee: inputSelection.fee,
       inputs: [...inputSelection.inputs].map(([txIn]) => txIn),
@@ -48,7 +49,7 @@ export const createTransactionInternals = async ({
       withdrawals
     };
     if (collaterals) body.collaterals = [...collaterals];
-    const cslBody = coreToCml.txBody(scope, body, auxiliaryData);
+    const cslBody = coreToCml.txBody(scope, body);
 
     return {
       body,

--- a/packages/wallet/src/TxBuilder/buildTx.ts
+++ b/packages/wallet/src/TxBuilder/buildTx.ts
@@ -147,7 +147,7 @@ export class ObservableWalletTxBuilder implements TxBuilder {
   }
 
   setMetadata(metadata: Cardano.TxMetadata): TxBuilder {
-    this.auxiliaryData = { ...this.auxiliaryData, body: { ...this.auxiliaryData?.body, blob: new Map(metadata) } };
+    this.auxiliaryData = { ...this.auxiliaryData, blob: new Map(metadata) };
     return this;
   }
 
@@ -167,6 +167,9 @@ export class ObservableWalletTxBuilder implements TxBuilder {
       this.#logger.debug('Building');
       await this.#addDelegationCertificates();
       await this.#validateOutputs();
+
+      if (this.auxiliaryData)
+        this.partialTxBody.auxiliaryDataHash = Cardano.computeAuxiliaryDataHash(this.auxiliaryData);
 
       const tx = await this.#observableWallet.initializeTx({
         auxiliaryData: this.auxiliaryData,

--- a/packages/wallet/test/integration/buildTx.test.ts
+++ b/packages/wallet/test/integration/buildTx.test.ts
@@ -93,13 +93,13 @@ describe('buildTx', () => {
       const initialAuxiliaryData = txBuilder.auxiliaryData;
       txBuilder.setMetadata(metadata);
       assertObjectRefsAreDifferent(txBuilder.auxiliaryData, initialAuxiliaryData);
-      expect(txBuilder.auxiliaryData?.body.blob).toEqual(metadata);
+      expect(txBuilder.auxiliaryData?.blob).toEqual(metadata);
     });
 
     it('can unset metadata by using empty map', () => {
       metadata = new Map();
       txBuilder.setMetadata(metadata);
-      expect(txBuilder.auxiliaryData?.body.blob?.entries.length).toBe(0);
+      expect(txBuilder.auxiliaryData?.blob?.entries.length).toBe(0);
     });
 
     it('can add metadata, sign and read it back', async () => {
@@ -107,10 +107,10 @@ describe('buildTx', () => {
       assertTxIsValid(tx);
 
       // ValidTxBody contains metadata
-      expect(tx.auxiliaryData?.body.blob).toEqual(metadata);
+      expect(tx.auxiliaryData?.blob).toEqual(metadata);
 
       const signedTx = await tx.sign();
-      expect(signedTx.tx.auxiliaryData?.body.blob).toEqual(metadata);
+      expect(signedTx.tx.auxiliaryData?.blob).toEqual(metadata);
     });
   });
 


### PR DESCRIPTION
# Context

Currently our Transaction body type is missing two fields, networkId (optional) and auxDataHash(optional). This is problematic when we deserialize TxBodies that come from a different sources.

Our TxBody should be compliant with the CDDL specification.

# Proposed Solution

- Add the two missing fields (networkId and auxDataHash).
- Auxiliary data was simplified, the hash was moved to the txBody and a new utility function to compute the auxiliary data hashes was introduced.

