### PR TITLE
fix(wallet): discovery should search for 1/0 too

### DIFF
--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -3,6 +3,7 @@ import { PersonalWallet, TransactionFailure } from '../../src';
 import { createWallet } from './util';
 import { firstValueFrom, of } from 'rxjs';
 import { mockProviders as mocks } from '@cardano-sdk/util-dev';
+import uniq from 'lodash/uniq';
 
 describe('integration/withdrawal', () => {
   let wallet: PersonalWallet;
@@ -77,7 +78,7 @@ describe('integration/withdrawal', () => {
 
   it('can submit transaction', async () => {
     const availableRewards = await firstValueFrom(wallet.balance.rewardAccounts.rewards$);
-    const accounts = (await firstValueFrom(wallet.addresses$)).map((address) => address.rewardAccount);
+    const accounts = uniq((await firstValueFrom(wallet.addresses$)).map((address) => address.rewardAccount));
     const txInternals = await wallet.initializeTx({
       certificates: [
         {

--- a/packages/wallet/test/services/addressDiscovery/HDSequentialDiscovery.test.ts
+++ b/packages/wallet/test/services/addressDiscovery/HDSequentialDiscovery.test.ts
@@ -24,6 +24,7 @@ describe('HDSequentialDiscovery', () => {
       createMockChainHistoryProvider(
         new Map([
           [asPaymentAddress('testAddress_0_0_0'), 1],
+          [asPaymentAddress('testAddress_0_0_1'), 1],
           [asPaymentAddress('testAddress_1_0_0'), 1],
           [asPaymentAddress('testAddress_1_0_1'), 1],
           [asPaymentAddress('testAddress_2_0_0'), 1]
@@ -34,7 +35,7 @@ describe('HDSequentialDiscovery', () => {
 
     const addresses = await discovery.discover(mockKeyAgent);
 
-    expect(addresses.length).toEqual(4);
+    expect(addresses.length).toEqual(5);
     expect(addresses[0]).toEqual({
       accountIndex: 0,
       address: 'testAddress_0_0_0',
@@ -49,6 +50,18 @@ describe('HDSequentialDiscovery', () => {
     });
     expect(addresses[1]).toEqual({
       accountIndex: 0,
+      address: 'testAddress_0_0_1',
+      index: 0,
+      networkId: 0,
+      rewardAccount: 'testStakeAddress_0',
+      stakeKeyDerivationPath: {
+        index: 0,
+        role: KeyRole.Stake
+      },
+      type: AddressType.Internal
+    });
+    expect(addresses[2]).toEqual({
+      accountIndex: 0,
       address: 'testAddress_1_0_0',
       index: 1,
       networkId: 0,
@@ -59,7 +72,7 @@ describe('HDSequentialDiscovery', () => {
       },
       type: AddressType.External
     });
-    expect(addresses[2]).toEqual({
+    expect(addresses[3]).toEqual({
       accountIndex: 0,
       address: 'testAddress_1_0_1',
       index: 1,
@@ -71,7 +84,7 @@ describe('HDSequentialDiscovery', () => {
       },
       type: AddressType.Internal
     });
-    expect(addresses[3]).toEqual({
+    expect(addresses[4]).toEqual({
       accountIndex: 0,
       address: 'testAddress_2_0_0',
       index: 2,


### PR DESCRIPTION
# Context

Internal address at payment index #0 is accidentally skipped on address discovery.

# Proposed Solution

# Important Changes Introduced
