### PR TITLE
Handle server and client providers

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -61,7 +61,7 @@ x-provider-server-environment: &provider-server-environment
   DISABLE_STAKE_POOL_METRIC_APY: ${DISABLE_STAKE_POOL_METRIC_APY:-false}
   ENABLE_METRICS: ${ENABLE_METRICS:-false}
   EPOCH_POLL_INTERVAL: ${EPOCH_POLL_INTERVAL:-500}
-  SERVICE_NAMES: ${SERVICE_NAMES:-asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo}
+  SERVICE_NAMES: ${SERVICE_NAMES:-asset,chain-history,handle,network-info,rewards,stake-pool,tx-submit,utxo}
   USE_BLOCKFROST: ${USE_BLOCKFROST:-false}
   USE_QUEUE: ${USE_QUEUE:-false}
 
@@ -69,16 +69,22 @@ x-sdk-environment: &sdk-environment
   LOGGER_MIN_SEVERITY: ${LOGGER_MIN_SEVERITY:-info}
   OGMIOS_URL: ws://cardano-node-ogmios:1337
   POSTGRES_DB_FILE_DB_SYNC: /run/secrets/postgres_db_db_sync
+  POSTGRES_DB_FILE_HANDLE: /run/secrets/postgres_db_handle
   POSTGRES_DB_FILE_STAKE_POOL: /run/secrets/postgres_db_stake_pool
   POSTGRES_HOST_DB_SYNC: postgres
+  POSTGRES_HOST_HANDLE: postgres
   POSTGRES_HOST_STAKE_POOL: postgres
   POSTGRES_POOL_MAX_DB_SYNC: ${POSTGRES_POOL_MAX:-10}
+  POSTGRES_POOL_MAX_HANDLE: ${POSTGRES_POOL_MAX:-10}
   POSTGRES_POOL_MAX_STAKE_POOL: ${POSTGRES_POOL_MAX:-10}
   POSTGRES_PASSWORD_FILE_DB_SYNC: /run/secrets/postgres_password
+  POSTGRES_PASSWORD_FILE_HANDLE: /run/secrets/postgres_password
   POSTGRES_PASSWORD_FILE_STAKE_POOL: /run/secrets/postgres_password
   POSTGRES_PORT_DB_SYNC: 5432
+  POSTGRES_PORT_HANDLE: 5432
   POSTGRES_PORT_STAKE_POOL: 5432
   POSTGRES_USER_FILE_DB_SYNC: /run/secrets/postgres_user
+  POSTGRES_USER_FILE_HANDLE: /run/secrets/postgres_user
   POSTGRES_USER_FILE_STAKE_POOL: /run/secrets/postgres_user
   RABBITMQ_URL: amqp://rabbitmq:5672
 

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -5,11 +5,15 @@ services:
     volumes:
       - ../..:/app
 
-  projector:
+  handle-projector:
     volumes:
       - ../..:/app
 
   provider-server:
+    volumes:
+      - ../..:/app
+
+  stake-pool-projector:
     volumes:
       - ../..:/app
 

