### PR TITLE
fix(web-extension): lw-7563 throw RemoteApiShutdownError on disconnec…

### DIFF
--- a/packages/e2e/test/web-extension/extension/ui.html
+++ b/packages/e2e/test/web-extension/extension/ui.html
@@ -27,6 +27,10 @@
   <div>Stake Address: <span id="stakeAddress">-</span></div>
   <div>Balance: <span id="balance">-</span></div>
   <div>Network-wide staked: <span id="supplyDistribution">-</span></div>
+  <div id="remoteApiPortDisconnect">
+    <p class="bgPortDisconnect">Waiting for UI api consumer promise to reject</p>
+    <p class="uiPortDisconnect">Waiting for BG api consumer promise to reject</p>
+  </div>
   <div id="multiDelegation">
     <div class="distribution">
       <h3>Delegation distribution:</h3>

--- a/packages/e2e/test/web-extension/extension/util.ts
+++ b/packages/e2e/test/web-extension/extension/util.ts
@@ -11,14 +11,25 @@ export interface UserPromptService {
 
 export interface BackgroundServices {
   adaUsd$: Observable<number>;
+  /** BG script will use this observable to send the result of consumedApi promise api call while port is disconnected by UI side */
+  apiDisconnectResult$: Observable<string>;
   clearAllowList(): Promise<void>;
   getPoolIds(count: number): Promise<Cardano.StakePool[]>;
 }
 
 export const adaPriceProperties: RemoteApiProperties<BackgroundServices> = {
   adaUsd$: RemoteApiPropertyType.HotObservable,
+  apiDisconnectResult$: RemoteApiPropertyType.HotObservable,
   clearAllowList: RemoteApiPropertyType.MethodReturningPromise,
   getPoolIds: RemoteApiPropertyType.MethodReturningPromise
+};
+
+// Dummy object to be used with remoteApi to test that promise rejects in case of disconnected port
+export interface DisconnectPortTestObj {
+  promiseMethod(): Promise<void>;
+}
+export const disconnectPortTestObjProperties: RemoteApiProperties<DisconnectPortTestObj> = {
+  promiseMethod: RemoteApiPropertyType.MethodReturningPromise
 };
 
 export const logger = console;

--- a/packages/e2e/test/web-extension/specs/wallet.spec.ts
+++ b/packages/e2e/test/web-extension/specs/wallet.spec.ts
@@ -44,6 +44,8 @@ describe('wallet', () => {
   const spanPoolIds = '#multiDelegation .delegate .pools';
   const liPools = '#multiDelegation .distribution li';
   const liPercents = '#multiDelegation .distribution li .percent';
+  const divBgPortDisconnectStatus = '#remoteApiPortDisconnect .bgPortDisconnect';
+  const divUiPortDisconnectStatus = '#remoteApiPortDisconnect .uiPortDisconnect';
 
   // The address is filled in by the tests, which are order dependent
   let walletAddr1 = '';
@@ -69,6 +71,11 @@ describe('wallet', () => {
   describe('wallet ui opens', () => {
     before(async () => {
       await switchToWalletUi();
+    });
+
+    it('should handle remoteApi disconnects as Promise.rejects', async () => {
+      await expect($(divBgPortDisconnectStatus)).toHaveText('Background port disconnect -> Promise rejects');
+      await expect($(divUiPortDisconnectStatus)).toHaveText('UI script port disconnect -> Promise rejects');
     });
 
     it('should display ADA price, provided by background process', async () => {

--- a/packages/web-extension/src/messaging/types.ts
+++ b/packages/web-extension/src/messaging/types.ts
@@ -159,11 +159,17 @@ export interface DeriveChannelOptions {
   detached?: boolean;
 }
 
+export interface DisconnectEvent {
+  disconnected: MinimalPort;
+  remaining: MinimalPort[];
+}
+
 export interface Messenger extends Shutdown {
   channel: ChannelName;
   connect$: Observable<MinimalPort>;
   postMessage(message: unknown): Observable<void>;
   message$: Observable<PortMessage>;
+  disconnect$: Observable<DisconnectEvent>;
   isShutdown: boolean;
   deriveChannel(path: string, options?: DeriveChannelOptions): Messenger;
 }

--- a/packages/web-extension/test/remoteApi/remoteApi.integration.test.ts
+++ b/packages/web-extension/test/remoteApi/remoteApi.integration.test.ts
@@ -15,6 +15,7 @@ import {
   exposeMessengerApi
 } from '../../src/messaging';
 import {
+  EMPTY,
   EmptyError,
   Observable,
   Subject,
@@ -79,6 +80,7 @@ const createMessenger = (channel: ChannelName, isHost: boolean): TestMessenger =
       derivedMessengers.push(messenger);
       return messenger;
     },
+    disconnect$: EMPTY,
     isShutdown: false,
     message$: local$.pipe(
       map((data): PortMessage => ({ data, port: { postMessage: (message) => postMessage(message).subscribe() } })),

--- a/packages/web-extension/test/remoteApi/remoteApi.test.ts
+++ b/packages/web-extension/test/remoteApi/remoteApi.test.ts
@@ -46,6 +46,7 @@ const createMockMessenger = (channel: ChannelName) => {
       return messenger;
     }),
     derivedMessengers,
+    disconnect$: EMPTY,
     get isShutdown() {
       return isShutdown;
     },
@@ -70,6 +71,7 @@ const setUp = (mode: ApiObjectType) => {
     channel: 'mockMessenger-someNumbers$',
     connect$: new Subject(),
     deriveChannel: jest.fn(),
+    disconnect$: EMPTY,
     isShutdown: false,
     message$: new Subject(),
     postMessage: jest.fn().mockImplementation(() => EMPTY),
@@ -79,6 +81,7 @@ const setUp = (mode: ApiObjectType) => {
     channel: 'mockMessenger',
     connect$: new Subject(),
     deriveChannel: jest.fn().mockImplementation(() => observablePropMessenger),
+    disconnect$: EMPTY,
     isShutdown: false,
     message$: incomingMsg$.asObservable(),
     postMessage: jest.fn().mockImplementation(() => EMPTY),
@@ -88,6 +91,7 @@ const setUp = (mode: ApiObjectType) => {
     channel: 'mockMessengerOuter',
     connect$: new Subject(),
     deriveChannel: jest.fn().mockImplementation(() => mockMessenger),
+    disconnect$: EMPTY,
     isShutdown: false,
     message$: new Subject(),
     postMessage: jest.fn().mockImplementation(() => EMPTY),


### PR DESCRIPTION
# Context

Handle the case where port disconnects while waiting for remote method execution result.
Currently, the caller (api consumer) will hang waiting for a message with the execution result.

# Proposed Solution
Messengers have a new `disconnect$` observable that emits when on port disconnect.
The remoteApi consumer promise calls will return rejected promise in case of disconnect$ event.

# Important Changes Introduced
