### PR TITLE
fix!: revert inclusion of version in the HttpProvider interface

### DIFF
--- a/packages/cardano-services-client/src/HttpProvider.ts
+++ b/packages/cardano-services-client/src/HttpProvider.ts
@@ -2,6 +2,7 @@
 import { HttpProviderConfigPaths, Provider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
 import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
+import { version } from './version';
 import axios, { AxiosAdapter, AxiosRequestConfig, AxiosResponseTransformer } from 'axios';
 
 const isEmptyResponse = (response: any) => response === '';
@@ -9,13 +10,6 @@ const isEmptyResponse = (response: any) => response === '';
 type ResponseTransformers<T> = { [K in keyof T]?: AxiosResponseTransformer };
 
 export interface HttpProviderConfig<T extends Provider> {
-  version: {
-    /**
-     * API version compatibility declaration.
-     */
-    api: string;
-    software: string;
-  };
   /**
    * Example: "http://localhost:3000"
    */
@@ -61,7 +55,7 @@ export interface HttpProviderConfig<T extends Provider> {
  */
 export type CreateHttpProviderConfig<T extends Provider> = Pick<
   HttpProviderConfig<T>,
-  'baseUrl' | 'adapter' | 'logger' | 'version'
+  'baseUrl' | 'adapter' | 'logger'
 >;
 
 /**
@@ -81,8 +75,7 @@ export const createHttpProvider = <T extends Provider>({
   paths,
   adapter,
   logger,
-  responseTransformers,
-  version
+  responseTransformers
 }: HttpProviderConfig<T>): T =>
   new Proxy<T>({} as T, {
     // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/packages/cardano-services-client/src/version.ts
+++ b/packages/cardano-services-client/src/version.ts
@@ -1,5 +1,5 @@
 // auto-generated using /home/rhys/code/iohk/cardano-js-sdk/packages/cardano-services-client/scripts/createVersionSource.js
 export const version = {
   api: '1.0.0',
-  software: '0.9.8'
+  software: '0.9.9'
 };

--- a/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/AssetInfoProvider/assetInfoHttpProvider.test.ts
@@ -1,10 +1,10 @@
 import { Cardano } from '@cardano-sdk/core';
-import { assetInfoHttpProvider, version } from '../../src';
+import { assetInfoHttpProvider } from '../../src';
 import { logger } from '@cardano-sdk/util-dev';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/asset', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/asset', logger };
 
 describe('assetInfoHttpProvider', () => {
   let axiosMock: MockAdapter;

--- a/packages/cardano-services-client/test/ChainHistoryProvider/chainHistoryProvider.test.ts
+++ b/packages/cardano-services-client/test/ChainHistoryProvider/chainHistoryProvider.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { ProviderFailure } from '@cardano-sdk/core';
 import { axiosError, healthCheckResponseWithState } from '../util';
-import { chainHistoryHttpProvider, version } from '../../src';
+import { chainHistoryHttpProvider } from '../../src';
 import { logger } from '@cardano-sdk/util-dev';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/history', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/history', logger };
 
 describe('chainHistoryProvider', () => {
   describe('healthCheck', () => {

--- a/packages/cardano-services-client/test/HandleProvider/handleHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HandleProvider/handleHttpProvider.test.ts
@@ -1,9 +1,9 @@
-import { handleHttpProvider, version } from '../../src';
+import { handleHttpProvider } from '../../src';
 import { logger } from '@cardano-sdk/util-dev';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/handle', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/handle', logger };
 
 describe('handleHttpProvider', () => {
   let axiosMock: MockAdapter;

--- a/packages/cardano-services-client/test/HttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HttpProvider.test.ts
@@ -43,7 +43,6 @@ describe('createHttpProvider', () => {
       baseUrl,
       logger,
       paths: stubProviderPaths,
-      version,
       ...config
     });
 
@@ -121,8 +120,7 @@ describe('createHttpProvider', () => {
           baseUrl: 'http://some-hostname:3000',
           logger,
           mapError: jest.fn(),
-          paths: stubProviderPaths,
-          version
+          paths: stubProviderPaths
         });
         try {
           await provider.noArgsEmptyReturn();

--- a/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/NetworkInfo/networkInfoHttpProvider.test.ts
@@ -1,9 +1,9 @@
 import { logger } from '@cardano-sdk/util-dev';
-import { networkInfoHttpProvider, version } from '../../src';
+import { networkInfoHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/network', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/network', logger };
 
 describe('networkInfoHttpProvider', () => {
   let axiosMock: MockAdapter;

--- a/packages/cardano-services-client/test/RewardProvider/rewardsHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/RewardProvider/rewardsHttpProvider.test.ts
@@ -1,12 +1,12 @@
 import { Cardano, EpochRewards } from '@cardano-sdk/core';
 import { healthCheckResponseWithState } from '../util';
 import { logger } from '@cardano-sdk/util-dev';
-import { rewardsHttpProvider, version } from '../../src';
+import { rewardsHttpProvider } from '../../src';
 import { toSerializableObject } from '@cardano-sdk/util';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/rewards', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/rewards', logger };
 
 describe('rewardsHttpProvider', () => {
   const rewardAccount = Cardano.RewardAccount('stake_test1uzxvhl83q8ujv2yvpy6n2krvpdlqqx28h7e9vsk6re43h3c3kufy6');

--- a/packages/cardano-services-client/test/StakePoolProvider/stakePoolHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/StakePoolProvider/stakePoolHttpProvider.test.ts
@@ -1,9 +1,9 @@
 import { logger } from '@cardano-sdk/util-dev';
-import { stakePoolHttpProvider, version } from '../../src';
+import { stakePoolHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/stake-pool', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/stake-pool', logger };
 
 describe('stakePoolHttpProvider', () => {
   let axiosMock: MockAdapter;

--- a/packages/cardano-services-client/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
@@ -2,11 +2,11 @@ import { CardanoNodeErrors, ProviderError, ProviderFailure } from '@cardano-sdk/
 import { axiosError, healthCheckResponseWithState } from '../util';
 import { bufferToHexString } from '@cardano-sdk/util';
 import { logger } from '@cardano-sdk/util-dev';
-import { txSubmitHttpProvider, version } from '../../src';
+import { txSubmitHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/tx-submit', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/tx-submit', logger };
 
 const emptyUintArrayAsHexString = bufferToHexString(Buffer.from(new Uint8Array()));
 

--- a/packages/cardano-services-client/test/Utxo/utxoHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/Utxo/utxoHttpProvider.test.ts
@@ -1,11 +1,11 @@
 import { Cardano } from '@cardano-sdk/core';
 import { healthCheckResponseWithState } from '../util';
 import { logger } from '@cardano-sdk/util-dev';
-import { utxoHttpProvider, version } from '../../src';
+import { utxoHttpProvider } from '../../src';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 
-const config = { baseUrl: 'http://some-hostname:3000/utxo', logger, version };
+const config = { baseUrl: 'http://some-hostname:3000/utxo', logger };
 
 describe('utxoHttpProvider', () => {
   let axiosMock: MockAdapter;

--- a/packages/cardano-services/src/PgBoss/stakePoolMetricsHandler.ts
+++ b/packages/cardano-services/src/PgBoss/stakePoolMetricsHandler.ts
@@ -4,7 +4,7 @@ import { DataSource } from 'typeorm';
 import { Logger } from 'ts-log';
 import { WorkerHandlerFactory } from './types';
 import { isErrorWithConstraint } from './util';
-import { stakePoolHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 
 interface RefreshPoolMetricsOptions {
   dataSource: DataSource;
@@ -67,7 +67,7 @@ export const refreshPoolMetrics = async (options: RefreshPoolMetricsOptions) => 
 
 export const stakePoolMetricsHandlerFactory: WorkerHandlerFactory = (options) => {
   const { dataSource, logger, stakePoolProviderUrl } = options;
-  const provider = stakePoolHttpProvider({ baseUrl: stakePoolProviderUrl, logger, version });
+  const provider = stakePoolHttpProvider({ baseUrl: stakePoolProviderUrl, logger });
 
   return async (data: StakePoolMetricsUpdateJob) => {
     const { slot } = data;

--- a/packages/cardano-services/test/Asset/AssetHttpService.test.ts
+++ b/packages/cardano-services/test/Asset/AssetHttpService.test.ts
@@ -15,7 +15,7 @@ import {
   UNLIMITED_CACHE_TTL
 } from '../../src';
 import { AssetProvider, Cardano } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, assetInfoHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { CreateHttpProviderConfig, assetInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DbPools, LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { INFO, createLogger } from 'bunyan';
 import { OgmiosCardanoNode } from '@cardano-sdk/ogmios';
@@ -57,8 +57,7 @@ describe('AssetHttpService', () => {
     config = { listen: { port } };
     clientConfig = {
       baseUrl: apiUrlBase,
-      logger: createLogger({ level: INFO, name: 'unit tests' }),
-      version
+      logger: createLogger({ level: INFO, name: 'unit tests' })
     };
   });
 

--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -12,7 +12,7 @@ import {
   InMemoryCache,
   UNLIMITED_CACHE_TTL
 } from '../../src';
-import { CreateHttpProviderConfig, chainHistoryHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { CreateHttpProviderConfig, chainHistoryHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DB_MAX_SAFE_INTEGER } from '../../src/ChainHistory/DbSyncChainHistory/queries';
 import { DataMocks } from '../data-mocks';
 import { DbPools, LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
@@ -52,7 +52,7 @@ describe('ChainHistoryHttpService', () => {
   beforeAll(async () => {
     port = await getPort();
     baseUrl = `http://localhost:${port}/chain-history`;
-    clientConfig = { baseUrl, logger, version };
+    clientConfig = { baseUrl, logger };
     config = { listen: { port } };
     dbPools = {
       healthCheck: new Pool({ connectionString: process.env.POSTGRES_CONNECTION_STRING_DB_SYNC }),

--- a/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
+++ b/packages/cardano-services/test/NetworkInfo/NetworkInfoHttpService.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable sonarjs/no-identical-functions */
-import { CreateHttpProviderConfig, networkInfoHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { CreateHttpProviderConfig, networkInfoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DbPools, DbSyncEpochPollService, LedgerTipModel, findLedgerTip, loadGenesisData } from '../../src/util';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../src/NetworkInfo';
 import { HttpServer, HttpServerConfig } from '../../src';
@@ -92,7 +92,7 @@ describe('NetworkInfoHttpService', () => {
       });
       service = new NetworkInfoHttpService({ logger, networkInfoProvider });
       httpServer = new HttpServer(config, { logger, runnableDependencies: [cardanoNode], services: [service] });
-      clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }), version };
+      clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }) };
       provider = networkInfoHttpProvider(clientConfig);
 
       await httpServer.initialize();

