### PR TITLE
Lw 6822 in memory key agent should take into account required signers

### DIFF
--- a/packages/hardware-ledger/src/transformers/requiredSigners.ts
+++ b/packages/hardware-ledger/src/transformers/requiredSigners.ts
@@ -10,18 +10,18 @@ export const toRequiredSigner: Transform<
   Ledger.RequiredSigner,
   LedgerTxTransformerContext
 > = (keyHash, context) => {
-  const knowAddress = context?.knownAddresses.find((address) => {
+  const paymentCredKnownAddress = context?.knownAddresses.find((address) => {
     const paymentCredential = Cardano.Address.fromBech32(address.address)?.asBase()?.getPaymentCredential().hash;
-    const stakingCredential = Cardano.RewardAccount.toHash(address.rewardAccount);
-
-    return (
-      (paymentCredential && paymentCredential.toString() === keyHash) ||
-      (stakingCredential && stakingCredential.toString() === keyHash)
-    );
+    return paymentCredential && paymentCredential.toString() === keyHash;
   });
 
-  const paymentPath = knowAddress ? paymentKeyPathFromGroupedAddress(knowAddress) : null;
-  const stakingPath = knowAddress ? stakeKeyPathFromGroupedAddress(knowAddress) : null;
+  const stakeCredKnownAddress = context?.knownAddresses.find((address) => {
+    const stakingCredential = Cardano.RewardAccount.toHash(address.rewardAccount);
+    return stakingCredential && stakingCredential.toString() === keyHash;
+  });
+
+  const paymentPath = paymentCredKnownAddress ? paymentKeyPathFromGroupedAddress(paymentCredKnownAddress) : null;
+  const stakingPath = stakeCredKnownAddress ? stakeKeyPathFromGroupedAddress(stakeCredKnownAddress) : null;
 
   if (paymentPath) {
     return {

--- a/packages/hardware-ledger/test/testData.ts
+++ b/packages/hardware-ledger/test/testData.ts
@@ -7,7 +7,7 @@ export const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
 export const paymentAddress = Cardano.PaymentAddress(
   'addr1qxdtr6wjx3kr7jlrvrfzhrh8w44qx9krcxhvu3e79zr7497tpmpxjfyhk3vwg6qjezjmlg5nr5dzm9j6nxyns28vsy8stu5lh6'
 );
-export const paymentHash = Crypto.Hash28ByteBase16('9ab1e9d2346c3f4be360d22b8ee7756a0316c3c1aece473e2887ea97');
+export const paymentHash = Crypto.Ed25519KeyHashHex('9ab1e9d2346c3f4be360d22b8ee7756a0316c3c1aece473e2887ea97');
 export const ownerRewardAccount = Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr');
 export const poolId = Cardano.PoolId('pool1ev8vy6fyj7693ergzty2t0azjvw35tvkt2vcjwpgajqs7z6u2vn');
 export const poolId2 = Cardano.PoolId('pool1z5uqdk7dzdxaae5633fqfcu2eqzy3a3rgtuvy087fdld7yws0xt');

--- a/packages/hardware-ledger/test/transformers/requiredsigners.test.ts
+++ b/packages/hardware-ledger/test/transformers/requiredsigners.test.ts
@@ -1,5 +1,5 @@
 import * as Ledger from '@cardano-foundation/ledgerjs-hw-app-cardano';
-import { CONTEXT_WITHOUT_KNOWN_ADDRESSES, CONTEXT_WITH_KNOWN_ADDRESSES, stakeKeyHash } from '../testData';
+import { CONTEXT_WITHOUT_KNOWN_ADDRESSES, CONTEXT_WITH_KNOWN_ADDRESSES, paymentHash, stakeKeyHash } from '../testData';
 import { CardanoKeyConst, util } from '@cardano-sdk/key-management';
 import { mapRequiredSigners, toRequiredSigner } from '../../src/transformers';
 
@@ -11,21 +11,20 @@ describe('requiredSigners', () => {
     });
 
     it('can map a a set of required signers', async () => {
-      const signers = await mapRequiredSigners(
-        [stakeKeyHash, stakeKeyHash, stakeKeyHash],
-        CONTEXT_WITH_KNOWN_ADDRESSES
-      );
+      const signers = await mapRequiredSigners([stakeKeyHash, paymentHash], CONTEXT_WITH_KNOWN_ADDRESSES);
 
-      expect(signers!.length).toEqual(3);
+      expect(signers).not.toBeNull();
+      expect(signers!.length).toEqual(2);
 
-      for (const signer of signers!) {
-        expect(signer).toEqual({
-          path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 1, 0],
-          type: Ledger.TxRequiredSignerType.PATH
-        });
-      }
+      expect(signers![0]).toEqual({
+        path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 2, 0],
+        type: Ledger.TxRequiredSignerType.PATH
+      });
 
-      expect.assertions(4);
+      expect(signers![1]).toEqual({
+        path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 1, 0],
+        type: Ledger.TxRequiredSignerType.PATH
+      });
     });
   });
   describe('toRequiredSigner', () => {
@@ -33,7 +32,7 @@ describe('requiredSigners', () => {
       const requiredSigner = toRequiredSigner(stakeKeyHash, CONTEXT_WITH_KNOWN_ADDRESSES);
 
       expect(requiredSigner).toEqual({
-        path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 1, 0],
+        path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 2, 0],
         type: Ledger.TxRequiredSignerType.PATH
       });
     });

