### PR TITLE
LW-6702 TxBuilder delegatePortfolio

### DIFF
--- a/packages/core/src/Cardano/types/DelegationsAndRewards.ts
+++ b/packages/core/src/Cardano/types/DelegationsAndRewards.ts
@@ -1,5 +1,5 @@
 import { Lovelace } from './Value';
-import { PoolId, StakePool } from './StakePool';
+import { PoolId, PoolIdHex, StakePool } from './StakePool';
 import { RewardAccount } from '../Address';
 
 export interface DelegationsAndRewards {
@@ -30,4 +30,17 @@ export interface RewardAccountInfo {
   delegatee?: Delegatee;
   rewardBalance: Lovelace;
   // Maybe add rewardsHistory for each reward account too
+}
+
+export interface Cip17Pool {
+  id: PoolIdHex;
+  weight: number;
+  name?: string;
+  ticker?: string;
+}
+export interface Cip17DelegationPortfolio {
+  name: string;
+  pools: Cip17Pool[];
+  description?: string;
+  author?: string;
 }

--- a/packages/e2e/test/long-running/delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/delegation-rewards.test.ts
@@ -70,7 +70,13 @@ describe('delegation rewards', () => {
 
     const submitDelegationTx = async () => {
       logger.info(`Creating delegation tx at epoch #${(await firstValueFrom(wallet1.currentEpoch$)).epochNo}`);
-      const { tx: signedTx } = await wallet1.createTxBuilder().delegate(poolId).build().sign();
+      const { tx: signedTx } = await wallet1
+        .createTxBuilder()
+        .delegatePortfolio({
+          pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolId)), weight: 1 }]
+        })
+        .build()
+        .sign();
       await wallet1.submitTx(signedTx);
       const { epochNo } = await firstValueFrom(wallet1.currentEpoch$);
       logger.info(`Delegation tx ${signedTx.id} submitted at epoch #${epochNo}`);

--- a/packages/e2e/test/wallet/PersonalWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/delegation.test.ts
@@ -113,7 +113,7 @@ describe('PersonalWallet/delegation', () => {
 
     const { tx } = await txBuilder
       .addOutput(await txBuilder.buildOutput().address(destAddresses).coin(tx1OutputCoins).build())
-      .delegate(poolId)
+      .delegatePortfolio({ pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolId)), weight: 1 }] })
       .build()
       .sign();
     await sourceWallet.submitTx(tx);
@@ -163,7 +163,7 @@ describe('PersonalWallet/delegation', () => {
     }
 
     // Make a 2nd tx with key de-registration
-    const { tx: txDeregisterSigned } = await sourceWallet.createTxBuilder().delegate().build().sign();
+    const { tx: txDeregisterSigned } = await sourceWallet.createTxBuilder().delegatePortfolio(null).build().sign();
     await sourceWallet.submitTx(txDeregisterSigned);
     await waitForTx(sourceWallet, txDeregisterSigned.id);
     const tx2ConfirmedState = await getWalletStateSnapshot(sourceWallet);

--- a/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
@@ -1,4 +1,3 @@
-import { AddressType } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import { DelegatedStake, PersonalWallet, createUtxoBalanceByAddressTracker } from '@cardano-sdk/wallet';
 import { MINUTE, firstValueFromTimed, getWallet, submitAndConfirm, walletReady } from '../../../src';
@@ -6,29 +5,17 @@ import { Observable, filter, firstValueFrom, map, tap } from 'rxjs';
 import { Percent } from '@cardano-sdk/util';
 import { createLogger } from '@cardano-sdk/util-dev';
 import { getEnv, walletVariables } from '../../../src/environment';
-import delay from 'delay';
 
 const env = getEnv(walletVariables);
 const logger = createLogger();
 const TEST_FUNDS = 1_000_000_000n;
+const POOLS_COUNT = 5;
 const distributionMessage = 'ObservableWallet.delegation.distribution$:';
-
-const deriveStakeKeys = async (wallet: PersonalWallet) => {
-  await walletReady(wallet, 0n);
-  // Add 4 new addresses with different stake keys.
-  for (let i = 1; i < 5; ++i) {
-    await wallet.keyAgent.deriveAddress({ index: 0, type: AddressType.External }, i);
-  }
-  // Allow status tracker to change status with debounce.
-  // Otherwise the updates are be debounced and next calls find the wallet ready before it had a chance to update the status.
-  await delay(2);
-};
 
 /** Distribute the wallet funds evenly across all its addresses */
 const distributeFunds = async (wallet: PersonalWallet) => {
   await walletReady(wallet, 0n);
   const addresses = await firstValueFrom(wallet.addresses$);
-  expect(addresses.length).toBeGreaterThan(1);
 
   // Check that we have enough funds. Otherwise, fund it from wallet account at index 0
   let { coins: totalCoins } = await firstValueFrom(wallet.balance.utxo.available$);
@@ -97,7 +84,7 @@ const deregisterAllStakeKeys = async (wallet: PersonalWallet): Promise<void> => 
   } catch {
     // Some stake keys are registered. Deregister them
     const txBuilder = wallet.createTxBuilder();
-    txBuilder.delegate();
+    txBuilder.delegatePortfolio(null);
     const { tx: deregTx } = await txBuilder.build().sign();
     await submitAndConfirm(wallet, deregTx);
 
@@ -109,36 +96,40 @@ const deregisterAllStakeKeys = async (wallet: PersonalWallet): Promise<void> => 
   }
 };
 
