### PR TITLE
Use prepared statement for the get ledger tip query

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/NetworkInfoBuilder.ts
@@ -1,6 +1,6 @@
 import { ActiveStakeModel, CirculatingSupplyModel, EpochModel, ProtocolParamsModel, TotalSupplyModel } from './types';
 import { Cardano } from '@cardano-sdk/core';
-import { LedgerTipModel, findLedgerTip } from '../../util/DbSyncProvider';
+import { LedgerTipModel, findLedgerTipOptions } from '../../util/DbSyncProvider';
 import { Logger } from 'ts-log';
 import { Pool, QueryResult } from 'pg';
 import Queries from './queries';
@@ -39,7 +39,7 @@ export class NetworkInfoBuilder {
 
   public async queryLedgerTip() {
     this.#logger.debug('About to query the ledger tip');
-    const result: QueryResult<LedgerTipModel> = await this.#db.query(findLedgerTip);
+    const result: QueryResult<LedgerTipModel> = await this.#db.query(findLedgerTipOptions);
     return result.rows[0];
   }
 

--- a/packages/cardano-services/src/util/DbSyncProvider/DbSyncProvider.ts
+++ b/packages/cardano-services/src/util/DbSyncProvider/DbSyncProvider.ts
@@ -41,6 +41,8 @@ export interface DbSyncProviderDependencies extends ProviderDependencies {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyArgs = any[];
 
+export const findLedgerTipOptions = { name: 'find_ledger_tip', text: findLedgerTip } as const;
+
 export const DbSyncProvider = <
   T extends (abstract new (...args: AnyArgs) => {}) | (new (...args: AnyArgs) => {}) = { new (): {} }
 >(
@@ -74,7 +76,7 @@ export const DbSyncProvider = <
         response.localNode = cardanoNode.localNode;
         const tip = await this.#cache.healthCheck.get(
           'db_tip',
-          async () => (await this.dbPools.healthCheck.query<LedgerTipModel>(findLedgerTip)).rows[0]
+          async () => (await this.dbPools.healthCheck.query<LedgerTipModel>(findLedgerTipOptions)).rows[0]
         );
 
         if (tip) {


### PR DESCRIPTION
# Context

The query to get the ledger tip is performed so often by the SDK, using the server side `PREPARED STATEMENT` feature should give some minor performances benefit.

# Proposed Solution

6d4d04bd8