--- a/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
+++ b/packages/cardano-services/test/Reward/RewardsHttpService.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cardano, RewardsProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, rewardsHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { CreateHttpProviderConfig, rewardsHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DbPools, LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import {
   DbSyncRewardsProvider,
@@ -43,7 +43,7 @@ describe('RewardsHttpService', () => {
   beforeAll(async () => {
     port = await getPort();
     baseUrl = `http://localhost:${port}/rewards`;
-    clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }), version };
+    clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }) };
     config = { listen: { port } };
     dbPools = {
       healthCheck: new Pool({ connectionString: process.env.POSTGRES_CONNECTION_STRING_DB_SYNC }),

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cardano, QueryStakePoolsArgs, SortField, StakePoolProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, stakePoolHttpProvider, version } from '../../../cardano-services-client';
+import { CreateHttpProviderConfig, stakePoolHttpProvider } from '../../../cardano-services-client';
 import { DbPools, LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import { DbSyncEpochPollService, loadGenesisData } from '../../src/util';
 import { DbSyncStakePoolFixtureBuilder, PoolInfo, PoolWith } from './fixtures/FixtureBuilder';
@@ -111,8 +111,7 @@ describe('StakePoolHttpService', () => {
     config = { listen: { port } };
     clientConfig = {
       baseUrl,
-      logger: createLogger({ level: INFO, name: 'unit tests' }),
-      version
+      logger: createLogger({ level: INFO, name: 'unit tests' })
     };
     fixtureBuilder = new DbSyncStakePoolFixtureBuilder(dbPools.main, logger);
     poolsInfo = await fixtureBuilder.getPools(3, { with: [PoolWith.Metadata] });

--- a/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
+++ b/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Cardano, QueryStakePoolsArgs, SortField, StakePoolProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, stakePoolHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { CreateHttpProviderConfig, stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { HttpServer } from '../../../src/Http/HttpServer';
 import { HttpServerConfig } from '../../../src/Http/types';
 import { INFO, createLogger } from 'bunyan';
@@ -81,7 +81,7 @@ describe('TypeormStakePoolProvider', () => {
     port = await getPort();
     baseUrl = `http://localhost:${port}/stake-pool`;
     config = { listen: { port } };
-    clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }), version };
+    clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }) };
     connectionConfig$ = getConnectionConfig(dnsResolver, 'projector', 'StakePool', {
       postgresConnectionStringStakePool: process.env.POSTGRES_CONNECTION_STRING_STAKE_POOL!
     });

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { APPLICATION_JSON, CONTENT_TYPE, HttpServer, HttpServerConfig, TxSubmitHttpService } from '../../src';
 import { CardanoNodeErrors, ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, txSubmitHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { CreateHttpProviderConfig, txSubmitHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { FATAL, createLogger } from 'bunyan';
 import { OgmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
 import { bufferToHexString, fromSerializableObject } from '@cardano-sdk/util';
@@ -39,7 +39,7 @@ describe('TxSubmitHttpService', () => {
   beforeAll(async () => {
     port = await getPort();
     baseUrl = `http://localhost:${port}/tx-submit`;
-    clientConfig = { baseUrl, logger: createLogger({ level: FATAL, name: 'unit tests' }), version };
+    clientConfig = { baseUrl, logger: createLogger({ level: FATAL, name: 'unit tests' }) };
     config = { listen: { port } };
   });
 

--- a/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
+++ b/packages/cardano-services/test/Utxo/UtxoHttpService.test.ts
@@ -1,6 +1,6 @@
 import { AddressWith, UtxoFixtureBuilder } from './fixtures/FixtureBuilder';
 import { Cardano, UtxoProvider } from '@cardano-sdk/core';
-import { CreateHttpProviderConfig, utxoHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { CreateHttpProviderConfig, utxoHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { DataMocks } from '../data-mocks';
 import { DbPools, LedgerTipModel, findLedgerTip } from '../../src/util/DbSyncProvider';
 import {
@@ -45,7 +45,7 @@ describe('UtxoHttpService', () => {
   beforeAll(async () => {
     port = await getPort();
     baseUrl = `http://localhost:${port}/utxo`;
-    clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }), version };
+    clientConfig = { baseUrl, logger: createLogger({ level: INFO, name: 'unit tests' }) };
     config = { listen: { port } };
     dbPools = {
       healthCheck: new Pool({

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -42,8 +42,7 @@ import {
   rewardsHttpProvider,
   stakePoolHttpProvider,
   txSubmitHttpProvider,
-  utxoHttpProvider,
-  version
+  utxoHttpProvider
 } from '@cardano-sdk/cardano-services-client';
 import { LedgerKeyAgent } from '@cardano-sdk/hardware-ledger';
 import { Logger } from 'ts-log';
@@ -105,8 +104,7 @@ assetProviderFactory.register(HTTP_PROVIDER, async (params: any, logger: Logger)
       assetInfoHttpProvider({
         adapter: customHttpFetchAdapter,
         baseUrl: params.baseUrl,
-        logger,
-        version
+        logger
       })
     );
   });
@@ -118,7 +116,7 @@ chainHistoryProviderFactory.register(
     if (params.baseUrl === undefined) throw new Error(`${chainHistoryHttpProvider.name}: ${MISSING_URL_PARAM}`);
 
     return new Promise<ChainHistoryProvider>(async (resolve) => {
-      resolve(chainHistoryHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger, version }));
+      resolve(chainHistoryHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger }));
     });
   }
 );
@@ -129,7 +127,7 @@ networkInfoProviderFactory.register(
     if (params.baseUrl === undefined) throw new Error(`${networkInfoHttpProvider.name}: ${MISSING_URL_PARAM}`);
 
     return new Promise<NetworkInfoProvider>(async (resolve) => {
-      resolve(networkInfoHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger, version }));
+      resolve(networkInfoHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger }));
     });
   }
 );
