### PR TITLE
feat: address projection

### DIFF
--- a/packages/cardano-services/src/Projection/migrations/1690955710125-address-table.ts
+++ b/packages/cardano-services/src/Projection/migrations/1690955710125-address-table.ts
@@ -1,0 +1,26 @@
+import { AddressEntity } from '@cardano-sdk/projection-typeorm';
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddressTableMigrations1690955710125 implements MigrationInterface {
+  static entity = AddressEntity;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      "CREATE TYPE \"public\".\"address_type_enum\" AS ENUM('0', '1', '2', '3', '4', '5', '6', '7', '8', '14', '15')"
+    );
+    await queryRunner.query(
+      'CREATE TABLE "address" ("address" character varying NOT NULL, "type" "public"."address_type_enum" NOT NULL, "payment_credential_hash" character(56), "stake_credential_hash" character(56), CONSTRAINT "PK_address_address" PRIMARY KEY ("address"))'
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_address_payment_credential_hash" ON "address" ("payment_credential_hash") '
+    );
+    await queryRunner.query('CREATE INDEX "IDX_address_stake_credential_hash" ON "address" ("stake_credential_hash") ');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP INDEX "public"."IDX_address_stake_credential_hash"');
+    await queryRunner.query('DROP INDEX "public"."IDX_address_payment_credential_hash"');
+    await queryRunner.query('DROP TABLE "address"');
+    await queryRunner.query('DROP TYPE "public"."address_type_enum"');
+  }
+}

--- a/packages/cardano-services/src/Projection/migrations/1690964880195-stake-key-registrations-table.ts
+++ b/packages/cardano-services/src/Projection/migrations/1690964880195-stake-key-registrations-table.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { StakeKeyRegistrationEntity } from '@cardano-sdk/projection-typeorm';
+
+export class StakeKeyRegistrationsTableMigrations1690964880195 implements MigrationInterface {
+  static entity = StakeKeyRegistrationEntity;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE "stake_key_registration" ("id" bigint NOT NULL, "stake_key_hash" character(56) NOT NULL, "block_slot" integer NOT NULL, CONSTRAINT "PK_stake_key_registration_id" PRIMARY KEY ("id"))'
+    );
+    await queryRunner.query(
+      'CREATE INDEX "IDX_stake_key_registration_stake_key_hash" ON "stake_key_registration" ("stake_key_hash") '
+    );
+    await queryRunner.query(
+      'ALTER TABLE "stake_key_registration" ADD CONSTRAINT "FK_stake_key_registration_block_slot" FOREIGN KEY ("block_slot") REFERENCES "block"("slot") ON DELETE CASCADE ON UPDATE NO ACTION'
+    );
+
+    await queryRunner.query('ALTER TABLE "address" ADD "registration_id" bigint');
+    await queryRunner.query(
+      'ALTER TABLE "address" ADD CONSTRAINT "FK_address_registration_id" FOREIGN KEY ("registration_id") REFERENCES "stake_key_registration"("id") ON DELETE CASCADE ON UPDATE NO ACTION'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "address" DROP CONSTRAINT "FK_address_registration_id"');
+    await queryRunner.query('ALTER TABLE "address" DROP COLUMN "registration_id"');
+
+    await queryRunner.query(
+      'ALTER TABLE "stake_key_registration" DROP CONSTRAINT "FK_stake_key_registration_block_slot"'
+    );
+    await queryRunner.query('DROP INDEX "public"."IDX_stake_key_registration_stake_key_hash"');
+    await queryRunner.query('DROP TABLE "stake_key_registration"');
+  }
+}

--- a/packages/cardano-services/src/Projection/migrations/1691042603934-tokens-quantity-numeric.ts
+++ b/packages/cardano-services/src/Projection/migrations/1691042603934-tokens-quantity-numeric.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { TokensEntity } from '@cardano-sdk/projection-typeorm';
+
+export class TokensQuantityNumericMigrations1691042603934 implements MigrationInterface {
+  static entity = TokensEntity;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "tokens" ALTER COLUMN "quantity" TYPE numeric(20,0) USING quantity::numeric');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "tokens" ALTER COLUMN "quantity" TYPE bigint USING quantity::bigint');
+  }
+}

--- a/packages/cardano-services/src/Projection/migrations/index.ts
+++ b/packages/cardano-services/src/Projection/migrations/index.ts
@@ -12,6 +12,7 @@ import { PoolMetricsMigrations1685011799580 } from './1685011799580-stake-pool-m
 import { PoolRegistrationTableMigration1682519108360 } from './1682519108360-pool-registration-table';
 import { PoolRetirementTableMigration1682519108361 } from './1682519108361-pool-retirement-table';
 import { StakePoolTableMigration1682519108362 } from './1682519108362-stake-pool-table';
