### PR TITLE
feat(wallet): discover used stake keys

### DIFF
--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -83,7 +83,7 @@ export const handleProviderFactory = new ProviderFactory<HandleProvider>();
 addressDiscoveryFactory.register('SingleAddressDiscovery', async () => new SingleAddressDiscovery());
 addressDiscoveryFactory.register(
   'HDSequentialDiscovery',
-  async ({ chainHistoryProvider }) => new HDSequentialDiscovery(chainHistoryProvider, 20, 5)
+  async ({ chainHistoryProvider }) => new HDSequentialDiscovery(chainHistoryProvider, 20)
 );
 
 // bip32Ed25519

--- a/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
@@ -39,20 +39,7 @@ describe('PersonalWallet/multiAddress', () => {
 
     let txBuilder = wallet.createTxBuilder();
 
-    let addressesToBeDiscovered = new Array<GroupedAddress>();
-
-    // Let's add the 5 stake keys.
-    for (let i = 0; i < 5; ++i) {
-      addressesToBeDiscovered.push(
-        await multiAddressKeyAgent.deriveAddress(
-          {
-            index: 0,
-            type: AddressType.External
-          },
-          i
-        )
-      );
-    }
+    const addressesToBeDiscovered = new Array<GroupedAddress>();
 
     // Deposit some tADA at some generated addresses from the previously generated mnemonics.
     for (let i = 0; i < PAYMENT_ADDRESSES_TO_GENERATE; ++i) {
@@ -67,9 +54,6 @@ describe('PersonalWallet/multiAddress', () => {
       addressesToBeDiscovered.push(address);
       txBuilder.addOutput(txBuilder.buildOutput().address(address.address).coin(3_000_000n).toTxOut());
     }
-
-    // Remove duplicates
-    addressesToBeDiscovered = [...new Set(addressesToBeDiscovered)];
 
     const { tx: signedTx } = await txBuilder.build().sign();
 

--- a/packages/wallet/src/services/AddressDiscovery/HDSequentialDiscovery.ts
+++ b/packages/wallet/src/services/AddressDiscovery/HDSequentialDiscovery.ts
@@ -1,12 +1,86 @@
+import { AccountAddressDerivationPath, AddressType, AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
 import { AddressDiscovery } from '../types';
-import { AddressType, AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
 import { ChainHistoryProvider } from '@cardano-sdk/core';
 import uniqBy from 'lodash/uniqBy';
 
+const STAKE_KEY_INDEX_LOOKAHEAD = 5;
+
 /**
- * By default, we support up to five stake keys in the multi delegation schema.
+ * Gets whether the given address has a transaction history.
+ *
+ * @param address The address to query.
+ * @param chainHistoryProvider The chain history provider where to fetch the history from.
  */
-const DEFAULT_STAKE_KEY_INDEX_LIMIT = 5;
+const addressHasTx = async (address: GroupedAddress, chainHistoryProvider: ChainHistoryProvider): Promise<boolean> => {
+  const txs = await chainHistoryProvider.transactionsByAddresses({
+    addresses: [address.address],
+    pagination: {
+      limit: 1,
+      startAt: 0
+    }
+  });
+
+  return txs.totalResultCount > 0;
+};
+
+/**
+ * Search for all base addresses composed with the given payment and staking credentials.
+ *
+ * @param keyAgent The key agent controlling the root key to be used to derive the addresses to be discovered.
+ * @param chainHistoryProvider The chain history provider.
+ * @param lookAheadCount Number down the derivation chain to be searched for.
+ * @param getDeriveAddressArgs Callback that retrieves the derivation path arguments.
+ * @returns A promise that will be resolved into a GroupedAddress list containing the discovered addresses.
+ */
+const discoverAddresses = async (
+  keyAgent: AsyncKeyAgent,
+  chainHistoryProvider: ChainHistoryProvider,
+  lookAheadCount: number,
+  getDeriveAddressArgs: (
+    index: number,
+    type: AddressType
+  ) => {
+    paymentKeyDerivationPath: AccountAddressDerivationPath;
+    stakeKeyDerivationIndex: number;
+  }
+): Promise<GroupedAddress[]> => {
+  let currentGap = 0;
+  let currentIndex = 0;
+  const addresses = new Array<GroupedAddress>();
+
+  while (currentGap <= lookAheadCount) {
+    const externalAddressArgs = getDeriveAddressArgs(currentIndex, AddressType.External);
+    const internalAddressArgs = getDeriveAddressArgs(currentIndex, AddressType.Internal);
+
+    const externalAddress = await keyAgent.deriveAddress(
+      externalAddressArgs.paymentKeyDerivationPath,
+      externalAddressArgs.stakeKeyDerivationIndex,
+      true
+    );
+
+    const internalAddress = await keyAgent.deriveAddress(
+      internalAddressArgs.paymentKeyDerivationPath,
+      internalAddressArgs.stakeKeyDerivationIndex,
+      true
+    );
+
+    const externalHasTx = await addressHasTx(externalAddress, chainHistoryProvider);
+    const internalHasTx = await addressHasTx(internalAddress, chainHistoryProvider);
+
+    if (externalHasTx) addresses.push(externalAddress);
+    if (internalHasTx) addresses.push(internalAddress);
+
+    if (externalHasTx || internalHasTx) {
+      currentGap = 0;
+    } else {
+      ++currentGap;
+    }
+
+    ++currentIndex;
+  }
+
+  return addresses;
+};
 
 /**
  * Provides a mechanism to discover addresses in Hierarchical Deterministic (HD) wallets
@@ -14,7 +88,7 @@ const DEFAULT_STAKE_KEY_INDEX_LIMIT = 5;
  *
  * - Derive base addresses with payment credential at index 0 and increasing stake credential until it reaches the given limit.
  * - Derives base addresses with increasing payment credential and stake credential at index 0.
- * - if no transactions are found, increase the gap count.
+ * - if no transactions are found for both internal and external address type, increase the gap count.
  * - if there are some transactions, increase the payment credential index and set the gap count to 0.
  * - if the gap count reaches the given lookAheadCount stop the discovery process.
  *
@@ -26,15 +100,9 @@ const DEFAULT_STAKE_KEY_INDEX_LIMIT = 5;
  */
 export class HDSequentialDiscovery implements AddressDiscovery {
   readonly #chainHistoryProvider: ChainHistoryProvider;
-  readonly #stakeKeyIndexLimit: number;
   readonly #lookAheadCount: number;
 
-  constructor(
-    chainHistoryProvider: ChainHistoryProvider,
-    lookAheadCount: number,
-    stakeKeyIndexLimit: number = DEFAULT_STAKE_KEY_INDEX_LIMIT
-  ) {
-    this.#stakeKeyIndexLimit = stakeKeyIndexLimit;
+  constructor(chainHistoryProvider: ChainHistoryProvider, lookAheadCount: number) {
     this.#chainHistoryProvider = chainHistoryProvider;
     this.#lookAheadCount = lookAheadCount;
   }
@@ -47,48 +115,43 @@ export class HDSequentialDiscovery implements AddressDiscovery {
    * @returns A promise that will be resolved into a GroupedAddress list containing the discovered addresses.
    */
   public async discover(keyAgent: AsyncKeyAgent): Promise<GroupedAddress[]> {
-    let currentGap = 0;
-    let currentIndex = 0;
-    const addresses = new Array<GroupedAddress>();
+    const firstAddress = await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0, true);
 
-    // Add to our known address pool, all possible stake keys combined with payment credential at index 0.
-    for (let index = 0; index < this.#stakeKeyIndexLimit; ++index) {
-      const address = await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, index, true);
-      addresses.push(address);
-    }
+    const stakeKeyAddresses = await discoverAddresses(
+      keyAgent,
+      this.#chainHistoryProvider,
+      STAKE_KEY_INDEX_LOOKAHEAD,
+      (currentIndex, type) => ({
+        paymentKeyDerivationPath: {
+          index: 0,
+          type
+        },
+        // We are going to offset this by 1, since we already know about the first address.
+        stakeKeyDerivationIndex: currentIndex + 1
+      })
+    );
 
-    // Search for all base addresses composed with the stake key at index 0. We are assuming this is
-    // the use case with multi address wallets.
-    while (currentGap <= this.#lookAheadCount) {
-      const address = await keyAgent.deriveAddress({ index: currentIndex, type: AddressType.External }, 0, true);
+    const paymentKeyAddresses = await discoverAddresses(
+      keyAgent,
+      this.#chainHistoryProvider,
+      this.#lookAheadCount,
+      (currentIndex, type) => ({
+        paymentKeyDerivationPath: {
+          // We are going to offset this by 1, since we already know about the first address.
+          index: currentIndex + 1,
+          type
+        },
+        stakeKeyDerivationIndex: 0
+      })
+    );
 
-      // We could fetch transactions from multiple addresses in a single query and then parse/organize the results, however, if these addresses
-      // contain huge transaction history we may get stuck retrieving all the transactions for longer than we can just query each address individually.
-      const txs = await this.#chainHistoryProvider.transactionsByAddresses({
-        addresses: [address.address],
-        pagination: {
-          limit: 1,
-          startAt: 0
-        }
-      });
-
-      if (txs.totalResultCount > 0) {
-        currentGap = 0;
-        addresses.push(address);
-      } else {
-        ++currentGap;
-      }
-
-      ++currentIndex;
-    }
-
-    const result = uniqBy(addresses, 'address');
+    const addresses = uniqBy([firstAddress, ...stakeKeyAddresses, ...paymentKeyAddresses], 'address');
 
     // We need to make sure the addresses are sorted since the wallet assumes that the first address
     // in the list is the change address (payment cred 0 and stake cred 0).
-    result.sort((a, b) => a.index - b.index || a.stakeKeyDerivationPath!.index - b.stakeKeyDerivationPath!.index);
-    await keyAgent.setKnownAddresses(result);
+    addresses.sort((a, b) => a.index - b.index || a.stakeKeyDerivationPath!.index - b.stakeKeyDerivationPath!.index);
+    await keyAgent.setKnownAddresses(addresses);
 
-    return result;
+    return addresses;
   }
 }

--- a/packages/wallet/test/services/addressDiscovery/HDSequentialDiscovery.test.ts
+++ b/packages/wallet/test/services/addressDiscovery/HDSequentialDiscovery.test.ts
@@ -1,8 +1,16 @@
 import { AddressType, AsyncKeyAgent, KeyRole } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import { HDSequentialDiscovery } from '../../../src';
+import {
+  createMockChainHistoryProvider,
+  mockAlwaysEmptyChainHistoryProvider,
+  mockAlwaysFailChainHistoryProvider,
+  mockChainHistoryProvider,
+  prepareMockKeyAgentWithData
+} from './mockData';
 import { firstValueFrom } from 'rxjs';
-import { mockAlwaysFailChainHistoryProvider, mockChainHistoryProvider, prepareMockKeyAgentWithData } from './mockData';
+
+const asPaymentAddress = (address: string) => address as Cardano.PaymentAddress;
 
 describe('HDSequentialDiscovery', () => {
   let mockKeyAgent: AsyncKeyAgent;
@@ -11,18 +19,140 @@ describe('HDSequentialDiscovery', () => {
     mockKeyAgent = prepareMockKeyAgentWithData();
   });
 
+  it('can return both "internal" and "external" type addresses', async () => {
+    const discovery = new HDSequentialDiscovery(
+      createMockChainHistoryProvider(
+        new Map([
+          [asPaymentAddress('testAddress_0_0_0'), 1],
+          [asPaymentAddress('testAddress_1_0_0'), 1],
+          [asPaymentAddress('testAddress_1_0_1'), 1],
+          [asPaymentAddress('testAddress_2_0_0'), 1]
+        ])
+      ),
+      25
+    );
+
+    const addresses = await discovery.discover(mockKeyAgent);
+
+    expect(addresses.length).toEqual(4);
+    expect(addresses[0]).toEqual({
+      accountIndex: 0,
+      address: 'testAddress_0_0_0',
+      index: 0,
+      networkId: 0,
+      rewardAccount: 'testStakeAddress_0',
+      stakeKeyDerivationPath: {
+        index: 0,
+        role: KeyRole.Stake
+      },
+      type: AddressType.External
+    });
+    expect(addresses[1]).toEqual({
+      accountIndex: 0,
+      address: 'testAddress_1_0_0',
+      index: 1,
+      networkId: 0,
+      rewardAccount: 'testStakeAddress_0',
+      stakeKeyDerivationPath: {
+        index: 0,
+        role: KeyRole.Stake
+      },
+      type: AddressType.External
+    });
+    expect(addresses[2]).toEqual({
+      accountIndex: 0,
+      address: 'testAddress_1_0_1',
+      index: 1,
+      networkId: 0,
+      rewardAccount: 'testStakeAddress_0',
+      stakeKeyDerivationPath: {
+        index: 0,
+        role: KeyRole.Stake
+      },
+      type: AddressType.Internal
+    });
+    expect(addresses[3]).toEqual({
+      accountIndex: 0,
+      address: 'testAddress_2_0_0',
+      index: 2,
+      networkId: 0,
+      rewardAccount: 'testStakeAddress_0',
+      stakeKeyDerivationPath: {
+        index: 0,
+        role: KeyRole.Stake
+      },
+      type: AddressType.External
+    });
+
+    const knownAddresses = await firstValueFrom(mockKeyAgent.knownAddresses$);
+
+    knownAddresses.sort(
+      (a, b) => a.index - b.index || a.stakeKeyDerivationPath!.index - b.stakeKeyDerivationPath!.index
+    );
+
+    expect(addresses).toEqual(knownAddresses);
+  });
+
+  it('derives exactly 1 address when no used addresses are found', async () => {
+    const discovery = new HDSequentialDiscovery(mockAlwaysEmptyChainHistoryProvider, 25);
+    const addresses = await discovery.discover(mockKeyAgent);
+    expect(addresses).toHaveLength(1);
+    expect(await firstValueFrom(mockKeyAgent.knownAddresses$)).toHaveLength(1);
+  });
+
+  it('return discovered addresses with different stake keys', async () => {
+    const discovery = new HDSequentialDiscovery(
+      createMockChainHistoryProvider(
+        new Map([
+          [asPaymentAddress('testAddress_0_0_0'), 1],
+          [asPaymentAddress('testAddress_0_1_0'), 1],
+          [asPaymentAddress('testAddress_0_2_0'), 1],
+          [asPaymentAddress('testAddress_0_3_0'), 1],
+          [asPaymentAddress('testAddress_1_0_0'), 1],
+          [asPaymentAddress('testAddress_2_0_0'), 1],
+          [asPaymentAddress('testAddress_3_0_0'), 1],
+          [asPaymentAddress('testAddress_4_0_0'), 1]
+        ])
+      ),
+      25
+    );
+
+    const addresses = await discovery.discover(mockKeyAgent);
+
+    // 5 payment key + 4 stake keys combined with payment index 0 (the first address overlaps in both sets).
+    expect(addresses.length).toEqual(8);
+
+    // Results are sorted by payment cred index and then stake key index.
+    expect(addresses[0]).toEqual({
+      accountIndex: 0,
+      address: 'testAddress_0_0_0',
+      index: 0,
+      networkId: 0,
+      rewardAccount: 'testStakeAddress_0',
+      stakeKeyDerivationPath: { index: 0, role: KeyRole.Stake },
+      type: 0
+    });
+
+    const knownAddresses = await firstValueFrom(mockKeyAgent.knownAddresses$);
+
+    knownAddresses.sort(
+      (a, b) => a.index - b.index || a.stakeKeyDerivationPath!.index - b.stakeKeyDerivationPath!.index
+    );
+
+    expect(addresses).toEqual(knownAddresses);
+  });
+
   it('return all discovered addresses', async () => {
     const discovery = new HDSequentialDiscovery(mockChainHistoryProvider, 25);
 
     const addresses = await discovery.discover(mockKeyAgent);
 
-    // 50 even indices + 5 stake keys combined with payment index 0 (the first address overlaps in both sets).
-    expect(addresses.length).toEqual(54);
+    expect(addresses.length).toEqual(50);
 
     // Results are sorted by payment cred index and then stake key index.
     expect(addresses[0]).toEqual({
       accountIndex: 0,
-      address: 'testAddress_0_0',
+      address: 'testAddress_0_0_0',
       index: 0,
       networkId: 0,
       rewardAccount: 'testStakeAddress_0',

--- a/packages/wallet/test/services/addressDiscovery/SingleAddressDiscovery.test.ts
+++ b/packages/wallet/test/services/addressDiscovery/SingleAddressDiscovery.test.ts
@@ -17,7 +17,7 @@ describe('SingleAddressDiscovery', () => {
     expect(addresses.length).toEqual(1);
     expect(addresses[0]).toEqual({
       accountIndex: 0,
-      address: 'testAddress_0_0',
+      address: 'testAddress_0_0_0',
       index: 0,
       networkId: 0,
       rewardAccount: 'testStakeAddress_0',


### PR DESCRIPTION
# Context

PersonalWallet currently derives and retains 5 addresses for stake keys [0;5) and the 1st external payment key.

It is not ideal, because in single delegation mode only one address is being used, and wallet with 5 addreses will query data for all 5 (utxo, tx history etc.).

# Proposed Solution

This commit changes the behavior to retain only used addresses.

NOTE: it is possible that stake key is registered, without having any associated transactions (no utxo for the addresses).

Side fix: also discover 'Internal' type addresses
