### PR TITLE
fix: correct ledger mapping canonical asset and asset group ordering

### DIFF
--- a/packages/hardware-ledger/src/transformers/assets.ts
+++ b/packages/hardware-ledger/src/transformers/assets.ts
@@ -2,18 +2,15 @@ import * as Ledger from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { Cardano } from '@cardano-sdk/core';
 
 const compareAssetNameCanonically = (a: Ledger.Token, b: Ledger.Token) => {
-  if (a.assetNameHex === b.assetNameHex) {
+  if (a.assetNameHex.length === b.assetNameHex.length) {
     return a.assetNameHex > b.assetNameHex ? 1 : -1;
   } else if (a.assetNameHex.length > b.assetNameHex.length) return 1;
   return -1;
 };
 
-const comparePolicyIdCanonically = (a: Ledger.AssetGroup, b: Ledger.AssetGroup) => {
-  if (a.policyIdHex === b.policyIdHex) {
-    return a.policyIdHex > b.policyIdHex ? 1 : -1;
-  } else if (a.policyIdHex.length > b.policyIdHex.length) return 1;
-  return -1;
-};
+const comparePolicyIdCanonically = (a: Ledger.AssetGroup, b: Ledger.AssetGroup) =>
+  // PolicyId is always of the same length
+  a.policyIdHex > b.policyIdHex ? 1 : -1;
 
 const tokenMapToAssetGroup = (tokenMap: Cardano.TokenMap): Ledger.AssetGroup[] => {
   const map = new Map<string, Array<Ledger.Token>>();

--- a/packages/hardware-ledger/test/transformers/assets.test.ts
+++ b/packages/hardware-ledger/test/transformers/assets.test.ts
@@ -16,19 +16,19 @@ describe('assets', () => {
 
       expect(ledgerAssets).toEqual([
         {
-          policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
-          tokens: [
-            { amount: 40n, assetNameHex: '' },
-            { amount: 30n, assetNameHex: '504154415445' }
-          ]
+          policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
+          tokens: [{ amount: 20n, assetNameHex: '' }]
         },
         {
           policyIdHex: '659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba82',
           tokens: [{ amount: -50n, assetNameHex: '54534c41' }]
         },
         {
-          policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
-          tokens: [{ amount: 20n, assetNameHex: '' }]
+          policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+          tokens: [
+            { amount: 40n, assetNameHex: '' },
+            { amount: 30n, assetNameHex: '504154415445' }
+          ]
         }
       ]);
     });

--- a/packages/hardware-ledger/test/transformers/tx.test.ts
+++ b/packages/hardware-ledger/test/transformers/tx.test.ts
@@ -47,15 +47,11 @@ describe('tx', () => {
         ],
         mint: [
           {
-            policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+            policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
             tokens: [
               {
-                amount: 40n,
+                amount: 20n,
                 assetNameHex: ''
-              },
-              {
-                amount: 30n,
-                assetNameHex: '504154415445'
               }
             ]
           },
@@ -69,11 +65,15 @@ describe('tx', () => {
             ]
           },
           {
-            policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
+            policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
             tokens: [
               {
-                amount: 20n,
+                amount: 40n,
                 assetNameHex: ''
+              },
+              {
+                amount: 30n,
+                assetNameHex: '504154415445'
               }
             ]
           }
@@ -96,15 +96,11 @@ describe('tx', () => {
             format: Ledger.TxOutputFormat.ARRAY_LEGACY,
             tokenBundle: [
               {
-                policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+                policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
                 tokens: [
                   {
-                    amount: 40n,
+                    amount: 20n,
                     assetNameHex: ''
-                  },
-                  {
-                    amount: 30n,
-                    assetNameHex: '504154415445'
                   }
                 ]
               },
@@ -118,11 +114,15 @@ describe('tx', () => {
                 ]
               },
               {
-                policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
+                policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
                 tokens: [
                   {
-                    amount: 20n,
+                    amount: 40n,
                     assetNameHex: ''
+                  },
+                  {
+                    amount: 30n,
+                    assetNameHex: '504154415445'
                   }
                 ]
               }

--- a/packages/hardware-ledger/test/transformers/txOut.test.ts
+++ b/packages/hardware-ledger/test/transformers/txOut.test.ts
@@ -79,15 +79,11 @@ describe('txOut', () => {
         format: Ledger.TxOutputFormat.ARRAY_LEGACY,
         tokenBundle: [
           {
-            policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+            policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
             tokens: [
               {
-                amount: 40n,
+                amount: 20n,
                 assetNameHex: ''
-              },
-              {
-                amount: 30n,
-                assetNameHex: '504154415445'
               }
             ]
           },
@@ -101,11 +97,15 @@ describe('txOut', () => {
             ]
           },
           {
-            policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
+            policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
             tokens: [
               {
-                amount: 20n,
+                amount: 40n,
                 assetNameHex: ''
+              },
+              {
+                amount: 30n,
+                assetNameHex: '504154415445'
               }
             ]
           }
@@ -144,15 +144,11 @@ describe('txOut', () => {
         format: Ledger.TxOutputFormat.ARRAY_LEGACY,
         tokenBundle: [
           {
-            policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+            policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
             tokens: [
               {
-                amount: 40n,
+                amount: 20n,
                 assetNameHex: ''
-              },
-              {
-                amount: 30n,
-                assetNameHex: '504154415445'
               }
             ]
           },
@@ -166,11 +162,15 @@ describe('txOut', () => {
             ]
           },
           {
-            policyIdHex: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
+            policyIdHex: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
             tokens: [
               {
-                amount: 20n,
+                amount: 40n,
                 assetNameHex: ''
+              },
+              {
+                amount: 30n,
+                assetNameHex: '504154415445'
               }
             ]
           }

--- a/packages/util-dev/src/mockProviders/mockUtxoProvider.ts
+++ b/packages/util-dev/src/mockProviders/mockUtxoProvider.ts
@@ -38,7 +38,10 @@ export const utxo: Cardano.Utxo[] = [
         'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
       ),
       value: {
-        assets: new Map([[AssetId.TSLA, 15n]]),
+        assets: new Map([
+          [AssetId.TSLA, 15n],
+          [AssetId.PXL, 20n]
+        ]),
         coins: 3_289_566n
       }
     }

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -110,7 +110,10 @@ describe('LedgerKeyAgent', () => {
           'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
         ),
         value: {
-          assets: new Map([[AssetId.TSLA, 6n]]),
+          assets: new Map([
+            [AssetId.PXL, 10n],
+            [AssetId.TSLA, 6n]
+          ]),
           coins: 5n
         }
       }


### PR DESCRIPTION
# Context

Some Ledger transactions are failing with

```
"Error: L: Transport failure: Ledger transport failed due to
 L: invalid asset group in multiasset token bundle - incorrect ordering of tokens
    at chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk/js/353.js:1:177432
    at async chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk/js/343.js:101:98823"
```

# Proposed Solution

Correct canonical ordering