+import { TokensQuantityNumericMigrations1691042603934 } from './1691042603934-tokens-quantity-numeric';
 import { TokensTableMigration1682519108368 } from './1682519108368-tokens-table';
 
 type ProjectionMigration = Function & {
@@ -33,5 +34,6 @@ export const migrations: ProjectionMigration[] = [
   PoolMetricsMigrations1685011799580,
   HandleTableMigration1686138943349,
   CostPledgeNumericMigration1689091319930,
-  NftMetadataTableMigration1690269355640
+  NftMetadataTableMigration1690269355640,
+  TokensQuantityNumericMigrations1691042603934
 ];

--- a/packages/cardano-services/src/Projection/migrations/index.ts
+++ b/packages/cardano-services/src/Projection/migrations/index.ts
@@ -1,3 +1,4 @@
+import { AddressTableMigrations1690955710125 } from './1690955710125-address-table';
 import { AssetTableMigration1682519108365 } from './1682519108365-asset-table';
 import { BlockDataTableMigration1682519108359 } from './1682519108359-block-data-table';
 import { BlockTableMigration1682519108358 } from './1682519108358-block-table';
@@ -11,6 +12,7 @@ import { PoolMetadataTableMigration1682519108363 } from './1682519108363-pool-me
 import { PoolMetricsMigrations1685011799580 } from './1685011799580-stake-pool-metrics-table';
 import { PoolRegistrationTableMigration1682519108360 } from './1682519108360-pool-registration-table';
 import { PoolRetirementTableMigration1682519108361 } from './1682519108361-pool-retirement-table';
+import { StakeKeyRegistrationsTableMigrations1690964880195 } from './1690964880195-stake-key-registrations-table';
 import { StakePoolTableMigration1682519108362 } from './1682519108362-stake-pool-table';
 import { TokensQuantityNumericMigrations1691042603934 } from './1691042603934-tokens-quantity-numeric';
 import { TokensTableMigration1682519108368 } from './1682519108368-tokens-table';
@@ -35,5 +37,7 @@ export const migrations: ProjectionMigration[] = [
   HandleTableMigration1686138943349,
   CostPledgeNumericMigration1689091319930,
   NftMetadataTableMigration1690269355640,
+  AddressTableMigrations1690955710125,
+  StakeKeyRegistrationsTableMigrations1690964880195,
   TokensQuantityNumericMigrations1691042603934
 ];

--- a/packages/projection-typeorm/src/entity/Address.entity.ts
+++ b/packages/projection-typeorm/src/entity/Address.entity.ts
@@ -1,0 +1,30 @@
+import { Cardano } from '@cardano-sdk/core';
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { StakeKeyRegistrationEntity } from './StakeKeyRegistration.entity';
+
+@Entity()
+export class AddressEntity {
+  @PrimaryColumn()
+  address?: Cardano.PaymentAddress;
+  @Column({ enum: Cardano.AddressType, type: 'enum' })
+  type?: Cardano.AddressType;
+  @Column('char', { length: 56, nullable: true })
+  @Index()
+  /**
+   * Applicable only for base/grouped, enterprise and pointer addresses
+   */
+  paymentCredentialHash?: Hash28ByteBase16 | null;
+  @Column('char', { length: 56, nullable: true })
+  @Index()
+  /**
+   * Applicable only for base/grouped and pointer addresses
+   */
+  stakeCredentialHash?: Hash28ByteBase16 | null;
+  @ManyToOne(() => StakeKeyRegistrationEntity, { nullable: true, onDelete: 'CASCADE' })
+  @JoinColumn()
+  /**
+   * Applicable only for pointer addresses
+   */
+  registration?: StakeKeyRegistrationEntity | null;
+}

--- a/packages/projection-typeorm/src/entity/PoolRegistration.entity.ts
+++ b/packages/projection-typeorm/src/entity/PoolRegistration.entity.ts
@@ -1,5 +1,5 @@
 /* eslint-disable brace-style */
-import { BigIntColumnOptions, ImaginaryCoinsColumnOptions, OnDeleteCascadeRelationOptions } from './util';
+import { BigIntColumnOptions, OnDeleteCascadeRelationOptions, UInt64ColumnOptions } from './util';
 import { BlockEntity } from './Block.entity';
 import { Cardano } from '@cardano-sdk/core';
 import { Column, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryColumn } from 'typeorm';
@@ -17,9 +17,9 @@ export class PoolRegistrationEntity {
   id?: bigint;
   @Column()
   rewardAccount?: Cardano.RewardAccount;
-  @Column(ImaginaryCoinsColumnOptions)
+  @Column(UInt64ColumnOptions)
   pledge?: bigint;
-  @Column(ImaginaryCoinsColumnOptions)
+  @Column(UInt64ColumnOptions)
   cost?: bigint;
   // Review: should we store this as 'double' instead?
   // Maybe both formats? If we'll need to do computations with this

--- a/packages/projection-typeorm/src/entity/StakeKeyRegistration.entity.ts
+++ b/packages/projection-typeorm/src/entity/StakeKeyRegistration.entity.ts
@@ -1,0 +1,20 @@
+import { BigIntColumnOptions, OnDeleteCascadeRelationOptions } from './util';
+import { BlockEntity } from './Block.entity';
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Ed25519KeyHashHex } from '@cardano-sdk/crypto';
+
+@Entity()
+export class StakeKeyRegistrationEntity {
+  /**
+   * Computed from certificate pointer.
+   * Can be used to query by pointer using `Cardano.PointerToId` util.
+   */
+  @PrimaryColumn(BigIntColumnOptions)
+  id?: bigint;
+  @Column('char', { length: 56 })
+  @Index()
+  stakeKeyHash?: Ed25519KeyHashHex;
+  @ManyToOne(() => BlockEntity, OnDeleteCascadeRelationOptions)
+  @JoinColumn()
+  block?: BlockEntity;
+}

--- a/packages/projection-typeorm/src/entity/Tokens.entity.ts
+++ b/packages/projection-typeorm/src/entity/Tokens.entity.ts
@@ -1,6 +1,6 @@
 import { AssetEntity } from './Asset.entity';
-import { BigIntColumnOptions, OnDeleteCascadeRelationOptions } from './util';
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { OnDeleteCascadeRelationOptions, UInt64ColumnOptions } from './util';
 import { OutputEntity } from './Output.entity';
 
 @Entity()
@@ -13,6 +13,6 @@ export class TokensEntity {
   @JoinColumn()
   @ManyToOne(() => OutputEntity, (output) => output.tokens, OnDeleteCascadeRelationOptions)
   output?: OutputEntity;
-  @Column(BigIntColumnOptions)
+  @Column(UInt64ColumnOptions)
   quantity?: bigint;
 }

--- a/packages/projection-typeorm/src/entity/index.ts
+++ b/packages/projection-typeorm/src/entity/index.ts
@@ -11,3 +11,5 @@ export * from './Output.entity';
 export * from './CurrentPoolMetrics.entity';
 export * from './Handle.entity';
 export * from './NftMetadata.entity';
+export * from './Address.entity';
+export * from './StakeKeyRegistration.entity';

--- a/packages/projection-typeorm/src/entity/transformers.ts
+++ b/packages/projection-typeorm/src/entity/transformers.ts
@@ -43,7 +43,7 @@ export const parseBigInt: ValueTransformer = {
     return typeof obj === 'string' ? BigInt(obj) : obj;
   },
   to(obj: any) {
-    // Works as-is
-    return obj;
+    // It can also be a FindOperator object
+    return typeof obj === 'bigint' ? obj.toString() : obj;
   }
 };

