### PR TITLE
Fix/software version source

### DIFF
--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",
     "build:cjs": "tsc --build src",
-    "build:version": "node ./scripts/createVersionSource.js",
+    "build:version": "node ./scripts/createVersionSource.js && shx cp ./package.json ./dist/package.json",
     "build": "yarn build:version && run-s build:cjs build:esm module-fixup",
     "module-fixup": "shx cp ../../build/cjs-package.json ./dist/cjs/package.json && cp ../../build/esm-package.json ./dist/esm/package.json",
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",

--- a/packages/cardano-services-client/scripts/createVersionSource.js
+++ b/packages/cardano-services-client/scripts/createVersionSource.js
@@ -1,14 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
-const packageJson = require('../package.json');
 const openApiSpec = require('../../cardano-services/src/Http/openApi.json');
 
 const contents = `// auto-generated using ../scripts/createVersionSource.js
-export const version = {
-  api: '${openApiSpec.info.version}',
-  software: '${packageJson.version}'
-};
+export const apiVersion = '${openApiSpec.info.version}';
 `;
 
 fs.writeFileSync(path.join(__dirname, '../src/version.ts'), contents, { encoding: 'utf8', flag: 'w' });

--- a/packages/cardano-services-client/scripts/createVersionSource.js
+++ b/packages/cardano-services-client/scripts/createVersionSource.js
@@ -4,7 +4,7 @@ const path = require('path');
 const packageJson = require('../package.json');
 const openApiSpec = require('../../cardano-services/src/Http/openApi.json');
 
-const contents = `// auto-generated using ${__filename}
+const contents = `// auto-generated using ../scripts/createVersionSource.js
 export const version = {
   api: '${openApiSpec.info.version}',
   software: '${packageJson.version}'

--- a/packages/cardano-services-client/src/version.ts
+++ b/packages/cardano-services-client/src/version.ts
@@ -1,5 +1,2 @@
 // auto-generated using ../scripts/createVersionSource.js
-export const version = {
-  api: '1.0.0',
-  software: '0.9.9'
-};
+export const apiVersion = '1.0.0';

--- a/packages/cardano-services-client/src/version.ts
+++ b/packages/cardano-services-client/src/version.ts
@@ -1,4 +1,4 @@
-// auto-generated using /home/rhys/code/iohk/cardano-js-sdk/packages/cardano-services-client/scripts/createVersionSource.js
+// auto-generated using ../scripts/createVersionSource.js
 export const version = {
   api: '1.0.0',
   software: '0.9.9'


### PR DESCRIPTION
# Context
- Software version source doesn't need to be separately maintained
- [The comment](https://github.com/input-output-hk/cardano-js-sdk/compare/fix/software-version-source?expand=1#diff-927718184f485156899e2d7eab22b7b4b1e7b47d5bb4d766cf3a75bfcdad9ce3L1) uses an absolute path to identify the generating script

# Proposed Solution
- Use the package.json version as a source
- Hard-code the script path

# Important Changes Introduced
- Rename the version.ts export
- Copies `./cardano-services-client/package.json` into the `dist`
