### PR TITLE
fix: wallet finalizeTx and CIP30 now wait for at least one known address

### DIFF
--- a/packages/key-management/src/cip8/cip30signData.ts
+++ b/packages/key-management/src/cip8/cip30signData.ts
@@ -19,7 +19,7 @@ import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { ComposableError, HexBlob } from '@cardano-sdk/util';
 import { CoseLabel } from './util';
 import { STAKE_KEY_DERIVATION_PATH } from '../util';
-import { firstValueFrom } from 'rxjs';
+import { filter, firstValueFrom } from 'rxjs';
 
 export interface Cip30SignDataRequest {
   keyAgent: AsyncKeyAgent;
@@ -52,7 +52,9 @@ const getAddressBytes = (signWith: Cardano.PaymentAddress | Cardano.RewardAccoun
 const getDerivationPath = async (signWith: Cardano.PaymentAddress | Cardano.RewardAccount, keyAgent: AsyncKeyAgent) => {
   const isRewardAccount = signWith.startsWith('stake');
 
-  const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
+  const knownAddresses = await firstValueFrom(
+    keyAgent.knownAddresses$.pipe(filter((addresses) => addresses.length > 0))
+  );
 
   if (isRewardAccount) {
     const knownRewardAddress = knownAddresses.find(({ rewardAccount }) => rewardAccount === signWith);

--- a/packages/tx-construction/src/tx-builder/finalizeTx.ts
+++ b/packages/tx-construction/src/tx-builder/finalizeTx.ts
@@ -6,6 +6,7 @@ import {
 } from '@cardano-sdk/key-management';
 import { Cardano, TxCBOR } from '@cardano-sdk/core';
 import { FinalizeTxDependencies, SignedTx, TxContext } from './types';
+import { filter, firstValueFrom } from 'rxjs';
 
 const getSignatures = async (
   keyAgent: AsyncKeyAgent,
@@ -13,6 +14,8 @@ const getSignatures = async (
   extraSigners?: TransactionSigner[],
   signingOptions?: SignTransactionOptions
 ) => {
+  // Wait until the async key agent has at least one known addresses.
+  await firstValueFrom(keyAgent.knownAddresses$.pipe(filter((addresses) => addresses.length > 0)));
   const signatures: Cardano.Signatures = await keyAgent.signTransaction(txInternals, signingOptions);
 
   if (extraSigners) {


### PR DESCRIPTION
# Context

With the introduction of HD wallet discovery, is taking longer for the known addresses array to be populated, this is causing issue when trying to sign transaction before the known addresses have been resolved.

# Proposed Solution

Wait in the relevant places for the addresses to be resolved.
