### PR TITLE
Docs/root readme badges + post-integration fix?

### DIFF
--- a/.github/workflows/post_integration.yml
+++ b/.github/workflows/post_integration.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: 🔨 Build Docs
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: "--max-old-space-size=10240"
         run: |
           yarn install --immutable --inline-builds
           yarn build

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 </p>
 
 [![PostIntegration][img_src_post-integration]][workflow_post-integration]
-[![Nightly][img_src_nightly]][workflow_nightly]
 [![Release][img_src_release]][workflow_release]
 
 <hr/>
@@ -142,8 +141,6 @@ yarn docs
 
 [img_src_post-integration]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/post_integration.yml/badge.svg
 [workflow_post-integration]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/post_integration.yml
-[img_src_nightly]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/nightly-test.yaml/badge.svg
-[workflow_nightly]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/nightly-test.yaml
 [img_src_release]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/release.yaml/badge.svg
 [workflow_release]: https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/release.yaml
 [Docker Desktop]: https://docs.docker.com/desktop/


### PR DESCRIPTION
# Context

1. The root readme has a badge for the legacy nightly workflow.
2. Post-integration workflow is failing on docs build. 

# Proposed Solution

1. Remove the link
2. Increase the allocation to `max-old-space-size` by 50%