-const getPoolIds = async (wallet: PersonalWallet, count: number): Promise<Cardano.StakePool[]> => {
+const getPoolIds = async (wallet: PersonalWallet): Promise<Cardano.StakePool[]> => {
   const activePools = await wallet.stakePoolProvider.queryStakePools({
     filters: { status: [Cardano.StakePoolStatus.Active] },
-    pagination: { limit: count, startAt: 0 }
+    pagination: { limit: POOLS_COUNT, startAt: 0 }
   });
-  expect(activePools.pageResults.length).toBeGreaterThanOrEqual(count);
-  return Array.from({ length: count }).map((_, index) => activePools.pageResults[index]);
+  expect(activePools.pageResults.length).toBeGreaterThanOrEqual(POOLS_COUNT);
+  return Array.from({ length: POOLS_COUNT }).map((_, index) => activePools.pageResults[index]);
 };
 
 const delegateToMultiplePools = async (wallet: PersonalWallet) => {
-  // Delegating to multiple pools should be added in TxBuilder. Doing it manually for now.
-  // Prepare stakeKey registration certificates
-  const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
-  const stakeKeyRegCertificates = rewardAccounts.map(({ address }) => Cardano.createStakeKeyRegistrationCert(address));
+  const poolIds = await getPoolIds(wallet);
+  const portfolio: Pick<Cardano.Cip17DelegationPortfolio, 'pools'> = {
+    pools: poolIds.map(({ hexId: id }) => ({ id, weight: 1 }))
+  };
+  logger.debug('Delegating portfolio', portfolio);
 
-  const poolIds = await getPoolIds(wallet, rewardAccounts.length);
-  const delegationCertificates = rewardAccounts.map(({ address }, index) =>
-    Cardano.createDelegationCert(address, poolIds[index].id)
-  );
-
-  logger.debug(
-    `Delegating to pools ${poolIds.map(({ id }) => id)} and registering ${stakeKeyRegCertificates.length} stake keys`
-  );
-
-  const txBuilder = wallet.createTxBuilder();
-  // Artificially add the certificates in TxBuilder. An api improvement will make the UX better
-  txBuilder.partialTxBody.certificates = [...stakeKeyRegCertificates, ...delegationCertificates];
-  const { tx } = await txBuilder.build().sign();
+  const { tx } = await wallet.createTxBuilder().delegatePortfolio(portfolio).build().sign();
   await submitAndConfirm(wallet, tx);
   return poolIds;
+};
+
+const delegateAllToSinglePool = async (wallet: PersonalWallet): Promise<void> => {
+  // This is a negative testcase, simulating an HD wallet that has multiple stake keys delegated
+  // to the same stake pool. txBuilder.delegatePortfolio does not support this scenario.
+  const [{ id: poolId }] = await getPoolIds(wallet);
+  const txBuilder = wallet.createTxBuilder();
+  const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
+  txBuilder.partialTxBody.certificates = rewardAccounts.map(({ address }) =>
+    Cardano.createDelegationCert(address, poolId)
+  );
+
+  logger.debug(`Delegating all stake keys to pool ${poolId}`);
+  const { tx } = await txBuilder.build().sign();
+  await submitAndConfirm(wallet, tx);
 };
 
 describe('PersonalWallet/delegationDistribution', () => {
@@ -146,7 +137,6 @@ describe('PersonalWallet/delegationDistribution', () => {
 
   beforeAll(async () => {
     wallet = (await getWallet({ env, idx: 3, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
-    await deriveStakeKeys(wallet);
     await deregisterAllStakeKeys(wallet);
     await distributeFunds(wallet);
   });
@@ -158,17 +148,17 @@ describe('PersonalWallet/delegationDistribution', () => {
   it('reports observable wallet multi delegation as delegationDistribution by pool', async () => {
     await walletReady(wallet);
 
-    const walletAddresses = await firstValueFromTimed(wallet.addresses$);
-    const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
-
-    expect(rewardAccounts.length).toBe(5);
-
     // No stake distribution initially
     const delegationDistribution = await firstValueFrom(wallet.delegation.distribution$);
     logger.info('Empty delegation distribution initially');
     expect(delegationDistribution).toEqual(new Map());
 
     const poolIds = await delegateToMultiplePools(wallet);
+    const walletAddresses = await firstValueFromTimed(wallet.addresses$);
+    const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
+
+    expect(rewardAccounts.length).toBe(POOLS_COUNT);
+
     // Redistribute the funds because delegation costs send change to the first account, messing up the uniform distribution
     await distributeFunds(wallet);
 
@@ -206,7 +196,7 @@ describe('PersonalWallet/delegationDistribution', () => {
 
     // Send all coins to the last address. Check that stake distribution is 100 for that address and 0 for the rest
     const { coins: totalCoins } = await firstValueFrom(wallet.balance.utxo.total$);
-    let txBuilder = wallet.createTxBuilder();
+    const txBuilder = wallet.createTxBuilder();
     const { tx: txMoveFunds } = await txBuilder
       .addOutput(
         txBuilder
@@ -246,9 +236,7 @@ describe('PersonalWallet/delegationDistribution', () => {
     );
 
     // Delegate all reward accounts to the same pool. delegationDistribution$ should have 1 entry with 100% distribution
-    txBuilder = wallet.createTxBuilder();
-    const { tx: txDelegateTo1Pool } = await txBuilder.delegate(poolIds[0].id).build().sign();
-    await submitAndConfirm(wallet, txDelegateTo1Pool);
+    await delegateAllToSinglePool(wallet);
     simplifiedDelegationDistribution = await firstValueFrom(
       wallet.delegation.distribution$.pipe(
         tap((distribution) => {

--- a/packages/key-management/src/util/ensureStakeKeys.ts
+++ b/packages/key-management/src/util/ensureStakeKeys.ts
@@ -1,0 +1,57 @@
+import { AddressType, AsyncKeyAgent, GroupedAddress, KeyRole } from '../types';
+import { Logger } from 'ts-log';
+import { firstValueFrom } from 'rxjs';
+import uniq from 'lodash/uniq';
+
+export interface EnsureStakeKeysParams {
+  /** Key agent to use */
+  keyAgent: AsyncKeyAgent;
+  /** Requested number of stake keys */
+  count: number;
+  /** The payment key index to use when more stake keys are needed */
+  paymentKeyIndex?: number;
+  logger: Logger;
+}
+
+/**
+ * Given a count, checks if enough stake keys exist and derives
+ * more if needed
+ */
+export const ensureStakeKeys = async ({
+  keyAgent,
+  count,
+  logger,
+  paymentKeyIndex: index = 0
+}: EnsureStakeKeysParams): Promise<void> => {
+  const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
+  // Get current number of derived stake keys
+  const stakeKeyIndices = uniq(
+    knownAddresses
+      .filter(
+        ({ stakeKeyDerivationPath }) =>
+          stakeKeyDerivationPath?.role === KeyRole.Stake && stakeKeyDerivationPath?.index !== undefined
+      )
+      .map(({ stakeKeyDerivationPath }) => stakeKeyDerivationPath!.index)
+  );
+
+  const countToDerive = count - stakeKeyIndices.length;
+
+  if (countToDerive <= 0) {
+    // Sufficient stake keys are already created
+    return;
+  }
+
+  logger.debug(`Stake keys requested: ${count}; got ${stakeKeyIndices.length}`);
+
+  // Need more stake keys for the portfolio
+  const derivedAddresses: Promise<GroupedAddress>[] = [];
+  for (let stakeKeyIdx = 0; derivedAddresses.length < countToDerive; stakeKeyIdx++) {
+    if (!stakeKeyIndices.includes(stakeKeyIdx)) {
+      logger.debug(`No derivation with stake key index ${stakeKeyIdx} exists. Deriving a new stake key.`);
+      derivedAddresses.push(keyAgent.deriveAddress({ index, type: AddressType.External }, stakeKeyIdx));
+    }
+  }
+
+  const newAddresses = await Promise.all(derivedAddresses);
+  logger.debug('Derived new addresses:', newAddresses);
+};

--- a/packages/key-management/src/util/index.ts
+++ b/packages/key-management/src/util/index.ts
@@ -5,3 +5,4 @@ export * from './ownSignatureKeyPaths';
 export * from './stubSignTransaction';
 export * from './mapHardwareSigningData';
 export * from './KeyAgentTransactionSigner';
+export * from './ensureStakeKeys';

--- a/packages/key-management/test/util/ensureStakeKeys.test.ts
+++ b/packages/key-management/test/util/ensureStakeKeys.test.ts
@@ -1,0 +1,97 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { AddressType, AsyncKeyAgent, InMemoryKeyAgent, util } from '../../src';
+import { CML, Cardano } from '@cardano-sdk/core';
+import { Logger, dummyLogger } from 'ts-log';
+import { firstValueFrom } from 'rxjs';
+
+describe('ensureStakeKeys', () => {
+  let keyAgent: AsyncKeyAgent;
+  let logger: Logger;
+
+  beforeEach(async () => {
+    logger = dummyLogger;
+    const mnemonicWords = util.generateMnemonicWords();
+    const getPassphrase = jest.fn().mockResolvedValue(Buffer.from('password'));
+    const inputResolver = { resolveInput: jest.fn() };
+    keyAgent = util.createAsyncKeyAgent(
+      await InMemoryKeyAgent.fromBip39MnemonicWords(
+        {
+          chainId: Cardano.ChainIds.Preview,
+          getPassphrase,
+          mnemonicWords
+        },
+        { bip32Ed25519: new Crypto.CmlBip32Ed25519(CML), inputResolver, logger: dummyLogger }
+      )
+    );
+  });
+
+  it('can derive one stake key', async () => {
+    await util.ensureStakeKeys({ count: 1, keyAgent, logger });
+    const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
+    expect(knownAddresses.length).toBe(1);
+  });
+
+  it('does not create more stake keys when sufficient exist', async () => {
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 1);
+
+    await util.ensureStakeKeys({ count: 2, keyAgent, logger });
+
+    const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
+    expect(knownAddresses.length).toBe(2);
+  });
+
+  it('derives new stake keys filling any existing gaps', async () => {
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 2);
+
+    await util.ensureStakeKeys({ count: 4, keyAgent, logger });
+
+    const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
+    const stakeKeyIndices = knownAddresses.map(({ stakeKeyDerivationPath }) => stakeKeyDerivationPath?.index).sort();
+    expect(stakeKeyIndices).toEqual([0, 1, 2, 3]);
+  });
+
+  it('generates new known addresses using the requested payment key index', async () => {
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 2);
+
+    await util.ensureStakeKeys({ count: 4, keyAgent, logger, paymentKeyIndex: 1 });
+
+    const stakeKeyIndicesPaymentKey1 = (await firstValueFrom(keyAgent.knownAddresses$))
+      .filter(({ index }) => index === 1)
+      .map(({ stakeKeyDerivationPath }) => stakeKeyDerivationPath?.index);
+    expect(stakeKeyIndicesPaymentKey1).toEqual(expect.arrayContaining([1, 3]));
+  });
+
+  it('can handle request of 0 stake keys', async () => {
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
+    await util.ensureStakeKeys({ count: 0, keyAgent, logger });
+
+    const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
+    expect(knownAddresses.length).toBe(1);
+  });
+
+  it('takes into account addresses with multiple stake keys and payment keys', async () => {
+    await Promise.all([
+      keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0),
+      keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 3),
+      keyAgent.deriveAddress({ index: 1, type: AddressType.External }, 0),
+      keyAgent.deriveAddress({ index: 1, type: AddressType.External }, 2)
+    ]);
+
+    await util.ensureStakeKeys({ count: 5, keyAgent, logger });
+    const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
+    expect(knownAddresses.length).toBe(6);
+
+    const stakeKeyIndicesPaymentKey0 = knownAddresses
+      .filter(({ index }) => index === 0)
+      .map(({ stakeKeyDerivationPath }) => stakeKeyDerivationPath?.index);
+    expect(stakeKeyIndicesPaymentKey0).toEqual(expect.arrayContaining([0, 1, 3, 4]));
+
+    const stakeKeyIndicesPaymentKey1 = knownAddresses
+      .filter(({ index }) => index === 1)
+      .map(({ stakeKeyDerivationPath }) => stakeKeyDerivationPath?.index);
+    expect(stakeKeyIndicesPaymentKey1).toEqual(expect.arrayContaining([0, 2]));
+  });
+});

--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -1,6 +1,7 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano, HandleProvider, HandleResolution } from '@cardano-sdk/core';
-import { Logger } from 'ts-log';
 import {
+  InsufficientRewardAccounts,
   OutputBuilderTxOut,
   PartialTx,
   PartialTxOut,
@@ -13,9 +14,11 @@ import {
   TxOutValidationError,
   UnsignedTx
 } from './types';
+import { Logger } from 'ts-log';
 import { OutputBuilderValidator, TxOutputBuilder } from './OutputBuilder';
+import { RewardAccountWithPoolId } from '../types';
 import { SelectionSkeleton } from '@cardano-sdk/input-selection';
-import { SignTransactionOptions, TransactionSigner } from '@cardano-sdk/key-management';
+import { SignTransactionOptions, TransactionSigner, util } from '@cardano-sdk/key-management';
 import { contextLogger, deepEquals } from '@cardano-sdk/util';
 import { createOutputValidator } from '../output-validation';
 import { finalizeTx } from './finalizeTx';
@@ -50,6 +53,8 @@ interface LazySignerProps {
   builder: Builder;
   signer: Signer;
 }
+
+type TxBuilderStakePool = Omit<Cardano.Cip17Pool, 'id'> & { id: Cardano.PoolId };
 
 class LazyTxSigner implements UnsignedTx {
   #built?: BuiltTx;
@@ -88,6 +93,7 @@ export class GenericTxBuilder implements TxBuilder {
   #dependencies: TxBuilderDependencies;
   #outputValidator: OutputBuilderValidator;
   #delegateConfig: DelegateConfig;
+  #requestedPortfolio?: TxBuilderStakePool[];
   #logger: Logger;
   #handleProvider?: HandleProvider;
   #handles: HandleResolution[];
@@ -146,6 +152,17 @@ export class GenericTxBuilder implements TxBuilder {
     return this;
   }
 
+  delegatePortfolio(portfolio: Pick<Cardano.Cip17DelegationPortfolio, 'pools'> | null): TxBuilder {
+    if (portfolio?.pools.length === 0) {
+      throw new Error('Portfolio should define at least one delegation pool.');
+    }
+    this.#requestedPortfolio = (portfolio?.pools ?? []).map((pool) => ({
+      ...pool,
+      id: Cardano.PoolId.fromKeyHash(pool.id as unknown as Crypto.Ed25519KeyHashHex)
+    }));
+    return this;
+  }
+
   metadata(metadata: Cardano.TxMetadata): TxBuilder {
     this.partialAuxiliaryData = { ...this.partialAuxiliaryData, blob: new Map(metadata) };
     return this;
@@ -168,6 +185,7 @@ export class GenericTxBuilder implements TxBuilder {
           this.#logger.debug('Building');
           try {
             await this.#addDelegationCertificates();
+            await this.#delegatePortfolio();
             await this.#validateOutputs();
             // Take a snapshot of returned properties,
             // so that they don't change while `initializeTx` is resolving
@@ -277,5 +295,92 @@ export class GenericTxBuilder implements TxBuilder {
         );
       }
     }
+  }
+
+  async #getOrCreateRewardAccounts(): Promise<RewardAccountWithPoolId[]> {
+    if (this.#requestedPortfolio) {
+      await util.ensureStakeKeys({
+        count: this.#requestedPortfolio.length,
+        keyAgent: this.#dependencies.keyAgent,
+        logger: contextLogger(this.#logger, 'getOrCreateRewardAccounts')
+      });
+    }
+
+    return this.#dependencies.txBuilderProviders.rewardAccounts();
+  }
+
+  async #delegatePortfolio(): Promise<void> {
+    if (!this.#requestedPortfolio) {
+      // Delegation using CIP17 portfolio was not requested
+      return;
+    }
+
+    // Create stake keys to match number of requested pools
+    const rewardAccounts = await this.#getOrCreateRewardAccounts();
+
+    // New poolIds will be allocated to un-delegated stake keys
+    const newPoolIds = this.#requestedPortfolio
+      .filter((cip17Pool) =>
+        rewardAccounts.every((rewardAccount) => rewardAccount.delegatee?.nextNextEpoch?.id !== cip17Pool.id)
+      )
+      .map(({ id }) => id)
+      .reverse();
+
+    this.#logger.debug('New poolIds requested in portfolio:', newPoolIds);
+
+    // Reward accounts which don't have the stake key registered or that were delegated but should not be anymore
+    const availableRewardAccounts = rewardAccounts
+      .filter(
+        (rewardAccount) =>
+          rewardAccount.keyStatus === Cardano.StakeKeyStatus.Unregistered ||
+          !rewardAccount.delegatee?.nextNextEpoch ||
+          this.#requestedPortfolio?.every(({ id }) => id !== rewardAccount.delegatee?.nextNextEpoch?.id)
+      )
+      .sort(GenericTxBuilder.#sortRewardAccountsDelegatedFirst)
+      .reverse(); // items will be popped from this array, so we want the most suitable at the end of the array
+
+    if (newPoolIds.length > availableRewardAccounts.length) {
+      throw new InsufficientRewardAccounts(
+        newPoolIds,
+        availableRewardAccounts.map(({ address }) => address)
+      );
+    }
+
+    // Code below will pop items one by one (poolId)-(available stake key)
+    const certificates: Cardano.Certificate[] = [];
+    while (newPoolIds.length > 0 && availableRewardAccounts.length > 0) {
+      const newPoolId = newPoolIds.pop()!;
+      const rewardAccount = availableRewardAccounts.pop()!;
+      this.#logger.debug(`Building delegation certificate for ${newPoolId} ${rewardAccount}`);
+      if (rewardAccount.keyStatus !== Cardano.StakeKeyStatus.Registered) {
+        certificates.push(Cardano.createStakeKeyRegistrationCert(rewardAccount.address));
+      }
+      certificates.push(Cardano.createDelegationCert(rewardAccount.address, newPoolId));
+    }
+
+    // Deregister stake keys no longer needed
+    this.#logger.debug(`De-registering ${availableRewardAccounts.length} stake keys`);
+    for (const rewardAccount of availableRewardAccounts) {
+      if (rewardAccount.keyStatus === Cardano.StakeKeyStatus.Registered) {
+        certificates.push(Cardano.createStakeKeyDeregistrationCert(rewardAccount.address));
+      }
+    }
+    this.partialTxBody = { ...this.partialTxBody, certificates };
+  }
+
+  /** Registered and delegated < Registered < Unregistered */
+  static #sortRewardAccountsDelegatedFirst(a: RewardAccountWithPoolId, b: RewardAccountWithPoolId): number {
+    const getScore = (acct: RewardAccountWithPoolId) => {
+      let score = 2;
+      if (acct.keyStatus === Cardano.StakeKeyStatus.Registered) {
+        score = 1;
+        if (acct.delegatee?.nextNextEpoch) {
+          score = 0;
+        }
+      }
+      return score;
+    };
+
+    return getScore(a) - getScore(b);
   }
 }

--- a/packages/tx-construction/src/tx-builder/types.ts
+++ b/packages/tx-construction/src/tx-builder/types.ts
@@ -183,7 +183,17 @@ export interface TxBuilder {
    */
   buildOutput(txOut?: PartialTxOut): OutputBuilder;
   /**
-   * Configure the transaction to include all the certificates needed to delegate to the pools from the portfolio.
+   * Configures the transaction to include all the certificates needed to delegate to the pools from the portfolio.
+   *
+   * IMPORTANT:
+   *  - When there are multiple reward accounts or a portfolio with multiple pools is requested, {@link GreedyInputSelector}
+   * will be used to distribute the funds according to the weights.
+   *  - Even when delegating to a single pool, the presence of
+   * multiple reward accounts implies the use of {@link GreedyInputSelector} to make sure that all funds are sent to the
+   * stake key being delegated.
+   *  - To avoid this behavior, please make sure that your wallet has a single reward account, AND you are delegating to a single pool.
+   *  - Please see documentation for {@link GreedyInputSelector} to understand the side effects.
+   *
    * - Portfolio delegations that already exist will be preserved.
    * - Delegation certificates will be sent for portfolio pools that are not already delegated.
    *   The order in which stake keys are used is:

--- a/packages/tx-construction/src/types.ts
+++ b/packages/tx-construction/src/types.ts
@@ -7,11 +7,15 @@ import { MinimumCoinQuantityPerOutput } from './output-validation';
 
 export type InitializeTxResult = Cardano.TxBodyWithHash & { inputSelection: SelectionSkeleton };
 
+export type RewardAccountWithPoolId = Omit<Cardano.RewardAccountInfo, 'delegatee'> & {
+  delegatee?: { nextNextEpoch?: { id: Cardano.PoolId } };
+};
+
 export interface TxBuilderProviders {
   tip: () => Promise<Cardano.Tip>;
   protocolParameters: () => Promise<Cardano.ProtocolParameters>;
   genesisParameters: () => Promise<Cardano.CompactGenesis>;
-  rewardAccounts: () => Promise<Omit<Cardano.RewardAccountInfo, 'delegatee'>[]>;
+  rewardAccounts: () => Promise<RewardAccountWithPoolId[]>;
   utxoAvailable: () => Promise<Cardano.Utxo[]>;
 }
 

--- a/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
@@ -53,12 +53,13 @@ describe('GenericTxBuilder', () => {
   let txBuilderProviders: jest.Mocked<TxBuilderProviders>;
   let output: Cardano.TxOut;
   let output2: Cardano.TxOut;
+  let inputResolver: Cardano.InputResolver;
 
   beforeEach(async () => {
     output = mocks.utxo[0][1];
     output2 = mocks.utxo[1][1];
     const rewardAccount = mocks.rewardAccount;
-    const inputResolver: Cardano.InputResolver = {
+    inputResolver = {
       resolveInput: async (txIn) =>
         mocks.utxo.find(
           ([hydratedTxIn]) => txIn.txId === hydratedTxIn.txId && txIn.index === hydratedTxIn.index
@@ -470,7 +471,7 @@ describe('GenericTxBuilder', () => {
     });
 
     it('adds both stake key and delegation certificates when stake key was not registered', async () => {
-      const txDelegate = await txBuilder.delegate(poolId).build();
+      const txDelegate = txBuilder.delegate(poolId).build();
       const [stakeKeyCert, delegationCert] = (await txDelegate.inspect()).body.certificates!;
       expect(stakeKeyCert.__typename).toBe(Cardano.CertificateType.StakeKeyRegistration);
 
@@ -499,6 +500,7 @@ describe('GenericTxBuilder', () => {
       txBuilderProviders.rewardAccounts.mockResolvedValueOnce([
         {
           address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
+          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
           keyStatus: Cardano.StakeKeyStatus.Registered,
           rewardBalance: 33_333n
         }
@@ -517,11 +519,13 @@ describe('GenericTxBuilder', () => {
       txBuilderProviders.rewardAccounts.mockResolvedValueOnce([
         {
           address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
+          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
           keyStatus: Cardano.StakeKeyStatus.Unregistered,
           rewardBalance: 33_333n
         },
         {
           address: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
+          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
           keyStatus: Cardano.StakeKeyStatus.Unregistered,
           rewardBalance: 44_444n
         }
@@ -534,6 +538,7 @@ describe('GenericTxBuilder', () => {
       txBuilderProviders.rewardAccounts.mockResolvedValueOnce([
         {
           address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
+          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
           keyStatus: Cardano.StakeKeyStatus.Registered,
           rewardBalance: 33_333n
         }

--- a/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
@@ -9,7 +9,7 @@ import {
   TransactionSigner,
   util
 } from '@cardano-sdk/key-management';
-import { AssetId, mockProviders as mocks, somePartialStakePools } from '@cardano-sdk/util-dev';
+import { AssetId, mockProviders as mocks } from '@cardano-sdk/util-dev';
 import { CML, Cardano, Handle, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import {
   GenericTxBuilder,
@@ -19,7 +19,6 @@ import {
   OutputValidation,
   OutputValidationMinimumCoinError,
   OutputValidationMissingRequiredError,
-  RewardAccountMissingError,
   TxBuilderProviders,
   TxOutValidationError,
   TxOutputBuilder,
@@ -452,106 +451,6 @@ describe('GenericTxBuilder', () => {
       it('legit output with valid with address and coin', async () => {
         await expect(txBuilder.buildOutput().address(address).coin(output1Coin).build()).resolves.not.toThrow();
       });
-    });
-  });
-
-  describe('delegate', () => {
-    let poolId: Cardano.PoolId;
-
-    beforeEach(() => {
-      poolId = somePartialStakePools[0].id;
-    });
-
-    it('certificates are added to tx.body on build', async () => {
-      const address = Cardano.PaymentAddress('addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg');
-      txBuilder.delegate(poolId);
-      const txOut = await txBuilder.buildOutput().address(address).coin(10_000_000n).build();
-      const txBuilt = await txBuilder.addOutput(txOut).build().inspect();
-      expect(txBuilt.body.certificates?.length).toBe(2);
-    });
-
-    it('adds both stake key and delegation certificates when stake key was not registered', async () => {
-      const txDelegate = txBuilder.delegate(poolId).build();
-      const [stakeKeyCert, delegationCert] = (await txDelegate.inspect()).body.certificates!;
-      expect(stakeKeyCert.__typename).toBe(Cardano.CertificateType.StakeKeyRegistration);
-
-      if (delegationCert.__typename === Cardano.CertificateType.StakeDelegation) {
-        expect(delegationCert.poolId).toBe(poolId);
-      }
-
-      expect.assertions(2);
-    });
-
-    it('delegate again removes previous certificates', async () => {
-      txBuilder.delegate(poolId).build();
-      const poolIdOther = somePartialStakePools[1].id;
-      const secondDelegationProps = await txBuilder.delegate(poolIdOther).build().inspect();
-      expect(secondDelegationProps.body.certificates?.length).toBe(2);
-      const delegationCert = secondDelegationProps.body.certificates![1] as Cardano.StakeDelegationCertificate;
-      expect(delegationCert.poolId).toBe(poolIdOther);
-    });
-
-    it('throws RewardAccountMissingError error if no reward accounts were found', async () => {
-      txBuilderProviders.rewardAccounts.mockResolvedValueOnce([]);
-      await expect(txBuilder.delegate(poolId).build().inspect()).rejects.toThrowError(RewardAccountMissingError);
-    });
-
-    it('adds only delegation certificate with correct poolId when stake key was already registered', async () => {
-      txBuilderProviders.rewardAccounts.mockResolvedValueOnce([
-        {
-          address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
-          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
-          keyStatus: Cardano.StakeKeyStatus.Registered,
-          rewardBalance: 33_333n
-        }
-      ]);
-      const txDelegateProps = await txBuilder.delegate(poolId).build().inspect();
-      expect(txDelegateProps.body.certificates?.length).toBe(1);
-      const [delegationCert] = txDelegateProps.body.certificates!;
-      if (delegationCert.__typename === Cardano.CertificateType.StakeDelegation) {
-        expect(delegationCert.poolId).toBe(poolId);
-      }
-
-      expect.assertions(2);
-    });
-
-    it('adds multiple certificates when handling multiple reward accounts', async () => {
-      txBuilderProviders.rewardAccounts.mockResolvedValueOnce([
-        {
-          address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
-          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
-          keyStatus: Cardano.StakeKeyStatus.Unregistered,
-          rewardBalance: 33_333n
-        },
-        {
-          address: Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'),
-          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
-          keyStatus: Cardano.StakeKeyStatus.Unregistered,
-          rewardBalance: 44_444n
-        }
-      ]);
-      const txDelegate = await txBuilder.delegate(poolId).build().inspect();
-      expect(txDelegate.body.certificates?.length).toBe(4);
-    });
-
-    it('undefined poolId adds stake key deregister certificate if already registered', async () => {
-      txBuilderProviders.rewardAccounts.mockResolvedValueOnce([
-        {
-          address: Cardano.RewardAccount('stake_test1uqu7qkgf00zwqupzqfzdq87dahwntcznklhp3x30t3ukz6gswungn'),
-          delegatee: { nextNextEpoch: { id: '' as Cardano.PoolId } },
-          keyStatus: Cardano.StakeKeyStatus.Registered,
-          rewardBalance: 33_333n
-        }
-      ]);
-      const txDeregister = await txBuilder.delegate().build().inspect();
-      expect(txDeregister.body.certificates?.length).toBe(1);
-      const [deregisterCert] = txDeregister.body.certificates!;
-      expect(deregisterCert.__typename).toBe(Cardano.CertificateType.StakeKeyDeregistration);
-    });
-
-    it('undefined poolId does NOT add certificate if not registered', async () => {
-      const txDeregister = await txBuilder.delegate().build().inspect();
-      expect(txDeregister.body.certificates?.length).toBeFalsy();
     });
   });
 

--- a/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
@@ -1,12 +1,45 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, GroupedAddress, InMemoryKeyAgent, util } from '@cardano-sdk/key-management';
 import { CML, Cardano } from '@cardano-sdk/core';
-import { GenericTxBuilder, OutputValidation, RewardAccountWithPoolId, TxBuilderProviders } from '../../src';
+import {
+  GenericTxBuilder,
+  OutputValidation,
+  RewardAccountWithPoolId,
+  TxBuilderProviders,
+  TxInspection
+} from '../../src';
+import { GreedyInputSelector, GreedySelectorProps, roundRobinRandomImprove } from '@cardano-sdk/input-selection';
 import { dummyLogger } from 'ts-log';
 import { mockProviders as mocks } from '@cardano-sdk/util-dev';
+import uniqBy from 'lodash/uniqBy';
 
+jest.mock('@cardano-sdk/input-selection', () => {
+  const actual = jest.requireActual('@cardano-sdk/input-selection');
+  return {
+    ...actual,
+    GreedyInputSelector: jest.fn((args) => new actual.GreedyInputSelector(args)),
+    roundRobinRandomImprove: jest.fn((args) => actual.roundRobinRandomImprove(args))
+  };
+});
+
+const expectGreedyInputSelectorWith = async (changeAddressesDistrib: Map<Cardano.PaymentAddress, number>) => {
+  expect(GreedyInputSelector).toHaveBeenCalled();
+  const greedySelectorProps: GreedySelectorProps = (GreedyInputSelector as jest.Mock).mock.calls[0][0];
+  const changeAddresses = await greedySelectorProps.getChangeAddresses();
+  expect(changeAddresses).toEqual(changeAddressesDistrib);
+};
+
+/**
+ * Utility factory for tests to create a GenericTxBuilder with mocked dependencies
+ *
+ * @param stakeKeyDelegations for each entry it derives an address + a stake key. Reward accounts are created from the stake keys.
+ *  Depending on the `keyStatus`, it configures the reward accounts to be registered, unregistered or delegated to a poolId
+ * @param useMultiplePaymentKeys simulates 2 addresses per stake key (HD wallet). If enabled, groupedAddresses will have 2 entries per stake key.
+ * @returns the txBuilder, groupedAddresses and other information useful in tests.
+ */
 const createTxBuilder = async (
-  stakeKeyDelegations: { keyStatus: Cardano.StakeKeyStatus; poolId?: Cardano.PoolId }[]
+  stakeKeyDelegations: { keyStatus: Cardano.StakeKeyStatus; poolId?: Cardano.PoolId }[],
+  useMultiplePaymentKeys = false
 ) => {
   const inputResolver: Cardano.InputResolver = {
     resolveInput: async (txIn) =>
@@ -21,24 +54,37 @@ const createTxBuilder = async (
     },
     { bip32Ed25519: new Crypto.CmlBip32Ed25519(CML), inputResolver, logger: dummyLogger }
   );
-  const address1 = await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
-  const address2 = await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 1);
-  const groupedAddresses = [address1, address2];
+
+  let groupedAddresses = await Promise.all(
+    stakeKeyDelegations.map(async (_, idx) => keyAgent.deriveAddress({ index: 0, type: AddressType.External }, idx))
+  );
+
+  // Simulate an HD wallet where a each stake key partitions 2 payment keys (2 addresses per stake key)
+  if (useMultiplePaymentKeys) {
+    const groupedAddresses2 = await Promise.all(
+      stakeKeyDelegations.map(async (_, idx) => keyAgent.deriveAddress({ index: 1, type: AddressType.External }, idx))
+    );
+    groupedAddresses = [...groupedAddresses, ...groupedAddresses2];
+  }
 
   const txBuilderProviders: jest.Mocked<TxBuilderProviders> = {
     genesisParameters: jest.fn().mockResolvedValue(mocks.genesisParameters),
     protocolParameters: jest.fn().mockResolvedValue(mocks.protocolParameters),
     rewardAccounts: jest.fn().mockImplementation(() =>
       Promise.resolve(
-        keyAgent.knownAddresses.map<RewardAccountWithPoolId>((knownAddr, index) => {
-          const { keyStatus, poolId } = stakeKeyDelegations[index] ?? {};
-          return {
-            address: knownAddr.rewardAccount,
-            keyStatus: keyStatus ?? Cardano.StakeKeyStatus.Unregistered,
-            rewardBalance: mocks.rewardAccountBalance,
-            ...(poolId ? { delegatee: { nextNextEpoch: { id: poolId } } } : undefined)
-          };
-        })
+        // There can be multiple addresses with the same reward account. Extract the uniq reward accounts
+        uniqBy(keyAgent.knownAddresses, ({ rewardAccount }) => rewardAccount)
+          // Create mock stakeKey/delegation status for each reward account according to the requested stakeKeyDelegations.
+          // This would normally be done by the wallet.delegation.rewardAccounts
+          .map<RewardAccountWithPoolId>(({ rewardAccount: address }, index) => {
+            const { keyStatus, poolId } = stakeKeyDelegations[index] ?? {};
+            return {
+              address,
+              keyStatus: keyStatus ?? Cardano.StakeKeyStatus.Unregistered,
+              rewardBalance: mocks.rewardAccountBalance,
+              ...(poolId ? { delegatee: { nextNextEpoch: { id: poolId } } } : undefined)
+            };
+          })
       )
     ),
     tip: jest.fn().mockResolvedValue(mocks.ledgerTip),
@@ -70,12 +116,43 @@ describe('TxBuilder/delegatePortfolio', () => {
   let txBuilder: GenericTxBuilder;
   let groupedAddresses: GroupedAddress[];
 
-  describe('no previous delegations', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('single reward account', () => {
     beforeEach(async () => {
-      const txBuilderFactory = await createTxBuilder([
-        { keyStatus: Cardano.StakeKeyStatus.Unregistered },
-        { keyStatus: Cardano.StakeKeyStatus.Unregistered }
-      ]);
+      const txBuilderFactory = await createTxBuilder([{ keyStatus: Cardano.StakeKeyStatus.Unregistered }]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+    });
+
+    it('uses random improve input selector when delegating to a single pool', async () => {
+      const tx = await txBuilder
+        .delegatePortfolio({ pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }] })
+        .build()
+        .inspect();
+
+      expect(tx.body.certificates?.length).toBe(2);
+      expect(tx.body.certificates).toContainEqual<Cardano.Certificate>({
+        __typename: Cardano.CertificateType.StakeKeyRegistration,
+        stakeKeyHash: Cardano.RewardAccount.toHash(groupedAddresses[0].rewardAccount)
+      });
+      expect(tx.body.certificates).toContainEqual({
+        __typename: Cardano.CertificateType.StakeDelegation,
+        poolId: poolIds[0],
+        stakeKeyHash: Cardano.RewardAccount.toHash(groupedAddresses[0].rewardAccount)
+      });
+
+      expect(GreedyInputSelector).not.toHaveBeenCalled();
+      expect(roundRobinRandomImprove).toHaveBeenCalled();
+    });
+  });
+
+  describe('no previous delegations, multiple addresses per stake key', () => {
+    beforeEach(async () => {
+      const txBuilderFactory = await createTxBuilder(
+        [{ keyStatus: Cardano.StakeKeyStatus.Unregistered }, { keyStatus: Cardano.StakeKeyStatus.Unregistered }],
+        true
+      );
       groupedAddresses = txBuilderFactory.groupedAddresses;
       txBuilder = txBuilderFactory.txBuilder;
     });
@@ -83,38 +160,62 @@ describe('TxBuilder/delegatePortfolio', () => {
     it('null portfolio does not add certificates', async () => {
       const tx = await txBuilder.delegatePortfolio(null).build().inspect();
       expect(tx.body.certificates?.length).toBeFalsy();
+      expect(GreedyInputSelector).not.toHaveBeenCalled();
     });
 
-    it('portfolio with multi-delegation adds certificates', async () => {
-      const tx = await txBuilder
-        .delegatePortfolio({
-          pools: [
-            {
-              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
-              weight: 1
-            },
-            {
-              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
-              weight: 1
-            }
-          ]
-        })
-        .build()
-        .inspect();
+    describe('transaction outputs and multi-delegation portfolio', () => {
+      let tx: TxInspection;
+      let output: Cardano.TxOut;
 
-      expect(tx.body.certificates?.length).toBe(4);
-      expect(tx.body.certificates).toContainEqual<Cardano.Certificate>(
-        Cardano.createStakeKeyRegistrationCert(groupedAddresses[0].rewardAccount)
-      );
-      expect(tx.body.certificates).toContainEqual(
-        Cardano.createDelegationCert(groupedAddresses[0].rewardAccount, poolIds[0])
-      );
-      expect(tx.body.certificates).toContainEqual(
-        Cardano.createStakeKeyRegistrationCert(groupedAddresses[1].rewardAccount)
-      );
-      expect(tx.body.certificates).toContainEqual(
-        Cardano.createDelegationCert(groupedAddresses[1].rewardAccount, poolIds[1])
-      );
+      beforeEach(async () => {
+        output = { address: groupedAddresses[3].address, value: { coins: 10n } };
+        tx = await txBuilder
+          .delegatePortfolio({
+            pools: [
+              {
+                id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
+                weight: 1
+              },
+              {
+                id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+                weight: 2
+              }
+            ]
+          })
+          .addOutput(txBuilder.buildOutput(output).toTxOut())
+          .build()
+          .inspect();
+      });
+
+      it('adds delegation certificates', () => {
+        expect(tx.body.certificates?.length).toBe(4);
+        expect(tx.body.certificates).toContainEqual<Cardano.Certificate>(
+          Cardano.createStakeKeyRegistrationCert(groupedAddresses[0].rewardAccount)
+        );
+        expect(tx.body.certificates).toContainEqual(
+          Cardano.createDelegationCert(groupedAddresses[0].rewardAccount, poolIds[0])
+        );
+        expect(tx.body.certificates).toContainEqual(
+          Cardano.createStakeKeyRegistrationCert(groupedAddresses[1].rewardAccount)
+        );
+        expect(tx.body.certificates).toContainEqual(
+          Cardano.createDelegationCert(groupedAddresses[1].rewardAccount, poolIds[1])
+        );
+      });
+
+      it(`configures only the first address per stake key as
+          change address with configured weights using greedy input selector`, async () => {
+        await expectGreedyInputSelectorWith(
+          new Map([
+            [groupedAddresses[0].address, 1],
+            [groupedAddresses[1].address, 2]
+          ])
+        );
+      });
+
+      it('adds the configured outputs', async () => {
+        expect(tx.body.outputs[0]).toEqual(output);
+      });
     });
   });
 
@@ -130,7 +231,7 @@ describe('TxBuilder/delegatePortfolio', () => {
       txBuilderProviders = txBuilderFactory.txBuilderProviders;
     });
 
-    it('null portfolio de-registers all stake keys', async () => {
+    it('null portfolio de-registers all stake keys, and uses random improve input selector', async () => {
       const tx = await txBuilder.delegatePortfolio(null).build().inspect();
       expect(tx.body.certificates?.length).toBe(2);
       expect(tx.body.certificates).toContainEqual(
@@ -139,19 +240,22 @@ describe('TxBuilder/delegatePortfolio', () => {
       expect(tx.body.certificates).toContainEqual(
         Cardano.createStakeKeyDeregistrationCert(groupedAddresses[1].rewardAccount)
       );
+
+      expect(GreedyInputSelector).not.toHaveBeenCalled();
+      expect(roundRobinRandomImprove).toHaveBeenCalled();
     });
 
-    it('does not change delegations when portfolio already satisfied', async () => {
+    it('does not change delegations when portfolio already satisfied, but updates distribution', async () => {
       const tx = await txBuilder
         .delegatePortfolio({
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
-              weight: 1
+              weight: 20
             },
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
-              weight: 1
+              weight: 10
             }
           ]
         })
@@ -159,19 +263,27 @@ describe('TxBuilder/delegatePortfolio', () => {
         .inspect();
 
       expect(tx.body.certificates?.length).toBeFalsy();
+
+      await expectGreedyInputSelectorWith(
+        new Map([
+          [groupedAddresses[0].address, 20],
+          [groupedAddresses[1].address, 10]
+        ])
+      );
     });
 
-    it('creates certificate to change delegation when one pool matches while the other was changed ', async () => {
+    it(`creates certificate to change delegation when one pool matches while the other was changed,
+        and updates change addresses distribution`, async () => {
       const tx = await txBuilder
         .delegatePortfolio({
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
-              weight: 1
+              weight: 95
             },
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
-              weight: 1
+              weight: 5
             }
           ]
         })
@@ -182,10 +294,18 @@ describe('TxBuilder/delegatePortfolio', () => {
       expect(tx.body.certificates![0]).toEqual(
         Cardano.createDelegationCert(groupedAddresses[0].rewardAccount, poolIds[2])
       );
+
+      await expectGreedyInputSelectorWith(
+        new Map([
+          [groupedAddresses[0].address, 95],
+          [groupedAddresses[1].address, 5]
+        ])
+      );
     });
 
     it(`portfolio is subset: adds stake deregistration certificates
-         for the delegations that are no longer in the portfolio`, async () => {
+         for the delegations that are no longer in the portfolio,
+         and configures change addresses so funds go to the delegated address`, async () => {
       const tx = await txBuilder
         .delegatePortfolio({
           pools: [
@@ -202,6 +322,8 @@ describe('TxBuilder/delegatePortfolio', () => {
       expect(tx.body.certificates![0]).toEqual(
         Cardano.createStakeKeyDeregistrationCert(groupedAddresses[0].rewardAccount)
       );
+
+      await expectGreedyInputSelectorWith(new Map([[groupedAddresses[1].address, 1]]));
     });
 
     it('portfolio with empty pools array is not a valid CIP17 portfolio', () => {
@@ -242,11 +364,11 @@ describe('TxBuilder/delegatePortfolio', () => {
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
-              weight: 1
+              weight: 3
             },
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
-              weight: 1
+              weight: 7
             }
           ]
         })
@@ -257,6 +379,13 @@ describe('TxBuilder/delegatePortfolio', () => {
       expect(tx.body.certificates![0]).toEqual(
         Cardano.createDelegationCert(groupedAddresses[1].rewardAccount, poolIds[1])
       );
+
+      await expectGreedyInputSelectorWith(
+        new Map([
+          [groupedAddresses[0].address, 3],
+          [groupedAddresses[1].address, 7]
+        ])
+      );
     });
 
     it('changes delegation and deregisters stake keys that are not delegated', async () => {
@@ -265,7 +394,7 @@ describe('TxBuilder/delegatePortfolio', () => {
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
-              weight: 1
+              weight: 5
             }
           ]
         })
@@ -279,6 +408,8 @@ describe('TxBuilder/delegatePortfolio', () => {
       expect(tx.body.certificates).toContainEqual(
         Cardano.createStakeKeyDeregistrationCert(groupedAddresses[1].rewardAccount)
       );
+
+      await expectGreedyInputSelectorWith(new Map([[groupedAddresses[0].address, 5]]));
     });
   });
 

--- a/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
@@ -1,0 +1,387 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { AddressType, GroupedAddress, InMemoryKeyAgent, util } from '@cardano-sdk/key-management';
+import { CML, Cardano } from '@cardano-sdk/core';
+import { GenericTxBuilder, OutputValidation, RewardAccountWithPoolId, TxBuilderProviders } from '../../src';
+import { dummyLogger } from 'ts-log';
+import { mockProviders as mocks } from '@cardano-sdk/util-dev';
+
+const createTxBuilder = async (
+  stakeKeyDelegations: { keyStatus: Cardano.StakeKeyStatus; poolId?: Cardano.PoolId }[]
+) => {
+  const inputResolver: Cardano.InputResolver = {
+    resolveInput: async (txIn) =>
+      mocks.utxo.find(([hydratedTxIn]) => txIn.txId === hydratedTxIn.txId && txIn.index === hydratedTxIn.index)?.[1] ||
+      null
+  };
+  const keyAgent: InMemoryKeyAgent = await InMemoryKeyAgent.fromBip39MnemonicWords(
+    {
+      chainId: Cardano.ChainIds.Preprod,
+      getPassphrase: async () => Buffer.from('passphrase'),
+      mnemonicWords: util.generateMnemonicWords()
+    },
+    { bip32Ed25519: new Crypto.CmlBip32Ed25519(CML), inputResolver, logger: dummyLogger }
+  );
+  const address1 = await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
+  const address2 = await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 1);
+  const groupedAddresses = [address1, address2];
+
+  const txBuilderProviders: jest.Mocked<TxBuilderProviders> = {
+    genesisParameters: jest.fn().mockResolvedValue(mocks.genesisParameters),
+    protocolParameters: jest.fn().mockResolvedValue(mocks.protocolParameters),
+    rewardAccounts: jest.fn().mockImplementation(() =>
+      Promise.resolve(
+        keyAgent.knownAddresses.map<RewardAccountWithPoolId>((knownAddr, index) => {
+          const { keyStatus, poolId } = stakeKeyDelegations[index] ?? {};
+          return {
+            address: knownAddr.rewardAccount,
+            keyStatus: keyStatus ?? Cardano.StakeKeyStatus.Unregistered,
+            rewardBalance: mocks.rewardAccountBalance,
+            ...(poolId ? { delegatee: { nextNextEpoch: { id: poolId } } } : undefined)
+          };
+        })
+      )
+    ),
+    tip: jest.fn().mockResolvedValue(mocks.ledgerTip),
+    utxoAvailable: jest.fn().mockResolvedValue(mocks.utxo)
+  };
+  const outputValidator = {
+    validateOutput: jest.fn().mockResolvedValue({ coinMissing: 0n } as OutputValidation)
+  };
+  return {
+    groupedAddresses,
+    txBuilder: new GenericTxBuilder({
+      inputResolver,
+      keyAgent: util.createAsyncKeyAgent(keyAgent),
+      logger: dummyLogger,
+      outputValidator,
+      txBuilderProviders
+    }),
+    txBuilderProviders
+  };
+};
+
+describe('TxBuilder/delegatePortfolio', () => {
+  const poolIds: Cardano.PoolId[] = [
+    Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh'),
+    Cardano.PoolId('pool1t9xlrjyk76c96jltaspgwcnulq6pdkmhnge8xgza8ku7qvpsy9r'),
+    Cardano.PoolId('pool1la4ghj4w4f8p4yk4qmx0qvqmzv6592ee9rs0vgla5w6lc2nc8w5'),
+    Cardano.PoolId('pool1lu6ll4rcxm92059ggy6uym2p804s5hcwqyyn5vyqhy35kuxtn2f')
+  ];
+  let txBuilder: GenericTxBuilder;
+  let groupedAddresses: GroupedAddress[];
+
+  describe('no previous delegations', () => {
+    beforeEach(async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Unregistered },
+        { keyStatus: Cardano.StakeKeyStatus.Unregistered }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+    });
+
+    it('null portfolio does not add certificates', async () => {
+      const tx = await txBuilder.delegatePortfolio(null).build().inspect();
+      expect(tx.body.certificates?.length).toBeFalsy();
+    });
+
+    it('portfolio with multi-delegation adds certificates', async () => {
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: [
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
+              weight: 1
+            },
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+              weight: 1
+            }
+          ]
+        })
+        .build()
+        .inspect();
+
+      expect(tx.body.certificates?.length).toBe(4);
+      expect(tx.body.certificates).toContainEqual<Cardano.Certificate>(
+        Cardano.createStakeKeyRegistrationCert(groupedAddresses[0].rewardAccount)
+      );
+      expect(tx.body.certificates).toContainEqual(
+        Cardano.createDelegationCert(groupedAddresses[0].rewardAccount, poolIds[0])
+      );
+      expect(tx.body.certificates).toContainEqual(
+        Cardano.createStakeKeyRegistrationCert(groupedAddresses[1].rewardAccount)
+      );
+      expect(tx.body.certificates).toContainEqual(
+        Cardano.createDelegationCert(groupedAddresses[1].rewardAccount, poolIds[1])
+      );
+    });
+  });
+
+  describe('pre-existing multi-delegation on all stake keys', () => {
+    let txBuilderProviders: jest.Mocked<TxBuilderProviders>;
+    beforeEach(async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Registered, poolId: poolIds[0] },
+        { keyStatus: Cardano.StakeKeyStatus.Registered, poolId: poolIds[1] }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+      txBuilderProviders = txBuilderFactory.txBuilderProviders;
+    });
+
+    it('null portfolio de-registers all stake keys', async () => {
+      const tx = await txBuilder.delegatePortfolio(null).build().inspect();
+      expect(tx.body.certificates?.length).toBe(2);
+      expect(tx.body.certificates).toContainEqual(
+        Cardano.createStakeKeyDeregistrationCert(groupedAddresses[0].rewardAccount)
+      );
+      expect(tx.body.certificates).toContainEqual(
+        Cardano.createStakeKeyDeregistrationCert(groupedAddresses[1].rewardAccount)
+      );
+    });
+
+    it('does not change delegations when portfolio already satisfied', async () => {
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: [
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
+              weight: 1
+            },
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+              weight: 1
+            }
+          ]
+        })
+        .build()
+        .inspect();
+
+      expect(tx.body.certificates?.length).toBeFalsy();
+    });
+
+    it('creates certificate to change delegation when one pool matches while the other was changed ', async () => {
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: [
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
+              weight: 1
+            },
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+              weight: 1
+            }
+          ]
+        })
+        .build()
+        .inspect();
+
+      expect(tx.body.certificates?.length).toBe(1);
+      expect(tx.body.certificates![0]).toEqual(
+        Cardano.createDelegationCert(groupedAddresses[0].rewardAccount, poolIds[2])
+      );
+    });
+
+    it(`portfolio is subset: adds stake deregistration certificates
+         for the delegations that are no longer in the portfolio`, async () => {
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: [
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+              weight: 1
+            }
+          ]
+        })
+        .build()
+        .inspect();
+
+      expect(tx.body.certificates?.length).toBe(1);
+      expect(tx.body.certificates![0]).toEqual(
+        Cardano.createStakeKeyDeregistrationCert(groupedAddresses[0].rewardAccount)
+      );
+    });
+
+    it('portfolio with empty pools array is not a valid CIP17 portfolio', () => {
+      expect(() => txBuilder.delegatePortfolio({ pools: [] })).toThrow();
+    });
+
+    it('derives more stake keys when portfolio has more pools than available keys', async () => {
+      const pools = poolIds.slice(0, 3);
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: pools.map((pool) => ({ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(pool)), weight: 1 }))
+        })
+        .build()
+        .inspect();
+
+      const rewardAccounts = await txBuilderProviders.rewardAccounts();
+
+      expect(tx.body.certificates).toEqual([
+        Cardano.createStakeKeyRegistrationCert(rewardAccounts[2].address),
+        Cardano.createDelegationCert(rewardAccounts[2].address, poolIds[2])
+      ]);
+    });
+  });
+
+  describe('partial pre-existing multi-delegation', () => {
+    beforeEach(async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Registered, poolId: poolIds[0] },
+        { keyStatus: Cardano.StakeKeyStatus.Registered }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+    });
+
+    it('portfolio is superset: adds certificates for the new delegations', async () => {
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: [
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
+              weight: 1
+            },
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+              weight: 1
+            }
+          ]
+        })
+        .build()
+        .inspect();
+
+      expect(tx.body.certificates?.length).toBe(1);
+      expect(tx.body.certificates![0]).toEqual(
+        Cardano.createDelegationCert(groupedAddresses[1].rewardAccount, poolIds[1])
+      );
+    });
+
+    it('changes delegation and deregisters stake keys that are not delegated', async () => {
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: [
+            {
+              id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
+              weight: 1
+            }
+          ]
+        })
+        .build()
+        .inspect();
+
+      expect(tx.body.certificates?.length).toBe(2);
+      expect(tx.body.certificates).toContainEqual(
+        Cardano.createDelegationCert(groupedAddresses[0].rewardAccount, poolIds[2])
+      );
+      expect(tx.body.certificates).toContainEqual(
+        Cardano.createStakeKeyDeregistrationCert(groupedAddresses[1].rewardAccount)
+      );
+    });
+  });
+
+  describe('rewardAccount selection', () => {
+    const portfolio: Pick<Cardano.Cip17DelegationPortfolio, 'pools'> = {
+      pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }]
+    };
+
+    it('uses first one when all stake keys are unregistered', async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Unregistered },
+        { keyStatus: Cardano.StakeKeyStatus.Unregistered }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+
+      const firstStakeKeyHash = Cardano.RewardAccount.toHash(groupedAddresses[0].rewardAccount);
+
+      const tx = await txBuilder.delegatePortfolio(portfolio).build().inspect();
+
+      const certs = tx.body.certificates;
+      expect(certs?.length).toBe(2);
+      expect((certs![1] as Cardano.StakeDelegationCertificate).stakeKeyHash).toEqual(firstStakeKeyHash);
+    });
+
+    it('uses first one when all stake keys are registered', async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Registered },
+        { keyStatus: Cardano.StakeKeyStatus.Registered }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+
+      const tx = await txBuilder.delegatePortfolio(portfolio).build().inspect();
+
+      const certs = tx.body.certificates as Cardano.StakeDelegationCertificate[];
+      expect(certs.length).toBe(2);
+      expect(certs).toEqual<Cardano.Certificate[]>([
+        Cardano.createDelegationCert(groupedAddresses[0].rewardAccount, poolIds[0]),
+        Cardano.createStakeKeyDeregistrationCert(groupedAddresses[1].rewardAccount)
+      ]);
+    });
+
+    it('uses stake keys in order when changing delegation', async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Registered, poolId: poolIds[0] },
+        { keyStatus: Cardano.StakeKeyStatus.Registered, poolId: poolIds[1] }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+
+      const firstStakeKeyHash = Cardano.RewardAccount.toHash(groupedAddresses[0].rewardAccount);
+      const secondStakeKeyHash = Cardano.RewardAccount.toHash(groupedAddresses[1].rewardAccount);
+
+      const tx = await txBuilder
+        .delegatePortfolio({
+          pools: [
+            { id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])), weight: 1 },
+            { id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[3])), weight: 1 }
+          ]
+        })
+        .build()
+        .inspect();
+
+      const certs = tx.body.certificates as Cardano.StakeDelegationCertificate[];
+      expect(certs.length).toBe(2);
+      expect(certs[0].stakeKeyHash).toEqual(firstStakeKeyHash);
+      expect(certs[1].stakeKeyHash).toEqual(secondStakeKeyHash);
+    });
+
+    it('uses registered stake keys over unregistered ones', async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Unregistered },
+        { keyStatus: Cardano.StakeKeyStatus.Registered }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+
+      const secondStakeKeyHash = Cardano.RewardAccount.toHash(groupedAddresses[1].rewardAccount);
+
+      const tx = await txBuilder.delegatePortfolio(portfolio).build().inspect();
+
+      const certs = tx.body.certificates as Cardano.StakeDelegationCertificate[];
+      expect(certs.length).toBe(1);
+      expect(certs[0].stakeKeyHash).toEqual(secondStakeKeyHash);
+    });
+
+    it('reuses delegated stake keys instead of registering new ones', async () => {
+      const txBuilderFactory = await createTxBuilder([
+        { keyStatus: Cardano.StakeKeyStatus.Registered },
+        { keyStatus: Cardano.StakeKeyStatus.Registered, poolId: poolIds[1] }
+      ]);
+      groupedAddresses = txBuilderFactory.groupedAddresses;
+      txBuilder = txBuilderFactory.txBuilder;
+
+      const tx = await txBuilder.delegatePortfolio(portfolio).build().inspect();
+
+      const certs = tx.body.certificates as Cardano.StakeDelegationCertificate[];
+      expect(certs.length).toBe(2);
+      expect(certs).toEqual<Cardano.Certificate[]>([
+        Cardano.createDelegationCert(groupedAddresses[1].rewardAccount, poolIds[0]),
+        Cardano.createStakeKeyDeregistrationCert(groupedAddresses[0].rewardAccount)
+      ]);
+    });
+  });
+});

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -57,6 +57,10 @@ export const txBuilderProperties: RemoteApiProperties<TxBuilder> = {
     getApiProperties: () => txBuilderProperties,
     propType: RemoteApiPropertyType.ApiFactory
   },
+  delegatePortfolio: {
+    getApiProperties: () => txBuilderProperties,
+    propType: RemoteApiPropertyType.ApiFactory
+  },
   extraSigners: {
     getApiProperties: () => txBuilderProperties,
     propType: RemoteApiPropertyType.ApiFactory

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -53,10 +53,6 @@ export const txBuilderProperties: RemoteApiProperties<TxBuilder> = {
     getApiProperties: () => outputBuilderProperties,
     propType: RemoteApiPropertyType.ApiFactory
   },
-  delegate: {
-    getApiProperties: () => txBuilderProperties,
-    propType: RemoteApiPropertyType.ApiFactory
-  },
   delegatePortfolio: {
     getApiProperties: () => txBuilderProperties,
     propType: RemoteApiPropertyType.ApiFactory


### PR DESCRIPTION
# Context

Delegating a CIP17 portfolio (multi-delegation).

# Proposed Solution

TxBuilder.delegatePortfolio accepts a CIP17 delegation portfolio and creates the certificates to satisfy it:
   * - Portfolio delegations that already exist will be preserved.
   * - Delegation certificates will be sent for portfolio pools that are not already delegated.
   *   The order in which stake keys are used is:
   *     1. Stake keys that are delegated but shouldn't be anymore
   *     2. Registered but not delegated stake keys.
   *     3. Unregistered stake keys.
   *     4. New stake keys are derived if number of pools exceeds the number of available stake keys.
   * - Deregister stake key certificates are sent for stake keys delegated to pools that are no longer
   *   part of the portfolio, and are not needed for re-delegation.
   * All certificates are created on build().

# Important Changes Introduced
1. TxBuilder.delegate() method has been **removed**.
2. TxBuilderProviders.rewardAccounts expects **RewardAccountWithPoolId** type,
      instead of Omit<RewardAccount, 'delegatee'>

# To do before merge:
- [x] Integrate greedy input selection to distribute funds according to weights