### PR TITLE
feat: remote method returning api

### DIFF
--- a/packages/util/src/freeable.ts
+++ b/packages/util/src/freeable.ts
@@ -1,4 +1,5 @@
 import { Freeable } from './types';
+import { isPromise } from './isPromise';
 
 /**
  * A scope to ease the management of objects that require manual resource management.
@@ -38,10 +39,6 @@ export class ManagedFreeableScope {
     this.#disposed = true;
   }
 }
-
-const isPromise = (obj: unknown): obj is Promise<unknown> =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  typeof obj === 'object' && typeof (obj as any).then === 'function';
 
 class AutoFree<TReturn> {
   #scope: ManagedFreeableScope;

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -15,4 +15,5 @@ export * from './RunnableModule';
 export * from './opaqueTypes';
 export * from './environment';
 export * from './patchObject';
+export * from './isPromise';
 export { PromiseOrValue, resolveObjectValues } from './util';

--- a/packages/util/src/isPromise.ts
+++ b/packages/util/src/isPromise.ts
@@ -1,0 +1,3 @@
+export const isPromise = <T>(obj: T | Promise<T>): obj is Promise<T> =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  typeof obj === 'object' && typeof (obj as any).then === 'function';

--- a/packages/util/test/isPromise.test.ts
+++ b/packages/util/test/isPromise.test.ts
@@ -1,0 +1,6 @@
+import { isPromise } from '../src';
+
+describe('isPromise', () => {
+  it('returns true for Promise-like objects', () => expect(isPromise(Promise.resolve())).toBe(true));
+  it('returns false for non-Promise-like objects', () => expect(isPromise({})).toBe(false));
+});

--- a/packages/web-extension/src/messaging/BackgroundMessenger.ts
+++ b/packages/web-extension/src/messaging/BackgroundMessenger.ts
@@ -101,6 +101,7 @@ export const generalizeBackgroundMessenger = (channel: ChannelName, messenger: B
   deriveChannel(path) {
     return generalizeBackgroundMessenger(deriveChannelName(channel, path), messenger);
   },
+  isShutdown: false,
   message$: messenger.getChannel(channel).message$,
   /**
    * @throws RxJS EmptyError if messenger is shutdown
@@ -121,5 +122,6 @@ export const generalizeBackgroundMessenger = (channel: ChannelName, messenger: B
 
   shutdown() {
     messenger.shutdownChannel(channel);
+    this.isShutdown = true;
   }
 });

--- a/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
+++ b/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
@@ -79,6 +79,9 @@ export const createNonBackgroundMessenger = (
       derivedMessengers.add(messenger);
       return messenger;
     },
+    get isShutdown() {
+      return isDestroyed;
+    },
     message$,
     /**
      * @throws RxJS EmptyError if client is shutdown
@@ -104,7 +107,7 @@ export const createNonBackgroundMessenger = (
         derivedMessengers.delete(messenger);
       }
       port$.complete();
-      logger.warn(`[NonBackgroundMessenger(${channel})] shutdown`);
+      logger.debug(`[NonBackgroundMessenger(${channel})] shutdown`);
     }
   };
 };

--- a/packages/web-extension/src/messaging/index.ts
+++ b/packages/web-extension/src/messaging/index.ts
@@ -1,5 +1,6 @@
 import { BackgroundMessenger, createBackgroundMessenger, generalizeBackgroundMessenger } from './BackgroundMessenger';
 import { ChannelName, ConsumeRemoteApiOptions, ExposeApiProps, MessengerDependencies } from './types';
+import { FinalizationRegistryDestructor } from './util';
 import { consumeMessengerRemoteApi, exposeMessengerApi } from './remoteApi';
 import { createNonBackgroundMessenger } from './NonBackgroundMessenger';
 
@@ -47,6 +48,7 @@ const _nonBackgroundConsumeRemoteApi = <T extends object>(
   dependencies: MessengerDependencies
 ) =>
   consumeMessengerRemoteApi(props, {
+    destructor: new FinalizationRegistryDestructor(dependencies.logger),
     messenger: createNonBackgroundMessenger(props, dependencies),
     ...dependencies
   });
@@ -58,7 +60,11 @@ const _backgroundConsumeRemoteApi: ConsumeApi = <T extends object>(
   dependencies: MessengerDependencies
 ) => {
   const messenger = generalizeBackgroundMessenger(props.baseChannel, getBackgroundMessenger(dependencies));
-  return consumeMessengerRemoteApi(props, { messenger, ...dependencies });
+  return consumeMessengerRemoteApi(props, {
+    destructor: new FinalizationRegistryDestructor(dependencies.logger),
+    messenger,
+    ...dependencies
+  });
 };
 
 /**

--- a/packages/web-extension/test/messaging/util.test.ts
+++ b/packages/web-extension/test/messaging/util.test.ts
@@ -1,11 +1,11 @@
 import {
+  CompletionMessage,
   EmitMessage,
   MethodRequest,
-  ObservableCompletionMessage,
   RequestMessage,
   ResponseMessage,
+  isCompletionMessage,
   isEmitMessage,
-  isObservableCompletionMessage,
   isRequest,
   isRequestMessage,
   isResponseMessage,
@@ -47,14 +47,12 @@ describe('messaging/util', () => {
   });
   describe('isObservableCompletionMessage', () => {
     it('returns true for objects matching SubscriptionMessage type', () => {
-      expect(
-        isObservableCompletionMessage({ messageId: 'messageId', subscribe: false } as ObservableCompletionMessage)
-      ).toBe(true);
+      expect(isCompletionMessage({ messageId: 'messageId', subscribe: false } as CompletionMessage)).toBe(true);
     });
     it('returns false for objects not matching SubscriptionMessage type', () => {
-      expect(isObservableCompletionMessage(null)).toBe(false);
-      expect(isObservableCompletionMessage({ messageId: 'messageId' })).toBe(false);
-      expect(isObservableCompletionMessage({ subscribe: true })).toBe(false);
+      expect(isCompletionMessage(null)).toBe(false);
+      expect(isCompletionMessage({ messageId: 'messageId' })).toBe(false);
+      expect(isCompletionMessage({ subscribe: true })).toBe(false);
     });
   });
   describe('isEmitMessage', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "commonjs",
-    "target": "es2020",
+    "target": "es2021",
     "esModuleInterop": true,
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
# Context

Remote API can only return POJOs, so it can't be used for fluent interface-style APIs (e.g. tx builder)

# Proposed Solution

eacad41b5b8570ca4e5d0cc4178c4b5740569a4c

# Important Changes Introduced

- cc0b3b0e10ef4eaf763bea085976669f8be72ed5
- 06939f65daf580b154aa98cc2162d5e1f399c2d7
