### PR TITLE
chore(key-management): rm extraneous util-dev dependency

### DIFF
--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -64,7 +64,6 @@
     "@cardano-sdk/crypto": "^0.1.3",
     "@cardano-sdk/dapp-connector": "^0.8.0",
     "@cardano-sdk/util": "^0.8.2",
-    "@cardano-sdk/util-dev": "^0.8.0",
     "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
     "@ledgerhq/hw-transport": "^6.28.1",
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.27.12",

--- a/packages/util-dev/esm-package.json
+++ b/packages/util-dev/esm-package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "sideEffects": false,
+  "browser": {
+    "./docker.js": false
+  }
+}

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -13,6 +13,10 @@
       "require": "./dist/cjs/index.js"
     }
   },
+  "browser": {
+    "./dist/esm/docker.js": false,
+    "./dist/cjs/docker.js": false
+  },
   "repository": "https://github.com/input-output-hk/cardano-js-sdk",
   "publishConfig": {
     "access": "public"
@@ -39,7 +43,7 @@
     "build:copy": "shx cp -rf src/chainSync/data dist/cjs/chainSync/",
     "build": "run-s build:cjs build:esm module-fixup build:copy",
     "circular-deps:check": "madge --circular dist/cjs",
-    "module-fixup": "shx cp ../../build/cjs-package.json ./dist/cjs/package.json && cp ../../build/esm-package.json ./dist/esm/package.json",
+    "module-fixup": "shx cp ../../build/cjs-package.json ./dist/cjs/package.json && cp ./esm-package.json ./dist/esm/package.json",
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "shx rm -rf dist",
     "cleanup:nm": "shx rm -rf node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,7 +2696,6 @@ __metadata:
     "@cardano-sdk/crypto": ^0.1.3
     "@cardano-sdk/dapp-connector": ^0.8.0
     "@cardano-sdk/util": ^0.8.2
-    "@cardano-sdk/util-dev": ^0.8.0
     "@emurgo/cardano-message-signing-nodejs": ^1.0.1
     "@ledgerhq/hw-transport": ^6.28.1
     "@ledgerhq/hw-transport-node-hid-noevents": ^6.27.12


### PR DESCRIPTION
# Context

`key-management` has a dependency on `util-dev` but it's not being used

# Proposed Solution

- Remove it
- Add "browser" field to util-dev esm package.json to omit docker utils from browser builds