### PR TITLE
feat: adds cardanoAddress type in HandleResolution interface

### DIFF
--- a/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
@@ -1,7 +1,7 @@
 import {
   Asset,
   Cardano,
-  Handle,
+  HandleResolution,
   HealthCheckResponse,
   ProviderError,
   ProviderFailure,
@@ -24,17 +24,6 @@ export interface KoraLabsHandleProviderDeps {
   serverUrl: string;
   adapter?: AxiosAdapter;
   policyId: Cardano.PolicyId;
-}
-
-export interface HandleResolution {
-  policyId: Cardano.PolicyId;
-  handle: Handle;
-  cardanoAddress: Cardano.PaymentAddress;
-  hasDatum: boolean;
-  defaultForStakeKey?: Handle;
-  defaultForPaymentKey?: Handle;
-  backgroundImage?: Asset.Uri;
-  profilePic?: Asset.Uri;
 }
 
 export const toHandleResolution = ({

--- a/packages/cardano-services/src/Handle/TypeOrmHandleProvider.ts
+++ b/packages/cardano-services/src/Handle/TypeOrmHandleProvider.ts
@@ -46,7 +46,7 @@ export class TypeOrmHandleProvider extends TypeormProvider implements HandleProv
 
         const { cardanoAddress, handle, hasDatum, policyId } = entity;
 
-        return { handle, hasDatum, policyId, resolvedAddresses: { cardano: cardanoAddress }, resolvedAt };
+        return { cardanoAddress, handle, hasDatum, policyId, resolvedAt };
       };
 
       const findOptions = { select: handleSelect, where: { handle: In(handles) } };

--- a/packages/cardano-services/src/Handle/openApi.json
+++ b/packages/cardano-services/src/Handle/openApi.json
@@ -53,7 +53,7 @@
       "HandleResolution": {
         "nullable": true,
         "type": "object",
-        "required": ["handle", "hasDatum", "policyId", "resolvedAddresses"],
+        "required": ["handle", "hasDatum", "policyId", "cardanoAddress"],
         "properties": {
           "handle": {
             "type": "string"
@@ -64,13 +64,8 @@
           "policyId": {
             "type": "string"
           },
-          "resolvedAddresses": {
-            "type": "object",
-            "properties": {
-              "cardano": {
-                "type": "string"
-              }
-            }
+          "cardanoAddress": {
+            "type": "string"
           },
           "resolvedAt": {
             "type": "object",

--- a/packages/cardano-services/test/Handle/HandleHttpService.test.ts
+++ b/packages/cardano-services/test/Handle/HandleHttpService.test.ts
@@ -122,10 +122,10 @@ describe('HandleHttpService', () => {
       resolveHandles: () =>
         Promise.resolve([
           {
+            cardanoAddress: <Cardano.PaymentAddress>'test_address',
             handle: 'test',
             hasDatum: true,
             policyId: <Cardano.PolicyId>'test_policy',
-            resolvedAddresses: { cardano: <Cardano.PaymentAddress>'test_address' },
             resolvedAt: { hash: <Cardano.BlockId>'test_hash', slot: <Cardano.Slot>42 }
           }
         ])
@@ -136,10 +136,10 @@ describe('HandleHttpService', () => {
     expect({ body, status }).toEqual({
       body: [
         {
+          cardanoAddress: 'test_address',
           handle: 'test',
           hasDatum: true,
           policyId: 'test_policy',
-          resolvedAddresses: { cardano: 'test_address' },
           resolvedAt: { hash: 'test_hash', slot: 42 }
         }
       ],

--- a/packages/core/src/Provider/HandleProvider/types.ts
+++ b/packages/core/src/Provider/HandleProvider/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, HttpProviderConfigPaths, Point, Provider } from '../..';
+import { Asset, Cardano, HttpProviderConfigPaths, Point, Provider } from '../..';
 
 export type Handle = string;
 
@@ -6,16 +6,18 @@ export type Handle = string;
  * @param policyId a hex encoded policyID
  * @param handle a personalized string to identify a user
  * @param hasDatum a boolean to indicated whether it contains a datum
- * @param resolvedAddresses the addresses resolved from the handle
+ * @param cardanoAddress the cardano payment address resolved from the handle
  * @param resolvedAt the point at which the Handle was resolved
  */
 export interface HandleResolution {
   policyId: Cardano.PolicyId;
   handle: Handle;
+  cardanoAddress: Cardano.PaymentAddress;
   hasDatum: boolean;
-  resolvedAddresses: {
-    cardano: Cardano.PaymentAddress;
-  };
+  defaultForStakeKey?: Handle;
+  defaultForPaymentKey?: Handle;
+  backgroundImage?: Asset.Uri;
+  profilePic?: Asset.Uri;
   resolvedAt?: Point;
 }
 

--- a/packages/tx-construction/src/tx-builder/OutputBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/OutputBuilder.ts
@@ -145,7 +145,7 @@ export class TxOutputBuilder implements OutputBuilder {
 
       if (resolution[0] !== null) {
         txOut.handle = resolution[0];
-        txOut.address = resolution[0].resolvedAddresses.cardano;
+        txOut.address = resolution[0].cardanoAddress;
       } else {
         // Throw an error because the handle resolved to null so we don't have
         // an address for the transaction.

--- a/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
@@ -31,12 +31,10 @@ function assertObjectRefsAreDifferent(obj1: unknown, obj2: unknown): void {
 }
 
 const resolvedHandle = {
+  cardanoAddress: Cardano.PaymentAddress('addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg'),
   handle: 'alice',
   hasDatum: false,
   policyId: Cardano.PolicyId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7'),
-  resolvedAddresses: {
-    cardano: Cardano.PaymentAddress('addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg')
-  },
   resolvedAt: {
     hash: Cardano.BlockId('7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298'),
     slot: Cardano.Slot(100)
@@ -419,7 +417,7 @@ describe('GenericTxBuilder', () => {
         const txOut = await txBuilder.buildOutput().handle('alice').coin(output1Coin).build();
 
         expect(txOut.handle).toBe(resolvedHandle);
-        expect(txOut.address).toBe(resolvedHandle.resolvedAddresses.cardano);
+        expect(txOut.address).toBe(resolvedHandle.cardanoAddress);
       });
 
       it('rejects with an error when a handle provider fails to resolve', async () => {

--- a/packages/util-dev/src/mockProviders/mockHandleProvider.ts
+++ b/packages/util-dev/src/mockProviders/mockHandleProvider.ts
@@ -1,13 +1,12 @@
 import { Cardano } from '@cardano-sdk/core';
 
 export const resolvedHandle = {
+  cardanoAddress: Cardano.PaymentAddress(
+    'addr_test1qqk4sr4f7vtqzd2w90d5nfu3n59jhhpawyphnek2y7er02nkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuqmcnecd'
+  ),
   handle: 'alice',
   hasDatum: false,
   policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
-  resolvedAddresses: {
-    cardano:
-      'addr_test1qqk4sr4f7vtqzd2w90d5nfu3n59jhhpawyphnek2y7er02nkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuqmcnecd'
-  },
   resolvedAt: {
     hash: Cardano.BlockId('10d64cc11e9b20e15b6c46aa7b1fed11246f437e62225655a30ea47bf8cc22d0'),
     slot: Cardano.Slot(37_834_496)

--- a/packages/wallet/src/services/HandlesTracker.ts
+++ b/packages/wallet/src/services/HandlesTracker.ts
@@ -61,11 +61,9 @@ export const createHandlesTracker = ({ tip$, assetInfo$, handlePolicyIds, logger
           }
           return {
             ...assetInfo,
+            cardanoAddress: txOut.address,
             handle: Buffer.from(Cardano.AssetId.getAssetName(handleAssetId), 'hex').toString('utf8'),
             hasDatum: !!txOut.datum,
-            resolvedAddresses: {
-              cardano: txOut.address
-            },
             resolvedAt: tip
           };
         })

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -286,7 +286,7 @@ describe('PersonalWallet methods', () => {
 
         const txPendingResult = await txPending;
 
-        expect(txPendingResult.body.outputs[0].address).toEqual(mocks.resolvedHandle.resolvedAddresses.cardano);
+        expect(txPendingResult.body.outputs[0].address).toEqual(mocks.resolvedHandle.cardanoAddress);
         expect(txSubmitProvider.submitTx).toHaveBeenCalledWith(submitTxArgsMock);
       });
     });

--- a/packages/wallet/test/services/HandlesTracker.test.ts
+++ b/packages/wallet/test/services/HandlesTracker.test.ts
@@ -14,6 +14,7 @@ const handleOutput = utxo.find(([_, { value: { assets } }]) =>
 
 const expectedHandleInfo = {
   assetId: handleAssetId,
+  cardanoAddress: handleOutput.address,
   fingerprint: handleFingerprint,
   handle,
   hasDatum: !!handleOutput.datum,
@@ -21,9 +22,6 @@ const expectedHandleInfo = {
   name: handleAssetName,
   policyId: handlePolicyId,
   quantity: 1n,
-  resolvedAddresses: {
-    cardano: handleOutput.address
-  },
   // We consider that handle was resolved when we got the utxo,
   // as AssetInfo is just some supplementary data
   resolvedAt: ledgerTip,


### PR DESCRIPTION
# Context

LW-7172
`HandleResolution` now resolves `cardanoAddress` instead of `resolvedAddresses.cardano`. 

# Proposed Solution
Do the appropriate refactor to accept the new type. 

# Important Changes Introduced
