### PR TITLE
refactor(cardano-services): bypass CORS policy when no Origin header set

### DIFF
--- a/packages/cardano-services/src/Http/util.ts
+++ b/packages/cardano-services/src/Http/util.ts
@@ -10,7 +10,7 @@ type StaticOrigin = boolean | string | RegExp | (boolean | string | RegExp)[];
 
 export const corsOptions = (allowedOrigins: Set<string>) => ({
   origin(requestOrigin: string | undefined, callback: (err: Error | null, options?: StaticOrigin) => void) {
-    if (requestOrigin && allowedOrigins.has(requestOrigin)) {
+    if (!requestOrigin || allowedOrigins.has(requestOrigin)) {
       callback(null, requestOrigin);
     } else {
       callback(new ProviderError(ProviderFailure.Forbidden, null, `Origin ${requestOrigin} not allowed by CORS`));

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -581,6 +581,28 @@ describe('HttpServer', () => {
       expect(res.headers['access-control-allow-origin']).toEqual(allowedOrigin);
     });
 
+    it('allows requests with no origin header', async () => {
+      httpServer = new HttpServer(
+        { allowedOrigins: [allowedOrigin], listen: { host: 'localhost', port } },
+        {
+          logger,
+          runnableDependencies: [cardanoNode],
+          services: [new SomeHttpService(ServiceNames.Utxo, provider, logger)]
+        }
+      );
+
+      await httpServer.initialize();
+      await httpServer.start();
+      await serverStarted(apiUrlBase, 404, { [ORIGIN]: allowedOrigin });
+
+      const res = await axios.get(`${apiUrlBase}/health`, {
+        headers: { [CONTENT_TYPE]: 'application/json' }
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.data).toBeDefined();
+    });
+
     it('rejects requests from disallowed origins', async () => {
       httpServer = new HttpServer(
         { allowedOrigins: [allowedOrigin], listen: { host: 'localhost', port } },


### PR DESCRIPTION


# Context
The current implementation blocks monitoring services from accessing `/metrics` and `/health` when CORS is enabled, which is too restrictive, given CORS is a client-side security measure.

# Proposed Solution
Only enforce CORS if an `Origin` HTTP header is set.