@@ -138,7 +136,7 @@ rewardsProviderFactory.register(HTTP_PROVIDER, async (params: any, logger: Logge
   if (params.baseUrl === undefined) throw new Error(`${rewardsHttpProvider.name}: ${MISSING_URL_PARAM}`);
 
   return new Promise<RewardsProvider>(async (resolve) => {
-    resolve(rewardsHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger, version }));
+    resolve(rewardsHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger }));
   });
 });
 
@@ -160,7 +158,7 @@ txSubmitProviderFactory.register(HTTP_PROVIDER, async (params: any, logger: Logg
   if (params.baseUrl === undefined) throw new Error(`${txSubmitHttpProvider.name}: ${MISSING_URL_PARAM}`);
 
   return new Promise<TxSubmitProvider>(async (resolve) => {
-    resolve(txSubmitHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger, version }));
+    resolve(txSubmitHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger }));
   });
 });
 
@@ -168,7 +166,7 @@ utxoProviderFactory.register(HTTP_PROVIDER, async (params: any, logger: Logger):
   if (params.baseUrl === undefined) throw new Error(`${utxoHttpProvider.name}: ${MISSING_URL_PARAM}`);
 
   return new Promise<UtxoProvider>(async (resolve) => {
-    resolve(utxoHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger, version }));
+    resolve(utxoHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger }));
   });
 });
 
