### PR TITLE
ci: double --max_old_space_size in unit tests

### DIFF
--- a/.github/workflows/continuous-integration-unit-tests.yaml
+++ b/.github/workflows/continuous-integration-unit-tests.yaml
@@ -41,4 +41,4 @@ jobs:
         yarn test:build:verify
         yarn test --forceExit
       env:
-        NODE_OPTIONS: "--max_old_space_size=4096"
+        NODE_OPTIONS: "--max_old_space_size=8192"

--- a/.github/workflows/nightly-test.yaml
+++ b/.github/workflows/nightly-test.yaml
@@ -50,4 +50,4 @@ jobs:
         yarn test:build:verify
         yarn test --forceExit
       env:
-        NODE_OPTIONS: "--max_old_space_size=4096"
+        NODE_OPTIONS: "--max_old_space_size=8192"


### PR DESCRIPTION
# Context
Nightly workflow is consistently failing with
```
RangeError: WebAssembly.Instance(): Out of memory: wasm memory
```
... at the point of exporting the entire  `@dcspark/cardano-multiplatform-lib-nodejs`.

# Proposed Solution
Double the memory allocation.
