### PR TITLE
fix(cardano-services): token metadata core mapping

### DIFF
--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -22,15 +22,18 @@ interface TokenMetadataServiceRecord {
   description?: StringValue;
   logo?: StringValue;
   name?: StringValue;
-  subject?: string;
+  subject: string;
   ticker?: StringValue;
   url?: StringValue;
 }
 
 const propertiesToChange: Record<string, string> = { description: 'desc', logo: 'icon', subject: 'assetId' };
-export const toCoreTokenMetadata = (record: TokenMetadataServiceRecord) =>
+export const toCoreTokenMetadata = (record: TokenMetadataServiceRecord): Asset.TokenMetadata =>
   Object.fromEntries(
-    Object.entries(record).map(([key, value]) => [propertiesToChange[key] || key, value.value || value])
+    Object.entries(record).map(([key, value]) => [
+      propertiesToChange[key] || key,
+      typeof value === 'string' ? value : value.value
+    ])
   ) as Asset.TokenMetadata;
 
 const toProviderError = (error: unknown, details: string) => {

--- a/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
+++ b/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
@@ -19,7 +19,7 @@ describe('CardanoTokenRegistry', () => {
     it('complete attributes', () =>
       expect(
         toCoreTokenMetadata({
-          decimals: { value: 23 },
+          decimals: { value: 0 },
           description: { value: testDescription },
           logo: { value: 'test logo' },
           name: { value: testName },
@@ -29,7 +29,7 @@ describe('CardanoTokenRegistry', () => {
         })
       ).toStrictEqual({
         assetId: testSubject,
-        decimals: 23,
+        decimals: 0,
         desc: testDescription,
         icon: 'test logo',
         name: testName,


### PR DESCRIPTION
# Context
AssetProvider returns the wrong types for token metadata fetched from Cardano Token Registry.

# Proposed Solution
Fix the core type mappings
