### PR TITLE
ci optimize cycle time

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -74,7 +74,7 @@ jobs:
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
       - uses: divnix/std-action/run@main
-        with: {ffBuildInstructions: true}
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 
   images:
     <<: *job
@@ -104,5 +104,5 @@ jobs:
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
       - uses: divnix/std-action/run@main
-        with: {ffBuildInstructions: true}
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -1,6 +1,7 @@
+# yq -y < std-unexploded.yml > workflows/std.yml
 name: STD
-'on':
-  workflow_dispatch: null
+on:
+  workflow_dispatch:
   pull_request:
     branches:
       - develop
@@ -12,8 +13,9 @@ name: STD
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::926093910549:role/lace-ci
+  # NIX_UPLOAD_CACHE: s3://lace-nix-cache?region=us-east-1
   DISCOVERY_USER_NAME: gha-runner
-  DISCOVERY_KNOWN_HOSTS_ENTRY: 65.109.126.156 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEOVVDZydvD+diYa6A3EtA3WGw5NfN0wv7ckQxa/fX1O
+  DISCOVERY_KNOWN_HOSTS_ENTRY: "65.109.126.156 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEOVVDZydvD+diYa6A3EtA3WGw5NfN0wv7ckQxa/fX1O"
 permissions:
   id-token: write
   contents: read
@@ -24,22 +26,26 @@ jobs:
   discover:
     outputs:
       hits: ${{ steps.discovery.outputs.hits }}
-    runs-on:
-      - self-hosted
-      - discovery
+    runs-on: [self-hosted, discovery]
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@main
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
+          # account is part of ecr url, thus part of `hits` output and needs to pass
           mask-aws-account-id: false
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+      # TODO: uncomment when nixbuild works well together with
+      #       nix daemon mode on hosted runners
+      # - uses: nixbuild/nixbuild-action@v17
+      #   with:
+      #     nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+      #     generate_summary_for: job
       - uses: divnix/std-action/discover@main
-        with:
-          ffBuildInstructions: true
+        with: {ffBuildInstructions: true}
         id: discovery
   build:
     needs: discover
@@ -61,14 +67,11 @@ jobs:
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
       - uses: divnix/std-action/run@main
-        with:
-          ffBuildInstructions: true
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
   images:
-    needs:
-      - discover
-      - build
     name: ${{ matrix.target.jobName }}
     runs-on: ubuntu-latest
+    needs: [discover, build]
     if: fromJSON(needs.discover.outputs.hits).oci-images.publish != '{}'
     strategy:
       matrix:
@@ -93,5 +96,4 @@ jobs:
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
       - uses: divnix/std-action/run@main
-        with:
-          ffBuildInstructions: true
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}

--- a/nix/local/envs.nix
+++ b/nix/local/envs.nix
@@ -5,7 +5,7 @@ let
     treefmt
     alejandra
     shfmt
-    yq
+    yq-go
     git-subrepo
     ;
   inherit
@@ -25,8 +25,7 @@ let
       shfmt
       prettier
       prettier-plugin-toml
-      yq
-      git-subrepo
+      yq-go
     ];
     devshell.startup.nodejs-setuphook = noDepEntry ''
       export NODE_PATH=${prettier-plugin-toml}/lib/node_modules:''${NODE_PATH-}
@@ -40,5 +39,6 @@ in {
     name = "Cardano JS SDK Local Env";
     imports = [formattingModule];
     commands = [{package = std;}];
+    packages = [git-subrepo];
   };
 }


### PR DESCRIPTION
- fix(local/envs): yq is provided by yq-go package - oversight
- ci: speed up cycle time via the use of remote store

# Context

Nix builds can use remote stores (on the cli seen as something like `--store ssh-ng://...`).

Their use significantly reduces the amount of back and forth copying when building on a remote builder and thereby notably reduces the cycle time.

# Proposed Solution

Newer versions of `std-action` (on current `main` branch) have support for this feature, so we enable it here.

The other fixes are incidential.
