### PR TITLE
LW-6949 benchmark tools

### DIFF
--- a/packages/cardano-services/src/Program/programs/projector.ts
+++ b/packages/cardano-services/src/Program/programs/projector.ts
@@ -1,4 +1,5 @@
 import { Bootstrap } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { CommonProgramOptions, OgmiosProgramOptions, PosgresProgramOptions } from '../options';
 import { DnsResolver, createDnsResolver } from '../utils';
 import {
@@ -24,6 +25,7 @@ export type ProjectorArgs = CommonProgramOptions &
   OgmiosProgramOptions & {
     dropSchema: boolean;
     dryRun: boolean;
+    exitAtBlockNo: Cardano.BlockNo;
     poolsMetricsInterval: number;
     projectionNames: ProjectionName[];
     synchronize: boolean;
@@ -48,11 +50,12 @@ const createProjectionHttpService = async (options: ProjectionMapFactoryOptions)
   });
   const connectionConfig$ = getConnectionConfig(dnsResolver, 'projector', '', args);
   const buffer = new TypeormStabilityWindowBuffer({ logger });
-  const { dropSchema, dryRun, projectionNames, synchronize, handlePolicyIds } = args;
+  const { dropSchema, dryRun, exitAtBlockNo, projectionNames, synchronize, handlePolicyIds } = args;
   const projection$ = createTypeormProjection({
     buffer,
     connectionConfig$,
     devOptions: { dropSchema, synchronize },
+    exitAtBlockNo,
     logger,
     projectionOptions: {
       handlePolicyIds

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -35,6 +35,7 @@ export const POOLS_METRICS_INTERVAL_DEFAULT = 1000;
 export enum ProjectorOptionDescriptions {
   DropSchema = 'Drop and recreate database schema to project from origin',
   DryRun = 'Initialize the projection, but do not start it',
+  ExitAtBlockNo = 'Exit after processing this block. Intended for benchmark testing',
   PoolsMetricsInterval = 'Interval between two stake pools metrics jobs in number of blocks',
   Synchronize = 'Synchronize the schema from the models'
 }

--- a/packages/cardano-services/src/Projection/ProjectionHttpService.ts
+++ b/packages/cardano-services/src/Projection/ProjectionHttpService.ts
@@ -1,5 +1,19 @@
 import { BaseProjectionEvent } from '@cardano-sdk/projection';
-import { EMPTY, Observable, Subscription, map, merge, of, startWith, switchMap, timer } from 'rxjs';
+import {
+  EMPTY,
+  Observable,
+  OperatorFunction,
+  Subscription,
+  last,
+  map,
+  merge,
+  of,
+  share,
+  startWith,
+  switchMap,
+  takeUntil,
+  timer
+} from 'rxjs';
 import { HealthCheckResponse, Milliseconds } from '@cardano-sdk/core';
 import { HttpService } from '../Http';
 import { Logger } from 'ts-log';
@@ -22,6 +36,13 @@ export interface ProjectionServiceDependencies {
   router?: express.Router;
 }
 
+const whileSourceOpen =
+  <In, Out>(op: OperatorFunction<In, Out>): OperatorFunction<In, Out> =>
+  (source$) => {
+    const sharedEvt$ = source$.pipe(share());
+    return sharedEvt$.pipe(op, takeUntil(sharedEvt$.pipe(last(null, null))));
+  };
+
 const toProjectionHealth = (maxFrequency: Milliseconds) => (evt$: Observable<BaseProjectionEvent>) =>
   evt$.pipe(
     map((e): HealthCheckResponse => {
@@ -41,12 +62,14 @@ const toProjectionHealth = (maxFrequency: Milliseconds) => (evt$: Observable<Bas
     }),
     map((health) => of(health)),
     startWith(EMPTY),
-    switchMap((health$) =>
-      merge(
-        health$,
-        // switchMap unsubscribes/cancels the timer if source emits sooner
-        timer(maxFrequency).pipe(
-          map((): HealthCheckResponse => ({ ok: false, reason: `Projection timeout (${maxFrequency}ms)` }))
+    whileSourceOpen(
+      switchMap((health$) =>
+        merge(
+          health$,
+          // switchMap unsubscribes/cancels the timer if source emits sooner
+          timer(maxFrequency).pipe(
+            map((): HealthCheckResponse => ({ ok: false, reason: `Projection timeout (${maxFrequency}ms)` }))
+          )
         )
       )
     )
@@ -81,10 +104,11 @@ export class ProjectionHttpService<T extends BaseProjectionEvent> extends HttpSe
 
   async startImpl(): Promise<void> {
     if (this.#dryRun) return;
-    this.#projectionSubscription = this.#projection$
-      .pipe(toProjectionHealth(this.#healthTimeout))
-      .subscribe((health) => {
-        this.#health = health;
-      });
+    this.#projectionSubscription = this.#projection$.pipe(toProjectionHealth(this.#healthTimeout)).subscribe({
+      complete: () => {
+        throw new Error('Projection stopped');
+      },
+      next: (health) => (this.#health = health)
+    });
   }
 }

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -139,6 +139,12 @@ withCommonOptions(
       .argParser((dryRun) => stringOptionToBoolean(dryRun, Programs.Projector, ProjectorOptionDescriptions.DryRun))
   )
   .addOption(
+    new Option('--exit-at-block-no <exitAtBlockNo>', ProjectorOptionDescriptions.ExitAtBlockNo)
+      .env('EXIT_AT_BLOCK_NO')
+      .default('')
+      .argParser((exitAtBlockNo) => (exitAtBlockNo ? Number.parseInt(exitAtBlockNo, 10) : 0))
+  )
+  .addOption(
     new Option('--pools-metrics-interval <poolsMetricsInterval>', ProjectorOptionDescriptions.PoolsMetricsInterval)
       .env('POOLS_METRICS_INTERVAL')
       .default(POOLS_METRICS_INTERVAL_DEFAULT)


### PR DESCRIPTION
# Context

We need to add benchmark capabilities to the projector to measure effect of changes.

# Proposed Solution

Added the `--exit-at-block-no` command line argument.

Sample logs of interest:
```
[2023-07-27T11:19:22.161Z]  INFO: projector/12 on 6d24b4d3ed48: [Projector] Initializing 0.08% at block #1000 All: eta 2023-07-27T15:03:08 at 90 b/s
[2023-07-27T11:19:26.581Z]  INFO: projector/12 on 6d24b4d3ed48: [Projector] Initializing 0.17% at block #2000 All: eta 2023-07-27T13:55:39 at 129 b/s - 1K: eta 2023-07-27T12:48:16 at 226 b/s
[2023-07-27T11:19:30.955Z]  INFO: projector/12 on 6d24b4d3ed48: [Projector] Initializing 0.25% at block #3000 All: eta 2023-07-27T13:32:50 at 151 b/s - 1K: eta 2023-07-27T12:47:20 at 229 b/s
[2023-07-27T11:19:34.770Z]  INFO: projector/12 on 6d24b4d3ed48: [Projector] Initializing 0.33% at block #4000 All: eta 2023-07-27T13:18:38 at 169 b/s - 1K: eta 2023-07-27T12:36:09 at 262 b/s
[2023-07-27T11:19:38.472Z]  INFO: projector/12 on 6d24b4d3ed48: [Projector] Initializing 0.41% at block #5000 All: eta 2023-07-27T13:09:39 at 182 b/s - 1K: eta 2023-07-27T12:33:51 at 270 b/s
```

# Important Changes Introduced

Added the 10K blocks and 100K blocks moving averages (to overall and 1K) to the logged projection progress message.