### PR TITLE
feat: add addressesShareAnyKey util

### DIFF
--- a/packages/core/src/Cardano/Address/EnterpriseAddress.ts
+++ b/packages/core/src/Cardano/Address/EnterpriseAddress.ts
@@ -35,9 +35,7 @@ export class EnterpriseAddress {
    * @param payment The payment credential.
    */
   static fromCredentials(networkId: NetworkId, payment: Credential): EnterpriseAddress {
-    let type = AddressType.EnterpriseKey;
-
-    if (payment.type === CredentialType.ScriptHash) type &= 0b0001;
+    const type = payment.type === CredentialType.ScriptHash ? AddressType.EnterpriseScript : AddressType.EnterpriseKey;
 
     return new EnterpriseAddress({
       networkId,

--- a/packages/core/src/Cardano/util/addressesShareAnyKey.ts
+++ b/packages/core/src/Cardano/util/addressesShareAnyKey.ts
@@ -1,0 +1,100 @@
+import { Address, AddressType, Credential } from '../Address/Address';
+import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { InvalidStringError } from '@cardano-sdk/util';
+import { PaymentAddress } from '../Address/PaymentAddress';
+import { Pointer } from '../Address/PointerAddress';
+
+type PaymentId = { credential: Credential } | { byronRoot: Hash28ByteBase16 };
+type StakingId = { credential: Credential } | { pointer: Pointer };
+type AddressKeyIDs = { paymentId?: PaymentId; stakingId?: StakingId };
+
+/**
+ * Payment ID is either
+ * - payment credential
+ * - Byron address root hash
+ *
+ * Stake ID is either
+ * - stake credential
+ * - pointer
+ */
+// eslint-disable-next-line complexity
+const getAddressKeyIDs = (input: Address | PaymentAddress): AddressKeyIDs => {
+  const address = typeof input === 'string' ? Address.fromString(input) : input;
+  if (!address) {
+    throw new InvalidStringError('Expected either bech32 or base58 address');
+  }
+  switch (address.getType()) {
+    case AddressType.BasePaymentKeyStakeKey:
+    case AddressType.BasePaymentKeyStakeScript:
+    case AddressType.BasePaymentScriptStakeKey:
+    case AddressType.BasePaymentScriptStakeScript: {
+      const baseAddr = address.asBase()!;
+      return {
+        paymentId: { credential: baseAddr.getPaymentCredential() },
+        stakingId: { credential: baseAddr.getStakingCredential() }
+      };
+    }
+    case AddressType.Byron:
+      return {
+        paymentId: { byronRoot: address.asByron()!.getRoot() }
+      };
+    case AddressType.EnterpriseKey:
+    case AddressType.EnterpriseScript: {
+      const enterpriseAddr = address.asEnterprise()!;
+      return {
+        paymentId: { credential: enterpriseAddr.getPaymentCredential() }
+      };
+    }
+    case AddressType.PointerKey:
+    case AddressType.PointerScript: {
+      const pointerAddr = address.asPointer()!;
+      return {
+        paymentId: { credential: pointerAddr.getPaymentCredential() },
+        stakingId: { pointer: pointerAddr.getStakePointer() }
+      };
+    }
+    case AddressType.RewardKey:
+    case AddressType.RewardScript: {
+      const rewardAddr = address.asReward()!;
+      return {
+        stakingId: { credential: rewardAddr.getPaymentCredential() }
+      };
+    }
+  }
+};
+
+const isPaymentIdPresentAndEquals = (id1: PaymentId | undefined, id2: PaymentId | undefined) => {
+  if (!id1 || !id2) return false;
+  if ('credential' in id1 && 'credential' in id2) {
+    return id1.credential.hash === id2.credential.hash;
+  }
+  if ('byronRoot' in id1 && 'byronRoot' in id2) {
+    return id1.byronRoot === id2.byronRoot;
+  }
+  return false;
+};
+
+const isStakingIdPresentAndEquals = (id1: StakingId | undefined, id2: StakingId | undefined) => {
+  if (!id1 || !id2) return false;
+  if ('credential' in id1 && 'credential' in id2) {
+    return id1.credential.hash === id2.credential.hash;
+  }
+  if ('pointer' in id1 && 'pointer' in id2) {
+    return (
+      id1.pointer.slot === id2.pointer.slot &&
+      id1.pointer.txIndex === id2.pointer.txIndex &&
+      id1.pointer.certIndex === id2.pointer.certIndex
+    );
+  }
+  return false;
+};
+
+export const addressesShareAnyKey = (address1: PaymentAddress, address2: PaymentAddress) => {
+  if (address1 === address2) return true;
+  const ids1 = getAddressKeyIDs(address1);
+  const ids2 = getAddressKeyIDs(address2);
+  return (
+    isPaymentIdPresentAndEquals(ids1.paymentId, ids2.paymentId) ||
+    isStakingIdPresentAndEquals(ids1.stakingId, ids2.stakingId)
+  );
+};

--- a/packages/core/src/Cardano/util/index.ts
+++ b/packages/core/src/Cardano/util/index.ts
@@ -4,3 +4,4 @@ export * from './estimateStakePoolAPY';
 export * from './txSubmissionErrors';
 export * from './resolveInputValue';
 export * from './phase2Validation';
+export * from './addressesShareAnyKey';

--- a/packages/core/test/Cardano/Address/EnterpriseAddress.test.ts
+++ b/packages/core/test/Cardano/Address/EnterpriseAddress.test.ts
@@ -2,11 +2,21 @@ import * as cip19TestVectors from './Cip19TestVectors';
 import { Cardano } from '../../../src';
 
 describe('Cardano/Address/EnterpriseAddress', () => {
-  it('fromCredentials can build the correct EnterpriseAddress instance', () => {
-    const address = Cardano.EnterpriseAddress.fromCredentials(
-      Cardano.NetworkId.Mainnet,
-      cip19TestVectors.KEY_PAYMENT_CREDENTIAL
-    );
-    expect(address.toAddress().toBech32()).toEqual(cip19TestVectors.enterpriseKey);
+  describe('fromCredentials', () => {
+    it('can build the correct EnterpriseAddress instance with key hash type', () => {
+      const address = Cardano.EnterpriseAddress.fromCredentials(
+        Cardano.NetworkId.Mainnet,
+        cip19TestVectors.KEY_PAYMENT_CREDENTIAL
+      );
+      expect(address.toAddress().toBech32()).toEqual(cip19TestVectors.enterpriseKey);
+    });
+
+    it('can build the correct EnterpriseAddress instance with script hash type', () => {
+      const address = Cardano.EnterpriseAddress.fromCredentials(
+        Cardano.NetworkId.Mainnet,
+        cip19TestVectors.SCRIPT_CREDENTIAL
+      );
+      expect(address.toAddress().toBech32()).toEqual(cip19TestVectors.enterpriseScript);
+    });
   });
 });

--- a/packages/core/test/Cardano/util/addressesShareAnyKey.test.ts
+++ b/packages/core/test/Cardano/util/addressesShareAnyKey.test.ts
@@ -1,0 +1,145 @@
+import { Cardano } from '../../../src';
+import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
+
+const pairs = <T>(arr: T[]) => arr.flatMap((v, i) => arr.slice(i + 1).map((w) => [v, w] as const));
+const allAddressesShareAnyKey = (addresses: Array<{ toAddress(): Cardano.Address }>) =>
+  pairs(addresses.map((addr) => addr.toAddress().toBech32() as Cardano.PaymentAddress)).every(([addr1, addr2]) =>
+    Cardano.util.addressesShareAnyKey(addr1, addr2)
+  );
+
+describe('addressesShareAnyKey', () => {
+  const paymentKeyHash1 = Hash28ByteBase16('8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80c');
+  const paymentKeyHash2 = Hash28ByteBase16('8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d');
+  const stakeKeyHash1 = Hash28ByteBase16('8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80e');
+  const stakeKeyHash2 = Hash28ByteBase16('8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80f');
+  const stakeKeyPointer: Cardano.Pointer = {
+    certIndex: Cardano.CertIndex(1),
+    slot: Cardano.Slot(123),
+    txIndex: Cardano.TxIndex(2)
+  };
+
+  it('returns false when addresses do not share any key', () => {
+    expect(
+      Cardano.util.addressesShareAnyKey(
+        Cardano.PaymentAddress('addr_test1wrsexavz37208qda7mwwu4k7hcpg26cz0ce86f5e9kul3hqzlh22t'),
+        Cardano.PaymentAddress(
+          'addr_test1qpcnmvyjmxmsm75f747u566gw7ewz4mesdw7yl278uf9r3f5l7d7dpx2ymfwlm3e56flupga8yamjr2kwdt7dw77ktyqqtx2r7'
+        )
+      )
+    ).toBe(false);
+  });
+
+  it('returns true when address equals', () => {
+    expect(
+      Cardano.util.addressesShareAnyKey(
+        Cardano.PaymentAddress('addr_test1wrsexavz37208qda7mwwu4k7hcpg26cz0ce86f5e9kul3hqzlh22t'),
+        Cardano.PaymentAddress('addr_test1wrsexavz37208qda7mwwu4k7hcpg26cz0ce86f5e9kul3hqzlh22t')
+      )
+    ).toBe(true);
+    expect(
+      Cardano.util.addressesShareAnyKey(
+        Cardano.PaymentAddress('5oP9ib6ym3Xc2XrPGC6S7AaJeHYBCmLjt98bnjKR58xXDhSDgLHr8tht3apMDXf2Mg'),
+        Cardano.PaymentAddress('5oP9ib6ym3Xc2XrPGC6S7AaJeHYBCmLjt98bnjKR58xXDhSDgLHr8tht3apMDXf2Mg')
+      )
+    ).toBe(true);
+  });
+
+  it('returns true when addresses have the same payment credential key hash', () => {
+    const mainnetEnterpriseAddr = Cardano.EnterpriseAddress.fromCredentials(Cardano.NetworkId.Mainnet, {
+      hash: paymentKeyHash1,
+      type: Cardano.CredentialType.KeyHash
+    });
+    const testnetEnterpriseAddr = Cardano.EnterpriseAddress.fromCredentials(Cardano.NetworkId.Testnet, {
+      hash: paymentKeyHash1,
+      type: Cardano.CredentialType.ScriptHash
+    });
+    const mainnetBaseStake1Addr = Cardano.BaseAddress.fromCredentials(
+      Cardano.NetworkId.Mainnet,
+      {
+        hash: paymentKeyHash1,
+        type: Cardano.CredentialType.KeyHash
+      },
+      {
+        hash: stakeKeyHash1,
+        type: Cardano.CredentialType.ScriptHash
+      }
+    );
+    const testnetBaseStake2Addr = Cardano.BaseAddress.fromCredentials(
+      Cardano.NetworkId.Testnet,
+      {
+        hash: paymentKeyHash1,
+        type: Cardano.CredentialType.KeyHash
+      },
+      {
+        hash: stakeKeyHash2,
+        type: Cardano.CredentialType.ScriptHash
+      }
+    );
+    const mainnetPointer = Cardano.PointerAddress.fromCredentials(
+      Cardano.NetworkId.Mainnet,
+      {
+        hash: paymentKeyHash1,
+        type: Cardano.CredentialType.KeyHash
+      },
+      stakeKeyPointer
+    );
+
+    expect(
+      allAddressesShareAnyKey([
+        mainnetBaseStake1Addr,
+        testnetBaseStake2Addr,
+        testnetEnterpriseAddr,
+        mainnetEnterpriseAddr,
+        mainnetPointer
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true when addresses have the same staking credential key hash', () => {
+    const addr1 = Cardano.BaseAddress.fromCredentials(
+      Cardano.NetworkId.Mainnet,
+      {
+        hash: paymentKeyHash1,
+        type: Cardano.CredentialType.KeyHash
+      },
+      {
+        hash: stakeKeyHash1,
+        type: Cardano.CredentialType.ScriptHash
+      }
+    );
+    const addr2 = Cardano.BaseAddress.fromCredentials(
+      Cardano.NetworkId.Testnet,
+      {
+        hash: paymentKeyHash2,
+        type: Cardano.CredentialType.KeyHash
+      },
+      {
+        hash: stakeKeyHash1,
+        type: Cardano.CredentialType.ScriptHash
+      }
+    );
+
+    expect(allAddressesShareAnyKey([addr1, addr2])).toBe(true);
+  });
+
+  it('returns true when addresses have the same stake key pointer', () => {
+    const addr1 = Cardano.PointerAddress.fromCredentials(
+      Cardano.NetworkId.Mainnet,
+      {
+        hash: paymentKeyHash1,
+        type: Cardano.CredentialType.KeyHash
+      },
+      stakeKeyPointer
+    );
+    const addr2 = Cardano.PointerAddress.fromCredentials(
+      Cardano.NetworkId.Mainnet,
+      {
+        hash: paymentKeyHash2,
+        type: Cardano.CredentialType.KeyHash
+      },
+      stakeKeyPointer
+    );
+
+    expect(allAddressesShareAnyKey([addr1, addr2])).toBe(true);
+  });
+});


### PR DESCRIPTION
# Context

Add a utility to determine whether 2 addresses share any (either payment or staking) key

# Important Changes Introduced

Fix EnterpriseAddress.fromCredential 9b647b77ddaa9364bf0aea32b3aded8661a832c9