### PR TITLE
ci: set default log level

### DIFF
--- a/.github/workflows/continuous-integration-e2e.yaml
+++ b/.github/workflows/continuous-integration-e2e.yaml
@@ -1,8 +1,8 @@
 name: Continuous Integration - E2E
 
 env:
-  TL_DEPTH: ${{ fromJson(vars.TL_DEPTH) }}
-  TL_LEVEL: ${{ vars.TL_LEVEL }}
+  TL_DEPTH: ${{ github.event.pull_request.head.repo.fork && '0' || fromJson(vars.TL_DEPTH) }}
+  TL_LEVEL: ${{ github.event.pull_request.head.repo.fork && 'info' || vars.TL_LEVEL }}
 
 on:
   pull_request:

--- a/.github/workflows/continuous-integration-unit-tests.yaml
+++ b/.github/workflows/continuous-integration-unit-tests.yaml
@@ -1,8 +1,8 @@
 name: Continuous Integration - Unit Tests
 
 env:
-  TL_DEPTH: ${{ fromJson(vars.TL_DEPTH) }}
-  TL_LEVEL: ${{ vars.TL_LEVEL }}
+  TL_DEPTH: ${{ github.event.pull_request.head.repo.fork && '0' || fromJson(vars.TL_DEPTH) }}
+  TL_LEVEL: ${{ github.event.pull_request.head.repo.fork && 'info' || vars.TL_LEVEL }}
 
 on:
   pull_request:


### PR DESCRIPTION
# Context

Set default values for TL_DEPTH and TL_LEVEL for unit and e2e test workflows if it launched from forked repository
