### PR TITLE
fix(tx-construction): rm redundant circular dependency on 'wallet' package

### DIFF
--- a/packages/tx-construction/package.json
+++ b/packages/tx-construction/package.json
@@ -56,7 +56,6 @@
     "@cardano-sdk/key-management": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
     "@cardano-sdk/util-rxjs": "workspace:~",
-    "@cardano-sdk/wallet": "workspace:~",
     "lodash": "^4.17.21",
     "npm": "^9.3.0",
     "rxjs": "^7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,7 +2863,6 @@ __metadata:
     "@cardano-sdk/util": "workspace:~"
     "@cardano-sdk/util-dev": "workspace:~"
     "@cardano-sdk/util-rxjs": "workspace:~"
-    "@cardano-sdk/wallet": "workspace:~"
     "@types/lodash": ^4.14.182
     delay: ^5.0.0
     eslint: ^7.32.0


### PR DESCRIPTION
# Context

`tx-construction` depends on `wallet` but does not use it. It creates a circular dependency messing up installed modules for the users