### PR TITLE
fix(input-selection): greedy input selector now produces a correct selection under all conditions

### DIFF
--- a/packages/input-selection/test/GreedySelection/util.test.ts
+++ b/packages/input-selection/test/GreedySelection/util.test.ts
@@ -16,7 +16,7 @@ describe('splitChange', () => {
       undefined,
       () => 10n,
       () => false,
-      2_000_000n
+      0n
     );
 
     expect(getCoinValueForAddress('A', change)).toEqual(50n);
@@ -46,7 +46,7 @@ describe('splitChange', () => {
       undefined,
       () => 10n,
       () => false,
-      2_000_000n
+      0n
     );
 
     expect(getCoinValueForAddress('A', change)).toEqual(34n);


### PR DESCRIPTION
# Context

After the last round of changes to the greedy input selector, some of the property tests were failing when testing some edge cases.

# Proposed Solution

Fix the greedy input selector so it can handle all edge cases correctly.

