### PR TITLE
feat(wallet): add optional callback for getCollateral

### DIFF
--- a/packages/e2e/test/web-extension/extension/background/cip30.ts
+++ b/packages/e2e/test/web-extension/extension/background/cip30.ts
@@ -8,7 +8,11 @@ import { wallet$ } from './walletManager';
 import { walletName } from '../const';
 
 // this should come from remote api
-const confirmationCallback: walletCip30.CallbackConfirmation = async () => true;
+const confirmationCallback: walletCip30.CallbackConfirmation = {
+  signData: async () => true,
+  signTx: async () => true,
+  submitTx: async () => true
+};
 
 const walletApi = walletCip30.createWalletApi(wallet$, confirmationCallback, { logger });
 cip30.initializeBackgroundScript({ walletName }, { authenticator, logger, runtime, walletApi });

--- a/packages/util-dev/src/mockProviders/mockData.ts
+++ b/packages/util-dev/src/mockProviders/mockData.ts
@@ -1,3 +1,4 @@
+import * as AssetId from '../assetId';
 import { Cardano, EpochRewards, Seconds } from '@cardano-sdk/core';
 
 export const rewardAccount = Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d');
@@ -114,3 +115,30 @@ export const utxosWithLowCoins: Cardano.Utxo[] = [
     }
   ]
 ];
