### PR TITLE
feat: asset cache

### DIFF
--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -1,4 +1,4 @@
-import { Asset, Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Asset, Cardano, Milliseconds, ProviderError, ProviderFailure, Seconds } from '@cardano-sdk/core';
 import { InMemoryCache } from '../InMemoryCache';
 import { Logger } from 'ts-log';
 import { TokenMetadataService } from './types';
@@ -6,8 +6,8 @@ import { contextLogger } from '@cardano-sdk/util';
 import axios, { AxiosInstance } from 'axios';
 import pick from 'lodash/pick';
 
-export const DEFAULT_TOKEN_METADATA_CACHE_TTL = 600;
-export const DEFAULT_TOKEN_METADATA_REQUEST_TIMEOUT = 3 * 1000;
+export const DEFAULT_TOKEN_METADATA_CACHE_TTL = Seconds(10 * 60);
+export const DEFAULT_TOKEN_METADATA_REQUEST_TIMEOUT = Milliseconds(3 * 1000);
 export const DEFAULT_TOKEN_METADATA_SERVER_URL = 'https://tokens.cardano.org';
 
 interface NumberValue {
@@ -52,7 +52,7 @@ export interface CardanoTokenRegistryConfiguration {
   /**
    * The cache TTL in seconds. Default: 10 minutes.
    */
-  tokenMetadataCacheTTL?: number;
+  tokenMetadataCacheTTL?: Seconds;
 
   /**
    * The Cardano Token Registry API base URL. Default: https://tokens.cardano.org
@@ -62,11 +62,11 @@ export interface CardanoTokenRegistryConfiguration {
   /**
    * The HTTP request timeout value
    */
-  tokenMetadataRequestTimeout?: number;
+  tokenMetadataRequestTimeout?: Milliseconds;
 }
 
 interface CardanoTokenRegistryConfigurationWithRequired extends CardanoTokenRegistryConfiguration {
-  tokenMetadataCacheTTL: number;
+  tokenMetadataCacheTTL: Seconds;
   tokenMetadataServerUrl: string;
 }
 

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -5,11 +5,13 @@ import {
   GetAssetArgs,
   GetAssetsArgs,
   ProviderError,
-  ProviderFailure
+  ProviderFailure,
+  Seconds
 } from '@cardano-sdk/core';
 import { AssetBuilder } from './AssetBuilder';
+import { AssetPolicyIdAndName, NftMetadataService, TokenMetadataService } from '../types';
+import { DB_CACHE_TTL_DEFAULT, InMemoryCache, NoCache } from '../../InMemoryCache';
 import { DbSyncProvider, DbSyncProviderDependencies } from '../../util/DbSyncProvider';
-import { NftMetadataService, TokenMetadataService } from '../types';
 
 /**
  * Properties that are need to create DbSyncAssetProvider
@@ -19,6 +21,14 @@ export interface DbSyncAssetProviderProps {
    * Pagination page size limit used for provider methods constraint.
    */
   paginationPageSizeLimit: number;
+  /**
+   * Cache TTL in seconds, defaults to 2 hours
+   */
+  cacheTTL?: Seconds;
+  /**
+   * Does not use in-memory cache if `true`
+   */
+  disableDbCache?: boolean;
 }
 
 /**
@@ -35,6 +45,9 @@ export interface DbSyncAssetProviderDependencies extends DbSyncProviderDependenc
   tokenMetadataService: TokenMetadataService;
 }
 
+const nftMetadataCacheKey = (assetId: Cardano.AssetId) => `nm_${assetId.toString()}`;
+const assetInfoCacheKey = (assetId: Cardano.AssetId) => `ai_${assetId.toString()}`;
+
 /**
  * AssetProvider implementation using {@link NftMetadataService}, {@link TokenMetadataService}
  * and `cardano-db-sync` database as sources
@@ -43,22 +56,26 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
   #builder: AssetBuilder;
   #dependencies: DbSyncAssetProviderDependencies;
   #paginationPageSizeLimit: number;
+  #cache: InMemoryCache;
 
-  constructor({ paginationPageSizeLimit }: DbSyncAssetProviderProps, dependencies: DbSyncAssetProviderDependencies) {
+  constructor(
+    { paginationPageSizeLimit, disableDbCache, cacheTTL = DB_CACHE_TTL_DEFAULT }: DbSyncAssetProviderProps,
+    dependencies: DbSyncAssetProviderDependencies
+  ) {
     const { cache, dbPools, cardanoNode, logger } = dependencies;
     super({ cache, cardanoNode, dbPools, logger });
 
     this.#builder = new AssetBuilder(dbPools.main, logger);
     this.#dependencies = dependencies;
     this.#paginationPageSizeLimit = paginationPageSizeLimit;
+    this.#cache = disableDbCache ? new NoCache() : new InMemoryCache(cacheTTL);
   }
 
   async getAsset({ assetId, extraData }: GetAssetArgs) {
-    const assetInfo = await this.getAssetInfo(assetId);
+    const assetInfo = await this.#getAssetInfo(assetId);
 
     if (extraData?.history) await this.loadHistory(assetInfo);
-    if (extraData?.nftMetadata)
-      assetInfo.nftMetadata = await this.#dependencies.ntfMetadataService.getNftMetadata(assetInfo);
+    if (extraData?.nftMetadata) assetInfo.nftMetadata = await this.#getNftMetadata(assetInfo);
     if (extraData?.tokenMetadata) {
       try {
         assetInfo.tokenMetadata = (await this.#dependencies.tokenMetadataService.getTokenMetadata([assetId]))[0];
@@ -104,10 +121,9 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
     const tokenMetadataListPromise = extraData?.tokenMetadata ? fetchTokenMetadataList() : undefined;
 
     const getAssetInfo = async (assetId: Cardano.AssetId) => {
-      const assetInfo = await this.getAssetInfo(assetId);
+      const assetInfo = await this.#getAssetInfo(assetId);
 
-      if (extraData?.nftMetadata)
-        assetInfo.nftMetadata = await this.#dependencies.ntfMetadataService.getNftMetadata(assetInfo);
+      if (extraData?.nftMetadata) assetInfo.nftMetadata = await this.#getNftMetadata(assetInfo);
       if (tokenMetadataListPromise)
         assetInfo.tokenMetadata = (await tokenMetadataListPromise)[assetIds.indexOf(assetId)];
 
@@ -126,24 +142,33 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
     }));
   }
 
-  private async getAssetInfo(assetId: Cardano.AssetId): Promise<Asset.AssetInfo> {
-    const name = Cardano.AssetId.getAssetName(assetId);
-    const policyId = Cardano.AssetId.getPolicyId(assetId);
-    const multiAsset = await this.#builder.queryMultiAsset(policyId, name);
+  async #getNftMetadata(asset: AssetPolicyIdAndName): Promise<Asset.NftMetadata | null> {
+    return this.#cache.get(
+      nftMetadataCacheKey(Cardano.AssetId.fromParts(asset.policyId, asset.name)),
+      async () => await this.#dependencies.ntfMetadataService.getNftMetadata(asset)
+    );
+  }
 
-    if (!multiAsset)
-      throw new ProviderError(
-        ProviderFailure.NotFound,
-        undefined,
-        `No entries found in multi_asset table for asset '${assetId}'`
-      );
+  async #getAssetInfo(assetId: Cardano.AssetId): Promise<Asset.AssetInfo> {
+    return this.#cache.get(assetInfoCacheKey(assetId), async () => {
+      const name = Cardano.AssetId.getAssetName(assetId);
+      const policyId = Cardano.AssetId.getPolicyId(assetId);
+      const multiAsset = await this.#builder.queryMultiAsset(policyId, name);
 
-    const fingerprint = multiAsset.fingerprint as unknown as Cardano.AssetFingerprint;
-    const supply = BigInt(multiAsset.sum);
-    // Backwards compatibility
-    const quantity = supply;
-    const mintOrBurnCount = Number(multiAsset.count);
+      if (!multiAsset)
+        throw new ProviderError(
+          ProviderFailure.NotFound,
+          undefined,
+          `No entries found in multi_asset table for asset '${assetId}'`
+        );
 
-    return { assetId, fingerprint, mintOrBurnCount, name, policyId, quantity, supply };
+      const fingerprint = multiAsset.fingerprint as unknown as Cardano.AssetFingerprint;
+      const supply = BigInt(multiAsset.sum);
+      // Backwards compatibility
+      const quantity = supply;
+      const mintOrBurnCount = Number(multiAsset.count);
+
+      return { assetId, fingerprint, mintOrBurnCount, name, policyId, quantity, supply };
+    });
   }
 }

--- a/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
+++ b/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
@@ -1,3 +1,4 @@
+import { Seconds } from '@cardano-sdk/core';
 import NodeCache from 'node-cache';
 
 export type Key = string | number;
@@ -12,7 +13,7 @@ export class InMemoryCache {
    * @param ttl The default time to live in seconds
    * @param cache The cache engine. It must extend NodeCache
    */
