### PR TITLE
Feat/Improve CardanoTokenRegistry logging

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
 
           cp -r ${production-deps}/libexec/$sourceRoot/node_modules $out/libexec/$sourceRoot/node_modules
           cp -r scripts $out/libexec/$sourceRoot/scripts
-          for p in cardano-services core ogmios util crypto projection projection-typeorm util-rxjs; do
+          for p in cardano-services cardano-services-client core ogmios util crypto projection projection-typeorm util-rxjs; do
             mkdir -p $out/libexec/$sourceRoot/packages/$p
             cp -r packages/$p/dist $out/libexec/$sourceRoot/packages/$p/dist
             cp -r packages/$p/package.json $out/libexec/$sourceRoot/packages/$p/package.json

--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -131,7 +131,7 @@ export class CardanoTokenRegistry implements TokenMetadataService {
     // All metadata was taken from cache
     if (assetIdsToRequest.length === 0) return tokenMetadata;
 
-    this.#logger.info(`Fetching batch of ${assetIdsToRequest.length} assetIds`);
+    this.#logger.debug(`Fetching batch of ${assetIdsToRequest.length} assetIds`);
 
     try {
       const response = await this.#axiosClient.post<{ subjects: TokenMetadataServiceRecord[] }>('metadata/query', {

--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -54,7 +54,7 @@ export interface CardanoTokenRegistryConfiguration {
   tokenMetadataCacheTTL?: number;
 
   /**
-   * The Cardano Token Registry public API base URL. Default: https://tokens.cardano.org
+   * The Cardano Token Registry API base URL. Default: https://tokens.cardano.org
    */
   tokenMetadataServerUrl?: string;
 
@@ -85,7 +85,7 @@ export interface CardanoTokenRegistryDependencies {
 }
 
 /**
- * TokenMetadataService implementation using Cardano Token Registry public API
+ * TokenMetadataService implementation using Cardano Token Registry API
  */
 export class CardanoTokenRegistry implements TokenMetadataService {
   /**

--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -4,6 +4,7 @@ import { Logger } from 'ts-log';
 import { TokenMetadataService } from './types';
 import { contextLogger } from '@cardano-sdk/util';
 import axios, { AxiosInstance } from 'axios';
+import pick from 'lodash/pick';
 
 export const DEFAULT_TOKEN_METADATA_CACHE_TTL = 600;
 export const DEFAULT_TOKEN_METADATA_REQUEST_TIMEOUT = 3 * 1000;
@@ -107,16 +108,17 @@ export class CardanoTokenRegistry implements TokenMetadataService {
     const defaultConfig: CardanoTokenRegistryConfigurationWithRequired = {
       tokenMetadataCacheTTL: DEFAULT_TOKEN_METADATA_CACHE_TTL,
       tokenMetadataRequestTimeout: DEFAULT_TOKEN_METADATA_REQUEST_TIMEOUT,
-      tokenMetadataServerUrl: DEFAULT_TOKEN_METADATA_SERVER_URL,
-      ...config
+      tokenMetadataServerUrl: DEFAULT_TOKEN_METADATA_SERVER_URL
     };
-
-    this.#cache = cache || new InMemoryCache(defaultConfig.tokenMetadataCacheTTL);
+    const configKeys = Object.keys(defaultConfig);
+    const mergedConfig = { ...defaultConfig, ...config };
+    this.#cache = cache || new InMemoryCache(mergedConfig.tokenMetadataCacheTTL);
     this.#axiosClient = axios.create({
-      baseURL: defaultConfig.tokenMetadataServerUrl,
-      timeout: defaultConfig.tokenMetadataRequestTimeout
+      baseURL: mergedConfig.tokenMetadataServerUrl,
+      timeout: mergedConfig.tokenMetadataRequestTimeout
     });
     this.#logger = contextLogger(logger, 'CardanoTokenRegistry');
+    this.#logger.info('Config:', pick(mergedConfig, configKeys));
   }
 
   shutdown() {

--- a/packages/util/src/RunnableModule.ts
+++ b/packages/util/src/RunnableModule.ts
@@ -64,7 +64,7 @@ export abstract class RunnableModule {
       throw new InvalidModuleState<RunnableModuleState>(this.name, 'start', 'initialized');
     }
     this.state = 'starting';
-    this.logger.info('Starting');
+    this.logger.info('Starting...');
   }
 
   startAfter() {
@@ -80,7 +80,7 @@ export abstract class RunnableModule {
       throw new InvalidModuleState<RunnableModuleState>(this.name, 'shutdown', 'running');
     }
     this.state = 'stopping';
-    this.logger.info('Stopping');
+    this.logger.info('Stopping...');
   }
 
   shutdownAfter() {
@@ -88,6 +88,6 @@ export abstract class RunnableModule {
       throw new InvalidModuleState<RunnableModuleState>(this.name, 'shutdown', 'stopping');
     }
     this.state = 'initialized';
-    this.logger.info('Shutdown complete...');
+    this.logger.info('Shutdown complete');
   }
 }


### PR DESCRIPTION
# Context
The configured `CardanoTokenRegistry` URL isn't logged anywhere, and with a default value in place, it would be more transparent to log when starting up.

# Proposed Solution
- Log the config object on construction.

# Important Changes Introduced
- Also changes the log level within `getTokenMetadata`, as it's too noisy for `info`, and more suited to `debug`. 