### PR TITLE
fix(wallet): cip30 getUsedAddresses now returns all known addresses

### DIFF
--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -278,15 +278,15 @@ export const createWalletApi = (
     return Promise.resolve([]);
   },
   getUsedAddresses: async (_paginate?: Paginate): Promise<Cbor[]> => {
-    logger.debug('getting changeAddress');
+    logger.debug('getting used addresses');
 
     const wallet = await firstValueFrom(wallet$);
-    const [{ address }] = await firstValueFrom(wallet.addresses$);
+    const addresses = await firstValueFrom(wallet.addresses$);
 
-    if (!address) {
+    if (addresses.length === 0) {
       throw new ApiError(APIErrorCode.InternalError, 'could not get used addresses');
     } else {
-      return [cardanoAddressToCbor(address)];
+      return addresses.map((groupAddresses) => cardanoAddressToCbor(groupAddresses.address));
     }
   },
   getUtxos: async (amount?: Cbor, paginate?: Paginate): Promise<Cbor[] | null> => {

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -349,8 +349,10 @@ describe('cip30', () => {
 
       test('api.getUsedAddresses', async () => {
         const cipUsedAddressess = await api.getUsedAddresses();
-        const [{ address: walletAddress }] = await firstValueFrom(wallet.addresses$);
-        expect(cipUsedAddressess.map((cipAddr) => Cardano.PaymentAddress(cipAddr))).toEqual([walletAddress]);
+        const usedAddresses = (await firstValueFrom(wallet.addresses$)).map((grouped) => grouped.address);
+
+        expect(cipUsedAddressess.length).toBeGreaterThan(1);
+        expect(cipUsedAddressess.map((cipAddr) => Cardano.PaymentAddress(cipAddr))).toEqual(usedAddresses);
       });
 
       test('api.getUnusedAddresses', async () => {


### PR DESCRIPTION
# Context

The API introduced in CIP-30 getUsedAddresses was implemented with the single address wallet in mind, but this is now returning an invalid response when used in conjunction with a multi-address wallet (either HD compatibility or multi-delegation)

# Proposed Solution

Update getUsedAddresses so it return all known addresses.