-  constructor(ttl: number, cache: NodeCache = new NodeCache()) {
+  constructor(ttl: Seconds | 0, cache: NodeCache = new NodeCache()) {
     this.#ttlDefault = ttl;
     this.#cache = cache;
   }

--- a/packages/cardano-services/src/InMemoryCache/defaults.ts
+++ b/packages/cardano-services/src/InMemoryCache/defaults.ts
@@ -1,5 +1,7 @@
-export const DB_CACHE_TTL_DEFAULT = 2 * 60 * 60; // Two hours
+import { Seconds } from '@cardano-sdk/core';
 
-export const CACHE_TTL_LOWER_LIMIT = 60; // One minute
-export const CACHE_TTL_UPPER_LIMIT = 2 * 24 * 60 * 60; // Two days
+export const DB_CACHE_TTL_DEFAULT = Seconds(2 * 60 * 60); // Two hours
+
+export const CACHE_TTL_LOWER_LIMIT = Seconds(60); // One minute
+export const CACHE_TTL_UPPER_LIMIT = Seconds(2 * 24 * 60 * 60); // Two days
 export const UNLIMITED_CACHE_TTL = 0;

--- a/packages/cardano-services/src/Program/options/common.ts
+++ b/packages/cardano-services/src/Program/options/common.ts
@@ -7,13 +7,14 @@ import {
   SERVICE_DISCOVERY_TIMEOUT_DEFAULT,
   stringOptionToBoolean
 } from '../utils';
+import { Seconds } from '@cardano-sdk/core';
 import { BuildInfo as ServiceBuildInfo } from '../../Http';
 import { URL } from 'url';
 import { buildInfoValidator, cacheTtlValidator } from '../../util/validators';
 import { loggerMethodNames } from '@cardano-sdk/util';
 
 export const ENABLE_METRICS_DEFAULT = false;
-export const DEFAULT_HEALTH_CHECK_CACHE_TTL = 5;
+export const DEFAULT_HEALTH_CHECK_CACHE_TTL = Seconds(5);
 
 export enum CommonOptionDescriptions {
   ApiUrl = 'API URL',

--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 /* eslint-disable sonarjs/cognitive-complexity */
 import { AssetHttpService } from '../../Asset/AssetHttpService';
-import { CardanoNode } from '@cardano-sdk/core';
+import { CardanoNode, Seconds } from '@cardano-sdk/core';
 import { CardanoTokenRegistry } from '../../Asset/CardanoTokenRegistry';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider } from '../../ChainHistory';
 import { DbPools, DbSyncEpochPollService } from '../../util';
@@ -74,7 +74,7 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
       return factory(pools as DbPools, node);
     };
 
