### PR TITLE
Feature/LW-6653 add context to txSubmit

### DIFF
--- a/packages/core/src/Provider/TxSubmitProvider/types.ts
+++ b/packages/core/src/Provider/TxSubmitProvider/types.ts
@@ -1,11 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import Cardano, { CardanoNodeErrors, Provider } from '../..';
+import Cardano, { CardanoNodeErrors, HandleResolution, Provider } from '../..';
 
 type SerializedTransaction = Cardano.util.HexBlob;
 
 export interface SubmitTxArgs {
   signedTransaction: SerializedTransaction;
+  context?: { handles: HandleResolution[] };
 }
 
 export interface TxSubmitProvider extends Provider {

--- a/packages/tx-construction/src/tx-builder/OutputBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/OutputBuilder.ts
@@ -140,11 +140,6 @@ export class TxOutputBuilder implements OutputBuilder {
   async build(): Promise<OutputBuilderTxOut> {
     const txOut = this.toTxOut();
 
-    const outputValidation = toOutputValidationError(txOut, await this.#outputValidator.validateOutput(txOut));
-    if (outputValidation) {
-      throw outputValidation;
-    }
-
     if (this.#partialOutput.handle && this.#handleProvider) {
       const resolution = await this.#handleProvider.resolveHandles({ handles: [this.#partialOutput.handle] });
 
@@ -156,6 +151,11 @@ export class TxOutputBuilder implements OutputBuilder {
         // an address for the transaction.
         throw new HandleNotFoundError(this.#partialOutput);
       }
+    }
+
+    const outputValidation = toOutputValidationError(txOut, await this.#outputValidator.validateOutput(txOut));
+    if (outputValidation) {
+      throw outputValidation;
     }
 
     return txOut;

--- a/packages/tx-construction/src/tx-builder/finalizeTx.ts
+++ b/packages/tx-construction/src/tx-builder/finalizeTx.ts
@@ -4,7 +4,7 @@ import {
   TransactionSigner,
   util as keyManagementUtil
 } from '@cardano-sdk/key-management';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, TxCBOR } from '@cardano-sdk/core';
 import { FinalizeTxDependencies, SignedTx, TxContext } from './types';
 
 const getSignatures = async (
@@ -41,19 +41,22 @@ export const finalizeTx = async (
       )
     : await getSignatures(keyAgent, tx, witness?.extraSigners, signingOptions);
 
+  const transaction = {
+    auxiliaryData,
+    body: tx.body,
+    id: tx.hash,
+    isValid,
+    witness: {
+      ...witness,
+      signatures: new Map([...signatures.entries(), ...(witness?.signatures?.entries() || [])])
+    }
+  };
+
   return {
-    ctx: {
+    cbor: TxCBOR.serialize(transaction),
+    context: {
       handles: handles ?? []
     },
-    tx: {
-      auxiliaryData,
-      body: tx.body,
-      id: tx.hash,
-      isValid,
-      witness: {
-        ...witness,
-        signatures: new Map([...signatures.entries(), ...(witness?.signatures?.entries() || [])])
-      }
-    }
+    tx: transaction
   };
 };

--- a/packages/tx-construction/src/tx-builder/types.ts
+++ b/packages/tx-construction/src/tx-builder/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, Handle, HandleProvider, HandleResolution } from '@cardano-sdk/core';
+import { Cardano, Handle, HandleProvider, HandleResolution, TxCBOR } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 
 import { InputSelectionError, InputSelector, SelectionSkeleton } from '@cardano-sdk/input-selection';
@@ -124,8 +124,9 @@ export type TxInspection = Cardano.TxBodyWithHash &
   };
 
 export interface SignedTx {
+  cbor: TxCBOR;
   tx: Cardano.Tx;
-  ctx: {
+  context: {
     handles: HandleResolution[];
   };
 }

--- a/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
@@ -227,8 +227,8 @@ describe('GenericTxBuilder', () => {
     });
 
     it('can set extraSigners for signing', async () => {
-      const { tx } = await txBuilder.addOutput(mocks.utxo[0][1]).extraSigners(signers).build().sign();
-      expect(tx.witness.signatures.get(pubKey)).toEqual(signature);
+      const { tx: signedTx } = await txBuilder.addOutput(mocks.utxo[0][1]).extraSigners(signers).build().sign();
+      expect(signedTx.witness.signatures.get(pubKey)).toEqual(signature);
     });
   });
 
@@ -583,8 +583,8 @@ describe('GenericTxBuilder', () => {
       .build();
     const { handles } = await tx.inspect();
     expect(handles).toEqual([resolvedHandle]);
-    const { ctx } = await tx.sign();
-    expect(ctx.handles).toEqual([resolvedHandle]);
+    const { context } = await tx.sign();
+    expect(context.handles).toEqual([resolvedHandle]);
   });
 
   it('can build transactions that are not modified by subsequent builder changes', async () => {

--- a/packages/util-dev/src/mockProviders/index.ts
+++ b/packages/util-dev/src/mockProviders/index.ts
@@ -6,3 +6,4 @@ export * from './mockAssetProvider';
 export * from './mockUtxoProvider';
 export * from './mockChainHistoryProvider';
 export * from './mockRewardsProvider';
+export * from './mockHandleProvider';

--- a/packages/util-dev/src/mockProviders/mockHandleProvider.ts
+++ b/packages/util-dev/src/mockProviders/mockHandleProvider.ts
@@ -1,0 +1,20 @@
+import { Cardano } from '@cardano-sdk/core';
+
+export const resolvedHandle = {
+  handle: 'alice',
+  hasDatum: false,
+  policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
+  resolvedAddresses: {
+    cardano:
+      'addr_test1qqk4sr4f7vtqzd2w90d5nfu3n59jhhpawyphnek2y7er02nkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuqmcnecd'
+  },
+  resolvedAt: {
+    hash: Cardano.BlockId('10d64cc11e9b20e15b6c46aa7b1fed11246f437e62225655a30ea47bf8cc22d0'),
+    slot: Cardano.Slot(37_834_496)
+  }
+};
+
+export const mockHandleProvider = () => ({
+  healthCheck: jest.fn().mockResolvedValue({ ok: true }),
+  resolveHandles: jest.fn().mockResolvedValue([resolvedHandle])
+});

--- a/packages/wallet/src/services/TransactionReemitter.ts
+++ b/packages/wallet/src/services/TransactionReemitter.ts
@@ -170,6 +170,8 @@ export const createTransactionReemitter = ({
 
   return {
     failed$,
-    reemit$: merge(rollbackRetry$, unsubmitted$, reemitUnconfirmed$).pipe(map((tx) => pick(tx, ['cbor', 'body', 'id'])))
+    reemit$: merge(rollbackRetry$, unsubmitted$, reemitUnconfirmed$).pipe(
+      map((tx) => pick(tx, ['cbor', 'body', 'id', 'context']))
+    )
   };
 };

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -2,6 +2,7 @@ import { AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
 import { Cardano, CardanoNodeErrors, EpochRewards, TxCBOR } from '@cardano-sdk/core';
 import { Observable } from 'rxjs';
 import { Percent } from '@cardano-sdk/util';
+import { SignedTx } from '@cardano-sdk/tx-construction';
 
 export enum TransactionFailure {
   InvalidTransaction = 'INVALID_TRANSACTION',
@@ -65,6 +66,7 @@ export interface OutgoingTx {
   cbor: TxCBOR;
   body: Cardano.TxBody;
   id: Cardano.TransactionId;
+  context?: SignedTx['context'];
 }
 
 export interface FailedTx extends OutgoingTx {

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -10,7 +10,7 @@ import {
 import { BalanceTracker, DelegationTracker, TransactionsTracker, UtxoTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { GroupedAddress, cip8 } from '@cardano-sdk/key-management';
-import { InitializeTxProps, InitializeTxResult, TxBuilder, TxContext } from '@cardano-sdk/tx-construction';
+import { InitializeTxProps, InitializeTxResult, SignedTx, TxBuilder, TxContext } from '@cardano-sdk/tx-construction';
 import { Observable } from 'rxjs';
 import { Shutdown } from '@cardano-sdk/util';
 
@@ -84,7 +84,7 @@ export interface ObservableWallet {
   /**
    * @throws CardanoNodeErrors.TxSubmissionError
    */
-  submitTx(tx: Cardano.Tx | TxCBOR): Promise<Cardano.TransactionId>;
+  submitTx(tx: Cardano.Tx | TxCBOR | SignedTx): Promise<Cardano.TransactionId>;
 
   /**
    * Create a TxBuilder from this wallet


### PR DESCRIPTION
# Context
We want to continue the implementation to return and work with standard handles. 
LW-6653

# Proposed Solution
- [x] Resolve the context with handles to return HandleResolution in `SubmitTxArgs`
- [ ] ~~Replace `SignedTx` with `SubmitTxArgs`~~
- [x] add signedTx or cbor to SignedTx type
- [x] Refactor `ObservableWallet.submitTx` to take the appropriate arguments  and implement it in `PersonalWallet`
- [x] Implement the handles from context in PersonalWallet
- [x] Add tests showcasing building and submitting a transaction that sends coins 

# Important Changes Introduced
- Wallet package: 
PersonalWallet now has the handles implementation. 
ObservableWallet now takes handles. 

- Tx-construction: 
~~Replaces signedTx with SubmitTxArgs~~
Adds Cbor to SignedTx