### PR TITLE
chore: remove contributors arrays everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,20 +44,6 @@
   "keywords": [
     "Cardano"
   ],
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/input-output-hk/cardano-js-sdk/issues"

--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -18,20 +18,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -19,20 +19,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:cjs": "tsc --build src && shx chmod +x ./dist/cjs/cli.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -18,15 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/dapp-connector/package.json
+++ b/packages/dapp-connector/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -73,20 +73,6 @@
     "wait-for-network": "ts-node src/scripts/is-local-network-ready.ts"
   },
   "repository": "https://github.com/input-output-hk/cardano-js-sdk",
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -19,20 +19,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -18,16 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/hardware-ledger/package.json
+++ b/packages/hardware-ledger/package.json
@@ -18,15 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/input-selection/package.json
+++ b/packages/input-selection/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -18,15 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/projection-typeorm/package.json
+++ b/packages/projection-typeorm/package.json
@@ -18,15 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/projection/package.json
+++ b/packages/projection/package.json
@@ -18,15 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/tx-construction/package.json
+++ b/packages/tx-construction/package.json
@@ -18,15 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -22,20 +22,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/util-rxjs/package.json
+++ b/packages/util-rxjs/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -18,20 +18,6 @@
     "access": "public"
   },
   "sideEffects": false,
-  "contributors": [
-    "Rhys Bartels-Waller <rhys.bartelswaller@iohk.io> (https://iohk.io)",
-    "Martynas Kazlauskas <martynas.kazlauskas@iohk.io> (https://iohk.io)",
-    "Daniele Ricci <daniele.ricci@iohk.io> (https://iohk.io)",
-    "Ivaylo Andonov <ivaylo.andonov@iohk.io> (https://iohk.io)",
-    "Mircea Hasegan <mircea.hasegan@iohk.io> (https://iohk.io)",
-    "Angel Castillo Bacigalupi <angel.castillo@iohk.io> (https://iohk.io)",
-    "Seung Eun Song <seungeun.song@iohk.io> (https://iohk.io)",
-    "Dmytro Iakymenko <dmytro.iakymenko@iohk.io> (https://iohk.io)",
-    "Tomislav Horaček <tomislav.horacek@iohk.io> (https://iohk.io)",
-    "Michael Chappell <michael.chappell@iohk.io> (https://iohk.io)",
-    "Leonel Gobbi <leonel.gobbi@globant.com> (https://www.globant.com)",
-    "Juan Cruz Vieiro <juan.vieiro@globant.com> (https://www.globant.com)"
-  ],
   "license": "Apache-2.0",
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",


### PR DESCRIPTION
# Context

This PR removes the `contributors` arrays in all package.json files since those are hard to maintain and contributions can be analyzed based on Git more easily.

# Important Changes Introduced

none
