### PR TITLE
fix(wallet): rewardAccounts duplicates HD wallet

### DIFF
--- a/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
+import { Cardano } from '@cardano-sdk/core';
 import { KeyAgentFactoryProps, getWallet } from '../../../src';
 import { PersonalWallet } from '@cardano-sdk/wallet';
 import { createLogger } from '@cardano-sdk/util-dev';
@@ -92,9 +93,16 @@ describe('PersonalWallet/multiAddress', () => {
 
     await walletReady(newWallet.wallet);
     const walletAddresses = await firstValueFromTimed(newWallet.wallet.addresses$);
+    const rewardAddresses = await firstValueFromTimed(newWallet.wallet.delegation.rewardAccounts$);
 
     // Let's check if all addresses has been discovered.
     expect(walletAddresses).toEqual(addressesToBeDiscovered);
+
+    // All addresses are built using the same stake key. Check that there is a single reward account
+    const expectedRewardAccount = walletAddresses[0].rewardAccount;
+    expect(rewardAddresses).toEqual([
+      expect.objectContaining<Partial<Cardano.RewardAccountInfo>>({ address: expectedRewardAccount })
+    ]);
 
     const totalBalance = await firstValueFromTimed(newWallet.wallet.balance.utxo.total$);
     const expectedAmount = PAYMENT_ADDRESSES_TO_GENERATE * Number(COINS_PER_ADDRESS);

--- a/packages/wallet/src/PersonalWallet/PersonalWallet.ts
+++ b/packages/wallet/src/PersonalWallet/PersonalWallet.ts
@@ -101,6 +101,7 @@ import { TrackedUtxoProvider } from '../services/ProviderTracker/TrackedUtxoProv
 import { WalletStores, createInMemoryWalletStores } from '../persistence';
 import { createTransactionReemitter } from '../services/TransactionReemitter';
 import isEqual from 'lodash/isEqual';
+import uniq from 'lodash/uniq';
 
 export interface PersonalWalletProps {
   readonly name: string;
@@ -460,7 +461,7 @@ export class PersonalWallet implements ObservableWallet {
       onFatalError,
       retryBackoffConfig,
       rewardAccountAddresses$: this.addresses$.pipe(
-        map((addresses) => addresses.map((groupedAddress) => groupedAddress.rewardAccount))
+        map((addresses) => uniq(addresses.map((groupedAddress) => groupedAddress.rewardAccount)))
       ),
       rewardsTracker: this.rewardsProvider,
       stakePoolProvider: this.stakePoolProvider,


### PR DESCRIPTION
# Context
Wallet delegation.rewardAccounts$ emits duplicates when addresses are partitioned to the same staking key.


