### PR TITLE
Fix/lw 7562 typeorm stakepool provider

### DIFF
--- a/.github/workflows/continuous-integration-e2e.yaml
+++ b/.github/workflows/continuous-integration-e2e.yaml
@@ -3,6 +3,29 @@ name: Continuous Integration - E2E
 env:
   TL_DEPTH: ${{ github.event.pull_request.head.repo.fork && '0' || fromJson(vars.TL_DEPTH) }}
   TL_LEVEL: ${{ github.event.pull_request.head.repo.fork && 'info' || vars.TL_LEVEL }}
+  # -----------------------------------------------------------------------------------------
+  KEY_MANAGEMENT_PROVIDER: 'inMemory'
+  KEY_MANAGEMENT_PARAMS: '{"bip32Ed25519": "CML", "accountIndex": 0, "chainId":{"networkId": 0, "networkMagic": 888}, "passphrase":"some_passphrase","mnemonic":"vacant violin soft weird deliver render brief always monitor general maid smart jelly core drastic erode echo there clump dizzy card filter option defense"}'
+  ASSET_PROVIDER: 'http'
+  ASSET_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/asset"}'
+  CHAIN_HISTORY_PROVIDER: 'http'
+  CHAIN_HISTORY_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/chain-history"}'
+  DB_SYNC_CONNECTION_STRING: 'postgresql://postgres:doNoUseThisSecret!@localhost:5435/cexplorer'
+  HANDLE_PROVIDER: 'http'
+  HANDLE_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/handle","policyId":""}'
+  STAKE_POOL_CONNECTION_STRING: 'postgresql://postgres:doNoUseThisSecret!@localhost:5435/stake_pool'
+  STAKE_POOL_TEST_CONNECTION_STRING: 'postgresql://postgres:doNoUseThisSecret!@localhost:5435/stake_pool_test'
+  NETWORK_INFO_PROVIDER: 'http'
+  NETWORK_INFO_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/network-info"}'
+  OGMIOS_URL: 'ws://localhost:1340/'
+  REWARDS_PROVIDER: 'http'
+  REWARDS_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/rewards"}'
+  TX_SUBMIT_PROVIDER: 'http'
+  TX_SUBMIT_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/tx-submit"}'
+  UTXO_PROVIDER: 'http'
+  UTXO_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/utxo"}'
+  STAKE_POOL_PROVIDER: 'http'
+  STAKE_POOL_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/stake-pool"}'
 
 on:
   pull_request:
@@ -60,28 +83,10 @@ jobs:
         yarn workspace @cardano-sdk/e2e test:projection
         yarn workspace @cardano-sdk/e2e test:pg-boss
       env:
-        KEY_MANAGEMENT_PROVIDER: 'inMemory'
-        KEY_MANAGEMENT_PARAMS: '{"bip32Ed25519": "CML", "accountIndex": 0, "chainId":{"networkId": 0, "networkMagic": 888}, "passphrase":"some_passphrase","mnemonic":"vacant violin soft weird deliver render brief always monitor general maid smart jelly core drastic erode echo there clump dizzy card filter option defense"}'
-        ASSET_PROVIDER: 'http'
-        ASSET_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/asset"}'
-        CHAIN_HISTORY_PROVIDER: 'http'
-        CHAIN_HISTORY_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/chain-history"}'
-        DB_SYNC_CONNECTION_STRING: 'postgresql://postgres:doNoUseThisSecret!@localhost:5435/cexplorer'
-        HANDLE_PROVIDER: 'http'
-        HANDLE_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/handle","policyId":""}'
-        KORA_LABS_HANDLE_PROVIDER: 'kora-labs'
-        KORA_LABS_HANDLE_PROVIDER_PARAMS: '{"serverUrl":"http://localhost:4000","policyId":""}'
-        STAKE_POOL_CONNECTION_STRING: 'postgresql://postgres:doNoUseThisSecret!@localhost:5435/stake_pool'
-        STAKE_POOL_TEST_CONNECTION_STRING: 'postgresql://postgres:doNoUseThisSecret!@localhost:5435/stake_pool_test'
-        NETWORK_INFO_PROVIDER: 'http'
-        NETWORK_INFO_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/network-info"}'
-        OGMIOS_URL: 'ws://localhost:1340/'
-        REWARDS_PROVIDER: 'http'
-        REWARDS_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/rewards"}'
-        TX_SUBMIT_PROVIDER: 'http'
-        TX_SUBMIT_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/tx-submit"}'
-        UTXO_PROVIDER: 'http'
-        UTXO_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/utxo"}'
-        STAKE_POOL_PROVIDER: 'http'
-        STAKE_POOL_PROVIDER_PARAMS: '{"baseUrl":"http://localhost:4000/stake-pool"}'
         STAKE_POOL_PROVIDER_URL: 'http://localhost:4000/stake-pool'