-  const getCache = (ttl: number) => (args.disableDbCache ? new NoCache() : new InMemoryCache(ttl));
+  const getCache = (ttl: Seconds | 0) => (args.disableDbCache ? new NoCache() : new InMemoryCache(ttl));
   const getDbCache = () => getCache(args.dbCacheTtl);
 
   // Shared cache across all providers
@@ -136,6 +136,8 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
         : new CardanoTokenRegistry({ logger }, args);
       const assetProvider = new DbSyncAssetProvider(
         {
+          cacheTTL: args.assetCacheTTL,
+          disableDbCache: args.disableDbCache,
           paginationPageSizeLimit: Math.min(args.paginationPageSizeLimit! * 10, PAGINATION_PAGE_SIZE_LIMIT_ASSETS)
         },
         {

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -1,4 +1,5 @@
 import { CommonProgramOptions } from '../options/common';
+import { Milliseconds, Seconds } from '@cardano-sdk/core';
 import { OgmiosProgramOptions } from '../options/ogmios';
 import { PosgresProgramOptions } from '../options/postgres';
 import { RabbitMqProgramOptions } from '../options/rabbitMq';
@@ -44,7 +45,8 @@ export enum ProviderServerOptionDescriptions {
   DisableDbCache = 'Disable DB cache',
   DisableStakePoolMetricApy = 'Omit this metric for improved query performance',
   EpochPollInterval = 'Epoch poll interval',
-  TokenMetadataCacheTtl = 'Token Metadata API cache TTL in minutes',
+  AssetCacheTtl = 'Asset info and NFT Metadata cache TTL in seconds (600 by default)',
+  TokenMetadataCacheTtl = 'Token Metadata API cache TTL in seconds',
   TokenMetadataServerUrl = 'Token Metadata API server URL',
   UseTypeOrmStakePoolProvider = 'Enables the TypeORM Stake Pool Provider',
   UseBlockfrost = 'Enables Blockfrost cached data DB',
@@ -61,12 +63,13 @@ export type ProviderServerArgs = CommonProgramOptions &
     cardanoNodeConfigPath?: string;
     disableDbCache?: boolean;
     disableStakePoolMetricApy?: boolean;
-    healthCheckCacheTtl: number;
-    tokenMetadataCacheTTL?: number;
+    healthCheckCacheTtl: Seconds;
+    assetCacheTTL?: Seconds;
+    tokenMetadataCacheTTL?: Seconds;
     tokenMetadataServerUrl?: string;
-    tokenMetadataRequestTimeout?: number;
+    tokenMetadataRequestTimeout?: Milliseconds;
     epochPollInterval: number;
-    dbCacheTtl: number;
+    dbCacheTtl: Seconds | 0;
     useBlockfrost?: boolean;
     useQueue?: boolean;
     useTypeormStakePoolProvider?: boolean;

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -265,6 +265,12 @@ withCommonOptions(
       .argParser(dbCacheValidator)
   )
   .addOption(
+    new Option('--asset-cache-ttl <assetCacheTTL>', ProviderServerOptionDescriptions.AssetCacheTtl)
+      .env('ASSET_CACHE_TTL')
+      .default(DB_CACHE_TTL_DEFAULT)
+      .argParser(dbCacheValidator)
+  )
+  .addOption(
     new Option(
       '--token-metadata-request-timeout <tokenMetadataRequestTimeout>',
       ProviderServerOptionDescriptions.PaginationPageSizeLimit

--- a/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
+++ b/packages/cardano-services/test/Asset/CardanoTokenRegistry.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Cardano, ProviderError, ProviderFailure, Seconds } from '@cardano-sdk/core';
 import { CardanoTokenRegistry, DEFAULT_TOKEN_METADATA_REQUEST_TIMEOUT, toCoreTokenMetadata } from '../../src/Asset';
 import { InMemoryCache, Key } from '../../src/InMemoryCache';
 import { logger } from '@cardano-sdk/util-dev';
@@ -115,7 +115,7 @@ describe('CardanoTokenRegistry', () => {
     beforeAll(async () => {
       ({ closeMock, serverUrl } = await mockTokenRegistry(async () => ({})));
       tokenRegistry = new CardanoTokenRegistry(
-        { cache: new TestInMemoryCache(60), logger },
+        { cache: new TestInMemoryCache(Seconds(60)), logger },
         { tokenMetadataServerUrl: serverUrl }
       );
     });

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -34,9 +34,10 @@ describe('DbSyncAssetProvider', () => {
   let tokenMetadataService: TokenMetadataService;
   let cardanoNode: OgmiosCardanoNode;
   let fixtureBuilder: AssetFixtureBuilder;
+  let nftMetadataSpy: jest.SpyInstance;
   const cache = { db: new InMemoryCache(UNLIMITED_CACHE_TTL), healthCheck: new InMemoryCache(UNLIMITED_CACHE_TTL) };
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     ({ closeMock, serverUrl } = await mockTokenRegistry(async () => ({})));
     dbPools = {
       healthCheck: new Pool({ connectionString: process.env.POSTGRES_CONNECTION_STRING_DB_SYNC }),
@@ -48,6 +49,7 @@ describe('DbSyncAssetProvider', () => {
       logger,
       metadataService: createDbSyncMetadataService(dbPools.main, logger)
     });
+    nftMetadataSpy = jest.spyOn(ntfMetadataService, 'getNftMetadata');
     tokenMetadataService = new CardanoTokenRegistry(
       { logger },
       { tokenMetadataRequestTimeout: defaultTimeout, tokenMetadataServerUrl: serverUrl }
@@ -66,7 +68,7 @@ describe('DbSyncAssetProvider', () => {
     fixtureBuilder = new AssetFixtureBuilder(dbPools.main, logger);
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     tokenMetadataService.shutdown();
     await clearDbPools(dbPools);
     await closeMock();
@@ -101,12 +103,29 @@ describe('DbSyncAssetProvider', () => {
     const history = await fixtureBuilder.getHistory(assets[0].policyId, assets[0].name);
 
     expect(asset.history).toEqual(history);
+    // TODO: review test data, this is false positive right now
+    // expect(asset.nftMetadata).toBeTruthy();
     expect(asset.nftMetadata).toStrictEqual(assets[0].metadata);
     expect(asset.tokenMetadata).toStrictEqual({
       assetId: '728847c7898b06f180de05c80b37d38bf77a9ea22bd1e222b8014d964e46542d66696c6573',
       desc: 'This is my second NFT',
       name: 'Bored Ape'
     });
+  });
+  it.todo('caches asset info query responses');
+  it('caches nft metadata', async () => {
+    const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
+    await Promise.all([
+      provider.getAsset({
+        assetId: assets[0].id,
+        extraData: { nftMetadata: true }
+      }),
+      provider.getAssets({
+        assetIds: [assets[0].id],
+        extraData: { nftMetadata: true }
+      })
+    ]);
+    expect(nftMetadataSpy).toBeCalledTimes(1);
   });
   it('returns undefined asset token metadata if the token registry throws a server internal error', async () => {
     const { serverUrl, closeMock } = await mockTokenRegistry(async () => ({ body: {}, code: 500 }));

--- a/packages/cardano-services/test/Program/programs/httpServer.test.ts
+++ b/packages/cardano-services/test/Program/programs/httpServer.test.ts
@@ -18,7 +18,7 @@ import {
   loadProviderServer
 } from '../../../src';
 import { Ogmios } from '@cardano-sdk/ogmios';
-import { ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { ProviderError, ProviderFailure, Seconds } from '@cardano-sdk/core';
 import { SrvRecord } from 'dns';
 import { URL } from 'url';
 import {
@@ -44,8 +44,8 @@ describe('HTTP Server', () => {
   let postgresDbDbSync: string;
   let postgresUserDbSync: string;
   let postgresPasswordDbSync: string;
-  let dbCacheTtl: number;
-  let healthCheckCacheTtl: number;
+  let dbCacheTtl: Seconds;
+  let healthCheckCacheTtl: Seconds;
   let epochPollInterval: number;
   let httpServer: HttpServer;
   let ogmiosConnection: Ogmios.Connection;

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -45,7 +45,7 @@
     "test:web-extension:watch:run": "yarn test:web-extension:run --watch",
     "test:web-extension:watch": "run-s test:web-extension:build test:web-extension:watch:bg",
     "test:web-extension:watch:bg": "run-p test:web-extension:watch:build test:web-extension:watch:run",
-    "local-network:common": "USE_BLOCKFROST=false docker compose -p local-network-e2e -f docker-compose.yml -f ../../compose/common.yml $FILES up",
+    "local-network:common": "DISABLE_DB_CACHE=${DISABLE_DB_CACHE:-true} USE_BLOCKFROST=false docker compose -p local-network-e2e -f docker-compose.yml -f ../../compose/common.yml $FILES up",
     "local-network:up": "FILES='' yarn local-network:common",
     "local-network:dev": "FILES='-f ../../compose/dev.yml' yarn local-network:common",
     "local-network:profile:up": "FILES='-f ../../compose/pg-agent.yml' yarn local-network:common",


### PR DESCRIPTION
# Context

`get-asset` queries are pretty expensive

# Proposed Solution

- cache NFT metadata and base AssetInfo in-memory

# Important Changes Introduced

- fix query logging
- set `pg.Pool` connection and query timeout to 1 minute