+
+export const utxosWithLowCoinsAndMixedAssets: Cardano.Utxo[] = [
+  ...utxosWithLowCoins,
+  [
+    {
+      address: Cardano.PaymentAddress(
+        'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+      ),
+      index: 3,
+      txId: Cardano.TransactionId('c7c0973c6bbf1a04a9f306da7814b4fa564db649bf48b0bd93c273bd03143547')
+    },
+    {
+      address: Cardano.PaymentAddress(
+        'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+      ),
+      value: {
+        assets: new Map([
+          [AssetId.PXL, 5n],
+          [AssetId.TSLA, 10n]
+        ]),
+        coins: 4_027_026_465n
+      }
+    }
+  ]
+];
+
+export const sortedUtxosWithLowCoins: Cardano.Utxo[] = [utxosWithLowCoins[1], utxosWithLowCoins[0]];

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -28,7 +28,8 @@ export type Cip30WalletDependencies = {
 export enum Cip30ConfirmationCallbackType {
   SignData = 'sign_data',
   SignTx = 'sign_tx',
-  SubmitTx = 'submit_tx'
+  SubmitTx = 'submit_tx',
+  GetCollateral = 'get_collateral'
 }
 
 export type SignDataCallbackParams = {
@@ -49,9 +50,23 @@ export type SubmitTxCallbackParams = {
   data: Cardano.Tx;
 };
 
-export type CallbackConfirmation = (
-  args: SignDataCallbackParams | SignTxCallbackParams | SubmitTxCallbackParams
-) => Promise<boolean>;
+// Optional callback
+export type GetCollateralCallbackParams = {
+  type: Cip30ConfirmationCallbackType.GetCollateral;
+  data: {
+    amount: Cardano.Lovelace;
+    utxos: Cardano.Utxo[];
+  };
+};
+
+type GetCollateralCallback = (args: GetCollateralCallbackParams) => Promise<Cardano.Utxo[]>;
+
+export type CallbackConfirmation = {
+  signData: (args: SignDataCallbackParams) => Promise<boolean>;
+  signTx: (args: SignTxCallbackParams) => Promise<boolean>;
+  submitTx: (args: SubmitTxCallbackParams) => Promise<boolean>;
+  getCollateral?: GetCollateralCallback;
+};
 
 interface CslInterface {
   to_bytes(): Uint8Array;
@@ -159,6 +174,76 @@ const selectUtxo = async (wallet: ObservableWallet, filterAmount: Cardano.Value,
     ? dumbSelection(await firstValueFrom(wallet.utxo.available$), filterAmount)
     : await walletSelection(filterAmount, wallet);
 
+/**
+ * Returns an array of UTxOs that do not contain assets
+ */
+const getUtxosWithoutAssets = (utxos: Cardano.Utxo[]): Cardano.Utxo[] => utxos.filter((utxo) => !utxo[1].value.assets);
+
+const getFilterAsBigNum = (amount: Cbor, scope: ManagedFreeableScope): CML.BigNum => {
+  try {
+    return scope.manage(CML.BigNum.from_bytes(Buffer.from(amount, 'hex')));
+  } catch {
+    return scope.manage(CML.BigNum.from_str(scope.manage(CML.BigInt.from_bytes(Buffer.from(amount, 'hex'))).to_str()));
+  }
+};
+
+const getFilterAmount = (amount: Cbor, scope: ManagedFreeableScope): CML.BigNum => {
+  try {
+    const filterAmount = getFilterAsBigNum(amount, scope);
+
+    if (filterAmount.compare(MAX_COLLATERAL_AMOUNT) > 0) {
+      throw new ApiError(APIErrorCode.InvalidRequest, 'requested amount is too big');
+    }
+    return filterAmount;
+  } catch (error) {
+    throw new ApiError(APIErrorCode.InternalError, formatUnknownError(error));
+  }
+};
+
+/**
+ * getCollateralCallback
+ *
+ * @param amount ADA collateral required in lovelaces
+ * @param availableUtxos available UTxOs
+ * @param callback Callback to execute to attempt setting new collateral
+ * @param scope The scope that will manage the CML resources.
+ * @param logger The logger instance
+ * @returns Promise<Cbor[]> or null
+ */
+const getCollateralCallback = async (
+  amount: Cardano.Lovelace,
+  availableUtxos: Cardano.Utxo[],
+  callback: GetCollateralCallback,
+  scope: ManagedFreeableScope,
+  logger: Logger
+) => {
+  const availableUtxosWithoutAssets = getUtxosWithoutAssets(availableUtxos);
+  if (availableUtxosWithoutAssets.length === 0) return null;
+  try {
+    // Send the amount and filtered available UTxOs to the callback
+    // Client can then choose to mark a UTxO set as unspendable
+    const newCollateral = await callback({
+      data: {
+        amount: BigInt(amount.toString()),
+        utxos: availableUtxosWithoutAssets
+      },
+      type: Cip30ConfirmationCallbackType.GetCollateral
+    });
+    return coreToCml.utxo(scope, newCollateral).map(cslToCbor);
+  } catch (error) {
+    logger.error(error);
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    throw new ApiError(APIErrorCode.InternalError, formatUnknownError(error));
+  }
+};
+
+const getSortedUtxos = async (observableUtxos: Observable<Cardano.Utxo[]>): Promise<Cardano.Utxo[]> => {
+  const utxos = await firstValueFrom(observableUtxos);
+  return utxos.sort(compareUtxos);
+};
+
 export const createWalletApi = (
   wallet$: Observable<ObservableWallet>,
   confirmationCallback: CallbackConfirmation,
@@ -195,37 +280,39 @@ export const createWalletApi = (
       throw new ApiError(APIErrorCode.InternalError, formatUnknownError(error));
     }
   },
-  // eslint-disable-next-line max-statements
+  // eslint-disable-next-line max-statements, sonarjs/cognitive-complexity
   getCollateral: async ({ amount = cslToCbor(MAX_COLLATERAL_AMOUNT) }: { amount?: Cbor } = {}): Promise<
     Cbor[] | null
-    // eslint-disable-next-line sonarjs/cognitive-complexity
+    // eslint-disable-next-line sonarjs/cognitive-complexity, max-statements
   > =>
+    // eslint-disable-next-line complexity
     usingAutoFree(async (scope) => {
       logger.debug('getting collateral');
       const wallet = await firstValueFrom(wallet$);
-      let unspendables = (await firstValueFrom(wallet.utxo.unspendable$)).sort(compareUtxos);
-
-      // No available unspendable UTXO
-      if (unspendables.length === 0) return null;
+      let unspendables = await getSortedUtxos(wallet.utxo.unspendable$);
+      const available = await getSortedUtxos(wallet.utxo.available$);
+      // No available unspendable UTxO
+      if (unspendables.length === 0) {
+        if (available.length > 0 && !!confirmationCallback.getCollateral) {
+          // available UTxOs could be set as collateral based on user preference
+          return await getCollateralCallback(
+            BigInt(getFilterAmount(amount, scope).to_str()),
+            available,
+            confirmationCallback.getCollateral,
+            scope,
+            logger
+          );
+        }
+        return null;
+      }
 
       if (unspendables.some((utxo) => utxo[1].value.assets && utxo[1].value.assets.size > 0)) {
         throw new ApiError(APIErrorCode.Refused, 'unspendable UTxOs must not contain assets when used as collateral');
       }
       if (amount) {
-        try {
-          const filterAmount = (() => {
-            try {
-              return scope.manage(CML.BigNum.from_bytes(Buffer.from(amount, 'hex')));
-            } catch {
-              return scope.manage(
-                CML.BigNum.from_str(scope.manage(CML.BigInt.from_bytes(Buffer.from(amount, 'hex'))).to_str())
-              );
-            }
-          })();
-          if (filterAmount.compare(MAX_COLLATERAL_AMOUNT) > 0) {
-            throw new ApiError(APIErrorCode.InvalidRequest, 'requested amount is too big');
-          }
+        const filterAmount = getFilterAmount(amount, scope);
 
+        try {
           const utxos = [];
           let totalCoins = scope.manage(CML.BigNum.from_str('0'));
           for (const utxo of unspendables) {
@@ -235,6 +322,18 @@ export const createWalletApi = (
             if (totalCoins.compare(filterAmount) !== -1) break;
           }
           if (totalCoins.compare(filterAmount) === -1) {
+            // if no collateral available by amount in unspendables, return callback if provided to set unspendables and return in the callback
+
+            if (available.length > 0 && !!confirmationCallback.getCollateral) {
+              return await getCollateralCallback(
+                BigInt(filterAmount.to_str()),
+                available,
+                confirmationCallback.getCollateral,
+                scope,
+                logger
+              );
+            }
+
             throw new ApiError(APIErrorCode.Refused, 'not enough coins in configured collateral UTxOs');
           }
           unspendables = utxos;
@@ -312,13 +411,15 @@ export const createWalletApi = (
     const hexBlobPayload = HexBlob(payload);
     const signWith = Cardano.PaymentAddress(addr);
 
-    const shouldProceed = await confirmationCallback({
-      data: {
-        addr: signWith,
-        payload: hexBlobPayload
-      },
-      type: Cip30ConfirmationCallbackType.SignData
-    }).catch((error) => mapCallbackFailure(error, logger));
+    const shouldProceed = await confirmationCallback
+      .signData({
+        data: {
+          addr: signWith,
+          payload: hexBlobPayload
+        },
+        type: Cip30ConfirmationCallbackType.SignData
+      })
+      .catch((error) => mapCallbackFailure(error, logger));
 
     if (shouldProceed) {
       const wallet = await firstValueFrom(wallet$);
@@ -337,10 +438,12 @@ export const createWalletApi = (
 
     const hash = txDecoded.getId();
     const coreTx = txDecoded.toCore();
-    const shouldProceed = await confirmationCallback({
-      data: coreTx,
-      type: Cip30ConfirmationCallbackType.SignTx
-    }).catch((error) => mapCallbackFailure(error, logger));
+    const shouldProceed = await confirmationCallback
+      .signTx({
+        data: coreTx,
+        type: Cip30ConfirmationCallbackType.SignTx
+      })
+      .catch((error) => mapCallbackFailure(error, logger));
     if (shouldProceed) {
       const wallet = await firstValueFrom(wallet$);
       try {
@@ -387,10 +490,12 @@ export const createWalletApi = (
   submitTx: async (input: Cbor): Promise<string> => {
     logger.debug('submitting tx');
     const { cbor, tx } = processTxInput(input);
-    const shouldProceed = await confirmationCallback({
-      data: tx,
-      type: Cip30ConfirmationCallbackType.SubmitTx
-    }).catch((error) => mapCallbackFailure(error, logger));
+    const shouldProceed = await confirmationCallback
+      .submitTx({
+        data: tx,
+        type: Cip30ConfirmationCallbackType.SubmitTx
+      })
+      .catch((error) => mapCallbackFailure(error, logger));
 
     if (shouldProceed) {
       try {


### PR DESCRIPTION
# Context

When calling `getCollateral` this could return null due to lack of `unspendables$` however there may be an available UTXO set that could be used in the `available$` UTXO set.

# Proposed Solution

Adding an optional callback allows a wallet to intercept this call if it will return null in this instance and allow the wallet owner to set collateral and return this set to the DApp without failing.

# Important Changes Introduced

Added optional `getCollateral` callback to `CallbackConfirmation` which is consumed by `createWalletApi` in `cip30.ts`