### PR TITLE
fix(tx-construction): builder now awaits for non-empty knownAddresses before building the tx

### DIFF
--- a/packages/key-management/test/util/ensureStakeKeys.test.ts
+++ b/packages/key-management/test/util/ensureStakeKeys.test.ts
@@ -73,6 +73,11 @@ describe('ensureStakeKeys', () => {
     expect(knownAddresses.length).toBe(1);
   });
 
+  it('returns all reward accounts', async () => {
+    await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
+    await expect(util.ensureStakeKeys({ count: 2, keyAgent, logger })).resolves.toHaveLength(2);
+  });
+
   it('takes into account addresses with multiple stake keys and payment keys', async () => {
     await Promise.all([
       keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0),

--- a/packages/tx-construction/package.json
+++ b/packages/tx-construction/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@cardano-sdk/util-dev": "workspace:~",
     "@types/lodash": "^4.14.182",
+    "delay": "^5.0.0",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",
     "madge": "^5.0.1",

--- a/packages/tx-construction/test/tx-builder/TxBuilder.bootstrap.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.bootstrap.test.ts
@@ -1,0 +1,109 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import * as Crypto from '@cardano-sdk/crypto';
+import { AddressType, AsyncKeyAgent, GroupedAddress, SignBlobResult, util } from '@cardano-sdk/key-management';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
+import { Cardano } from '@cardano-sdk/core';
+import { GenericTxBuilder, OutputValidation } from '../../src';
+import { dummyLogger } from 'ts-log';
+import { generateRandomHexString, mockProviders as mocks } from '@cardano-sdk/util-dev';
+import delay from 'delay';
+
+class StubKeyAgent implements AsyncKeyAgent {
+  knownAddresses$ = new BehaviorSubject<GroupedAddress[]>([]);
+
+  constructor(private inputResolver: Cardano.InputResolver) {}
+
+  deriveAddress(): Promise<GroupedAddress> {
+    throw new Error('Method not implemented.');
+  }
+  derivePublicKey(): Promise<Crypto.Ed25519PublicKeyHex> {
+    throw new Error('Method not implemented.');
+  }
+  signBlob(): Promise<SignBlobResult> {
+    throw new Error('Method not implemented.');
+  }
+  async signTransaction(txInternals: Cardano.TxBodyWithHash): Promise<Cardano.Signatures> {
+    const signatures = new Map<Crypto.Ed25519PublicKeyHex, Crypto.Ed25519SignatureHex>();
+    const knownAddresses = await firstValueFrom(this.knownAddresses$);
+    for (const _ of await util.ownSignatureKeyPaths(txInternals.body, knownAddresses, this.inputResolver)) {
+      signatures.set(
+        Crypto.Ed25519PublicKeyHex(generateRandomHexString(64)),
+        Crypto.Ed25519SignatureHex(generateRandomHexString(128))
+      );
+    }
+    return signatures;
+  }
+  getChainId(): Promise<Cardano.ChainId> {
+    throw new Error('Method not implemented.');
+  }
+  getBip32Ed25519(): Promise<Crypto.Bip32Ed25519> {
+    throw new Error('Method not implemented.');
+  }
+  getExtendedAccountPublicKey(): Promise<Crypto.Bip32PublicKeyHex> {
+    throw new Error('Method not implemented.');
+  }
+  async setKnownAddresses(addresses: GroupedAddress[]): Promise<void> {
+    this.knownAddresses$.next(addresses);
+  }
+  shutdown(): void {
+    throw new Error('Method not implemented.');
+  }
+}
+
+describe('TxBuilder bootstrap', () => {
+  it('awaits for non-empty knownAddresses$', async () => {
+    // Initialize the TxBuilder
+    const output = mocks.utxo[0][1];
+    const rewardAccount = mocks.rewardAccount;
+    const inputResolver: Cardano.InputResolver = {
+      resolveInput: async (txIn) =>
+        mocks.utxo.find(
+          ([hydratedTxIn]) => txIn.txId === hydratedTxIn.txId && txIn.index === hydratedTxIn.index
+        )?.[1] || null
+    };
+    const keyAgent = new StubKeyAgent(inputResolver);
+    const txBuilderProviders = {
+      genesisParameters: jest.fn().mockResolvedValue(mocks.genesisParameters),
+      protocolParameters: jest.fn().mockResolvedValue(mocks.protocolParameters),
+      rewardAccounts: jest.fn().mockResolvedValue([
+        {
+          address: rewardAccount,
+          keyStatus: Cardano.StakeKeyStatus.Unregistered,
+          rewardBalance: mocks.rewardAccountBalance
+        }
+      ]),
+      tip: jest.fn().mockResolvedValue(mocks.ledgerTip),
+      utxoAvailable: jest.fn().mockResolvedValue(mocks.utxo)
+    };
+    const outputValidator = {
+      validateOutput: jest.fn().mockResolvedValue({ coinMissing: 0n } as OutputValidation)
+    };
+    const builderParams = {
+      inputResolver,
+      keyAgent,
+      logger: dummyLogger,
+      outputValidator,
+      txBuilderProviders
+    };
+    const txBuilder = new GenericTxBuilder(builderParams);
+
+    // Build and sign a tx
+    const signedTxReady = txBuilder.addOutput(output).build().sign();
+    await delay(1);
+    // keyAgent knownAddresses are initially [],
+    // but then eventually resolves to some addresses
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    keyAgent.setKnownAddresses([
+      {
+        accountIndex: 0,
+        address: mocks.utxo[0][1].address,
+        index: 0,
+        networkId: Cardano.NetworkId.Testnet,
+        rewardAccount: mocks.rewardAccount,
+        type: AddressType.External
+      }
+    ]);
+    const signedTx = await signedTxReady;
+    expect(signedTx.tx.witness.signatures.size).toBe(1);
+  });
+});

--- a/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
@@ -563,6 +563,7 @@ describe('TxBuilder/delegatePortfolio', () => {
   describe('rewardAccount syncing', () => {
     const normalRewardAccountsCalls = 3;
     it('can wait for delayed key agent stake keys', async () => {
+      await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
       const rewardAccountsProvider = jest
         .fn()
         .mockResolvedValueOnce([])
@@ -597,6 +598,7 @@ describe('TxBuilder/delegatePortfolio', () => {
     });
 
     it('throws if new stake keys are not part of reward accounts in a reasonable time', async () => {
+      await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
       const rewardAccountsProvider = jest.fn().mockResolvedValue([]);
       const txBuilderFactory = await createTxBuilder({
         keyAgent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2866,6 +2866,7 @@ __metadata:
     "@cardano-sdk/util-rxjs": "workspace:~"
     "@cardano-sdk/wallet": "workspace:~"
     "@types/lodash": ^4.14.182
+    delay: ^5.0.0
     eslint: ^7.32.0
     jest: ^28.1.3
     lodash: ^4.17.21


### PR DESCRIPTION
# Context

`KeyAgent` doesn't wait for wallet to settle before taking the current value of `knownAddresses$` when building the transaction.

# Proposed Solution

KeyAgent now awaits for non-empty knownAddresses$ for all it's uses
