### PR TITLE
fix: cip30 getUtxos compliance

### DIFF
--- a/packages/core/src/CML/cmlToCore/cmlToCore.ts
+++ b/packages/core/src/CML/cmlToCore/cmlToCore.ts
@@ -480,5 +480,5 @@ export const txAuxiliaryData = (auxiliaryData?: CML.AuxiliaryData): Cardano.Auxi
 
 export const utxo = (cslUtxos: CML.TransactionUnspentOutput[]) =>
   usingAutoFree((scope) =>
-    cslUtxos.map((cslUtxo) => [txIn(scope.manage(cslUtxo.input())), txOut(scope.manage(cslUtxo.output()))])
+    cslUtxos.map((cslUtxo) => [txIn(scope.manage(cslUtxo.input())), txOut(scope.manage(cslUtxo.output()))] as const)
   );

--- a/packages/dapp-connector/src/WalletApi/types.ts
+++ b/packages/dapp-connector/src/WalletApi/types.ts
@@ -55,7 +55,7 @@ export type GetNetworkId = () => Promise<Cardano.NetworkId>;
  * @throws ApiError
  * @throws PaginateError
  */
-export type GetUtxos = (amount?: Cbor, paginate?: Paginate) => Promise<Cbor[] | undefined>;
+export type GetUtxos = (amount?: Cbor, paginate?: Paginate) => Promise<Cbor[] | null>;
 
 /**
  * @returns a list of one or more UTxOs (unspent transaction outputs) controlled by the wallet


### PR DESCRIPTION
# Context

1. "If amount is not undefined, this request shall be limited to just the UTXOs that are required to reach the combined ADA/multiasset value target specified in amount, and if this cannot be attained, null shall be returned". Currently null is never returned.
2. `getUtxos` 'paginate' argument doesn't work when used with 'amount' argument

# Proposed Solution

See commit log
