### PR TITLE
Feat/lw 7373 improvements to greedy input selection

### DIFF
--- a/packages/e2e/src/tools/multi-delegation-data-gen/index.ts
+++ b/packages/e2e/src/tools/multi-delegation-data-gen/index.ts
@@ -5,9 +5,7 @@ import {
   TaskResult,
   TerminalProgressMonitor,
   createDelegationWallet,
-  delegateToMultiplePools,
   distributeStake,
-  generateStakeAddresses,
   getOutputPathName,
   loadConfiguration,
   logState,
@@ -70,17 +68,7 @@ const monitor = new TerminalProgressMonitor();
 
     monitor.endTask('Delegation wallet ready.', TaskResult.Success);
 
-    const stakeAddresses = await generateStakeAddresses(delegationWallet, config.stakeDistribution.length, monitor);
-
-    const pools = await delegateToMultiplePools(delegationWallet, stakeAddresses, monitor);
-    const portfolio = await distributeStake(
-      delegationWallet,
-      config.startingFunds,
-      config.stakeDistribution,
-      stakeAddresses,
-      monitor,
-      pools
-    );
+    const portfolio = await distributeStake(delegationWallet, config.stakeDistribution, monitor);
 
     monitor.startTask('Waiting for delegation to be updated on the wallet.');
     await rewardAccountStatuses(delegationWallet.delegation.rewardAccounts$, [

--- a/packages/input-selection/test/GreedySelection/GreedySelection.test.ts
+++ b/packages/input-selection/test/GreedySelection/GreedySelection.test.ts
@@ -2,7 +2,13 @@ import { Cardano } from '@cardano-sdk/core';
 import { GreedyInputSelector } from '../../src';
 import { MOCK_NO_CONSTRAINTS, mockConstraintsToConstraints } from '../util/selectionConstraints';
 import { TxTestUtil } from '@cardano-sdk/util-dev';
-import { asAssetId, asPaymentAddress, asTokenMap, assertInputSelectionProperties } from '../util';
+import {
+  asAssetId,
+  asPaymentAddress,
+  asTokenMap,
+  assertInputSelectionProperties,
+  getCoinValueForAddress
+} from '../util';
 
 describe('GreedySelection', () => {
   it('consumes all the UTXOs in the set and returns that total amount distributed in the change minus the fee', async () => {
@@ -45,13 +51,34 @@ describe('GreedySelection', () => {
     expect(inputs).toEqual(utxo);
     expect(remainingUTxO.size).toEqual(0);
     expect(fee).toEqual(expectedFee);
-    expect(change.length).toEqual(3);
-    expect(change[0].address).toEqual(asPaymentAddress('A'));
-    expect(change[0].value.coins).toEqual(3_333_334n - expectedFee);
-    expect(change[1].address).toEqual(asPaymentAddress('B'));
-    expect(change[1].value.coins).toEqual(3_333_334n);
-    expect(change[2].address).toEqual(asPaymentAddress('C'));
-    expect(change[2].value.coins).toEqual(3_333_332n);
+
+    expect(getCoinValueForAddress('A', change)).toEqual(3_333_334n - expectedFee);
+    expect(getCoinValueForAddress('B', change)).toEqual(3_333_334n);
+    expect(getCoinValueForAddress('C', change)).toEqual(3_333_332n);
+
+    expect(change).toEqual([
+      { address: 'A', value: { assets: new Map([]), coins: 1_666_167n } },
+      { address: 'B', value: { coins: 1_666_667n } },
+      { address: 'C', value: { coins: 1_666_666n } },
+      { address: 'A', value: { coins: 833_334n } },
+      { address: 'B', value: { coins: 833_334n } },
+      { address: 'C', value: { coins: 833_333n } },
+      { address: 'A', value: { coins: 416_667n } },
+      { address: 'B', value: { coins: 416_667n } },
+      { address: 'C', value: { coins: 416_667n } },
+      { address: 'A', value: { coins: 208_333n } },
+      { address: 'B', value: { coins: 208_333n } },
+      { address: 'C', value: { coins: 208_333n } },
+      { address: 'A', value: { coins: 104_167n } },
+      { address: 'B', value: { coins: 104_167n } },
+      { address: 'C', value: { coins: 104_167n } },
+      { address: 'A', value: { coins: 52_083n } },
+      { address: 'A', value: { coins: 52_083n } },
+      { address: 'B', value: { coins: 52_083n } },
+      { address: 'B', value: { coins: 52_083n } },
+      { address: 'C', value: { coins: 52_083n } },
+      { address: 'C', value: { coins: 52_083n } }
+    ]);
 
     assertInputSelectionProperties({
       constraints,
@@ -110,17 +137,50 @@ describe('GreedySelection', () => {
     expect(inputs).toEqual(utxo);
     expect(remainingUTxO.size).toEqual(0);
     expect(fee).toEqual(expectedFee);
-    expect(change.length).toEqual(5);
-    expect(change[0].address).toEqual(asPaymentAddress('A'));
-    expect(change[0].value.coins).toEqual(3_000_000n - expectedFee);
-    expect(change[1].address).toEqual(asPaymentAddress('B'));
-    expect(change[1].value.coins).toEqual(3_000_000n);
-    expect(change[2].address).toEqual(asPaymentAddress('C'));
-    expect(change[2].value.coins).toEqual(3_000_000n);
-    expect(change[3].address).toEqual(asPaymentAddress('D'));
-    expect(change[3].value.coins).toEqual(3_000_000n);
-    expect(change[4].address).toEqual(asPaymentAddress('E'));
-    expect(change[4].value.coins).toEqual(3_000_000n);
+
+    expect(getCoinValueForAddress('A', change)).toEqual(3_000_000n - expectedFee);
+    expect(getCoinValueForAddress('B', change)).toEqual(3_000_000n);
+    expect(getCoinValueForAddress('C', change)).toEqual(3_000_000n);
+    expect(getCoinValueForAddress('D', change)).toEqual(3_000_000n);
+    expect(getCoinValueForAddress('E', change)).toEqual(3_000_000n);
+
+    expect(change).toEqual([
+      { address: 'A', value: { assets: new Map([]), coins: 1_499_500n } },
+      { address: 'B', value: { coins: 1_500_000n } },
+      { address: 'C', value: { coins: 1_500_000n } },
+      { address: 'D', value: { coins: 1_500_000n } },
+      { address: 'E', value: { coins: 1_500_000n } },
+      { address: 'A', value: { coins: 750_000n } },
+      { address: 'B', value: { coins: 750_000n } },
+      { address: 'C', value: { coins: 750_000n } },
+      { address: 'D', value: { coins: 750_000n } },
+      { address: 'E', value: { coins: 750_000n } },
+      { address: 'A', value: { coins: 375_000n } },
+      { address: 'B', value: { coins: 375_000n } },
+      { address: 'C', value: { coins: 375_000n } },
+      { address: 'D', value: { coins: 375_000n } },
+      { address: 'E', value: { coins: 375_000n } },
+      { address: 'A', value: { coins: 187_500n } },
+      { address: 'B', value: { coins: 187_500n } },
+      { address: 'C', value: { coins: 187_500n } },
+      { address: 'D', value: { coins: 187_500n } },
+      { address: 'E', value: { coins: 187_500n } },
+      { address: 'A', value: { coins: 93_750n } },
+      { address: 'B', value: { coins: 93_750n } },
+      { address: 'C', value: { coins: 93_750n } },
+      { address: 'D', value: { coins: 93_750n } },
+      { address: 'E', value: { coins: 93_750n } },
+      { address: 'A', value: { coins: 46_875n } },
+      { address: 'A', value: { coins: 46_875n } },
+      { address: 'B', value: { coins: 46_875n } },
+      { address: 'B', value: { coins: 46_875n } },
+      { address: 'C', value: { coins: 46_875n } },
+      { address: 'C', value: { coins: 46_875n } },
+      { address: 'D', value: { coins: 46_875n } },
+      { address: 'D', value: { coins: 46_875n } },
+      { address: 'E', value: { coins: 46_875n } },
+      { address: 'E', value: { coins: 46_875n } }
+    ]);
 
     assertInputSelectionProperties({
       constraints,
@@ -197,28 +257,59 @@ describe('GreedySelection', () => {
     expect(inputs).toEqual(utxo);
     expect(remainingUTxO.size).toEqual(0);
     expect(fee).toEqual(expectedFee);
-    expect(change.length).toEqual(4);
-    expect(change[0].address).toEqual(asPaymentAddress('A'));
-    expect(change[0].value.coins).toEqual(4_250_000n - expectedFee);
-    expect(change[0].value.assets).toEqual(
-      asTokenMap([
-        [asAssetId('0'), 100n],
-        [asAssetId('1'), 23n],
-        [asAssetId('2'), 1n],
-        [asAssetId('3'), 1000n],
-        [asAssetId('4'), 1500n],
-        [asAssetId('5'), 500n]
-      ])
-    );
-    expect(change[1].address).toEqual(asPaymentAddress('B'));
-    expect(change[1].value.coins).toEqual(4_250_000n);
-    expect(change[1].value.assets).toBeUndefined();
-    expect(change[2].address).toEqual(asPaymentAddress('C'));
-    expect(change[2].value.coins).toEqual(4_250_000n);
-    expect(change[2].value.assets).toBeUndefined();
-    expect(change[3].address).toEqual(asPaymentAddress('D'));
-    expect(change[3].value.coins).toEqual(4_250_000n);
-    expect(change[2].value.assets).toBeUndefined();
+
+    expect(getCoinValueForAddress('A', change)).toEqual(4_250_000n - expectedFee);
+    expect(getCoinValueForAddress('B', change)).toEqual(4_250_000n);
+    expect(getCoinValueForAddress('C', change)).toEqual(4_250_000n);
+    expect(getCoinValueForAddress('D', change)).toEqual(4_250_000n);
+
+    expect(change).toEqual([
+      {
+        address: 'A',
+        value: {
+          assets: asTokenMap([
+            [asAssetId('0'), 100n],
+            [asAssetId('1'), 23n],
+            [asAssetId('2'), 1n],
+            [asAssetId('3'), 1000n],
+            [asAssetId('4'), 1500n],
+            [asAssetId('5'), 500n]
+          ]),
+          coins: 2_124_500n
+        }
+      },
+      { address: 'B', value: { coins: 2_125_000n } },
+      { address: 'C', value: { coins: 2_125_000n } },
+      { address: 'D', value: { coins: 2_125_000n } },
+      { address: 'A', value: { coins: 1_062_500n } },
+      { address: 'B', value: { coins: 1_062_500n } },
+      { address: 'C', value: { coins: 1_062_500n } },
+      { address: 'D', value: { coins: 1_062_500n } },
+      { address: 'A', value: { coins: 531_250n } },
+      { address: 'B', value: { coins: 531_250n } },
+      { address: 'C', value: { coins: 531_250n } },
+      { address: 'D', value: { coins: 531_250n } },
+      { address: 'A', value: { coins: 265_625n } },
+      { address: 'B', value: { coins: 265_625n } },
+      { address: 'C', value: { coins: 265_625n } },
+      { address: 'D', value: { coins: 265_625n } },
+      { address: 'A', value: { coins: 132_813n } },
+      { address: 'B', value: { coins: 132_813n } },
+      { address: 'C', value: { coins: 132_813n } },
+      { address: 'D', value: { coins: 132_813n } },
+      { address: 'A', value: { coins: 66_406n } },
+      { address: 'B', value: { coins: 66_406n } },
+      { address: 'C', value: { coins: 66_406n } },
+      { address: 'D', value: { coins: 66_406n } },
+      { address: 'A', value: { coins: 33_203n } },
+      { address: 'A', value: { coins: 33_203n } },
+      { address: 'B', value: { coins: 33_203n } },
+      { address: 'B', value: { coins: 33_203n } },
+      { address: 'C', value: { coins: 33_203n } },
+      { address: 'C', value: { coins: 33_203n } },
+      { address: 'D', value: { coins: 33_203n } },
+      { address: 'D', value: { coins: 33_203n } }
+    ]);
 
     assertInputSelectionProperties({
       constraints,
@@ -295,31 +386,65 @@ describe('GreedySelection', () => {
     expect(inputs).toEqual(utxo);
     expect(remainingUTxO.size).toEqual(0);
     expect(fee).toEqual(expectedFee);
-    expect(change.length).toEqual(3);
-    expect(change[0].address).toEqual(asPaymentAddress('A'));
-    expect(change[0].value.coins).toEqual(8_500_000n - expectedFee);
-    expect(change[0].value.assets).toEqual(
-      asTokenMap([
-        [asAssetId('4'), 1500n],
-        [asAssetId('5'), 500n]
-      ])
-    );
-    expect(change[1].address).toEqual(asPaymentAddress('B'));
-    expect(change[1].value.coins).toEqual(4_250_000n);
-    expect(change[1].value.assets).toEqual(
-      asTokenMap([
-        [asAssetId('2'), 1n],
-        [asAssetId('3'), 1000n]
-      ])
-    );
-    expect(change[2].address).toEqual(asPaymentAddress('C'));
-    expect(change[2].value.coins).toEqual(4_250_000n);
-    expect(change[2].value.assets).toEqual(
-      asTokenMap([
-        [asAssetId('0'), 100n],
-        [asAssetId('1'), 23n]
-      ])
-    );
+
+    expect(getCoinValueForAddress('A', change)).toEqual(8_500_000n - expectedFee);
+    expect(getCoinValueForAddress('B', change)).toEqual(4_250_000n);
+    expect(getCoinValueForAddress('C', change)).toEqual(4_250_000n);
+
+    expect(change).toEqual([
+      {
+        address: 'A',
+        value: {
+          assets: asTokenMap([
+            [asAssetId('4'), 1500n],
+            [asAssetId('5'), 500n]
+          ]),
+          coins: 4_249_500n
+        }
+      },
+      {
+        address: 'A',
+        value: {
+          assets: asTokenMap([
+            [asAssetId('2'), 1n],
+            [asAssetId('3'), 1000n]
+          ]),
+          coins: 2_125_000n
+        }
+      },
+      {
+        address: 'B',
+        value: {
+          assets: asTokenMap([
+            [asAssetId('0'), 100n],
+            [asAssetId('1'), 23n]
+          ]),
+          coins: 2_125_000n
+        }
+      },
+      { address: 'C', value: { coins: 2_125_000n } },
+      { address: 'A', value: { coins: 1_062_500n } },
+      { address: 'B', value: { coins: 1_062_500n } },
+      { address: 'C', value: { coins: 1_062_500n } },
+      { address: 'A', value: { coins: 531_250n } },
+      { address: 'B', value: { coins: 531_250n } },
+      { address: 'C', value: { coins: 531_250n } },
+      { address: 'A', value: { coins: 265_625n } },
+      { address: 'B', value: { coins: 265_625n } },
+      { address: 'C', value: { coins: 265_625n } },
+      { address: 'A', value: { coins: 132_813n } },
+      { address: 'B', value: { coins: 132_813n } },
+      { address: 'C', value: { coins: 132_813n } },
+      { address: 'A', value: { coins: 66_406n } },
+      { address: 'B', value: { coins: 66_406n } },
+      { address: 'C', value: { coins: 66_406n } },
+      { address: 'A', value: { coins: 33_203n } },
+      { address: 'A', value: { coins: 33_203n } },
+      { address: 'B', value: { coins: 33_203n } },
+      { address: 'B', value: { coins: 33_203n } },
+      { address: 'C', value: { coins: 33_203n } },
+      { address: 'C', value: { coins: 33_203n } }
+    ]);
 
     assertInputSelectionProperties({
       constraints,
@@ -371,11 +496,28 @@ describe('GreedySelection', () => {
     expect(inputs).toEqual(utxo);
     expect(remainingUTxO.size).toEqual(0);
     expect(fee).toEqual(expectedFee);
-    expect(change.length).toEqual(2);
-    expect(change[0].address).toEqual(asPaymentAddress('A'));
-    expect(change[0].value.coins).toEqual(4_000_000n - expectedFee);
-    expect(change[1].address).toEqual(asPaymentAddress('B'));
-    expect(change[1].value.coins).toEqual(4_000_000n);
+
+    expect(getCoinValueForAddress('A', change)).toEqual(4_000_000n - expectedFee);
+    expect(getCoinValueForAddress('B', change)).toEqual(4_000_000n);
+
+    expect(change).toEqual([
+      { address: 'A', value: { assets: new Map([]), coins: 1_999_800n } },
+      { address: 'B', value: { coins: 2_000_000n } },
+      { address: 'A', value: { coins: 1_000_000n } },
+      { address: 'B', value: { coins: 1_000_000n } },
+      { address: 'A', value: { coins: 500_000n } },
+      { address: 'B', value: { coins: 500_000n } },
+      { address: 'A', value: { coins: 250_000n } },
+      { address: 'B', value: { coins: 250_000n } },
+      { address: 'A', value: { coins: 125_000n } },
+      { address: 'B', value: { coins: 125_000n } },
+      { address: 'A', value: { coins: 62_500n } },
+      { address: 'B', value: { coins: 62_500n } },
+      { address: 'A', value: { coins: 31_250n } },
+      { address: 'A', value: { coins: 31_250n } },
+      { address: 'B', value: { coins: 31_250n } },
+      { address: 'B', value: { coins: 31_250n } }
+    ]);
 
     assertInputSelectionProperties({
       constraints,
@@ -425,10 +567,17 @@ describe('GreedySelection', () => {
     expect(inputs).toEqual(utxo);
     expect(remainingUTxO.size).toEqual(0);
     expect(fee).toEqual(expectedFee);
-    expect(change.length).toEqual(1);
-    expect(change[0].address).toEqual(asPaymentAddress('A'));
-    expect(change[0].value.coins).toEqual(10_000_000n - expectedFee);
-    expect(change[0].value.assets).toEqual(asTokenMap([[asAssetId('0'), 1n]]));
+
+    expect(getCoinValueForAddress('A', change)).toEqual(10_000_000n - expectedFee);
+
+    expect(change).toEqual([
+      { address: 'A', value: { assets: asTokenMap([[asAssetId('0'), 1n]]), coins: 4_999_800n } },
+      { address: 'A', value: { coins: 2_500_000n } },
+      { address: 'A', value: { coins: 1_250_000n } },
+      { address: 'A', value: { coins: 625_000n } },
+      { address: 'A', value: { coins: 312_500n } },
+      { address: 'A', value: { coins: 312_500n } }
+    ]);
 
     assertInputSelectionProperties({
       constraints,
@@ -479,10 +628,17 @@ describe('GreedySelection', () => {
     expect(inputs).toEqual(utxo);
     expect(remainingUTxO.size).toEqual(0);
     expect(fee).toEqual(expectedFee);
-    expect(change.length).toEqual(1);
-    expect(change[0].address).toEqual(asPaymentAddress('A'));
-    expect(change[0].value.coins).toEqual(10_000_000n - expectedFee);
-    expect(change[0].value.assets).toEqual(asTokenMap([[asAssetId('0'), 500n]]));
+
+    expect(getCoinValueForAddress('A', change)).toEqual(10_000_000n - expectedFee);
+
+    expect(change).toEqual([
+      { address: 'A', value: { assets: asTokenMap([[asAssetId('0'), 500n]]), coins: 4_999_800n } },
+      { address: 'A', value: { coins: 2_500_000n } },
+      { address: 'A', value: { coins: 1_250_000n } },
+      { address: 'A', value: { coins: 625_000n } },
+      { address: 'A', value: { coins: 312_500n } },
+      { address: 'A', value: { coins: 312_500n } }
+    ]);
 
     assertInputSelectionProperties({
       constraints,

--- a/packages/input-selection/test/InputSelectionPropertyTesting.test.ts
+++ b/packages/input-selection/test/InputSelectionPropertyTesting.test.ts
@@ -51,7 +51,7 @@ const testInputSelection = (name: string, getAlgorithm: () => InputSelector) => 
         // Regression
         await testInputSelectionProperties({
           createOutputs: () => [],
-          createUtxo: () => [TxTestUtil.createUnspentTxOutput({ coins: 20_999_994n })],
+          createUtxo: () => [TxTestUtil.createUnspentTxOutput({ coins: 30_999_994n })],
           getAlgorithm,
           mockConstraints: {
             ...SelectionConstraints.MOCK_NO_CONSTRAINTS,
@@ -234,7 +234,12 @@ const testInputSelection = (name: string, getAlgorithm: () => InputSelector) => 
               TxTestUtil.createUnspentTxOutput({
                 assets: new Map([
                   [AssetId.TSLA, 1000n],
-                  [AssetId.PXL, 1000n]
+                  [AssetId.PXL, 1000n],
+                  [AssetId.Unit, 1000n],
+                  [AssetId.A, 1000n],
+                  [AssetId.B, 1000n],
+                  [AssetId.C, 1000n],
+                  [AssetId.D, 1000n]
                 ]),
                 coins: 2_000_000n
               })

--- a/packages/input-selection/test/util/index.ts
+++ b/packages/input-selection/test/util/index.ts
@@ -18,3 +18,15 @@ export class MockChangeAddressResolver implements ChangeAddressResolver {
     }));
   }
 }
+
+/**
+ * Coalesce all coin values from all outputs in the change set that belongs to the given address.
+ *
+ * @param address The address to query.
+ * @param change The change set.
+ */
+export const getCoinValueForAddress = (address: string, change: Array<Cardano.TxOut>) =>
+  change
+    .filter((out) => out.address === address)
+    .map((out) => out.value.coins)
+    .reduce((cur, prev) => cur + prev, 0n);

--- a/packages/util-dev/src/assetId.ts
+++ b/packages/util-dev/src/assetId.ts
@@ -3,5 +3,10 @@ import { Cardano } from '@cardano-sdk/core';
 export const TSLA = Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41');
 export const PXL = Cardano.AssetId('1ec85dcee27f2d90ec1f9a1e4ce74a667dc9be8b184463223f9c960150584c');
 export const Unit = Cardano.AssetId('a5425bd7bc4182325188af2340415827a73f845846c165d9e14c5aed556e6974');
+export const A = Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8241');
+export const B = Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8242');
+export const C = Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8243');
+export const D = Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8244');
+export const E = Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8245');
 
 export const All = [TSLA, PXL, Unit];


### PR DESCRIPTION
# Context

The greedy input selector currently generates on output per stake id. Ideally we want a more robust and varied UTXO set so our strategy for maintaining multi delegation stake distribution is more consistent in active wallets.

# Proposed Solution

Split then change outputs following an exponential distribution. For example 100000 will yield:

`[ 50000n, 25000n, 12500n, 6250n, 3125n, 3125n ]`

The exponential distribution (n**2),was the best compromise in granularity and amount of UTXOs generated. We don't want too many UTXOs as this could make the transaction exceed the max allow TX size, but at the same time we want a diverse and big enough amount of UTXOs to reasonably build any TX with a fairly small amount of inputs.

Using an exponential distribution also guarantees that the number of UTXOs generated will be more or less the same
regardless of the amount of total available lovelace, for example:

```
10      => [ 5n,      2n,      1n,      1n,     1n             ]
100     => [ 50n,     25n,     12n,     6n,     3n,     4n     ]
1000    => [ 500n,    250n,    125n,    62n,    31n,    32n    ]
10000   => [ 5000n,   2500n,   1250n,   625n,   312n,   313n   ]
100000  => [ 50000n,  25000n,  12500n,  6250n,  3125n,  3125n  ]
1000000 => [ 500000n, 250000n, 125000n, 62500n, 31250n, 31250n ]
```
# Important Changes Introduced

The greedy input selector now generates more than one change output per stake address.