+
+    - name: 🔬 Test - e2e - wallet - typeorm stake pool provider
+      run: |
+        yarn workspace @cardano-sdk/e2e test:providers
+      env:
+        STAKE_POOL_PROVIDER_URL: 'http://localhost:4010/stake-pool'

--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.ts
@@ -73,7 +73,7 @@ export class TypeormStakePoolProvider extends TypeormProvider implements StakePo
         .select(stakePoolSearchSelection)
         .addSelect(stakePoolSearchTotalCount)
         .where(clause, args)
-        .orderBy(field, order, nullsInSort)
+        .orderBy(field, order, !field.includes('cost') ? nullsInSort : undefined)
         .addOrderBy('pool.id', 'ASC')
         .offset(pagination.startAt)
         .limit(pagination.limit)

--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
@@ -99,6 +99,13 @@ export const getWhereClauseAndArgs = (filters: QueryStakePoolsArgs['filters']) =
     const identifierFilters = identifierClauses.join(` ${identifierCondition} `);
     clauses.push(` (${identifierFilters}) `);
   }
+  if (filters.pledgeMet !== undefined && filters.pledgeMet !== null) {
+    if (filters.pledgeMet) {
+      clauses.push('params.pledge<=metrics.live_pledge');
+    } else {
+      clauses.push('params.pledge>metrics.live_pledge');
+    }
+  }
 
   return {
     args: { ...args, ...identifierArgs },

--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
@@ -51,14 +51,21 @@ export const stakePoolSearchTotalCount = 'count(*) over () as total_count';
 export const getSortOptions = (
   sort?: StakePoolSortOptions,
   defaultField: SortField = 'name',
-  defaultOrder: Uppercase<SortOrder> = 'ASC'
+  defaultOrder: SortOrder = 'asc'
 ) => {
-  if (sort)
+  if (!sort) {
+    sort = { field: defaultField, order: defaultOrder };
+  }
+  if (sort.field === 'name') {
     return {
-      field: sortSelectionMap[sort.field as SortField],
+      field: `lower(${sortSelectionMap[sort.field as SortField]})`,
       order: sort.order.toUpperCase() as Uppercase<SortOrder>
     };
-  return { field: defaultField, order: defaultOrder };
+  }
+  return {
+    field: sortSelectionMap[sort.field as SortField],
+    order: sort.order.toUpperCase() as Uppercase<SortOrder>
+  };
 };
 
 export const getFilterCondition = (condition?: FilterCondition, defaultCondition: Uppercase<FilterCondition> = 'OR') =>

--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
@@ -39,8 +39,8 @@ export const stakePoolSearchSelection = [
 
 export const sortSelectionMap: { [key in SortField]: string } = {
   apy: 'metrics_apy',
-  cost: 'params_cost',
-  name: 'metadata_name',
+  cost: 'params.cost',
+  name: 'metadata.name',
   saturation: 'metrics_live_saturation'
 };
 

--- a/packages/e2e/test/providers/StakePoolProvider.test.ts
+++ b/packages/e2e/test/providers/StakePoolProvider.test.ts
@@ -378,6 +378,87 @@ describe('StakePoolProvider', () => {
           );
         });
       });
