### PR TITLE
fix(cardano-services-client): type of KoraLabsHandleProvider to be implementing HandleProvider

### DIFF
--- a/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
@@ -1,6 +1,7 @@
 import {
   Asset,
   Cardano,
+  HandleProvider,
   HandleResolution,
   HealthCheckResponse,
   ProviderError,
@@ -47,7 +48,7 @@ export const toHandleResolution = ({
  *
  * @param KoraLabsHandleProviderDeps The configuration object fot the KoraLabs Handle Provider.
  */
-export class KoraLabsHandleProvider {
+export class KoraLabsHandleProvider implements HandleProvider {
   private axiosClient: AxiosInstance;
   policyId: Cardano.PolicyId;
 


### PR DESCRIPTION
# Context
The type was not defined to be a `HandleProvider`

# Proposed Solution
Add the missing declaration

# Important Changes Introduced
