### PR TITLE
LW-7811(hardware-trezor) additional witness requests mapper

### DIFF
--- a/packages/hardware-trezor/package.json
+++ b/packages/hardware-trezor/package.json
@@ -63,6 +63,7 @@
     "@cardano-sdk/key-management": "workspace:~",
     "@cardano-sdk/tx-construction": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
+    "lodash": "4.17.21",
     "trezor-connect": "8.2.11-extended",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.4"

--- a/packages/hardware-trezor/package.json
+++ b/packages/hardware-trezor/package.json
@@ -63,7 +63,7 @@
     "@cardano-sdk/key-management": "workspace:~",
     "@cardano-sdk/tx-construction": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
-    "lodash": "4.17.21",
+    "lodash": "^4.17.21",
     "trezor-connect": "8.2.11-extended",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.4"

--- a/packages/hardware-trezor/src/transformers/additionalWitnessRequests.ts
+++ b/packages/hardware-trezor/src/transformers/additionalWitnessRequests.ts
@@ -1,0 +1,23 @@
+import * as Trezor from 'trezor-connect';
+import { CardanoKeyConst, GroupedAddress, util } from '@cardano-sdk/key-management';
+import { TrezorTxTransformerContext } from '../types';
+import { isNotNil } from '@cardano-sdk/util';
+import concat from 'lodash/concat';
+import uniq from 'lodash/uniq';
+
+export const createRewardAccountKeyPath = (knownAddress: GroupedAddress) => [
+  util.harden(CardanoKeyConst.PURPOSE),
+  util.harden(CardanoKeyConst.COIN_TYPE),
+  util.harden(knownAddress.accountIndex),
+  util.STAKE_KEY_DERIVATION_PATH.role,
+  util.STAKE_KEY_DERIVATION_PATH.index
+];
+
+export const mapAdditionalWitnessRequests = (inputs: Trezor.CardanoInput[], context: TrezorTxTransformerContext) => {
+  const paymentKeyPaths = uniq(inputs.map((i) => i.path).filter(isNotNil));
+  const additionalWitnessPaths = concat([], paymentKeyPaths);
+  if (context.knownAddresses.length > 0) {
+    additionalWitnessPaths.push(createRewardAccountKeyPath(context.knownAddresses[0]));
+  }
+  return additionalWitnessPaths;
+};

--- a/packages/hardware-trezor/test/transformers/additionalWitnessRequests.test.ts
+++ b/packages/hardware-trezor/test/transformers/additionalWitnessRequests.test.ts
@@ -1,0 +1,25 @@
+import { contextWithKnownAddresses, txIn } from '../testData';
+import {
+  createRewardAccountKeyPath,
+  mapAdditionalWitnessRequests
+} from '../../src/transformers/additionalWitnessRequests';
+import { toTrezorTxIn } from '../../src';
+
+describe('createRewardAccountKeyPath', () => {
+  it('should construct a correct reward account key path from a known address', () => {
+    expect(createRewardAccountKeyPath(contextWithKnownAddresses.knownAddresses[0])).toEqual([
+      2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0
+    ]);
+  });
+});
+
+describe('additionalWitnessRequests', () => {
+  it('should include payment key paths and reward account key path from given inputs', async () => {
+    const mappedTrezorTxIn = await toTrezorTxIn(txIn, contextWithKnownAddresses);
+    const result = mapAdditionalWitnessRequests([mappedTrezorTxIn], contextWithKnownAddresses);
+    expect(result).toEqual([
+      [2_147_485_500, 2_147_485_463, 2_147_483_648, 1, 0], // payment key path
+      [2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0] // reward account key path
+    ]);
+  });
+});

--- a/packages/hardware-trezor/test/transformers/additionalWitnessRequests.test.ts
+++ b/packages/hardware-trezor/test/transformers/additionalWitnessRequests.test.ts
@@ -1,17 +1,6 @@
 import { contextWithKnownAddresses, txIn } from '../testData';
-import {
-  createRewardAccountKeyPath,
-  mapAdditionalWitnessRequests
-} from '../../src/transformers/additionalWitnessRequests';
+import { mapAdditionalWitnessRequests } from '../../src/transformers/additionalWitnessRequests';
 import { toTrezorTxIn } from '../../src';
-
-describe('createRewardAccountKeyPath', () => {
-  it('should construct a correct reward account key path from a known address', () => {
-    expect(createRewardAccountKeyPath(contextWithKnownAddresses.knownAddresses[0])).toEqual([
-      2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0
-    ]);
-  });
-});
 
 describe('additionalWitnessRequests', () => {
   it('should include payment key paths and reward account key path from given inputs', async () => {

--- a/packages/hardware-trezor/test/transformers/assets.test.ts
+++ b/packages/hardware-trezor/test/transformers/assets.test.ts
@@ -4,11 +4,10 @@ import { mintTokenMap } from '../testData';
 
 describe('assets', () => {
   describe('mapTokenMap', () => {
-    it('returns null when given an undefined token map', async () => {
+    it('returns undefined when given an undefined token map', async () => {
       const tokeMap: Cardano.TokenMap | undefined = undefined;
       const trezorAssets = mapTokenMap(tokeMap);
-
-      expect(trezorAssets).toEqual(null);
+      expect(trezorAssets).toBeUndefined();
     });
 
     it('can map a valid token map to asset group', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2725,6 +2725,7 @@ __metadata:
     "@cardano-sdk/util": "workspace:~"
     eslint: ^7.32.0
     jest: ^28.1.3
+    lodash: 4.17.21
     madge: ^5.0.1
     npm-run-all: ^4.1.5
     shx: ^0.3.3
@@ -17066,7 +17067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.5":
+"lodash@npm:4.17.21, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.5":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7

--- a/yarn.lock
+++ b/yarn.lock
@@ -2725,7 +2725,7 @@ __metadata:
     "@cardano-sdk/util": "workspace:~"
     eslint: ^7.32.0
     jest: ^28.1.3
-    lodash: 4.17.21
+    lodash: ^4.17.21
     madge: ^5.0.1
     npm-run-all: ^4.1.5
     shx: ^0.3.3
@@ -17067,7 +17067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.5":
+"lodash@npm:^4.17.10, lodash@npm:^4.17.11, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.5":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7


### PR DESCRIPTION
# Context

This PR implements the `additionalWitnessRequests` required for multi-sig and and token minting witness requests: https://github.com/trezor/connect/blob/e92440e4af786bab7f326397b3e9a64e6c9df77c/docs/methods/cardanoSignTransaction.md?plain=1#L36 

it also fixes one broken unit test for the asset mapper.