--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -1,8 +1,11 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { AccountKeyDerivationPath, GroupedAddress } from '../types';
 import { Cardano } from '@cardano-sdk/core';
 import { isNotNil } from '@cardano-sdk/util';
+import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import uniqBy from 'lodash/uniqBy';
+import uniqWith from 'lodash/uniqWith';
 
 /**
  * Gets whether any certificate in the provided certificate list requires a stake key signature.
@@ -60,6 +63,39 @@ const getStakingKeyPaths = (
 };
 
 /**
+ * Search for the key hashes provided in the requiredSigners in our current set of known addresses.
+ *
+ * @param groupedAddresses The known grouped addresses.
+ * @param keyHashes The list of required signers key hashes (or undefined if none).
+ * @returns A set of derivation paths if any of the key hashes is found.
+ */
+const getRequiredSignersKeyPaths = (
+  groupedAddresses: GroupedAddress[],
+  keyHashes?: Crypto.Ed25519KeyHashHex[]
+): Set<AccountKeyDerivationPath> => {
+  const paths: Set<AccountKeyDerivationPath> = new Set();
+
+  if (!keyHashes) return paths;
+
+  for (const keyHash of keyHashes) {
+    for (const address of groupedAddresses) {
+      const paymentCredential = Cardano.Address.fromBech32(address.address)?.asBase()?.getPaymentCredential().hash;
+      const stakingCredential = Cardano.RewardAccount.toHash(address.rewardAccount);
+
+      if (paymentCredential && paymentCredential.toString() === keyHash) {
+        paths.add({ index: address.index, role: Number(address.type) });
+      }
+
+      if (stakingCredential && address.stakeKeyDerivationPath && stakingCredential.toString() === keyHash) {
+        paths.add(address.stakeKeyDerivationPath);
+      }
+    }
+  }
+
+  return paths;
+};
+
+/**
  * Assumes that a single staking key is used for all addresses (index=0)
  *
  * @returns {AccountKeyDerivationPath[]} derivation paths for keys to sign transaction with
@@ -82,5 +118,12 @@ export const ownSignatureKeyPaths = async (
     ).filter(isNotNil)
   ).map(({ type, index }) => ({ index, role: Number(type) }));
 
-  return [...paymentKeyPaths, ...getStakingKeyPaths(knownAddresses, txBody)];
+  return uniqWith(
+    [
+      ...paymentKeyPaths,
+      ...getStakingKeyPaths(knownAddresses, txBody),
+      ...getRequiredSignersKeyPaths(knownAddresses, txBody.requiredExtraSignatures)
+    ],
+    isEqual
+  );
 };


### PR DESCRIPTION
# Context

The InMemoryKeyAgent is ignoring the requireSigners field of the transaction when determining which key to use to sign the transaction.

# Proposed Solution

Make the InMemoryKeyAgent search for the keys specified in the requireSigners field.

# Important Changes Introduced

- Fixed an issue in the InMemoryKeyAgent which was preventing added signers to the requireSigners to be consider for signing.
- Fixed an issue in the LedgerKeyAgent that was preventing stake key hashes in the requiredSigners field to be map correctly