--- a/packages/projection-typeorm/src/entity/util.ts
+++ b/packages/projection-typeorm/src/entity/util.ts
@@ -22,12 +22,12 @@ export const BigIntColumnOptions: Pick<ColumnOptions, 'transformer' | 'type'> = 
 };
 
 /**
- * To be used for user-specified coin quantities that are not validated by the node
- * to not exceed max lovelace supply (up to unsigned 64 bit integer):
- * - pool registration cost
- * - pool registration pledge
+ * To be used for
+ * - user-specified coin quantities that are not validated by the node
+ *   to not exceed max lovelace supply
+ * - native asset quantities
  */
-export const ImaginaryCoinsColumnOptions: Pick<ColumnOptions, 'transformer' | 'type' | 'precision' | 'scale'> = {
+export const UInt64ColumnOptions: Pick<ColumnOptions, 'transformer' | 'type' | 'precision' | 'scale'> = {
   precision: 20,
   scale: 0,
   transformer: parseBigInt,

--- a/packages/projection-typeorm/src/operators/index.ts
+++ b/packages/projection-typeorm/src/operators/index.ts
@@ -9,3 +9,5 @@ export * from './storeHandles';
 export * from './util';
 export * from './storePoolMetricsUpdateJob';
 export * from './storeNftMetadata';
+export * from './storeAddresses';
+export * from './storeStakeKeyRegistrations';

--- a/packages/projection-typeorm/src/operators/storeAddresses.ts
+++ b/packages/projection-typeorm/src/operators/storeAddresses.ts
@@ -1,0 +1,43 @@
+import { AddressEntity } from '../entity/Address.entity';
+import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { Mappers } from '@cardano-sdk/projection';
+import { QueryRunner } from 'typeorm';
+import { StakeKeyRegistrationEntity } from '../entity';
+import { certificatePointerToId, typeormOperator } from './util';
+
+const lookupStakeKeyRegistration = async (pointer: Cardano.Pointer | undefined, queryRunner: QueryRunner) => {
+  if (!pointer) return;
+  const registrationId = certificatePointerToId(pointer);
+  const stakeKeyRegistration = await queryRunner.manager
+    .getRepository(StakeKeyRegistrationEntity)
+    .findOne({ select: { stakeKeyHash: true }, where: { id: registrationId } });
+  if (!stakeKeyRegistration?.stakeKeyHash) return;
+  return Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyRegistration.stakeKeyHash);
+};
+
+export const storeAddresses = typeormOperator<Mappers.WithAddresses>(async (evt) => {
+  const { addresses, eventType, queryRunner } = evt;
+  if (addresses.length === 0 || eventType !== ChainSyncEventType.RollForward) return;
+  const addressEntities = await Promise.all(
+    addresses.map(async ({ paymentCredentialHash, stakeCredential, address, type }): Promise<AddressEntity> => {
+      const stakeCredentialHash =
+        typeof stakeCredential === 'string'
+          ? stakeCredential
+          : await lookupStakeKeyRegistration(stakeCredential, queryRunner);
+      return {
+        address,
+        paymentCredentialHash,
+        stakeCredentialHash,
+        type
+      };
+    })
+  );
+  await queryRunner.manager
+    .createQueryBuilder()
+    .insert()
+    .into(AddressEntity)
+    .values(addressEntities)
+    .orIgnore()
+    .execute();
+});

--- a/packages/projection-typeorm/src/operators/storeStakeKeyRegistrations.ts
+++ b/packages/projection-typeorm/src/operators/storeStakeKeyRegistrations.ts
@@ -1,0 +1,23 @@
+import { ChainSyncEventType } from '@cardano-sdk/core';
+import { Mappers } from '@cardano-sdk/projection';
+import { StakeKeyRegistrationEntity } from '../entity';
+import { certificatePointerToId, typeormOperator } from './util';
+
+export const storeStakeKeyRegistrations = typeormOperator<Mappers.WithStakeKeyRegistrations>(
+  async ({ eventType, queryRunner, block, stakeKeyRegistrations }) => {
+    // Deleted by db with ON DELETE CASCADE
+    if (eventType !== ChainSyncEventType.RollForward || stakeKeyRegistrations.length === 0) return;
+    const stakeKeyRegistrationsRepo = queryRunner.manager.getRepository(StakeKeyRegistrationEntity);
+    await stakeKeyRegistrationsRepo.insert(
+      stakeKeyRegistrations.map(
+        (reg): StakeKeyRegistrationEntity => ({
+          block: {
+            slot: block.header.slot
+          },
+          id: certificatePointerToId(reg.pointer),
+          stakeKeyHash: reg.stakeKeyHash
+        })
+      )
+    );
+  }
+);

--- a/packages/projection-typeorm/test/operators/storeAddresses.test.ts
+++ b/packages/projection-typeorm/test/operators/storeAddresses.test.ts
@@ -1,0 +1,196 @@
+import {
+  AddressEntity,
+  AssetEntity,
+  BlockDataEntity,
+  BlockEntity,
+  NftMetadataEntity,
+  OutputEntity,
+  StakeKeyRegistrationEntity,
+  TokensEntity,
+  TypeormStabilityWindowBuffer,
+  storeAddresses,
+  storeAssets,
+  storeBlock,
+  storeStakeKeyRegistrations,
+  storeUtxo,
+  typeormTransactionCommit,
+  withTypeormTransaction
+} from '../../src';
+import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
+import {
+  ChainSyncDataSet,
+  chainSyncData,
+  cip19TestVectors,
+  generateRandomHexString,
+  logger
+} from '@cardano-sdk/util-dev';
+import { Observable, defer, firstValueFrom, from } from 'rxjs';
+import { QueryRunner, Repository } from 'typeorm';
+import {
+  createProjectorTilFirst,
+  createRollForwardEventBasedOn,
+  createStubBlockHeader,
+  createStubProjectionSource,
+  createStubRollForwardEvent
+} from './util';
+import { initializeDataSource } from '../util';
+
+const isAddressWithBothCredentials = (addr: Mappers.Address) =>
+  typeof addr.stakeCredential === 'string' && !!addr.paymentCredentialHash;
+
+describe('storeAddresses', () => {
+  const stubEvents = chainSyncData(ChainSyncDataSet.WithStakeKeyDeregistration);
+  let queryRunner: QueryRunner;
+  let buffer: TypeormStabilityWindowBuffer;
+  const entities = [
+    BlockEntity,
+    BlockDataEntity,
+    AssetEntity,
+    NftMetadataEntity,
+    TokensEntity,
+    OutputEntity,
+    StakeKeyRegistrationEntity,
+    AddressEntity
+  ];
+  let addressesRepo: Repository<AddressEntity>;
+
+  const dataSource$ = defer(() =>
+    from(initializeDataSource({ devOptions: { dropSchema: false, synchronize: false }, entities }))
+  );
+
+  const storeData = (
+    evt$: Observable<
+      ProjectionEvent<Mappers.WithUtxo & Mappers.WithMint & Mappers.WithStakeKeyRegistrations & Mappers.WithAddresses>
+    >
+  ) =>
+    evt$.pipe(
+      withTypeormTransaction({ dataSource$, logger }),
+      storeBlock(),
+      storeAssets(),
+      storeUtxo(),
+      storeStakeKeyRegistrations(),
+      storeAddresses(),
+      buffer.storeBlockData(),
+      typeormTransactionCommit()
+    );
+
+  const applyOperators = (evt$: Observable<ProjectionEvent<{}>>) =>
+    evt$.pipe(
+      Mappers.withMint(),
+      Mappers.withUtxo(),
+      Mappers.withCertificates(),
+      Mappers.withStakeKeyRegistrations(),
+      Mappers.withAddresses(),
+      storeData,
+      requestNext()
+    );
+
+  const project$ = () =>
+    Bootstrap.fromCardanoNode({
+      buffer,
+      cardanoNode: stubEvents.cardanoNode,
+      logger
+    }).pipe(applyOperators);
+
+  const projectTilFirst = createProjectorTilFirst(project$);
+
+  beforeEach(async () => {
+    const dataSource = await initializeDataSource({ entities });
+    queryRunner = dataSource.createQueryRunner();
+    addressesRepo = queryRunner.manager.getRepository(AddressEntity);
+    buffer = new TypeormStabilityWindowBuffer({ allowNonSequentialBlockHeights: true, logger });
+    await buffer.initialize(queryRunner);
+  });
+
+  afterEach(async () => {
+    await queryRunner.release();
+    buffer.shutdown();
+  });
+
+  it('inserts addresses with their type, payment credential and stake credential', async () => {
+    const { addresses } = await projectTilFirst((evt) => evt.addresses.some(isAddressWithBothCredentials));
+    const { address, type, paymentCredentialHash, stakeCredential } = addresses.find(isAddressWithBothCredentials)!;
+    const projectedAddress = await addressesRepo.findOne({ where: { address } })!;
+    expect(projectedAddress).toEqual({
+      address,
+      paymentCredentialHash,
+      stakeCredentialHash: stakeCredential,
+      type
+    });
+  });
+
+  describe('pointer addresses', () => {
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const projectEvtWithAddress = (address: Cardano.PaymentAddress, blockNo: Cardano.BlockNo) =>
+      firstValueFrom(
+        // clone the same block, just bump/patch the header
+        createStubProjectionSource([
+          createStubRollForwardEvent(
+            {
+              blockBody: [
+                {
+                  body: {
+                    fee: 123n,
+                    inputs: [],
+                    outputs: [
+                      {
+                        address,
+                        value: {
+                          coins: 123n
+                        }
+                      }
+                    ]
+                  },
+                  id: Cardano.TransactionId(generateRandomHexString(64)),
+                  inputSource: Cardano.InputSource.inputs,
+                  witness: { signatures: new Map() }
+                }
+              ],
+              blockHeader: createStubBlockHeader(blockNo)
+            },
+            stubEvents.networkInfo
+          )
+        ]).pipe(applyOperators)
+      );
+
+    it('looks up stake key hash by pointer', async () => {
+      const stakeKeyRegistrationEvent = await projectTilFirst((evt) => evt.stakeKeyRegistrations.length > 0);
+      const registration = stakeKeyRegistrationEvent.stakeKeyRegistrations[0];
+      const address = Cardano.PointerAddress.fromCredentials(
+        Cardano.NetworkId.Testnet,
+        cip19TestVectors.KEY_PAYMENT_CREDENTIAL,
+        registration.pointer
+      )
+        .toAddress()
+        .toBech32() as Cardano.PaymentAddress;
+      await projectEvtWithAddress(address, Cardano.BlockNo(stakeKeyRegistrationEvent.block.header.blockNo + 1));
+      const projectedAddress = await addressesRepo.findOne({ where: { address } });
+      expect(typeof projectedAddress!.stakeCredentialHash).toBe('string');
+    });
+
+    it('projects null pointers as undefined stake credential', async () => {
+      const address = Cardano.PointerAddress.fromCredentials(
+        Cardano.NetworkId.Testnet,
+        cip19TestVectors.KEY_PAYMENT_CREDENTIAL,
+        cip19TestVectors.POINTER
+      )
+        .toAddress()
+        .toBech32() as Cardano.PaymentAddress;
+      await projectEvtWithAddress(address, Cardano.BlockNo(0));
+      const projectedAddress = await addressesRepo.findOne({ where: { address } });
+      expect(projectedAddress).not.toBeNull();
+      expect(projectedAddress!.stakeCredentialHash).toBeNull();
+    });
+  });
+
+  it('is idempotent', async () => {
+    const evt = await projectTilFirst(({ addresses }) => addresses.some(isAddressWithBothCredentials));
+    await expect(
+      firstValueFrom(
+        // clone the same block, just bump/patch the header
+        createStubProjectionSource([createRollForwardEventBasedOn(evt, (block) => block)]).pipe(applyOperators)
+      )
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
@@ -15,13 +15,14 @@ import {
   typeormTransactionCommit,
   withTypeormTransaction
 } from '../../src';
-import { BaseProjectionEvent, Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { ChainSyncDataSet, chainSyncData, generateRandomHexString, logger } from '@cardano-sdk/util-dev';
 import { Observable, defer, firstValueFrom, from, lastValueFrom, toArray } from 'rxjs';
 import { QueryRunner, Repository } from 'typeorm';
 import {
   createProjectorTilFirst,
   createRollBackwardEventFor,
+  createRollForwardEventBasedOn,
   createStubBlockHeader,
   createStubProjectionSource,
   createStubRollForwardEvent
@@ -123,29 +124,6 @@ const patchNftMetadataNameCip68InTx = (
     }
   }
   return tx;
-};
-
-const createRollForwardEventBasedOn = (
-  evt: BaseProjectionEvent,
-  patchBlock: (block: Cardano.Block) => Cardano.Block
-): BaseProjectionEvent => {
-  const updateBlockHeader: Cardano.PartialBlockHeader = {
-    blockNo: Cardano.BlockNo(evt.block.header.blockNo + 1),
-    hash: Cardano.BlockId(generateRandomHexString(64)),
-    slot: Cardano.Slot(evt.block.header.slot + 20)
-  };
-  return {
-    block: {
-      ...patchBlock(evt.block),
-      header: updateBlockHeader
-    },
-    crossEpochBoundary: false,
-    epochNo: evt.epochNo,
-    eraSummaries: evt.eraSummaries,
-    eventType: ChainSyncEventType.RollForward,
-    genesisParameters: evt.genesisParameters,
-    tip: updateBlockHeader
-  };
 };
 
 /**

--- a/packages/projection-typeorm/test/operators/storeStakeKeyRegistrations.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakeKeyRegistrations.test.ts
@@ -1,0 +1,87 @@
+import {
+  BlockDataEntity,
+  BlockEntity,
+  StakeKeyRegistrationEntity,
+  TypeormStabilityWindowBuffer,
+  certificatePointerToId,
+  storeBlock,
+  storeStakeKeyRegistrations,
+  typeormTransactionCommit,
+  withTypeormTransaction
+} from '../../src';
+import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
+import { Observable, firstValueFrom, of, pairwise, takeWhile } from 'rxjs';
+import { createProjectorTilFirst, createRollBackwardEventFor, createStubProjectionSource } from './util';
+import { initializeDataSource } from '../util';
+
+describe('storeStakeKeyRegistrations', () => {
+  const data = chainSyncData(ChainSyncDataSet.WithPoolRetirement);
+  let stakeKeyRegistrationsRepo: Repository<StakeKeyRegistrationEntity>;
+  let dataSource: DataSource;
+  let queryRunner: QueryRunner;
+  let buffer: TypeormStabilityWindowBuffer;
+
+  const applyOperators = (evt$: Observable<ProjectionEvent<{}>>) =>
+    evt$.pipe(
+      Mappers.withCertificates(),
+      Mappers.withStakeKeyRegistrations(),
+      withTypeormTransaction({ dataSource$: of(dataSource), logger }),
+      storeBlock(),
+      storeStakeKeyRegistrations(),
+      buffer.storeBlockData(),
+      typeormTransactionCommit(),
+      requestNext()
+    );
+
+  const project = () =>
+    Bootstrap.fromCardanoNode({
+      buffer,
+      cardanoNode: data.cardanoNode,
+      logger
+    }).pipe(applyOperators);
+  const projectTilFirst = createProjectorTilFirst(project);
+
+  beforeEach(async () => {
+    dataSource = await initializeDataSource({
+      entities: [BlockDataEntity, BlockEntity, StakeKeyRegistrationEntity]
+    });
+    queryRunner = dataSource.createQueryRunner();
+    stakeKeyRegistrationsRepo = queryRunner.manager.getRepository(StakeKeyRegistrationEntity);
+    buffer = new TypeormStabilityWindowBuffer({ allowNonSequentialBlockHeights: true, logger });
+    await buffer.initialize(queryRunner);
+  });
+
+  afterEach(async () => {
+    await queryRunner.release();
+    await dataSource.destroy();
+    buffer.shutdown();
+  });
+
+  it('inserts and deletes stake key registrations', async () => {
+    const [prevEvent, rollForwardEvent] = await firstValueFrom(
+      project().pipe(
+        pairwise(),
+        takeWhile(([_, evt]) => evt.stakeKeyRegistrations.length === 0)
+      )
+    );
+    expect(await stakeKeyRegistrationsRepo.count()).toBe(rollForwardEvent.stakeKeyRegistrations.length);
+    await firstValueFrom(
+      createStubProjectionSource([createRollBackwardEventFor(rollForwardEvent, prevEvent.block.header)]).pipe(
+        applyOperators
+      )
+    );
+    expect(await stakeKeyRegistrationsRepo.count()).toBe(0);
+  });
+
+  it('is queryable by certificate pointer', async () => {
+    const { stakeKeyRegistrations } = await projectTilFirst((evt) => evt.stakeKeyRegistrations.length > 0);
+    const registration = await stakeKeyRegistrationsRepo.findOne({
+      where: {
+        id: certificatePointerToId(stakeKeyRegistrations[0].pointer)
+      }
+    });
+    expect(registration?.stakeKeyHash).toEqual(stakeKeyRegistrations[0].stakeKeyHash);
+  });
+});

--- a/packages/projection-typeorm/test/operators/util.ts
+++ b/packages/projection-typeorm/test/operators/util.ts
@@ -75,3 +75,26 @@ export const createRollBackwardEventFor = (
   eventType: ChainSyncEventType.RollBackward,
   point: rollbackPoint
 });
+
+export const createRollForwardEventBasedOn = (
+  evt: BaseProjectionEvent,
+  patchBlock: (block: Cardano.Block) => Cardano.Block
+): BaseProjectionEvent => {
+  const updateBlockHeader: Cardano.PartialBlockHeader = {
+    blockNo: Cardano.BlockNo(evt.block.header.blockNo + 1),
+    hash: Cardano.BlockId(generateRandomHexString(64)),
+    slot: Cardano.Slot(evt.block.header.slot + 20)
+  };
+  return {
+    block: {
+      ...patchBlock(evt.block),
+      header: updateBlockHeader
+    },
+    crossEpochBoundary: false,
+    epochNo: evt.epochNo,
+    eraSummaries: evt.eraSummaries,
+    eventType: ChainSyncEventType.RollForward,
+    genesisParameters: evt.genesisParameters,
+    tip: updateBlockHeader
+  };
+};

--- a/packages/projection/src/operators/Mappers/certificates/index.ts
+++ b/packages/projection/src/operators/Mappers/certificates/index.ts
@@ -1,3 +1,4 @@
 export * from './withCertificates';
 export * from './withStakeKeys';
 export * from './withStakePools';
+export * from './withStakeKeyRegistrations';

--- a/packages/projection/src/operators/Mappers/certificates/withStakeKeyRegistrations.ts
+++ b/packages/projection/src/operators/Mappers/certificates/withStakeKeyRegistrations.ts
@@ -1,0 +1,34 @@
+import { Cardano } from '@cardano-sdk/core';
+import { Ed25519KeyHashHex } from '@cardano-sdk/crypto';
+import { WithCertificates } from './withCertificates';
+import { isNotNil } from '@cardano-sdk/util';
+import { unifiedProjectorOperator } from '../../utils';
+
+export interface StakeKeyRegistration {
+  pointer: Cardano.Pointer;
+  stakeKeyHash: Ed25519KeyHashHex;
+}
+
+export interface WithStakeKeyRegistrations {
+  stakeKeyRegistrations: StakeKeyRegistration[];
+}
+
+/**
+ * Collect all stake key registration certificates
+ */
+export const withStakeKeyRegistrations = unifiedProjectorOperator<WithCertificates, WithStakeKeyRegistrations>(
+  (evt) => ({
+    ...evt,
+    stakeKeyRegistrations: evt.certificates
+      .map(({ pointer, certificate }): StakeKeyRegistration | null => {
+        if (certificate.__typename === Cardano.CertificateType.StakeKeyRegistration) {
+          return {
+            pointer,
+            stakeKeyHash: certificate.stakeKeyHash
+          };
+        }
+        return null;
+      })
+      .filter(isNotNil)
+  })
+);

--- a/packages/projection/src/operators/Mappers/index.ts
+++ b/packages/projection/src/operators/Mappers/index.ts
@@ -4,3 +4,4 @@ export * from './withMint';
 export * from './withHandles';
 export * from './withNftMetadata';
 export * from './withCIP67';
+export * from './withAddresses';

--- a/packages/projection/src/operators/Mappers/withAddresses.ts
+++ b/packages/projection/src/operators/Mappers/withAddresses.ts
@@ -1,0 +1,67 @@
+import { Cardano } from '@cardano-sdk/core';
+import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { WithUtxo } from './withUtxo';
+import { unifiedProjectorOperator } from '../utils';
+import uniq from 'lodash/uniq';
+
+export interface Address {
+  address: Cardano.PaymentAddress;
+  type: Cardano.AddressType;
+  /**
+   * Applicable only for base/grouped, enterprise and pointer addresses
+   */
+  paymentCredentialHash?: Hash28ByteBase16;
+  /**
+   * Hash28ByteBase16 for base/grouped addresses.
+   * Pointer for pointer addresses.
+   */
+  stakeCredential?: Hash28ByteBase16 | Cardano.Pointer;
+}
+
+export interface WithAddresses {
+  addresses: Address[];
+}
+
+/**
+ * Collect all unique addresses from produced utxo
+ */
+export const withAddresses = unifiedProjectorOperator<WithUtxo, WithAddresses>((evt) => ({
+  ...evt,
+  addresses: uniq(evt.utxo.produced.map(([_, txOut]) => txOut.address)).map((address): Address => {
+    const parsed = Cardano.Address.fromString(address)!;
+    let paymentCredentialHash: Hash28ByteBase16 | undefined;
+    let stakeCredentialHash: Hash28ByteBase16 | undefined;
+    let pointer: Cardano.Pointer | undefined;
+    const type = parsed.getType();
+    switch (type) {
+      case Cardano.AddressType.BasePaymentKeyStakeKey:
+      case Cardano.AddressType.BasePaymentKeyStakeScript:
+      case Cardano.AddressType.BasePaymentScriptStakeKey:
+      case Cardano.AddressType.BasePaymentScriptStakeScript: {
+        const baseAddress = parsed.asBase()!;
+        paymentCredentialHash = baseAddress.getPaymentCredential().hash;
+        stakeCredentialHash = baseAddress.getStakeCredential().hash;
+        break;
+      }
+      case Cardano.AddressType.EnterpriseKey:
+      case Cardano.AddressType.EnterpriseScript: {
+        const enterpriseAddress = parsed.asEnterprise()!;
+        paymentCredentialHash = enterpriseAddress.getPaymentCredential().hash;
+        break;
+      }
+      case Cardano.AddressType.PointerKey:
+      case Cardano.AddressType.PointerScript: {
+        const pointerAddress = parsed.asPointer()!;
+        paymentCredentialHash = pointerAddress.getPaymentCredential().hash;
+        pointer = pointerAddress.getStakePointer();
+        break;
+      }
+    }
+    return {
+      address,
+      paymentCredentialHash,
+      stakeCredential: stakeCredentialHash || pointer,
+      type
+    };
+  })
+}));

--- a/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
@@ -1,0 +1,45 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Mappers, UnifiedExtChainSyncEvent, WithBlock } from '../../../../src';
+import { firstValueFrom, of } from 'rxjs';
+
+type EventData = Mappers.WithCertificates & { eventType: ChainSyncEventType };
+
+describe('withStakeKeyRegistrations', () => {
+  it('collects all key registration certificates', async () => {
+    const pointer: Cardano.Pointer = {
+      certIndex: Cardano.CertIndex(1),
+      slot: Cardano.Slot(123),
+      txIndex: Cardano.TxIndex(2)
+    };
+    const data: EventData = {
+      certificates: [
+        {
+          certificate: {
+            __typename: Cardano.CertificateType.StakeKeyRegistration,
+            stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+          },
+          pointer
+        },
+        {
+          certificate: {
+            __typename: Cardano.CertificateType.StakeKeyDeregistration,
+            stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')
+          },
+          pointer: {} as Cardano.Pointer
+        }
+      ],
+      eventType: ChainSyncEventType.RollForward
+    };
+
+    const result = await firstValueFrom(
+      Mappers.withStakeKeyRegistrations()(of(data as UnifiedExtChainSyncEvent<Mappers.WithCertificates & WithBlock>))
+    );
+    expect(result.stakeKeyRegistrations).toEqual([
+      {
+        pointer,
+        stakeKeyHash: '3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'
+      }
+    ]);
+  });
+});

--- a/packages/projection/test/operators/Mappers/withAddresses.test.ts
+++ b/packages/projection/test/operators/Mappers/withAddresses.test.ts
@@ -1,0 +1,107 @@
+import { Cardano } from '@cardano-sdk/core';
+import { ProjectionEvent } from '../../../src';
+import { WithUtxo } from '../../../src/operators/Mappers';
+import { cip19TestVectors, generateRandomHexString } from '@cardano-sdk/util-dev';
+import { firstValueFrom, of } from 'rxjs';
+import { withAddresses } from '../../../src/operators/Mappers/withAddresses';
+
+const projectEvent = async (addresses: Cardano.PaymentAddress[]) => {
+  const event = {
+    utxo: {
+      produced: addresses.map((address) => [
+        { index: 0, txId: generateRandomHexString(64) },
+        { address, value: { coins: 123n } }
+      ])
+    } as WithUtxo['utxo']
+  } as ProjectionEvent<WithUtxo>;
+  return firstValueFrom(of(event).pipe(withAddresses()));
+};
+
+describe('withAddresses', () => {
+  it('maps both payment and stake credential for base/grouped addresses', async () => {
+    const addresses = [
+      cip19TestVectors.basePaymentKeyStakeKey,
+      cip19TestVectors.basePaymentKeyStakeScript,
+      cip19TestVectors.basePaymentScriptStakeKey,
+      cip19TestVectors.basePaymentScriptStakeScript
+    ];
+    const mappedEvent = await projectEvent(addresses);
+    expect(mappedEvent.addresses).toEqual([
+      {
+        address: addresses[0],
+        paymentCredentialHash: cip19TestVectors.PAYMENT_KEY_HASH,
+        stakeCredential: cip19TestVectors.STAKE_KEY_HASH,
+        type: Cardano.AddressType.BasePaymentKeyStakeKey
+      },
+      {
+        address: addresses[1],
+        paymentCredentialHash: cip19TestVectors.PAYMENT_KEY_HASH,
+        stakeCredential: cip19TestVectors.SCRIPT_HASH,
+        type: Cardano.AddressType.BasePaymentKeyStakeScript
+      },
+      {
+        address: addresses[2],
+        paymentCredentialHash: cip19TestVectors.SCRIPT_HASH,
+        stakeCredential: cip19TestVectors.STAKE_KEY_HASH,
+        type: Cardano.AddressType.BasePaymentScriptStakeKey
+      },
+      {
+        address: addresses[3],
+        paymentCredentialHash: cip19TestVectors.SCRIPT_HASH,
+        stakeCredential: cip19TestVectors.SCRIPT_HASH,
+        type: Cardano.AddressType.BasePaymentScriptStakeScript
+      }
+    ]);
+  });
+
+  it('maps payment credential for enterprise addresses', async () => {
+    const addresses = [cip19TestVectors.enterpriseKey, cip19TestVectors.enterpriseScript];
+    const mappedEvent = await projectEvent(addresses);
+    expect(mappedEvent.addresses).toEqual([
+      {
+        address: addresses[0],
+        paymentCredentialHash: cip19TestVectors.PAYMENT_KEY_HASH,
+        type: Cardano.AddressType.EnterpriseKey
+      },
+      {
+        address: addresses[1],
+        paymentCredentialHash: cip19TestVectors.SCRIPT_HASH,
+        type: Cardano.AddressType.EnterpriseScript
+      }
+    ]);
+  });
+
+  it('maps payment and stake credential for pointer addresses', async () => {
+    const addresses = [cip19TestVectors.pointerKey, cip19TestVectors.pointerScript];
+    const mappedEvent = await projectEvent(addresses);
+    expect(mappedEvent.addresses).toEqual([
+      {
+        address: addresses[0],
+        paymentCredentialHash: cip19TestVectors.PAYMENT_KEY_HASH,
+        stakeCredential: cip19TestVectors.POINTER,
+        type: Cardano.AddressType.PointerKey
+      },
+      {
+        address: addresses[1],
+        paymentCredentialHash: cip19TestVectors.SCRIPT_HASH,
+        stakeCredential: cip19TestVectors.POINTER,
+        type: Cardano.AddressType.PointerScript
+      }
+    ]);
+  });
+
+  it('maps byron addresses without any credentials', async () => {
+    const addresses = [cip19TestVectors.byronMainnetYoroi, cip19TestVectors.byronTestnetDaedalus];
+    const mappedEvent = await projectEvent(addresses);
+    expect(mappedEvent.addresses).toEqual([
+      {
+        address: addresses[0],
+        type: Cardano.AddressType.Byron
+      },
+      {
+        address: addresses[1],
+        type: Cardano.AddressType.Byron
+      }
+    ]);
+  });
+});

--- a/packages/util-dev/src/chainSync/data/with-pool-retirement.json
+++ b/packages/util-dev/src/chainSync/data/with-pool-retirement.json
@@ -101,6 +101,7 @@
               "withdrawals": []
             },
             "id": "f28b40e2bf87ae513b3dbe169ef02a49b292b7f21e924e19fc2576e34712f29c",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -395,6 +396,7 @@
               "withdrawals": []
             },
             "id": "ad7853c96f139df1b87a1ba1eba4c81fbaffbd0da81a7fbc308a183d0ea6e2bf",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -1790,6 +1792,7 @@
               "withdrawals": []
             },
             "id": "82c4e6a33e485cbec31276cc415ee8075d60662daf002ef1f3755bb80204ac6b",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -2070,6 +2073,7 @@
               "withdrawals": []
             },
             "id": "82c4e6a33e485cbec31276cc415ee8075d60662daf002ef1f3755bb80204ac6b",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -2249,6 +2253,7 @@
               "withdrawals": []
             },
             "id": "ecc5a664bd2cd14b505baeb824d1f74b0dafadfc34a2af6bcb73288d43baf858",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -2617,6 +2622,7 @@
               "withdrawals": []
             },
             "id": "5b72b20dfa1f887902b953bd58c21f5ec32ba69212ea028d0623391b975bba17",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -2743,6 +2749,7 @@
               "withdrawals": []
             },
             "id": "73e26ff267b5ee32d8e413635f4f4c9547db1c2af1694faf51be20b9f508b8f6",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -2904,6 +2911,7 @@
               "withdrawals": []
             },
             "id": "24437590bd5a1ad0da898bc19687d7a7c7476326a767e17efb86cbbb997e4eb6",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -3040,6 +3048,7 @@
               "withdrawals": []
             },
             "id": "133b3489197a2dae6a208189b6d22e8a06378e549a8a2a01af382c6e9686b414",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -3217,6 +3226,7 @@
               "withdrawals": []
             },
             "id": "24437590bd5a1ad0da898bc19687d7a7c7476326a767e17efb86cbbb997e4eb6",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -3353,6 +3363,7 @@
               "withdrawals": []
             },
             "id": "133b3489197a2dae6a208189b6d22e8a06378e549a8a2a01af382c6e9686b414",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -3715,6 +3726,7 @@
               "withdrawals": []
             },
             "id": "1469d68940ca6c1b0a002dccf000164d56c7dcbf299be6585d83ba83004c3f9c",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -3886,6 +3898,7 @@
               "withdrawals": []
             },
             "id": "d6ff1d30f5bf335f4b610999ea2cb84d44c364367fc64410bdc48f926f294d6f",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],

