### PR TITLE
fix(key-management): fixed ttl

### DIFF
--- a/packages/key-management/src/util/mapHardwareSigningData.ts
+++ b/packages/key-management/src/util/mapHardwareSigningData.ts
@@ -961,7 +961,7 @@ export const txToTrezor = async ({
   let ttl;
   const cslTTL = cslTxBody.ttl();
   if (cslTTL) {
-    ttl = cslTTL.toString();
+    ttl = cslTTL.to_str();
   }
 
   const validityIntervalStart = cslTxBody.validity_start_interval()?.to_str();


### PR DESCRIPTION
# Context

Incorrect TTL value prevented transaction from signing.