--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -1,5 +1,5 @@
-import { AssetProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { AssetProvider, HttpProviderConfigPaths } from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
 
 /**
  * The AssetProvider endpoint paths.

--- a/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
+++ b/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
@@ -1,5 +1,5 @@
-import { ChainHistoryProvider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { ChainHistoryProvider, HttpProviderConfigPaths, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
 
 /**
  * The ChainHistoryProvider endpoint paths.

--- a/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
@@ -1,0 +1,21 @@
+import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import { HandleProvider } from '@cardano-sdk/core';
+
+/**
+ * The HandleProvider endpoint paths.
+ */
+const paths: HttpProviderConfigPaths<HandleProvider> = {
+  healthCheck: '/health',
+  resolveHandles: '/resolve'
+};
+
+/**
+ * Connect to a Cardano Services HttpServer instance with the service available
+ *
+ * @param config The configuration object fot the HandleProvider.
+ */
+export const handleHttpProvider = (config: CreateHttpProviderConfig<HandleProvider>): HandleProvider =>
+  createHttpProvider<HandleProvider>({
+    ...config,
+    paths
+  });

--- a/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
@@ -1,13 +1,5 @@
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
-import { HandleProvider } from '@cardano-sdk/core';
-
-/**
- * The HandleProvider endpoint paths.
- */
-const paths: HttpProviderConfigPaths<HandleProvider> = {
-  healthCheck: '/health',
-  resolveHandles: '/resolve'
-};
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
+import { HandleProvider, handleProviderPaths } from '@cardano-sdk/core';
 
 /**
  * Connect to a Cardano Services HttpServer instance with the service available
@@ -17,5 +9,5 @@ const paths: HttpProviderConfigPaths<HandleProvider> = {
 export const handleHttpProvider = (config: CreateHttpProviderConfig<HandleProvider>): HandleProvider =>
   createHttpProvider<HandleProvider>({
     ...config,
-    paths
+    paths: handleProviderPaths
   });

--- a/packages/cardano-services-client/src/HandleProvider/index.ts
+++ b/packages/cardano-services-client/src/HandleProvider/index.ts
@@ -1,1 +1,2 @@
 export * from './KoraLabsHandleProvider';
+export * from './handleHttpProvider';

--- a/packages/cardano-services-client/src/HttpProvider.ts
+++ b/packages/cardano-services-client/src/HttpProvider.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { HttpProviderConfigPaths, Provider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
-import { ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
 import axios, { AxiosAdapter, AxiosRequestConfig, AxiosResponseTransformer } from 'axios';
 
 const isEmptyResponse = (response: any) => response === '';
 
-export type HttpProviderConfigPaths<T> = { [methodName in keyof T]: string };
 type ResponseTransformers<T> = { [K in keyof T]?: AxiosResponseTransformer };
 
-export interface HttpProviderConfig<T> {
+export interface HttpProviderConfig<T extends Provider> {
   /**
    * Example: "http://localhost:3000"
    */
@@ -53,7 +52,10 @@ export interface HttpProviderConfig<T> {
  * The subset of parameters from HttpProviderConfig that must be set by the
  * client code.
  */
-export type CreateHttpProviderConfig<T> = Pick<HttpProviderConfig<T>, 'baseUrl' | 'adapter' | 'logger'>;
+export type CreateHttpProviderConfig<T extends Provider> = Pick<
+  HttpProviderConfig<T>,
+  'baseUrl' | 'adapter' | 'logger'
+>;
 
 /**
  * Creates a HTTP client for specified provider type, following some conventions:
@@ -65,7 +67,7 @@ export type CreateHttpProviderConfig<T> = Pick<HttpProviderConfig<T>, 'baseUrl' 
  *
  * @returns provider that fetches data over http
  */
-export const createHttpProvider = <T extends object>({
+export const createHttpProvider = <T extends Provider>({
   baseUrl,
   axiosOptions,
   mapError,

--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -1,5 +1,5 @@
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
-import { NetworkInfoProvider } from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
+import { HttpProviderConfigPaths, NetworkInfoProvider } from '@cardano-sdk/core';
 
 /**
  * The NetworkInfoProvider endpoint paths.

--- a/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
+++ b/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
@@ -1,5 +1,5 @@
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
-import { ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
+import { HttpProviderConfigPaths, ProviderError, ProviderFailure, RewardsProvider } from '@cardano-sdk/core';
 import { mapHealthCheckError } from '../mapHealthCheckError';
 
 /**

--- a/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
+++ b/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
@@ -1,5 +1,5 @@
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
-import { StakePoolProvider } from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
+import { HttpProviderConfigPaths, StakePoolProvider } from '@cardano-sdk/core';
 
 /**
  * The StakePoolProvider endpoint paths.

--- a/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
@@ -1,6 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { CardanoNodeErrors, ProviderError, ProviderFailure, TxSubmitProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
+import {
+  CardanoNodeErrors,
+  HttpProviderConfigPaths,
+  ProviderError,
+  ProviderFailure,
+  TxSubmitProvider
+} from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
 import { mapHealthCheckError } from '../mapHealthCheckError';
 
 /**

--- a/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
+++ b/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
@@ -1,5 +1,5 @@
-import { CreateHttpProviderConfig, HttpProviderConfigPaths, createHttpProvider } from '../HttpProvider';
-import { ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
+import { CreateHttpProviderConfig, createHttpProvider } from '../HttpProvider';
+import { HttpProviderConfigPaths, ProviderError, ProviderFailure, UtxoProvider } from '@cardano-sdk/core';
 import { mapHealthCheckError } from '../mapHealthCheckError';
 
 /**

--- a/packages/cardano-services-client/test/HandleProvider/handleHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HandleProvider/handleHttpProvider.test.ts
@@ -1,0 +1,29 @@
+import { handleHttpProvider } from '../../src';
+import { logger } from '@cardano-sdk/util-dev';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+const config = { baseUrl: 'http://some-hostname:3000/handle', logger };
+
+describe('handleHttpProvider', () => {
+  let axiosMock: MockAdapter;
+
+  beforeAll(() => {
+    axiosMock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  afterAll(() => {
+    axiosMock.restore();
+  });
+
+  test("resolve handles doesn't throw when called with an empty array of handles", async () => {
+    const provider = handleHttpProvider(config);
+
+    axiosMock.onPost().replyOnce(200, []);
+    await expect(provider.resolveHandles({ handles: [] })).resolves.toEqual([]);
+  });
+});

--- a/packages/cardano-services-client/test/HttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HttpProvider.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable sonarjs/no-duplicate-string */
 import { HttpProviderConfig, createHttpProvider } from '../src';
-import { ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Provider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { Server } from 'http';
 import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
 import { getPort } from 'get-port-please';
@@ -10,7 +10,7 @@ import express, { RequestHandler } from 'express';
 
 type ComplexArg2 = { map: Map<string, Buffer> };
 type ComplexResponse = Map<bigint, Buffer>[];
-interface TestProvider {
+interface TestProvider extends Provider {
   noArgsEmptyReturn(): Promise<void>;
   complexArgsAndReturn({ arg1, arg2 }: { arg1: bigint; arg2: ComplexArg2 }): Promise<ComplexResponse>;
 }
@@ -27,6 +27,7 @@ const createStubHttpProviderServer = async (port: number, path: string, handler:
 
 const stubProviderPaths = {
   complexArgsAndReturn: '/complex',
+  healthCheck: '/health',
   noArgsEmptyReturn: '/simple'
 };
 

--- a/packages/cardano-services/copy-assets.sh
+++ b/packages/cardano-services/copy-assets.sh
@@ -1,25 +1,20 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # TODO: run this with 'shx' or replace this with some cross-platform script
 
+# TODO: uncomment esm lines when ESM builds are enabled for this package
+
 cp ./package.json ./dist/cjs/original-package.json
-
-cp ./src/Http/openApi.json ./dist/cjs/Http/openApi.json
-cp ./src/Asset/openApi.json ./dist/cjs/Asset/openApi.json
-cp ./src/ChainHistory/openApi.json ./dist/cjs/ChainHistory/openApi.json
-cp ./src/NetworkInfo/openApi.json ./dist/cjs/NetworkInfo/openApi.json
-cp ./src/Rewards/openApi.json ./dist/cjs/Rewards/openApi.json
-cp ./src/StakePool/openApi.json ./dist/cjs/StakePool/openApi.json
-cp ./src/TxSubmit/openApi.json ./dist/cjs/TxSubmit/openApi.json
-cp ./src/Utxo/openApi.json ./dist/cjs/Utxo/openApi.json
-cp -R ./src/StakePool/HttpStakePoolMetadata/schemas ./dist/cjs/StakePool/HttpStakePoolMetadata/schemas
-
-# TODO: uncomment when ESM builds are enabled for this package
-# cp ./src/StakePool/openApi.json ./dist/esm/StakePool/openApi.json
-# cp ./src/TxSubmit/openApi.json ./dist/esm/TxSubmit/openApi.json
-# cp ./src/Utxo/openApi.json ./dist/esm/Utxo/openApi.json
-# cp ./src/ChainHistory/openApi.json ./dist/esm/ChainHistory/openApi.json
-# cp ./src/NetworkInfo/openApi.json ./dist/esm/NetworkInfo/openApi.json
-# cp ./src/Rewards/openApi.json ./dist/esm/Rewards/openApi.json
-
 # cp ./package.json ./dist/esm/original-package.json
+
+for i in `ls ./src` ; do
+  SRC=./src/$i/openApi.json
+
+  if [ -f $SRC ] ; then
+    cp $SRC ./dist/cjs/$i/openApi.json
+    # cp $SRC ./dist/esm/$i/openApi.json
+  fi
+done
+
+cp -R ./src/StakePool/HttpStakePoolMetadata/schemas ./dist/cjs/StakePool/HttpStakePoolMetadata/schemas
+# cp -R ./src/StakePool/HttpStakePoolMetadata/schemas ./dist/esm/StakePool/HttpStakePoolMetadata/schemas

--- a/packages/cardano-services/src/Handle/HandleHttpService.ts
+++ b/packages/cardano-services/src/Handle/HandleHttpService.ts
@@ -1,4 +1,4 @@
-import { HandleProvider } from '@cardano-sdk/core';
+import { HandleProvider, handleProviderPaths } from '@cardano-sdk/core';
 import { HttpService } from '../Http';
 import { Logger } from 'ts-log';
 import { Router } from 'express';
@@ -17,7 +17,7 @@ export class HandleHttpService extends HttpService {
     useOpenApi(__dirname, router);
 
     router.post(
-      '/resolve',
+      handleProviderPaths.resolveHandles,
       providerHandler(handleProvider.resolveHandles.bind(handleProvider))(HttpService.routeHandler(logger), logger)
     );
   }

--- a/packages/cardano-services/src/Handle/HandleHttpService.ts
+++ b/packages/cardano-services/src/Handle/HandleHttpService.ts
@@ -1,0 +1,24 @@
+import { HandleProvider } from '@cardano-sdk/core';
+import { HttpService } from '../Http';
+import { Logger } from 'ts-log';
+import { Router } from 'express';
+import { ServiceNames } from '../Program/programs/types';
+import { providerHandler, useOpenApi } from '../util';
+
+export interface HandleServiceDependencies {
+  handleProvider: HandleProvider;
+  logger: Logger;
+}
+
+export class HandleHttpService extends HttpService {
+  constructor({ logger, handleProvider }: HandleServiceDependencies, router: Router = Router()) {
+    super(ServiceNames.Handle, handleProvider, router, logger);
+
+    useOpenApi(__dirname, router);
+
+    router.post(
+      '/resolve',
+      providerHandler(handleProvider.resolveHandles.bind(handleProvider))(HttpService.routeHandler(logger), logger)
+    );
+  }
+}

--- a/packages/cardano-services/src/Handle/TypeOrmHandleProvider.ts
+++ b/packages/cardano-services/src/Handle/TypeOrmHandleProvider.ts
@@ -1,0 +1,58 @@
+import { HandleEntity } from '@cardano-sdk/projection-typeorm';
+import {
+  HandleProvider,
+  HandleResolution,
+  Point,
+  ProviderError,
+  ProviderFailure,
+  ResolveHandlesArgs
+} from '@cardano-sdk/core';
+import { In } from 'typeorm';
+import { TypeormProvider, TypeormProviderDependencies } from '../util/TypeormProvider';
+
+export type TypeOrmHandleProviderDependencies = TypeormProviderDependencies;
+
+const handleFields = ['cardanoAddress', 'handle', 'hasDatum', 'policyId'] as const;
+
+type HandleFields = typeof handleFields[number];
+type PartialHandleEntity = {
+  [k in HandleFields]: Required<HandleEntity>[k];
+};
+
+const handleSelect = <{ [k in HandleFields]: true }>Object.fromEntries(handleFields.map((_) => [_, true]));
+
+export const emptyStringHandleResolutionRequestError = () =>
+  new ProviderError(ProviderFailure.BadRequest, undefined, "Empty string handle can't be resolved");
+
+export class TypeOrmHandleProvider extends TypeormProvider implements HandleProvider {
+  constructor(deps: TypeOrmHandleProviderDependencies) {
+    super('TypeOrmHandleProvider', deps);
+  }
+
+  async resolveHandles(args: ResolveHandlesArgs) {
+    const { handles } = args;
+
+    for (const handle of handles) if (!handle) throw emptyStringHandleResolutionRequestError();
+
+    return this.withDataSource(async (dataSource) => {
+      const queryRunner = dataSource.createQueryRunner();
+      const query = 'SELECT hash, slot FROM block WHERE slot = (SELECT MAX(slot) FROM block)';
+      const resolvedAt = <Point>(await queryRunner.query(query))[0];
+
+      await queryRunner.release();
+
+      const mapEntity = (entity: PartialHandleEntity | undefined): HandleResolution | null => {
+        if (!entity) return null;
+
+        const { cardanoAddress, handle, hasDatum, policyId } = entity;
+
+        return { handle, hasDatum, policyId, resolvedAddresses: { cardano: cardanoAddress }, resolvedAt };
+      };
+
+      const findOptions = { select: handleSelect, where: { handle: In(handles) } };
+      const entities = await dataSource.getRepository<PartialHandleEntity>(HandleEntity).find(findOptions);
+
+      return handles.map((handle) => mapEntity(entities.find((entity) => entity.handle === handle)));
+    });
+  }
+}

--- a/packages/cardano-services/src/Handle/index.ts
+++ b/packages/cardano-services/src/Handle/index.ts
@@ -1,0 +1,2 @@
+export * from './HandleHttpService';
+export * from './TypeOrmHandleProvider';

--- a/packages/cardano-services/src/Handle/openApi.json
+++ b/packages/cardano-services/src/Handle/openApi.json
@@ -1,0 +1,109 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Rewards",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/handle/resolve": {
+      "post": {
+        "summary": "Resolve handles",
+        "operationId": "handleResolve",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HandleResolutionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved addresses of given handles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HandleResolutionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HandleResolution": {
+        "nullable": true,
+        "type": "object",
+        "required": ["handle", "hasDatum", "policyId", "resolvedAddresses", "resolvedAt"],
+        "properties": {
+          "handle": {
+            "type": "string"
+          },
+          "hasDatum": {
+            "type": "boolean"
+          },
+          "policyId": {
+            "type": "string"
+          },
+          "resolvedAddresses": {
+            "type": "object",
+            "properties": {
+              "cardano": {
+                "type": "string"
+              }
+            }
+          },
+          "resolvedAt": {
+            "type": "object",
+            "required": ["hash", "slot"],
+            "properties": {
+              "hash": {
+                "type": "string"
+              },
+              "slot": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      },
+      "HandleResolutionRequest": {
+        "type": "object",
+        "required": ["handles"],
+        "properties": {
+          "handles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "HandleResolutionResponse": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/HandleResolution"
+        }
+      }
+    }
+  }
+}

--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -115,6 +115,7 @@ export class HttpServer extends RunnableModule {
       if (err instanceof ProviderError) {
         HttpServer.sendJSON(res, err, providerFailureToStatusCodeMap[err.reason]);
       } else {
+        this.logger.error(err);
         HttpServer.sendJSON(res, new ProviderError(ProviderFailure.Unhealthy, err), err.status || 500);
       }
     });

--- a/packages/cardano-services/src/Program/options/postgres.ts
+++ b/packages/cardano-services/src/Program/options/postgres.ts
@@ -32,7 +32,7 @@ export interface BasePosgresProgramOptions {
   postgresSslCaFile?: string;
 }
 
-export type ConnectionNames = 'DbSync' | 'StakePool' | '';
+export type ConnectionNames = 'DbSync' | 'Handle' | 'StakePool' | '';
 
 export type PosgresProgramOptions<
   Suffix extends ConnectionNames,
@@ -45,8 +45,10 @@ export const getPostgresOption = <Suffix extends ConnectionNames, Options extend
   args: PosgresProgramOptions<Suffix, Options> | undefined
 ) => args?.[`${option}${suffix}`] as BasePosgresProgramOptions[typeof option];
 
+export const suffixType2Cli = (suffix: ConnectionNames) => suffix.replace(/[A-Z]/g, (_) => `-${_.toLowerCase()}`);
+
 export const withPostgresOptions = (command: Command, suffix: ConnectionNames) => {
-  const cliSuffix = suffix ? suffix.replace(/[A-Z]/g, (_) => `-${_.toLowerCase()}`) : '';
+  const cliSuffix = suffix ? suffixType2Cli(suffix) : '';
   const dscSuffix = suffix ? suffix.replace(/[A-Z]/g, (_) => ` ${_.toLowerCase()}`) : '';
   const envSuffix = suffix ? suffix.replace(/[A-Z]/g, (_) => `_${_}`).replace(/[a-z]/g, (_) => _.toUpperCase()) : '';
 

--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -14,6 +14,7 @@ import { DbSyncStakePoolProvider, StakePoolHttpService, createHttpStakePoolMetad
 import { DbSyncUtxoProvider, UtxoHttpService } from '../../Utxo';
 import { DnsResolver, createDnsResolver, getCardanoNode, getDbPools, getGenesisData } from '../utils';
 import { GenesisData } from '../../types';
+import { HandleHttpService, TypeOrmHandleProvider } from '../../Handle';
 import { HttpServer, HttpServerConfig, HttpService, getListen } from '../../Http';
 import { InMemoryCache, NoCache } from '../../InMemoryCache';
 import { Logger } from 'ts-log';
@@ -199,6 +200,12 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
       );
       return new ChainHistoryHttpService({ chainHistoryProvider, logger });
     }, ServiceNames.ChainHistory),
+    [ServiceNames.Handle]: withTypeOrmProvider('Handle', async (connectionConfig$) => {
+      const entities = getEntities(['handle']);
+      const handleProvider = new TypeOrmHandleProvider({ connectionConfig$, entities, logger });
+
+      return new HandleHttpService({ handleProvider, logger });
+    }),
     [ServiceNames.Rewards]: withDbSyncProvider(async (dbPools, cardanoNode) => {
       const rewardsProvider = new DbSyncRewardsProvider(
         { paginationPageSizeLimit: args.paginationPageSizeLimit! },

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -20,12 +20,13 @@ export enum Programs {
  */
 export enum ServiceNames {
   Asset = 'asset',
-  StakePool = 'stake-pool',
-  NetworkInfo = 'network-info',
-  TxSubmit = 'tx-submit',
-  Utxo = 'utxo',
   ChainHistory = 'chain-history',
-  Rewards = 'rewards'
+  Handle = 'handle',
+  NetworkInfo = 'network-info',
+  Rewards = 'rewards',
+  StakePool = 'stake-pool',
+  TxSubmit = 'tx-submit',
+  Utxo = 'utxo'
 }
 
 export const POOLS_METRICS_INTERVAL_DEFAULT = 1000;

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -56,6 +56,7 @@ export enum ProviderServerOptionDescriptions {
 
 export type ProviderServerArgs = CommonProgramOptions &
   PosgresProgramOptions<'DbSync'> &
+  PosgresProgramOptions<'Handle'> &
   PosgresProgramOptions<'StakePool'> &
   OgmiosProgramOptions &
   RabbitMqProgramOptions & {

--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.ts
@@ -33,7 +33,7 @@ export class TypeormStakePoolProvider extends TypeormProvider implements StakePo
   #paginationPageSizeLimit: number;
 
   constructor({ paginationPageSizeLimit }: TypeOrmStakePoolProviderProps, deps: TypeormProviderDependencies) {
-    super(deps);
+    super('TypeormStakePoolProvider', deps);
     this.#paginationPageSizeLimit = paginationPageSizeLimit;
   }
 

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -178,13 +178,16 @@ withCommonOptions(
   withOgmiosOptions(
     withPostgresOptions(
       withPostgresOptions(
-        withRabbitMqOptions(
-          program
-            .command('start-provider-server')
-            .description('Start the Provider Server')
-            .argument('[serviceNames...]', `List of services to attach: ${Object.values(ServiceNames).toString()}`)
+        withPostgresOptions(
+          withRabbitMqOptions(
+            program
+              .command('start-provider-server')
+              .description('Start the Provider Server')
+              .argument('[serviceNames...]', `List of services to attach: ${Object.values(ServiceNames).toString()}`)
+          ),
+          'StakePool'
         ),
-        'StakePool'
+        'Handle'
       ),
       'DbSync'
     )
@@ -324,6 +327,7 @@ withCommonOptions(
       loadProviderServer({
         ...args,
         postgresConnectionStringDbSync: connectionStringFromArgs(args, 'DbSync'),
+        postgresConnectionStringHandle: connectionStringFromArgs(args, 'Handle'),
         postgresConnectionStringStakePool: connectionStringFromArgs(args, 'StakePool'),
         // Setting the service names via env variable takes preference over command line argument
         serviceNames: args.serviceNames ? args.serviceNames : serviceNames

--- a/packages/cardano-services/src/index.ts
+++ b/packages/cardano-services/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Asset';
 export * from './Blockfrost';
 export * from './ChainHistory';
+export * from './Handle';
 export * from './Http';
 export * from './InMemoryCache';
 export * from './Program';

--- a/packages/cardano-services/src/util/TypeormProvider/TypeormProvider.ts
+++ b/packages/cardano-services/src/util/TypeormProvider/TypeormProvider.ts
@@ -21,8 +21,8 @@ export abstract class TypeormProvider extends RunnableModule implements Provider
   logger: Logger;
   health: HealthCheckResponse = { ok: false, reason: 'not started' };
 
-  constructor({ connectionConfig$, logger, entities }: TypeormProviderDependencies) {
-    super('TypeormProvider', logger);
+  constructor(name: string, { connectionConfig$, logger, entities }: TypeormProviderDependencies) {
+    super(name, logger);
     this.#entities = entities;
     this.#connectionConfig$ = connectionConfig$;
   }

--- a/packages/cardano-services/src/util/http.ts
+++ b/packages/cardano-services/src/util/http.ts
@@ -1,6 +1,8 @@
-import { Application } from 'express';
+import * as OpenApiValidator from 'express-openapi-validator';
+import { Application, Router } from 'express';
 import { ListenOptions } from 'net';
 import http from 'http';
+import path from 'path';
 
 export const listenPromise = (
   serverLike: http.Server | Application,
@@ -16,3 +18,11 @@ export const serverClosePromise = (server: http.Server): Promise<void> =>
     server.once('close', resolve);
     server.close((error) => (error ? reject(error) : null));
   });
+
+export const useOpenApi = (dirname: string, router: Router) => {
+  const apiSpec = path.join(dirname, 'openApi.json');
+
+  router.use(
+    OpenApiValidator.middleware({ apiSpec, ignoreUndocumented: true, validateRequests: true, validateResponses: true })
+  );
+};

--- a/packages/cardano-services/test/Handle/HandleHttpService.test.ts
+++ b/packages/cardano-services/test/Handle/HandleHttpService.test.ts
@@ -1,0 +1,165 @@
+import { Cardano, HandleProvider, ProviderError, ProviderFailure, ResolveHandlesArgs } from '@cardano-sdk/core';
+import { HandleHttpService, HttpServer, emptyStringHandleResolutionRequestError } from '../../src';
+import { getRandomPort } from 'get-port-please';
+import { logger } from '@cardano-sdk/util-dev';
+import axios, { AxiosResponse } from 'axios';
+
+const parseBody = (data: unknown): { body?: unknown; rawBody: string } => {
+  if (typeof data === 'string') {
+    const rawBody = data;
+    let body: unknown;
+
+    try {
+      body = JSON.parse(data);
+    } catch {
+      return { rawBody };
+    }
+
+    return { body, rawBody };
+  }
+
+  return { body: data, rawBody: JSON.stringify(data) };
+};
+
+describe('HandleHttpService', () => {
+  let port: number;
+  let server: HttpServer;
+
+  const createServer = async (handleProvider: HandleProvider) => {
+    const service = new HandleHttpService({ handleProvider, logger });
+
+    port = await getRandomPort();
+    server = new HttpServer({ listen: { port } }, { logger, services: [service] });
+
+    await server.initialize();
+    await server.start();
+  };
+
+  const performRequest = async (
+    path: 'health' | 'resolve',
+    args: Partial<ResolveHandlesArgs>
+  ): Promise<{
+    body?: unknown;
+    message?: string;
+    rawBody?: string;
+    status?: number;
+    statusText?: string;
+  }> => {
+    let res: AxiosResponse;
+
+    try {
+      res = await axios.post(`http://localhost:${port}/handle/${path}`, JSON.stringify(args), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    } catch (error) {
+      if (!axios.isAxiosError(error)) throw error;
+
+      const { message, response } = error;
+
+      if (!response) return { message, statusText: error.status };
+
+      const { data, status, statusText } = response;
+
+      return { message, status, statusText, ...parseBody(data) };
+    }
+
+    const { data, status, statusText } = res;
+
+    return { status, statusText, ...parseBody(data) };
+  };
+
+  afterEach(() => server.shutdown());
+
+  describe('unhealthy state', () => {
+    beforeEach(() =>
+      createServer({
+        healthCheck: () => Promise.resolve({ ok: false, reason: 'test reason' }),
+        resolveHandles: () => {
+          throw new ProviderError(ProviderFailure.Unhealthy, new Error('test error'), 'test details');
+        }
+      })
+    );
+
+    it('HandleHttpService /health gives correct unhealthy response', async () => {
+      const { body, status } = await performRequest('health', {});
+
+      expect({ body, status }).toEqual({ body: { ok: false, reason: 'test reason' }, status: 200 });
+    });
+
+    it('HandleHttpService /resolve fails with correct error details', async () => {
+      const { message, rawBody, status, statusText } = await performRequest('resolve', { handles: ['test'] });
+
+      expect({ message, status, statusText }).toEqual({
+        message: 'Request failed with status code 500',
+        status: 500,
+        statusText: 'Internal Server Error'
+      });
+      expect(rawBody).toMatch(/UNHEALTHY \(test details\) due to\\n Error: test error/);
+    });
+  });
+
+  describe('healthy state', () => {
+    beforeEach(() =>
+      createServer({ healthCheck: () => Promise.resolve({ ok: true }), resolveHandles: () => Promise.resolve([null]) })
+    );
+
+    it('HandleHttpService /health gives correct healthy response', async () => {
+      const { body, status } = await performRequest('health', {});
+
+      expect({ body, status }).toEqual({ body: { ok: true }, status: 200 });
+    });
+
+    it('HandleHttpService /resolve responds with provider response', async () => {
+      const { body, status } = await performRequest('resolve', { handles: ['test'] });
+
+      expect({ body, status }).toEqual({ body: [null], status: 200 });
+    });
+  });
+
+  it('valid not empty response is openApi schema compliant', async () => {
+    await createServer({
+      healthCheck: () => Promise.resolve({ ok: true }),
+      resolveHandles: () =>
+        Promise.resolve([
+          {
+            handle: 'test',
+            hasDatum: true,
+            policyId: <Cardano.PolicyId>'test_policy',
+            resolvedAddresses: { cardano: <Cardano.PaymentAddress>'test_address' },
+            resolvedAt: { hash: <Cardano.BlockId>'test_hash', slot: <Cardano.Slot>42 }
+          }
+        ])
+    });
+
+    const { body, status } = await performRequest('resolve', { handles: ['test'] });
+
+    expect({ body, status }).toEqual({
+      body: [
+        {
+          handle: 'test',
+          hasDatum: true,
+          policyId: 'test_policy',
+          resolvedAddresses: { cardano: 'test_address' },
+          resolvedAt: { hash: 'test_hash', slot: 42 }
+        }
+      ],
+      status: 200
+    });
+  });
+
+  it('converts BadRequest ProviderError into a 400 HTTP response', async () => {
+    await createServer({
+      healthCheck: () => Promise.resolve({ ok: true }),
+      resolveHandles: () => Promise.reject(emptyStringHandleResolutionRequestError())
+    });
+
+    const { message, rawBody, status, statusText } = await performRequest('resolve', { handles: [''] });
+
+    expect({ message, status, statusText }).toEqual({
+      message: 'Request failed with status code 400',
+      status: 400,
+      statusText: 'Bad Request'
+    });
+    expect(rawBody).toMatch(/Empty string handle can't be resolved/);
+  });
+});

--- a/packages/cardano-services/test/Handle/TypeOrmHandleProvider.test.ts
+++ b/packages/cardano-services/test/Handle/TypeOrmHandleProvider.test.ts
@@ -1,0 +1,34 @@
+import { TypeOrmHandleProvider, createDnsResolver, getConnectionConfig, getEntities } from '../../src';
+import { logger } from '@cardano-sdk/util-dev';
+
+describe('TypeOrmHandleProvider', () => {
+  let provider: TypeOrmHandleProvider;
+
+  beforeAll(async () => {
+    const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
+    const entities = getEntities(['handle']);
+    const connectionConfig$ = getConnectionConfig(dnsResolver, 'test', 'Handle', {
+      postgresConnectionStringHandle: process.env.POSTGRES_CONNECTION_STRING_STAKE_POOL!
+    });
+
+    provider = new TypeOrmHandleProvider({ connectionConfig$, entities, logger });
+
+    await provider.initialize();
+    await provider.start();
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+
+    await provider.shutdown();
+  });
+
+  it('throws error if requested resolution for an empty string handle', () =>
+    expect(provider.resolveHandles({ handles: ['none', '', 'test'] })).rejects.toThrow(
+      "BAD_REQUEST (Empty string handle can't be resolved)"
+    ));
+
+  it.skip('resolve method correctly resolves handles', () =>
+    // TODO: complete this test with mock or fixtures
+    expect(provider.resolveHandles({ handles: ['none', 'test'] })).resolves.toBe([null, {}]));
+});

--- a/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
+++ b/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
@@ -74,14 +74,7 @@ describe('TypeormStakePoolProvider', () => {
   let poolsInfoWithMetrics: PoolInfo[];
 
   const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
-  const entities = getEntities([
-    'block',
-    'poolMetadata',
-    'poolRegistration',
-    'poolRetirement',
-    'stakePool',
-    'currentPoolMetrics'
-  ]);
+  const entities = getEntities(['currentPoolMetrics']);
   const db = new Pool({ connectionString: process.env.POSTGRES_CONNECTION_STRING_STAKE_POOL, max: 1, min: 1 });
 
   beforeAll(async () => {

--- a/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
+++ b/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
@@ -6,17 +6,29 @@ PACKAGES_DIR="$(dirname "$(dirname "$(dirname "${SCRIPT_DIR}")")")"
 WORKSPACE_ROOT="$(dirname "${PACKAGES_DIR}")"
 SECRETS_DIR="$WORKSPACE_ROOT"/compose/placeholder-secrets
 
+export DB_SYNC_CONNECTION_STRING="postgresql://$(cat "$SECRETS_DIR"/postgres_user):$(cat "$SECRETS_DIR"/postgres_password)@localhost:5435/$(cat "$SECRETS_DIR"/postgres_db_db_sync)"
+
 yarn --cwd "$PACKAGES_DIR"/e2e local-network:down
 yarn --cwd "$PACKAGES_DIR"/e2e local-network:up -d --build
 yarn --cwd "$WORKSPACE_ROOT" build
+yarn --cwd "$PACKAGES_DIR"/e2e wait-for-network
 yarn --cwd "$PACKAGES_DIR"/e2e test:wallet
 yarn --cwd "$PACKAGES_DIR"/e2e test:long-running
 yarn --cwd "$PACKAGES_DIR"/e2e test:local-network register-pool.test.ts
 echo 'Stop writing data'
 docker compose -p local-network-e2e stop cardano-db-sync
+docker compose -p local-network-e2e stop handle-projector
+docker compose -p local-network-e2e stop stake-pool-projector
 echo 'Creating snapshot...'
 docker compose -p local-network-e2e exec -it postgres /bin/bash -c "pg_dump --username $(cat "$SECRETS_DIR"/postgres_user) $(cat "$SECRETS_DIR"/postgres_db_db_sync)" > "$SCRIPT_DIR"/localnetwork.bak
-cd "$SCRIPT_DIR" && tar -cvf localnetwork-db-snapshot.tar localnetwork.bak
+docker compose -p local-network-e2e exec -it postgres /bin/bash -c "pg_dump --username $(cat "$SECRETS_DIR"/postgres_user) $(cat "$SECRETS_DIR"/postgres_db_handle)" > "$SCRIPT_DIR"/localnetwork-handle.bak
+docker compose -p local-network-e2e exec -it postgres /bin/bash -c "pg_dump --username $(cat "$SECRETS_DIR"/postgres_user) $(cat "$SECRETS_DIR"/postgres_db_stake_pool)" > "$SCRIPT_DIR"/localnetwork-stake-pool.bak
+cd "$SCRIPT_DIR"
+tar -cvf localnetwork-db-snapshot.tar localnetwork.bak
+tar -cvf localnetwork-handle-db-snapshot.tar localnetwork-handle.bak
+tar -cvf localnetwork-stake-pool-db-snapshot.tar localnetwork-stake-pool.bak
 rm localnetwork.bak
+#rm localnetwork-handle.bak
+rm localnetwork-stake-pool.bak
 echo 'Snapshot created.'
 yarn --cwd "$PACKAGES_DIR"/e2e local-network:down

--- a/packages/core/src/Provider/HandleProvider/types.ts
+++ b/packages/core/src/Provider/HandleProvider/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, Point, Provider } from '../..';
+import { Cardano, HttpProviderConfigPaths, Point, Provider } from '../..';
 
 export type Handle = string;
 
@@ -31,3 +31,8 @@ export interface ResolveHandlesArgs {
 export interface HandleProvider extends Provider {
   resolveHandles(args: ResolveHandlesArgs): Promise<Array<HandleResolution | null>>;
 }
+
+export const handleProviderPaths: HttpProviderConfigPaths<HandleProvider> = {
+  healthCheck: '/health',
+  resolveHandles: '/resolve'
+};

--- a/packages/core/src/Provider/Provider.ts
+++ b/packages/core/src/Provider/Provider.ts
@@ -25,3 +25,5 @@ export interface Provider {
    */
   healthCheck(): Promise<HealthCheckResponse>;
 }
+
+export type HttpProviderConfigPaths<T extends Provider> = { [methodName in keyof T]: string };

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     <<: *logging
     build:
       context: ./local-network
+    environment:
+      CARDANO_NODE_LOG_LEVEL: ${CARDANO_NODE_LOG_LEVEL:-Info}
+      CARDANO_NODE_CHAINDB_LOG_LEVEL: ${CARDANO_NODE_CHAINDB_LOG_LEVEL:-Notice}
     ports:
       - 3001:3001
     volumes:

--- a/packages/e2e/local-network/scripts/make-babbage.sh
+++ b/packages/e2e/local-network/scripts/make-babbage.sh
@@ -113,7 +113,9 @@ $SED -i "${ROOT}/configuration.yaml" \
      -e '/ByronGenesisFile/ aAlonzoGenesisFile: genesis/shelley/genesis.alonzo.json' \
      -e 's/RequiresNoMagic/RequiresMagic/' \
      -e 's/LastKnownBlockVersion-Major: 0/LastKnownBlockVersion-Major: 6/' \
-     -e 's/LastKnownBlockVersion-Minor: 2/LastKnownBlockVersion-Minor: 0/'
+     -e 's/LastKnownBlockVersion-Minor: 2/LastKnownBlockVersion-Minor: 0/' \
+     -e "s/minSeverity: Info/minSeverity: ${CARDANO_NODE_LOG_LEVEL}/" \
+     -e "s/cardano.node.ChainDB: Notice/cardano.node.ChainDB: ${CARDANO_NODE_CHAINDB_LOG_LEVEL}/"
 
   echo "" >> "${ROOT}/configuration.yaml"
   echo "PBftSignatureThreshold: 0.6" >> "${ROOT}/configuration.yaml"


### PR DESCRIPTION
# Context

We need to make the SDK able to serve ADA handles data.

# Proposed Solution

- Added `handleHttpProvider`.
- Added `TypeOrmHandleProvider`.
- Added `HandleServiceDependencies`.

# Important Changes Introduced

- Improved the error middleware to log unknown errors (required to detect `oneApi` related errors).
- Refactored `copy-assets.sh` to copy all the `OpenApi` spec files.
- Added env vars to give the ability to override `cardano-node` log in docker compose infrastructures.
- Fixed dev docker compose with new projector services.
- Improved `getEntities` to get all entities traversing entities dependencies.
- Some refactors in _provider server_ to generalize `TypeOrmProviders` initialization.
- Added the `handle` database to _server provider_.
- Updated the fixtures generation script to reflect the new _one db for each projector_ structure.
- Refactor on `HttpProviderConfigPaths` and hoisted it into `core` package to enforce the types when using `Provider`s both in client and server sides.

# Important notes

The `TypeOrmHandleProvider` integration test is not complete because the fixtures generation procedure still doesn't produces the data required to run it (i.e. some ADA handles projected as records in `handle` table). Follow up: LW-7051