### PR TITLE
LW-6950 change createObservableChainSyncClient to read blocks in a buffered way

### DIFF
--- a/packages/ogmios/test/CardanoNode/ObservableOgmiosCardanoNode.test.ts
+++ b/packages/ogmios/test/CardanoNode/ObservableOgmiosCardanoNode.test.ts
@@ -19,7 +19,19 @@ import delay from 'delay';
 const defaultConfig: MockOgmiosServerConfig = {
   chainSync: {
     requestNext: {
-      responses: ['135.json']
+      responses: [
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json',
+        '135.json'
+      ]
     }
   },
   findIntersect: () => ({


### PR DESCRIPTION
# Context

We need to optimize the sync phase of the projector

# Proposed Solution

Changed `createObservableChainSyncClient` to read blocks in a buffered way.