--- a/packages/util-dev/src/chainSync/data/with-stake-key-deregistration.json
+++ b/packages/util-dev/src/chainSync/data/with-stake-key-deregistration.json
@@ -66,6 +66,7 @@
               "withdrawals": []
             },
             "id": "4cd8341d672afb28e0121b9d1f6d97e225dd7f96727781b925466c74faa4934c",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -498,6 +499,7 @@
               "withdrawals": []
             },
             "id": "f2b6d368b2e7ef19e3a556bb044ce6c8debf49ccae81000e2f963b306eb5fe7a",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -652,6 +654,7 @@
               "withdrawals": []
             },
             "id": "f2b6d368b2e7ef19e3a556bb044ce6c8debf49ccae81000e2f963b306eb5fe7a",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -2444,6 +2447,7 @@
               "withdrawals": []
             },
             "id": "233502d5ec014d7a41ab2d88b61067fcee57e14f9e5d12ab20b3b4c13682722f",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -4152,6 +4156,7 @@
               "withdrawals": []
             },
             "id": "4b3764ef3c8fbf5c7161d0e5a35048d1f074f616adeade3cc367270b46f36aba",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],
@@ -4281,6 +4286,7 @@
               "withdrawals": []
             },
             "id": "4b3764ef3c8fbf5c7161d0e5a35048d1f074f616adeade3cc367270b46f36aba",
+            "inputSource": "inputs",
             "witness": {
               "bootstrap": [],
               "datums": [],


### PR DESCRIPTION
# Context

Handle and utxo/chain history projections will require storing key hashes (payment and stake credentials) in order to be able to query by it.

# Proposed Solution

4f211bee5a92d390b53a3db3054a110f040168b4

# Important Changes Introduced

See commit log: all other commits are general fixes and refactors 