### PR TITLE
Refactor: removes networkInfoProvider dependency from KoralabHandleProvider

### DIFF
--- a/packages/cardano-services-client/test/HandleProvider/KoraLabsHandleProvider.test.ts
+++ b/packages/cardano-services-client/test/HandleProvider/KoraLabsHandleProvider.test.ts
@@ -8,12 +8,10 @@ import {
   getBobHandleAPIResponse,
   getBobHandleProviderResponse
 } from '../util';
-import { mockProviders as mocks } from '@cardano-sdk/util-dev';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
 const config = {
-  networkInfoProvider: mocks.mockNetworkInfoProvider2(100),
   policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
   serverUrl: 'http://some-hostname:3000'
 };
@@ -93,7 +91,6 @@ describe('KoraLabsHandleProvider', () => {
 
     test('HandleProvider should get not ok health check', async () => {
       const providerWithBadConfig = new KoraLabsHandleProvider({
-        networkInfoProvider: mocks.mockNetworkInfoProvider2(100),
         policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
         serverUrl: ''
       });

--- a/packages/cardano-services-client/test/util.ts
+++ b/packages/cardano-services-client/test/util.ts
@@ -30,10 +30,6 @@ export const getAliceHandleProviderResponse = {
   resolvedAddresses: {
     cardano:
       'addr_test1qqk4sr4f7vtqzd2w90d5nfu3n59jhhpawyphnek2y7er02nkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuqmcnecd'
-  },
-  resolvedAt: {
-    hash: Cardano.BlockId('10d64cc11e9b20e15b6c46aa7b1fed11246f437e62225655a30ea47bf8cc22d0'),
-    slot: Cardano.Slot(37_834_496)
   }
 };
 
@@ -44,10 +40,6 @@ export const getBobHandleProviderResponse = {
   resolvedAddresses: {
     cardano:
       'addr_test1qzrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuql9tk0g'
-  },
-  resolvedAt: {
-    hash: Cardano.BlockId('10d64cc11e9b20e15b6c46aa7b1fed11246f437e62225655a30ea47bf8cc22d0'),
-    slot: Cardano.Slot(37_834_496)
   }
 };
 

--- a/packages/cardano-services/src/Handle/openApi.json
+++ b/packages/cardano-services/src/Handle/openApi.json
@@ -53,7 +53,7 @@
       "HandleResolution": {
         "nullable": true,
         "type": "object",
-        "required": ["handle", "hasDatum", "policyId", "resolvedAddresses", "resolvedAt"],
+        "required": ["handle", "hasDatum", "policyId", "resolvedAddresses"],
         "properties": {
           "handle": {
             "type": "string"

--- a/packages/core/src/Provider/HandleProvider/types.ts
+++ b/packages/core/src/Provider/HandleProvider/types.ts
@@ -16,7 +16,7 @@ export interface HandleResolution {
   resolvedAddresses: {
     cardano: Cardano.PaymentAddress;
   };
-  resolvedAt: Point;
+  resolvedAt?: Point;
 }
 
 export interface ResolveHandlesArgs {

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -169,7 +169,6 @@ handleProviderFactory.register(HANDLE_PROVIDER, async (params: any): Promise<Han
 
   return new KoraLabsHandleProvider({
     adapter: customHttpFetchAdapter,
-    networkInfoProvider: params.networkInfoProvider,
     policyId: params.policyId,
     serverUrl: params.serverUrl
   });

--- a/packages/wallet/src/services/HandlesTracker.ts
+++ b/packages/wallet/src/services/HandlesTracker.ts
@@ -26,7 +26,7 @@ export interface HandlesTrackerProps {
 
 const handleInfoEquals = (a: HandleInfo, b: HandleInfo) =>
   a.assetId === b.assetId &&
-  a.resolvedAt.hash === b.resolvedAt.hash &&
+  a.resolvedAt?.hash === b.resolvedAt?.hash &&
   deepEquals(a.tokenMetadata, b.tokenMetadata) &&
   deepEquals(a.nftMetadata, b.nftMetadata);
 


### PR DESCRIPTION
# Context
The current implementation of KoralabsHandleProvider depends on the network info provider to return a `resolvedAt` property. However, this is not returned by KoralabsHandleProvider, so we are making that property option but not returning it as the API doesn't have it. 

# Proposed Solution
- [x] remove the network info provider dependency from KoralabsHandleProvider
- [x] make `resolvedAt` property, optional. 

# Important Changes Introduced

N/A