### PR TITLE
Test/lw 6414 spend rewards from multiple accounts

### DIFF
--- a/packages/e2e/test/long-running/delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/delegation-rewards.test.ts
@@ -1,4 +1,4 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, StakePoolProvider } from '@cardano-sdk/core';
 import { PersonalWallet } from '@cardano-sdk/wallet';
 import {
   TestWallet,
@@ -15,6 +15,64 @@ import { logger } from '@cardano-sdk/util-dev';
 import { waitForWalletStateSettle } from '../../../wallet/test/util';
 
 const env = getEnv(walletVariables);
+
+const submitDelegationTx = async (wallet: PersonalWallet, pools: Cardano.PoolId[]) => {
+  logger.info(`Creating delegation tx at epoch #${(await firstValueFrom(wallet.currentEpoch$)).epochNo}`);
+  const { tx: signedTx } = await wallet
+    .createTxBuilder()
+    .delegatePortfolio({
+      pools: pools.map((poolId) => ({ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolId)), weight: 1 }))
+    })
+    .build()
+    .sign();
+  await wallet.submitTx(signedTx);
+  const { epochNo } = await firstValueFrom(wallet.currentEpoch$);
+  logger.info(`Delegation tx ${signedTx.id} submitted at epoch #${epochNo}`);
+
+  return signedTx;
+};
+
+const generateTxs = async (sendingWallet: PersonalWallet, receivingWallet: PersonalWallet) => {
+  logger.info('Sending 100 txs to generate reward fees');
+
+  const tAdaToSend = 5_000_000n;
+  const [{ address: receivingAddress }] = await firstValueFrom(receivingWallet.addresses$);
+
+  for (let i = 0; i < 100; i++) {
+    const txBuilder = sendingWallet.createTxBuilder();
+    const txOut = await txBuilder.buildOutput().address(receivingAddress).coin(tAdaToSend).build();
+    const { tx: signedTx } = await txBuilder.addOutput(txOut).build().sign();
+    await sendingWallet.submitTx(signedTx);
+  }
+};
+
+const buildSpendRewardTx = async (sendingWallet: PersonalWallet, receivingWallet: PersonalWallet) => {
+  const tAdaToSend = 5_000_000n;
+  const [{ address: receivingAddress }] = await firstValueFrom(receivingWallet.addresses$);
+  const txBuilder = sendingWallet.createTxBuilder();
+  const txOut = await txBuilder.buildOutput().address(receivingAddress).coin(tAdaToSend).build();
+  const tx = txBuilder.addOutput(txOut).build();
+  const { body } = await tx.inspect();
+  logger.debug('Body of tx before sign');
+  logger.debug(body);
+  const { tx: signedTx } = await tx.sign();
+  logger.debug('Body of tx after sign');
+  logger.debug(signedTx.body);
+
+  return signedTx;
+};
+
+const getPoolIds = async (stakePoolProvider: StakePoolProvider, count: number) => {
+  const activePools = await stakePoolProvider.queryStakePools({
+    filters: { pledgeMet: true, status: [Cardano.StakePoolStatus.Active] },
+    pagination: { limit: count, startAt: 0 }
+  });
+  expect(activePools.totalResultCount).toBeGreaterThanOrEqual(count);
+  const poolIds = activePools.pageResults.map(({ id }) => id);
+  expect(poolIds.every((poolId) => poolId !== undefined)).toBeTruthy();
+  logger.info('Wallet funds will be staked to pools:', poolIds);
+  return poolIds;
+};
 
 describe('delegation rewards', () => {
   let providers: TestWallet['providers'];
@@ -51,64 +109,11 @@ describe('delegation rewards', () => {
     await initializeWallets();
 
     // Arrange
-    const activePools = await providers.stakePoolProvider.queryStakePools({
-      filters: { pledgeMet: true, status: [Cardano.StakePoolStatus.Active] },
-      pagination: { limit: 1, startAt: 0 }
-    });
-    expect(activePools.totalResultCount).toBeGreaterThan(0);
-    const poolId = activePools.pageResults[0].id;
-    expect(poolId).toBeDefined();
-    logger.info(`Wallet funds will be staked to pool ${poolId}.`);
-
-    const submitDelegationTx = async () => {
-      logger.info(`Creating delegation tx at epoch #${(await firstValueFrom(wallet1.currentEpoch$)).epochNo}`);
-      const { tx: signedTx } = await wallet1
-        .createTxBuilder()
-        .delegatePortfolio({
-          pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolId)), weight: 1 }]
-        })
-        .build()
-        .sign();
-      await wallet1.submitTx(signedTx);
-      const { epochNo } = await firstValueFrom(wallet1.currentEpoch$);
-      logger.info(`Delegation tx ${signedTx.id} submitted at epoch #${epochNo}`);
-
-      return signedTx;
-    };
-
-    const generateTxs = async () => {
-      logger.info('Sending 100 txs to generate reward fees');
-
-      const tAdaToSend = 5_000_000n;
-      const [{ address: receivingAddress }] = await firstValueFrom(wallet2.addresses$);
-
-      for (let i = 0; i < 100; i++) {
-        const txBuilder = wallet1.createTxBuilder();
-        const txOut = await txBuilder.buildOutput().address(receivingAddress).coin(tAdaToSend).build();
-        const { tx: signedTx } = await txBuilder.addOutput(txOut).build().sign();
-        await wallet1.submitTx(signedTx);
-      }
-    };
-
-    const buildSpendRewardTx = async () => {
-      const tAdaToSend = 5_000_000n;
-      const [{ address: receivingAddress }] = await firstValueFrom(wallet2.addresses$);
-      const txBuilder = wallet1.createTxBuilder();
-      const txOut = await txBuilder.buildOutput().address(receivingAddress).coin(tAdaToSend).build();
-      const tx = await txBuilder.addOutput(txOut).build();
-      const { body } = await tx.inspect();
-      logger.debug('Body of tx before sign');
-      logger.debug(body);
-      const { tx: signedTx } = await tx.sign();
-      logger.debug('Body of tx after sign');
-      logger.debug(signedTx.body);
-
-      return signedTx;
-    };
+    const [poolId] = await getPoolIds(providers.stakePoolProvider, 1);
 
     // Stake and wait for reward
 
-    const signedTx = await submitDelegationTx();
+    const signedTx = await submitDelegationTx(wallet1, [poolId]);
 
     const delegationTxConfirmedAtEpoch = await getTxConfirmationEpoch(wallet1, signedTx);
 
@@ -116,7 +121,7 @@ describe('delegation rewards', () => {
 
     await waitForEpoch(wallet1, delegationTxConfirmedAtEpoch + 2);
 
-    await generateTxs();
+    await generateTxs(wallet1, wallet2);
     await waitForEpoch(wallet1, delegationTxConfirmedAtEpoch + 4);
 
     // Check reward
@@ -127,7 +132,7 @@ describe('delegation rewards', () => {
     logger.info(`Generated rewards: ${rewards} tLovelace`);
 
     // Spend reward
-    const spendRewardTx = await buildSpendRewardTx();
+    const spendRewardTx = await buildSpendRewardTx(wallet1, wallet2);
     expect(spendRewardTx.body.withdrawals?.length).toBeGreaterThan(0);
     await submitAndConfirm(wallet1, spendRewardTx);
   });


### PR DESCRIPTION
# Context

Create e2e test to check that txBuilder withdraws rewards from multiple accounts when constructing transactions.