+
+      describe('sort by live saturation', () => {
+        let filters: QueryStakePoolsArgs['filters'] = {};
+        const poolsId: Cardano.PoolId[] = [];
+
+        beforeAll(() => {
+          for (const pool of pools) if (poolsId.length < 20) poolsId.push(pool.id);
+
+          filters = { identifier: { values: poolsId.map((id) => ({ id })) } };
+        });
+        it('ascending sort by live saturation', async () => {
+          if (poolsId.length < 2)
+            return console.log(
+              "test 'ascending sort by live saturation' can't run because no suitable pools were found"
+            );
+          const { pageResults, totalResultCount } = await query(filters, { field: 'saturation', order: 'asc' });
+
+          expect(totalResultCount).toBe(poolsId.length);
+          expect(pageResults.map((p) => p.metrics!.saturation)).toStrictEqual(
+            pools
+              .filter(({ id }) => poolsId.includes(id))
+              .sort((a, b) => (a.metrics!.saturation < b.metrics!.saturation ? -1 : 1))
+              .map((p) => p.metrics?.saturation)
+          );
+        });
+        it('descending sort by live saturation', async () => {
+          if (poolsId.length < 2)
+            return console.log(
+              "test 'descending sort by live saturation' can't run because no suitable pools were found"
+            );
+          const { pageResults, totalResultCount } = await query(filters, { field: 'saturation', order: 'desc' });
+
+          expect(totalResultCount).toBe(poolsId.length);
+          expect(pageResults.map((p) => p.metrics?.saturation)).toStrictEqual(
+            pools
+              .filter(({ id }) => poolsId.includes(id))
+              .sort((a, b) => (a.metrics!.saturation > b.metrics!.saturation ? -1 : 1))
+              .map((p) => p.metrics?.saturation)
+          );
+        });
+      });
+
+      describe('sort by apy', () => {
+        let filters: QueryStakePoolsArgs['filters'] = {};
+        const poolsId: Cardano.PoolId[] = [];
+
+        beforeAll(() => {
+          for (const pool of pools) {
+            if (poolsId.length < 20 && pool.metrics?.apy !== undefined && pool.metrics?.apy > 0) {
+              poolsId.push(pool.id);
+            }
+          }
+          filters = { identifier: { values: poolsId.map((id) => ({ id })) } };
+        });
+        it('ascending sort by apy', async () => {
+          if (poolsId.length < 2)
+            return console.log("test 'ascending sort by apy' can't run because no suitable pools were found");
+          const { pageResults, totalResultCount } = await query(filters, { field: 'apy', order: 'asc' });
+
+          expect(totalResultCount).toBe(poolsId.length);
+          expect(pageResults.map((p) => p.metrics?.apy)).toStrictEqual(
+            pools
+              .filter(({ id }) => poolsId.includes(id))
+              .sort((a, b) => (a.metrics!.apy! < b.metrics!.apy! ? -1 : 1))
+              .map((p) => p.metrics?.apy)
+          );
+        });
+        it('descending sort by apy', async () => {
+          if (poolsId.length < 2)
+            return console.log("test 'descending sort by apy' can't run because no suitable pools were found");
+          const { pageResults, totalResultCount } = await query(filters, { field: 'apy', order: 'desc' });
+
+          expect(totalResultCount).toBe(poolsId.length);
+          expect(pageResults.map((p) => p.metrics?.apy)).toStrictEqual(
+            pools
+              .filter(({ id }) => poolsId.includes(id))
+              .sort((a, b) => (a.metrics!.apy! > b.metrics!.apy! ? -1 : 1))
+              .map((p) => p.metrics?.apy)
+          );
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
# Context

Updated Typeorm stake pool provider to pass e2e tests and added to CI e2e suite

# Importand changes

- excluded `cost` from `nullsInSort` 
- updated table names for `cost` and `name` in queries 
- switched to case-insensitive sort by `name`
- added `pledgeMet` filter
- added wildcard search by `name` and `ticker` 
 