@@ -195,7 +193,7 @@ stakePoolProviderFactory.register(HTTP_PROVIDER, async (params: any, logger: Log
   if (params.baseUrl === undefined) throw new Error(`${stakePoolHttpProvider.name}: ${MISSING_URL_PARAM}`);
 
   return new Promise<StakePoolProvider>(async (resolve) => {
-    resolve(stakePoolHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger, version }));
+    resolve(stakePoolHttpProvider({ adapter: customHttpFetchAdapter, baseUrl: params.baseUrl, logger }));
   });
 });
 

--- a/packages/e2e/test/artillery/StakePoolSearch.ts
+++ b/packages/e2e/test/artillery/StakePoolSearch.ts
@@ -2,7 +2,7 @@ import * as envalid from 'envalid';
 import { ArtilleryContext, FunctionHook, WhileTrueHook } from './artillery';
 import { Cardano, Paginated, QueryStakePoolsArgs } from '@cardano-sdk/core';
 import { logger } from '@cardano-sdk/util-dev';
-import { stakePoolHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 
 /**
  * The context variables shared between all the hooks.
@@ -26,7 +26,7 @@ interface StakePoolSearchVars extends Paginated<Cardano.StakePool> {
 }
 
 const env = envalid.cleanEnv(process.env, { STAKE_POOL_PROVIDER_URL: envalid.str() });
-const provider = stakePoolHttpProvider({ baseUrl: env.STAKE_POOL_PROVIDER_URL, logger, version });
+const provider = stakePoolHttpProvider({ baseUrl: env.STAKE_POOL_PROVIDER_URL, logger });
 
 const PAGE_SIZE = 20;
 

--- a/packages/e2e/test/blockfrost/StakePoolCompare.test.ts
+++ b/packages/e2e/test/blockfrost/StakePoolCompare.test.ts
@@ -4,7 +4,7 @@ import { ChildProcess, fork } from 'child_process';
 import { WriteStream, createWriteStream } from 'fs';
 import { getRandomPort } from 'get-port-please';
 import { logger } from '@cardano-sdk/util-dev';
-import { stakePoolHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 import path from 'path';
 
 type StakePoolRecord = Record<string, Cardano.StakePool>;
@@ -127,7 +127,7 @@ describe('StakePoolCompare', () => {
   };
 
   const setupProvider = async (args: string[] = []) => {
-    const provider = stakePoolHttpProvider({ baseUrl: await startServer(args), logger, version });
+    const provider = stakePoolHttpProvider({ baseUrl: await startServer(args), logger });
 
     // eslint-disable-next-line no-constant-condition
     while (true) {

--- a/packages/e2e/test/load-test-custom/stake-pool-search/stake-pool-search.test.ts
+++ b/packages/e2e/test/load-test-custom/stake-pool-search/stake-pool-search.test.ts
@@ -4,7 +4,7 @@ import { Logger } from 'ts-log';
 import { MeasurementUtil, getEnv, getLoadTestScheduler } from '../../../src';
 import { bufferTime, from, tap } from 'rxjs';
 import { logger } from '@cardano-sdk/util-dev';
-import { stakePoolHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 
 // Example call:
 /* STAKE_POOL_PROVIDER_URL="http://mhvm:4000/stake-pool" \
@@ -14,7 +14,7 @@ import { stakePoolHttpProvider, version } from '@cardano-sdk/cardano-services-cl
 */
 
 const { STAKE_POOL_PROVIDER_URL } = envalid.cleanEnv(process.env, { STAKE_POOL_PROVIDER_URL: envalid.str() });
-const provider = stakePoolHttpProvider({ baseUrl: STAKE_POOL_PROVIDER_URL, logger, version });
+const provider = stakePoolHttpProvider({ baseUrl: STAKE_POOL_PROVIDER_URL, logger });
 const testLogger: Logger = console;
 const intermediateResultsInterval = 10_000;
 

--- a/packages/e2e/test/providers/StakePoolProvider.test.ts
+++ b/packages/e2e/test/providers/StakePoolProvider.test.ts
@@ -3,7 +3,7 @@
 import * as envalid from 'envalid';
 import { Cardano, QueryStakePoolsArgs, StakePoolProvider } from '@cardano-sdk/core';
 import { logger } from '@cardano-sdk/util-dev';
-import { stakePoolHttpProvider, version } from '@cardano-sdk/cardano-services-client';
+import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 
 const stringToRegExEqualsTo = (str: string) => `^${str.replace(/[$()*+.?[\\\]^{|}-]/g, '\\$&')}$`;
 
@@ -140,7 +140,7 @@ describe('StakePoolProvider', () => {
 
   beforeAll(async () => {
     const env = envalid.cleanEnv(process.env, { STAKE_POOL_PROVIDER_URL: envalid.url() });
-    const config = { baseUrl: env.STAKE_POOL_PROVIDER_URL, logger, version };
+    const config = { baseUrl: env.STAKE_POOL_PROVIDER_URL, logger };
 
     provider = stakePoolHttpProvider(config);
     pools = await fetchAllPools();


### PR DESCRIPTION

# Context

#634 introduced a change in the `HttpProvider` interface that was unnecessary, since the version can be just read in directly, and making it configurable is undesirable.

# Proposed Solution

partial revert of 2e9664fcaff56adcfa4f21eb2b71b2fb6a3b411d to keep the version definition an internal concern.

