### PR TITLE
fix(cardano-services-client): package.json import

### DIFF
--- a/packages/cardano-services-client/src/HttpProvider.ts
+++ b/packages/cardano-services-client/src/HttpProvider.ts
@@ -4,9 +4,7 @@ import { Logger } from 'ts-log';
 import { apiVersion } from './version';
 import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
 import axios, { AxiosAdapter, AxiosRequestConfig, AxiosResponseTransformer } from 'axios';
-import path from 'path';
-
-const packageJson = require(path.join(__dirname, '..', 'package.json'));
+import packageJson from '../package.json';
 
 const isEmptyResponse = (response: any) => response === '';
 

--- a/packages/cardano-services-client/src/typings.d.ts
+++ b/packages/cardano-services-client/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module '*.json';


### PR DESCRIPTION
# Context

In lace, we get the error bellow  [here](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/cardano-services-client/src/HttpProvider.ts#L9), since `require` is not available in the browser

`Error: ReferenceError: require is not defined
`

# Proposed Solution

# Important Changes Introduced
