### PR TITLE
LW-7360 refactor some tests to use a dedicated database

### DIFF
--- a/packages/cardano-services/test/PgBoss/util.ts
+++ b/packages/cardano-services/test/PgBoss/util.ts
@@ -16,7 +16,7 @@ export const poolId = 'test_pool' as Cardano.PoolId;
 
 export const initHandlerTest = async () => {
   const connectionConfig = {
-    database: process.env.POSTGRES_DB_STAKE_POOL!,
+    database: 'projection',
     host: process.env.POSTGRES_HOST_DB_SYNC!,
     password: process.env.POSTGRES_PASSWORD_DB_SYNC!,
     port: Number.parseInt(process.env.POSTGRES_PORT_DB_SYNC!, 10),

--- a/packages/cardano-services/test/Program/services/pgboss.test.ts
+++ b/packages/cardano-services/test/Program/services/pgboss.test.ts
@@ -68,7 +68,7 @@ describe('PgBossHttpService', () => {
   beforeAll(async () => {
     const args = {
       postgresDbDbSync: process.env.POSTGRES_DB_DB_SYNC!,
-      postgresDbStakePool: process.env.POSTGRES_DB_STAKE_POOL!,
+      postgresDbStakePool: 'projection',
       postgresPasswordDbSync: process.env.POSTGRES_PASSWORD_DB_SYNC!,
       postgresPasswordStakePool: process.env.POSTGRES_PASSWORD_DB_SYNC!,
       postgresSrvServiceNameDbSync: process.env.POSTGRES_SRV_SERVICE_NAME_DB_SYNC!,

--- a/packages/cardano-services/test/jest-setup/snapshots/projection.sql
+++ b/packages/cardano-services/test/jest-setup/snapshots/projection.sql
@@ -1,0 +1,47 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 11.5
+-- Dumped by pg_dump version 11.5
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: projection; Type: DATABASE; Schema: -; Owner: postgres
+--
+
+CREATE DATABASE projection WITH TEMPLATE = template0 ENCODING = 'UTF8' LC_COLLATE = 'en_US.utf8' LC_CTYPE = 'en_US.utf8';
+
+
+ALTER DATABASE projection OWNER TO postgres;
+
+\connect projection
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- PostgreSQL database dump complete
+--


### PR DESCRIPTION
# Context

Unit tests are affected by a flakiness which ends with a No stake pools found error.
Some tests deletes the fixtures due to the call `createObservableDataSource({ devOptions: { dropSchema: true } })`: the source of the flakiness is the order jest execute the tests.

# Proposed Solution

Refactored the tests which need the described call to use a dedicated database