### PR TITLE
Refactor cache invalidation test

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -149,6 +149,8 @@
     "buffer": "^6.0.3",
     "chromedriver": "^114.0.0",
     "copy-webpack-plugin": "^10.2.4",
+    "dockerode": "^3.3.1",
+    "dockerode-utils": "^0.0.7",
     "eslint": "^7.32.0",
     "events": "^3.3.0",
     "expect-webdriverio": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,6 +2587,8 @@ __metadata:
     convict: ^6.2.4
     copy-webpack-plugin: ^10.2.4
     delay: 5.0.0
+    dockerode: ^3.3.1
+    dockerode-utils: ^0.0.7
     dotenv: ^16.0.1
     envalid: ^7.3.1
     eslint: ^7.32.0


### PR DESCRIPTION
# Context

Recently we changed the `DISABLE_DB_CACHE` setting of our test _local-network_ to `true` while the cache invalidation tests requires it to `false`: it needs a cache to check it is invalidated.

# Proposed Solution

Changed the test in order to start its own provider-server with the setting configured as it needs.

# Important Changes Introduced

Also refactored the main `Dockerfile` to take more advantage from docker build cache