### PR TITLE
fix: mainnet projection issues

### DIFF
--- a/packages/cardano-services/src/Projection/migrations/1689091319930-cost-pledge-numeric.ts
+++ b/packages/cardano-services/src/Projection/migrations/1689091319930-cost-pledge-numeric.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { PoolRegistrationEntity } from '@cardano-sdk/projection-typeorm';
+
+export class CostPledgeNumericMigration1689091319930 implements MigrationInterface {
+  static entity = PoolRegistrationEntity;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "pool_registration" ALTER COLUMN "pledge" TYPE numeric(20,0) USING pledge::numeric'
+    );
+    await queryRunner.query(
+      'ALTER TABLE "pool_registration" ALTER COLUMN "cost" TYPE numeric(20,0) USING cost::numeric'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "pool_registration" ALTER COLUMN "cost" TYPE bigint USING cost::bigint');
+    await queryRunner.query('ALTER TABLE "pool_registration" ALTER COLUMN "pledge" TYPE bigint USING pledge::bigint');
+  }
+}

--- a/packages/cardano-services/src/Projection/migrations/index.ts
+++ b/packages/cardano-services/src/Projection/migrations/index.ts
@@ -1,6 +1,7 @@
 import { AssetTableMigration1682519108365 } from './1682519108365-asset-table';
 import { BlockDataTableMigration1682519108359 } from './1682519108359-block-data-table';
 import { BlockTableMigration1682519108358 } from './1682519108358-block-table';
+import { CostPledgeNumericMigration1689091319930 } from './1689091319930-cost-pledge-numeric';
 import { FkPoolRegistrationMigration1682519108369 } from './1682519108369-fk-pool-registration';
 import { FkPoolRetirementMigration1682519108370 } from './1682519108370-fk-pool-retirement';
 import { HandleTableMigration1686138943349 } from './1686138943349-handle-table';
@@ -29,5 +30,6 @@ export const migrations: ProjectionMigration[] = [
   FkPoolRegistrationMigration1682519108369,
   FkPoolRetirementMigration1682519108370,
   PoolMetricsMigrations1685011799580,
-  HandleTableMigration1686138943349
+  HandleTableMigration1686138943349,
+  CostPledgeNumericMigration1689091319930
 ];

--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -104,9 +104,9 @@ const storeEntities: Partial<Record<StoreName, EntityName[]>> = {
   storeAssets: ['asset'],
   storeBlock: ['block'],
   storeHandles: ['handle', 'asset', 'tokens', 'output'],
-  storePoolMetricsUpdateJob: ['currentPoolMetrics'],
-  storeStakePoolMetadataJob: ['block', 'poolMetadata'],
-  storeStakePools: ['stakePool', 'poolRegistration', 'poolRetirement'],
+  storePoolMetricsUpdateJob: ['stakePool', 'currentPoolMetrics', 'poolMetadata'],
+  storeStakePoolMetadataJob: ['stakePool', 'currentPoolMetrics', 'poolMetadata'],
+  storeStakePools: ['stakePool', 'currentPoolMetrics', 'poolMetadata'],
   storeUtxo: ['tokens', 'output']
 };
 
@@ -116,9 +116,10 @@ const entityInterDependencies: Partial<Record<EntityName, EntityName[]>> = {
   currentPoolMetrics: ['stakePool'],
   handle: ['asset'],
   output: ['block'],
+  poolMetadata: ['stakePool'],
   poolRegistration: ['block'],
   poolRetirement: ['block'],
-  stakePool: ['block', 'poolRegistration', 'poolRetirement', 'poolMetadata'],
+  stakePool: ['block', 'poolRegistration', 'poolRetirement'],
   tokens: ['asset']
 };
 

