### PR TITLE
refactor: restore `AssetInfo.quantity` as depreciated field for backwards compat

### DIFF
--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -1,10 +1,5 @@
-import { Asset, AssetProvider } from '@cardano-sdk/core';
-import {
-  CreateHttpProviderConfig,
-  HttpProviderConfig,
-  HttpProviderConfigPaths,
-  createHttpProvider
-} from '../HttpProvider';
+import { AssetProvider } from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
 
 /**
  * The AssetProvider endpoint paths.
@@ -15,23 +10,6 @@ const paths: HttpProviderConfigPaths<AssetProvider> = {
   healthCheck: '/health'
 };
 
-const isAssetInfo = (assetInfo: unknown): assetInfo is Asset.AssetInfo => !!(assetInfo as Asset.AssetInfo)?.assetId;
-
-const transformQuantityToSupply = (assetInfo: Asset.AssetInfo | unknown): Asset.AssetInfo | unknown => {
-  if (isAssetInfo(assetInfo) && assetInfo.supply === undefined) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { quantity, ...assetInfoReduced } = assetInfo as any;
-    return { ...assetInfoReduced, supply: quantity } as Asset.AssetInfo;
-  }
-  return assetInfo;
-};
-
-const responseTransformers: HttpProviderConfig<AssetProvider>['responseTransformers'] = {
-  getAsset: (data: unknown): unknown => transformQuantityToSupply(data),
-  getAssets: (data: unknown): unknown =>
-    Array.isArray(data) ? data.map((assetInfo) => transformQuantityToSupply(assetInfo)) : data
-};
-
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
  *
@@ -40,6 +18,5 @@ const responseTransformers: HttpProviderConfig<AssetProvider>['responseTransform
 export const assetInfoHttpProvider = (config: CreateHttpProviderConfig<AssetProvider>): AssetProvider =>
   createHttpProvider<AssetProvider>({
     ...config,
-    paths,
-    responseTransformers
+    paths
   });

--- a/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
@@ -1,7 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
 import { assetInfoHttpProvider } from '../../src';
 import { logger } from '@cardano-sdk/util-dev';
-import { toSerializableObject } from '@cardano-sdk/util';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
@@ -41,26 +40,6 @@ describe('assetInfoHttpProvider', () => {
           assetIds: [Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958')]
         })
       ).resolves.toEqual({});
-    });
-
-    test('getAsset maps legacy assetInfo `quantity` as `supply`', async () => {
-      axiosMock.onPost().replyOnce(200, toSerializableObject({ assetId: 'dummy', quantity: 2n }));
-      const provider = assetInfoHttpProvider(config);
-      await expect(
-        provider.getAsset({
-          assetId: Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958')
-        })
-      ).resolves.toEqual({ assetId: 'dummy', supply: 2n });
-    });
-
-    test('getAssets maps legacy assetInfo `quantity` as `supply`', async () => {
-      axiosMock.onPost().replyOnce(200, toSerializableObject([{ assetId: 'dummy', quantity: 2n }]));
-      const provider = assetInfoHttpProvider(config);
-      await expect(
-        provider.getAssets({
-          assetIds: [Cardano.AssetId('f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc53541474958')]
-        })
-      ).resolves.toEqual([{ assetId: 'dummy', supply: 2n }]);
     });
   });
 });

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -132,8 +132,10 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
 
     const fingerprint = multiAsset.fingerprint as unknown as Cardano.AssetFingerprint;
     const supply = BigInt(multiAsset.sum);
+    // Backwards compatibility
+    const quantity = supply;
     const mintOrBurnCount = Number(multiAsset.count);
 
-    return { assetId, fingerprint, mintOrBurnCount, name, policyId, supply };
+    return { assetId, fingerprint, mintOrBurnCount, name, policyId, quantity, supply };
   }
 }

--- a/packages/cardano-services/src/Asset/openApi.json
+++ b/packages/cardano-services/src/Asset/openApi.json
@@ -129,6 +129,10 @@
           },
           "supply": {
             "$ref": "#/components/schemas/BigInt"
+          },
+          "quantity": {
+            "$ref": "#/components/schemas/BigInt",
+            "deprecated": true
           }
         }
       },

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -84,6 +84,7 @@ describe('DbSyncAssetProvider', () => {
       mintOrBurnCount: 1,
       name: '6d616361726f6e2d63616b65',
       policyId: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb',
+      quantity: 1n,
       supply: 1n
     });
   });

--- a/packages/core/src/Asset/types/AssetInfo.ts
+++ b/packages/core/src/Asset/types/AssetInfo.ts
@@ -16,6 +16,10 @@ export interface AssetInfo {
   policyId: PolicyId;
   name: AssetName;
   fingerprint: AssetFingerprint;
+  /**
+   * @deprecated Use `supply` instead
+   */
+  quantity: bigint;
   supply: bigint;
   mintOrBurnCount: number;
   /**

--- a/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
@@ -198,6 +198,7 @@ describe('PersonalWallet.assets/nft', () => {
       policyId,
       // in case of repeated tests on the same network, total asset supply is not updated due to
       // the limitation that asset info is not refreshed on wallet balance changes
+      quantity: expect.anything(),
       supply: expect.anything(),
       tokenMetadata: null
     });
@@ -356,6 +357,7 @@ describe('PersonalWallet.assets/nft', () => {
             version: '1.0'
           },
           policyId,
+          quantity: expect.anything(),
           supply: expect.anything(),
           tokenMetadata: null
         });

--- a/packages/util-dev/src/mockProviders/mockAssetProvider.ts
+++ b/packages/util-dev/src/mockProviders/mockAssetProvider.ts
@@ -12,6 +12,7 @@ export const asset = {
   name: Cardano.AssetName('54534c41'),
   nftMetadata: null,
   policyId: Cardano.PolicyId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373'),
+  quantity: 1000n,
   supply: 1000n,
   tokenMetadata: null
 } as Asset.AssetInfo;


### PR DESCRIPTION
# Context
A compatibility mapping was made in 6e28df412797974b8ce6f6deb0c3346ff5938a05, however it's only sufficient for newer clients connecting to the older API, but was a breaking change, and didn't cover backwards compatibility with older clients.

# Proposed Solution
- Restore the field as depreciated
- Remove the client-side compatibility mapping, which is no longer required.


