### PR TITLE
refactor(wallet): split hardware wallet tests

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -49,7 +49,8 @@
     "prepack": "yarn build",
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
-    "test:hw": "jest ./test/hardware/* -c ./hw.jest.config.js --runInBand",
+    "test:hw:ledger": "jest ./test/hardware/ledger/* -c ./hw.jest.config.js --runInBand",
+    "test:hw:trezor": "jest ./test/hardware/trezor/* -c ./hw.jest.config.js --runInBand",
     "test:debug": "DEBUG=true yarn test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet"
   },

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.integration.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.integration.test.ts
@@ -2,7 +2,7 @@ import * as Crypto from '@cardano-sdk/crypto';
 import { CML, Cardano } from '@cardano-sdk/core';
 import { CommunicationType, KeyAgent, util } from '@cardano-sdk/key-management';
 import { LedgerKeyAgent } from '@cardano-sdk/hardware-ledger';
-import { ObservableWallet, SingleAddressWallet, restoreKeyAgent, setupWallet } from '../../src';
+import { ObservableWallet, SingleAddressWallet, restoreKeyAgent, setupWallet } from '../../../src';
 import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { firstValueFrom } from 'rxjs';
 import { dummyLogger as logger } from 'ts-log';
@@ -13,7 +13,7 @@ import {
   mockRewardsProvider,
   mockTxSubmitProvider,
   mockUtxoProvider
-} from '../mocks';
+} from '../../mocks';
 
 const createWallet = async (keyAgent: KeyAgent) => {
   const txSubmitProvider = mockTxSubmitProvider();

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
-import * as mocks from '../mocks';
+import * as mocks from '../../mocks';
 import { AddressType, CommunicationType, SerializableLedgerKeyAgentData, util } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { CML, Cardano } from '@cardano-sdk/core';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
-import { InitializeTxProps, InitializeTxResult, SingleAddressWallet, setupWallet } from '../../src';
+import { InitializeTxProps, InitializeTxResult, SingleAddressWallet, setupWallet } from '../../../src';
 import { LedgerKeyAgent, LedgerTransportType } from '@cardano-sdk/hardware-ledger';
 import { dummyLogger as logger } from 'ts-log';
-import { mockKeyAgentDependencies } from '../../../key-management/test/mocks';
+import { mockKeyAgentDependencies } from '../../../../key-management/test/mocks';
 import DeviceConnection from '@cardano-foundation/ledgerjs-hw-app-cardano';
 
 describe('LedgerKeyAgent', () => {

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.integration.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.integration.test.ts
@@ -1,7 +1,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { CML, Cardano } from '@cardano-sdk/core';
 import { CommunicationType, KeyAgent, TrezorKeyAgent, util } from '@cardano-sdk/key-management';
-import { ObservableWallet, SingleAddressWallet, restoreKeyAgent, setupWallet } from '../../src';
+import { ObservableWallet, SingleAddressWallet, restoreKeyAgent, setupWallet } from '../../../src';
 import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { firstValueFrom } from 'rxjs';
 import { dummyLogger as logger } from 'ts-log';
@@ -12,7 +12,7 @@ import {
   mockRewardsProvider,
   mockTxSubmitProvider,
   mockUtxoProvider
-} from '../mocks';
+} from '../../mocks';
 
 const createWallet = async (keyAgent: KeyAgent) => {
   const txSubmitProvider = mockTxSubmitProvider();

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
@@ -1,5 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import * as mocks from '../mocks';
+import * as mocks from '../../mocks';
 import {
   AddressType,
   CommunicationType,
@@ -10,9 +10,9 @@ import {
 } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider } from '@cardano-sdk/util-dev';
 import { CML, Cardano } from '@cardano-sdk/core';
-import { SingleAddressWallet, setupWallet } from '../../src';
+import { SingleAddressWallet, setupWallet } from '../../../src';
 import { dummyLogger as logger } from 'ts-log';
-import { mockKeyAgentDependencies } from '../../../key-management/test/mocks';
+import { mockKeyAgentDependencies } from '../../../../key-management/test/mocks';
 
 describe('TrezorKeyAgent', () => {
   let keyAgent: TrezorKeyAgent;


### PR DESCRIPTION
# Context

Tests for hardware wallets split in two for Trezor and Ledger.
