### PR TITLE
[LW-6529]: feat: key agent 'deriveAddress' now takes an additional parameter 'stakeKeyDerivationIndex'

### DIFF
--- a/packages/e2e/src/scripts/mnemonic.ts
+++ b/packages/e2e/src/scripts/mnemonic.ts
@@ -26,10 +26,13 @@ import { localNetworkChainId } from '../util';
     }
   );
 
-  const derivedAddress = await keyAgentFromMnemonic.deriveAddress({
-    index: 0,
-    type: AddressType.External
-  });
+  const derivedAddress = await keyAgentFromMnemonic.deriveAddress(
+    {
+      index: 0,
+      type: AddressType.External
+    },
+    0
+  );
 
   console.log('');
   console.log(`  Mnemonic:   ${mnemonic}`);

--- a/packages/e2e/test/local-network/register-pool.test.ts
+++ b/packages/e2e/test/local-network/register-pool.test.ts
@@ -78,10 +78,13 @@ describe('local-network/register-pool', () => {
     const poolKeyHash = await bip32Ed25519.getPubKeyHash(poolPubKey);
     const poolId = Cardano.PoolId.fromKeyHash(poolKeyHash);
     const poolRewardAccount = (
-      await poolKeyAgent.deriveAddress({
-        index: 0,
-        type: AddressType.External
-      })
+      await poolKeyAgent.deriveAddress(
+        {
+          index: 0,
+          type: AddressType.External
+        },
+        0
+      )
     ).rewardAccount;
 
     const registrationCert: Cardano.PoolRegistrationCertificate = {
@@ -160,10 +163,13 @@ describe('local-network/register-pool', () => {
     const poolKeyHash = await bip32Ed25519.getPubKeyHash(poolPubKey);
     const poolId = Cardano.PoolId.fromKeyHash(poolKeyHash);
     const poolRewardAccount = (
-      await poolKeyAgent.deriveAddress({
-        index: 0,
-        type: AddressType.External
-      })
+      await poolKeyAgent.deriveAddress(
+        {
+          index: 0,
+          type: AddressType.External
+        },
+        0
+      )
     ).rewardAccount;
 
     const registrationCert: Cardano.PoolRegistrationCertificate = {

--- a/packages/e2e/test/long-running/cache-invalidation.test.ts
+++ b/packages/e2e/test/long-running/cache-invalidation.test.ts
@@ -59,10 +59,13 @@ describe('cache invalidation', () => {
     const poolKeyHash = await bip32Ed25519.getPubKeyHash(poolPubKey);
     const poolId = Cardano.PoolId.fromKeyHash(poolKeyHash);
     const poolRewardAccount = (
-      await poolKeyAgent.deriveAddress({
-        index: 0,
-        type: AddressType.External
-      })
+      await poolKeyAgent.deriveAddress(
+        {
+          index: 0,
+          type: AddressType.External
+        },
+        0
+      )
     ).rewardAccount;
 
     const registrationCert: Cardano.PoolRegistrationCertificate = {

--- a/packages/governance/test/integration/cip36KeyAgents.test.ts
+++ b/packages/governance/test/integration/cip36KeyAgents.test.ts
@@ -37,7 +37,7 @@ describe('cip36', () => {
 
     it('can create cip36 voting registration metadata', async () => {
       // Just ensuring we have some address. SingleAddressWallet already does this internally.
-      await walletKeyAgent.deriveAddress({ index: 0, type: AddressType.External });
+      await walletKeyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
       const paymentAddress = walletKeyAgent.knownAddresses[0].address;
       // InMemoryKeyAgent uses this derivation path for stake key.
       const stakeKey = await walletKeyAgent.derivePublicKey(util.STAKE_KEY_DERIVATION_PATH);

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -160,10 +160,17 @@ export interface KeyAgent {
    * @throws AuthenticationError
    */
   derivePublicKey(derivationPath: AccountKeyDerivationPath): Promise<Crypto.Ed25519PublicKeyHex>;
+
   /**
-   * @throws AuthenticationError
+   * Derives an address from the given payment key and stake key derivation path.
+   *
+   * @param paymentKeyDerivationPath The payment key derivation path.
+   * @param stakeKeyDerivationIndex The stake key index. This field is optional. If not provided it defaults to index 0.
    */
-  deriveAddress(derivationPath: AccountAddressDerivationPath): Promise<GroupedAddress>;
+  deriveAddress(
+    paymentKeyDerivationPath: AccountAddressDerivationPath,
+    stakeKeyDerivationIndex: number
+  ): Promise<GroupedAddress>;
   /**
    * @throws AuthenticationError
    */

--- a/packages/key-management/src/util/createAsyncKeyAgent.ts
+++ b/packages/key-management/src/util/createAsyncKeyAgent.ts
@@ -4,9 +4,9 @@ import { BehaviorSubject } from 'rxjs';
 export const createAsyncKeyAgent = (keyAgent: KeyAgent, onShutdown?: () => void): AsyncKeyAgent => {
   const knownAddresses$ = new BehaviorSubject(keyAgent.knownAddresses);
   return {
-    async deriveAddress(derivationPath) {
+    async deriveAddress(derivationPath, stakeKeyDerivationIndex: number) {
       const numAddresses = keyAgent.knownAddresses.length;
-      const address = await keyAgent.deriveAddress(derivationPath);
+      const address = await keyAgent.deriveAddress(derivationPath, stakeKeyDerivationIndex);
       if (keyAgent.knownAddresses.length > numAddresses) {
         knownAddresses$.next(keyAgent.knownAddresses);
       }

--- a/packages/key-management/test/InMemoryKeyAgent.test.ts
+++ b/packages/key-management/test/InMemoryKeyAgent.test.ts
@@ -107,7 +107,7 @@ describe('InMemoryKeyAgent', () => {
   });
 
   test('deriveAddress', async () => {
-    const address = await keyAgent.deriveAddress({ index: 1, type: AddressType.Internal });
+    const address = await keyAgent.deriveAddress({ index: 1, type: AddressType.Internal }, 0);
     expect(address).toBeDefined();
   });
 
@@ -257,10 +257,13 @@ describe('InMemoryKeyAgent', () => {
         },
         { bip32Ed25519, inputResolver, logger: dummyLogger }
       );
-      const derivedAddress = await keyAgentFromEncryptedKey.deriveAddress({
-        index: 1,
-        type: AddressType.External
-      });
+      const derivedAddress = await keyAgentFromEncryptedKey.deriveAddress(
+        {
+          index: 1,
+          type: AddressType.External
+        },
+        0
+      );
       expect(derivedAddress.rewardAccount).toEqual(daedelusStakeAddress);
     });
 
@@ -273,10 +276,13 @@ describe('InMemoryKeyAgent', () => {
         },
         { bip32Ed25519, inputResolver, logger: dummyLogger }
       );
-      const derivedAddress = await keyAgentFromMnemonic.deriveAddress({
-        index: 1,
-        type: AddressType.External
-      });
+      const derivedAddress = await keyAgentFromMnemonic.deriveAddress(
+        {
+          index: 1,
+          type: AddressType.External
+        },
+        0
+      );
       expect(derivedAddress.rewardAccount).toEqual(daedelusStakeAddress);
     });
   });

--- a/packages/key-management/test/KeyAgentBase.test.ts
+++ b/packages/key-management/test/KeyAgentBase.test.ts
@@ -1,6 +1,13 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, KeyAgentBase, KeyAgentType, KeyRole, SerializableInMemoryKeyAgentData } from '../src';
+import {
+  AccountKeyDerivationPath,
+  AddressType,
+  KeyAgentBase,
+  KeyAgentType,
+  KeyRole,
+  SerializableInMemoryKeyAgentData
+} from '../src';
 import { CML, Cardano } from '@cardano-sdk/core';
 import { dummyLogger } from 'ts-log';
 
@@ -52,7 +59,7 @@ describe('KeyAgentBase', () => {
 
     const index = 1;
     const type = AddressType.External;
-    const address = await keyAgent.deriveAddress({ index, type });
+    const address = await keyAgent.deriveAddress({ index, type }, 0);
 
     expect(address.index).toBe(index);
     expect(address.type).toBe(type);
@@ -64,9 +71,56 @@ describe('KeyAgentBase', () => {
     // creates a new array obj
     expect(keyAgent.knownAddresses).not.toBe(initialAddresses);
 
-    const sameAddress = await keyAgent.deriveAddress({ index, type });
+    const sameAddress = await keyAgent.deriveAddress({ index, type }, 0);
     expect(sameAddress.address).toEqual(address.address);
     expect(keyAgent.knownAddresses.length).toEqual(1);
+  });
+
+  test('deriveAddress derives the address with stake key of the given index', async () => {
+    const keyMap = new Map<number, string>([
+      [0, '0000000000000000000000000000000000000000000000000000000000000000'],
+      [1, '1111111111111111111111111111111111111111111111111111111111111111'],
+      [2, '2222222222222222222222222222222222222222222222222222222222222222'],
+      [3, '3333333333333333333333333333333333333333333333333333333333333333'],
+      [4, '4444444444444444444444444444444444444444444444444444444444444444']
+    ]);
+
+    keyAgent.derivePublicKey = jest.fn((x: AccountKeyDerivationPath) =>
+      Promise.resolve(Crypto.Ed25519PublicKeyHex(keyMap.get(x.index)!))
+    );
+
+    const index = 0;
+    const type = AddressType.External;
+    const addresses = [
+      await keyAgent.deriveAddress({ index, type }, 0),
+      await keyAgent.deriveAddress({ index, type }, 1),
+      await keyAgent.deriveAddress({ index, type }, 2),
+      await keyAgent.deriveAddress({ index, type }, 3)
+    ];
+
+    expect(addresses[0].stakeKeyDerivationPath).toEqual({ index: 0, role: KeyRole.Stake });
+    expect(addresses[0].rewardAccount).toEqual('stake_test1uruaegs6djpxaj9vkn8njh9uys63jdaluetqkf5r4w95zhc8cxn3h');
+    expect(addresses[0].address).toEqual(
+      'addr_test1qruaegs6djpxaj9vkn8njh9uys63jdaluetqkf5r4w95zhlemj3p5myzdmy2edx089wtcfp4rymmlejkpvng82utg90s4cadlm'
+    );
+
+    expect(addresses[1].stakeKeyDerivationPath).toEqual({ index: 1, role: KeyRole.Stake });
+    expect(addresses[1].rewardAccount).toEqual('stake_test1uzx0qqs06evy77cnpk6u5q3fc50exjpp5t4s0swl2ykc4jsmh8tej');
+    expect(addresses[1].address).toEqual(
+      'addr_test1qruaegs6djpxaj9vkn8njh9uys63jdaluetqkf5r4w95zhuv7qpql4jcfaa3xrd4egpzn3gljdyzrghtqlqa75fd3t9qqnvgeq'
+    );
+
+    expect(addresses[2].stakeKeyDerivationPath).toEqual({ index: 2, role: KeyRole.Stake });
+    expect(addresses[2].rewardAccount).toEqual('stake_test1uqcnxxxatdgmqdmz0rhg72kn3n0egek5s0nqcvfy9ztyltc9cpuz4');
+    expect(addresses[2].address).toEqual(
+      'addr_test1qruaegs6djpxaj9vkn8njh9uys63jdaluetqkf5r4w95zhe3xvvd6k63kqmky78w3u4d8rxlj3ndfqlxpscjg2ykf7hs8qc48l'
+    );
+
+    expect(addresses[3].stakeKeyDerivationPath).toEqual({ index: 3, role: KeyRole.Stake });
+    expect(addresses[3].rewardAccount).toEqual('stake_test1urj8hvwxxz0t6pnfttj9ne5leu74shjlg83a8kxww9ft2fqtdhssu');
+    expect(addresses[3].address).toEqual(
+      'addr_test1qruaegs6djpxaj9vkn8njh9uys63jdaluetqkf5r4w95zhly0wcuvvy7h5rxjkhyt8nflneatp097s0r60vvuu2jk5jq73efq0'
+    );
   });
 
   test('derivePublicKey', async () => {

--- a/packages/key-management/test/cip8/cip30signData.test.ts
+++ b/packages/key-management/test/cip8/cip30signData.test.ts
@@ -15,7 +15,7 @@ describe('cip30signData', () => {
     const keyAgentReady = testKeyAgent();
     keyAgent = await keyAgentReady;
     asyncKeyAgent = await testAsyncKeyAgent(undefined, undefined, keyAgentReady);
-    address = await asyncKeyAgent.deriveAddress(addressDerivationPath);
+    address = await asyncKeyAgent.deriveAddress(addressDerivationPath, 0);
   });
 
   const signAndDecode = async (signWith: Cardano.PaymentAddress | Cardano.RewardAccount) => {

--- a/packages/key-management/test/util/createAsyncKeyAgent.test.ts
+++ b/packages/key-management/test/util/createAsyncKeyAgent.test.ts
@@ -29,8 +29,8 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
     expect(await asyncKeyAgent.getChainId()).toEqual(keyAgent.chainId);
   });
   it('deriveAddress/signBlob/signTransaction are unchanged', async () => {
-    await expect(asyncKeyAgent.deriveAddress(addressDerivationPath)).resolves.toEqual(
-      await keyAgent.deriveAddress(addressDerivationPath)
+    await expect(asyncKeyAgent.deriveAddress(addressDerivationPath, 0)).resolves.toEqual(
+      await keyAgent.deriveAddress(addressDerivationPath, 0)
     );
     const keyDerivationPath = { index: 0, role: 0 };
     const blob = HexBlob('abc123');
@@ -48,7 +48,7 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
   });
   it('knownAddresses$ is emits initial addresses and after new address derivation', async () => {
     await expect(firstValueFrom(asyncKeyAgent.knownAddresses$)).resolves.toEqual(keyAgent.knownAddresses);
-    await asyncKeyAgent.deriveAddress(addressDerivationPath);
+    await asyncKeyAgent.deriveAddress(addressDerivationPath, 0);
     await expect(firstValueFrom(asyncKeyAgent.knownAddresses$)).resolves.toEqual(keyAgent.knownAddresses);
   });
   it('stops emitting addresses$ after shutdown', (done) => {
@@ -59,6 +59,6 @@ describe('createAsyncKeyAgent maps KeyAgent to AsyncKeyAgent', () => {
         throw new Error('Should not emit');
       }
     });
-    void asyncKeyAgent.deriveAddress(addressDerivationPath);
+    void asyncKeyAgent.deriveAddress(addressDerivationPath, 0);
   });
 });

--- a/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
+++ b/packages/wallet/src/SingleAddressWallet/SingleAddressWallet.ts
@@ -260,7 +260,7 @@ export class SingleAddressWallet implements ObservableWallet {
               if (addresses.length === 0) {
                 this.#logger.debug('No addresses available; deriving one');
                 void keyAgent
-                  .deriveAddress({ index: 0, type: AddressType.External })
+                  .deriveAddress({ index: 0, type: AddressType.External }, 0)
                   .catch(() => this.#logger.error('Failed to derive address'));
               }
             }

--- a/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/LedgerKeyAgent.test.ts
@@ -34,7 +34,10 @@ describe('LedgerKeyAgent', () => {
           dependencies
         ),
       createWallet: async (ledgerKeyAgent) => {
-        const { address, rewardAccount } = await ledgerKeyAgent.deriveAddress({ index: 0, type: AddressType.External });
+        const { address, rewardAccount } = await ledgerKeyAgent.deriveAddress(
+          { index: 0, type: AddressType.External },
+          0
+        );
         const assetProvider = mocks.mockAssetProvider();
         const stakePoolProvider = createStubStakePoolProvider();
         const networkInfoProvider = mocks.mockNetworkInfoProvider();


### PR DESCRIPTION
# Context

We must update the key agent to support multiple stake address derivation. This is needed to implement multiple staking.

# Proposed Solution

Add a new parameter to the `deriveAddress` function of the key agent that allow us to specify which stake key index we want to generate. 

# Important Changes Introduced

A new optional parameter `stakeKeyDerivationIndex` introduced to the key agent `deriveAddress` function 
