### PR TITLE
chore: bump cardano-node to 1.35.7

### DIFF
--- a/packages/cardano-services/README.md
+++ b/packages/cardano-services/README.md
@@ -144,6 +144,15 @@ RABBITMQ_SRV_SERVICE_NAME=some-domain-for-rabbitmq \
 The _Docker images_ produced by the SDK and the _docker compose infrastructures_ (_mainnet_, _preprod_ and _local-network_) it includes are ready to be used in
 production environment.
 
+Running [cardano node] on _mainnet_ requires a minimum of 24GB RAM.
+
+- **WSL2**: add following content to `/etc/wsl.conf` file.
+
+  ```
+  [wsl2]
+  memory = 30GB
+  ```
+
 **Note:** the _docker compose infrastructures_ included in the SDK are mainly used for development purposes: to use
 them in production environments, the projector service(s) must be instructed to run the _migration scripts_ rather than
 to use the `synchronize` development option from **TypeORM**. This can be achieved through environment variables:

--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -9,7 +9,7 @@ x-logging: &logging
 
 services:
   cardano-node-ogmios:
-    image: cardanosolutions/cardano-node-ogmios:v${OGMIOS_VERSION:-5.6.0}_${CARDANO_NODE_VERSION:-1.35.5}-${NETWORK:-mainnet}
+    image: cardanosolutions/cardano-node-ogmios:v${OGMIOS_VERSION:-5.6.0}_${CARDANO_NODE_VERSION:-1.35.7}-${NETWORK:-mainnet}
     volumes:
       - ./config/network/${NETWORK:-mainnet}:/config
 

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
   cardano-node-ogmios:
     entrypoint: ['/tini', '-g', '--', '/scripts/cardano-node-ogmios.sh']
-    image: cardanosolutions/cardano-node-ogmios:v${OGMIOS_VERSION:-5.6.0}_${CARDANO_NODE_VERSION:-1.35.5}
+    image: cardanosolutions/cardano-node-ogmios:v${OGMIOS_VERSION:-5.6.0}_${CARDANO_NODE_VERSION:-1.35.7}
     depends_on:
       local-testnet:
         condition: service_healthy

--- a/packages/e2e/local-network/Dockerfile
+++ b/packages/e2e/local-network/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:${UBUNTU_VERSION} as builder
 ENV DEBIAN_FRONTEND=nonintercative
 
 WORKDIR /build
-ARG CARDANO_NODE_BUILD_URL=https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.4-linux.tar.gz
+ARG CARDANO_NODE_BUILD_URL=https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.7-linux.tar.gz
 RUN apt-get update -y && \
   apt-get install -y wget tar && \
   wget $CARDANO_NODE_BUILD_URL -O cardano-node.tar.gz && \


### PR DESCRIPTION
# Context

A new version of `cardano-node` was released.

# Proposed Solution

Bump the image version our docker compose.

# Important Changes Introduced

Added to the doc some info about possible `cardano-node` OOM related problems.