### PR TITLE
fix(cardano-services-client): background and profile image as ipfs url

### DIFF
--- a/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
@@ -34,13 +34,13 @@ export const toHandleResolution = ({
   apiResponse: IHandle;
   policyId: Cardano.PolicyId;
 }): HandleResolution => ({
-  backgroundImage: apiResponse.bg_image ? Asset.Uri(`ipfs://${apiResponse.bg_image}`) : undefined,
+  backgroundImage: apiResponse.bg_image ? Asset.Uri(apiResponse.bg_image) : undefined,
   cardanoAddress: Cardano.PaymentAddress(apiResponse.resolved_addresses.ada),
   handle: apiResponse.name,
   hasDatum: apiResponse.has_datum,
   image: apiResponse.image ? Asset.Uri(apiResponse.image) : undefined,
   policyId,
-  profilePic: apiResponse.pfp_image ? Asset.Uri(`ipfs://${apiResponse.pfp_image}`) : undefined
+  profilePic: apiResponse.pfp_image ? Asset.Uri(apiResponse.pfp_image) : undefined
 });
 
 /**

--- a/packages/cardano-services-client/test/util.ts
+++ b/packages/cardano-services-client/test/util.ts
@@ -49,14 +49,14 @@ export const getAliceHandleProviderResponse = {
 };
 
 export const getBobHandleProviderResponse = {
-  backgroundImage: 'ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd',
+  backgroundImage: Asset.Uri('ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd'),
   cardanoAddress:
     'addr_test1qzrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuql9tk0g',
   handle: 'bob',
   hasDatum: false,
   image: Asset.Uri('ipfs://c8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe'),
   policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
-  profilePic: 'ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd'
+  profilePic: Asset.Uri('ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd1')
 };
 
 export const getAliceHandleAPIResponse: Partial<IHandle> = {
@@ -81,7 +81,7 @@ export const getAliceHandleAPIResponse: Partial<IHandle> = {
 };
 
 export const getBobHandleAPIResponse: Partial<IHandle> = {
-  bg_image: 'zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd',
+  bg_image: 'ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd',
   characters: 'rljm7n/23455',
   created_slot_number: 33,
   default_in_wallet: 'bob_default_handle',
@@ -93,7 +93,7 @@ export const getBobHandleAPIResponse: Partial<IHandle> = {
   name: 'bob',
   numeric_modifiers: '-12.9',
   og_number: 5,
-  pfp_image: 'zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd',
+  pfp_image: 'ipfs://zrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3yd1',
   rarity: Rarity.rare,
   resolved_addresses: {
     ada: 'addr_test1qzrljm7nskakjydxlr450ktsj08zuw6aktvgfkmmyw9semrkrezryq3ydtmkg0e7e2jvzg443h0ffzfwd09wpcxy2fuql9tk0g'


### PR DESCRIPTION
# Context

Background and profile image from handle public api are ipfs url and not ipfs hash as stated in the documentation.

# Proposed Solution

# Important Changes Introduced