--- a/packages/cardano-services/test/Projection/prepareTypeormProjection.test.ts
+++ b/packages/cardano-services/test/Projection/prepareTypeormProjection.test.ts
@@ -31,7 +31,7 @@ describe('prepareTypeormProjection', () => {
     test('stake-pool,stake-pool-metadata', () => {
       const { entities, mappers, stores } = prepare([ProjectionName.StakePool, ProjectionName.StakePoolMetadataJob]);
       expect(new Set(entities)).toEqual(
-        new Set(['block', 'stakePool', 'poolRegistration', 'poolRetirement', 'poolMetadata'])
+        new Set(['block', 'stakePool', 'poolRegistration', 'poolRetirement', 'poolMetadata', 'currentPoolMetrics'])
       );
       expect(mappers).toEqual(['withCertificates', 'withStakePools']);
       expect(stores).toEqual(['storeBlock', 'storeStakePools', 'storeStakePoolMetadataJob']);

--- a/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
+++ b/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
@@ -76,7 +76,7 @@ describe('TypeormStakePoolProvider', () => {
   let poolsInfoWithMetricsFiltered: PoolInfo[];
 
   const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
-  const entities = getEntities(['currentPoolMetrics']);
+  const entities = getEntities(['currentPoolMetrics', 'poolMetadata']);
 
   beforeAll(async () => {
     port = await getPort();

--- a/packages/ogmios/test/mocks/mockOgmiosServer.ts
+++ b/packages/ogmios/test/mocks/mockOgmiosServer.ts
@@ -1,7 +1,13 @@
 /* eslint-disable sonarjs/no-nested-switch */
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { EraMismatch, IntersectionFound, IntersectionNotFound, PointOrOrigin } from '@cardano-ogmios/schema';
+import {
+  EraMismatch,
+  EraSummary,
+  IntersectionFound,
+  IntersectionNotFound,
+  PointOrOrigin
+} from '@cardano-ogmios/schema';
 import {
   EraSummariesResponse,
   GenesisConfigResponse,
@@ -34,13 +40,13 @@ export interface MockOgmiosServerConfig {
   };
   stateQuery?: {
     eraSummaries?: {
-      response: EraSummariesResponse;
+      response: EraSummariesResponse | EraSummariesResponse[];
     };
     genesisConfig?: {
       response: GenesisConfigResponse | GenesisConfigResponse[];
     };
     systemStart?: {
-      response: SystemStartResponse;
+      response: SystemStartResponse | SystemStartResponse[];
     };
     stakeDistribution?: {
       response: StakeDistributionResponse;
@@ -75,6 +81,19 @@ export const mockGenesisConfig = {
   systemStart: '2022-08-09T00:00:00Z',
   updateQuorum: 5
 } as Schema.CompactGenesis;
+
+export const mockEraSummaries: EraSummary[] = [
+  {
+    end: { epoch: 74, slot: 1_598_400, time: 31_968_000 },
+    parameters: { epochLength: 21_600, safeZone: 4320, slotLength: 20 },
+    start: { epoch: 0, slot: 0, time: 0 }
+  },
+  {
+    end: { epoch: 102, slot: 13_694_400, time: 44_064_000 },
+    parameters: { epochLength: 432_000, safeZone: 129_600, slotLength: 1 },
+    start: { epoch: 74, slot: 1_598_400, time: 31_968_000 }
+  }
+];
 
 const handleFindIntersect = (args: any, config: MockOgmiosServerConfig, send: (result: unknown) => void) => {
   const response = config.findIntersect?.(args.points);
@@ -132,39 +151,34 @@ const handleSubmitTx = async (
   send(result);
 };
 
-// eslint-disable-next-line complexity, sonarjs/cognitive-complexity
+// eslint-disable-next-line complexity, sonarjs/cognitive-complexity, max-statements
 const handleQuery = async (query: string, config: MockOgmiosServerConfig, send: (result: unknown) => void) => {
   let result: any;
   switch (query) {
-    case 'eraSummaries':
-      if (config.stateQuery?.eraSummaries?.response.success) {
-        result = [
-          {
-            end: { epoch: 74, slot: 1_598_400, time: 31_968_000 },
-            parameters: { epochLength: 21_600, safeZone: 4320, slotLength: 20 },
-            start: { epoch: 0, slot: 0, time: 0 }
-          },
-          {
-            end: { epoch: 102, slot: 13_694_400, time: 44_064_000 },
-            parameters: { epochLength: 432_000, safeZone: 129_600, slotLength: 1 },
-            start: { epoch: 74, slot: 1_598_400, time: 31_968_000 }
-          }
-        ];
-      } else if (config.stateQuery?.eraSummaries?.response.failWith?.type === 'unknownResultError') {
+    case 'eraSummaries': {
+      const responseConfig = config.stateQuery?.eraSummaries?.response;
+      const response = Array.isArray(responseConfig) ? responseConfig.shift() : responseConfig;
+      if (response?.success) {
+        result = response.eraSummaries || mockEraSummaries;
+      } else if (response?.failWith?.type === 'unknownResultError') {
         result = 'unknown';
       } else {
         throw new Error('Unknown mock response');
       }
       break;
-    case 'systemStart':
-      if (config.stateQuery?.systemStart?.response.success) {
-        result = new Date(1_506_203_091_000);
-      } else if (config.stateQuery?.systemStart?.response.failWith?.type === 'queryUnavailableInEra') {
+    }
+    case 'systemStart': {
+      const responseConfig = config.stateQuery?.systemStart?.response;
+      const response = Array.isArray(responseConfig) ? responseConfig.shift() : responseConfig;
+      if (response?.success) {
+        result = response.systemStart || new Date(1_506_203_091_000);
+      } else if (response?.failWith?.type === 'queryUnavailableInEra') {
         result = 'QueryUnavailableInCurrentEra';
       } else {
         throw new Error('Unknown mock response');
       }
       break;
+    }
     case 'genesisConfig': {
       const responseConfig = config.stateQuery?.genesisConfig?.response;
       const response = Array.isArray(responseConfig) ? responseConfig.shift() : responseConfig;

--- a/packages/ogmios/test/mocks/types.ts
+++ b/packages/ogmios/test/mocks/types.ts
@@ -15,6 +15,7 @@ export type TxSubmitResponse = {
 };
 
 export type EraSummariesResponse = {
+  eraSummaries?: Schema.EraSummary[];
   success: boolean;
   failWith?: {
     type: 'unknownResultError';
@@ -31,6 +32,7 @@ export type GenesisConfigResponse = {
 
 export type SystemStartResponse = {
   success: boolean;
+  systemStart?: Date;
   failWith?: {
     type: 'queryUnavailableInEra';
   };

--- a/packages/projection-typeorm/src/entity/PoolRegistration.entity.ts
+++ b/packages/projection-typeorm/src/entity/PoolRegistration.entity.ts
@@ -1,5 +1,5 @@
 /* eslint-disable brace-style */
-import { BigIntColumnOptions, DeleteCascadeRelationOptions } from './util';
+import { BigIntColumnOptions, DeleteCascadeRelationOptions, ImaginaryCoinsColumnOptions } from './util';
 import { BlockEntity } from './Block.entity';
 import { Cardano } from '@cardano-sdk/core';
 import { Column, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryColumn } from 'typeorm';
@@ -17,9 +17,9 @@ export class PoolRegistrationEntity {
   id?: bigint;
   @Column()
   rewardAccount?: Cardano.RewardAccount;
-  @Column(BigIntColumnOptions)
+  @Column(ImaginaryCoinsColumnOptions)
   pledge?: bigint;
-  @Column(BigIntColumnOptions)
+  @Column(ImaginaryCoinsColumnOptions)
   cost?: bigint;
   // Review: should we store this as 'double' instead?
   // Maybe both formats? If we'll need to do computations with this

--- a/packages/projection-typeorm/src/entity/util.ts
+++ b/packages/projection-typeorm/src/entity/util.ts
@@ -15,3 +15,16 @@ export const BigIntColumnOptions: Pick<ColumnOptions, 'transformer' | 'type'> = 
   transformer: parseBigInt,
   type: 'bigint'
 };
+
+/**
+ * To be used for user-specified coin quantities that are not validated by the node
+ * to not exceed max lovelace supply (up to unsigned 64 bit integer):
+ * - pool registration cost
+ * - pool registration pledge
+ */
+export const ImaginaryCoinsColumnOptions: Pick<ColumnOptions, 'transformer' | 'type' | 'precision' | 'scale'> = {
+  precision: 20,
+  scale: 0,
+  transformer: parseBigInt,
+  type: 'numeric'
+};


### PR DESCRIPTION
# Context

When running projection services on mainnet, we ran into several issues:
1. Projector stops due to local state queries being unavailable in Byron era
2. Fails to insert some pool registrations, where `cost` or `pledge` exceeds postgres `bigint` (signed 64bit integer)

# Proposed Solution

See commits
