### PR TITLE
debug/nixbuild action with custom gh runner

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      # TODO: uncomment when nixbuild works well together with
-      #       nix daemon mode on hosted runners
-      # - uses: nixbuild/nixbuild-action@v17
-      #   with:
-      #     nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
-      #     generate_summary_for: job
+
+      - uses: nixbuild/nixbuild-action@main
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
+
       - uses: divnix/std-action/discover@main
         with: {ffBuildInstructions: true}
         id: discovery

--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -106,3 +106,48 @@ jobs:
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 
+  deploy-to-eu:
+    <<: *job
+    needs: [discover, images]
+    name: ${{ matrix.target.jobName }} (eu-central-1)
+    env:
+      AWS_REGION: eu-central-1
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    environment:
+      name: dev-preview
+      url: https://backend.dev-preview.eks.lw.iog.io
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@main
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nixbuild-action@v17
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
+      - uses: divnix/std-action/setup-discovery-ssh@main
+        with:
+          ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          user_name: ${{ env.DISCOVERY_USER_NAME }}
+          ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+
+      - name: Configure K8S Cluster Access
+        shell: bash
+        run: |
+          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
+          aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+
+      - uses: divnix/std-action/run@main
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
+      
+

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -97,3 +97,43 @@ jobs:
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
+  deploy-to-eu:
+    runs-on: ubuntu-latest
+    needs: [discover, images]
+    name: ${{ matrix.target.jobName }} (eu-central-1)
+    env:
+      AWS_REGION: eu-central-1
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    environment:
+      name: dev-preview
+      url: https://backend.dev-preview.eks.lw.iog.io
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@main
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nixbuild-action@v17
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
+      - uses: divnix/std-action/setup-discovery-ssh@main
+        with:
+          ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          user_name: ${{ env.DISCOVERY_USER_NAME }}
+          ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+      - name: Configure K8S Cluster Access
+        shell: bash
+        run: |
+          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
+          aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+      - uses: divnix/std-action/run@main
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -38,12 +38,10 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      # TODO: uncomment when nixbuild works well together with
-      #       nix daemon mode on hosted runners
-      # - uses: nixbuild/nixbuild-action@v17
-      #   with:
-      #     nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
-      #     generate_summary_for: job
+      - uses: nixbuild/nixbuild-action@main
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
       - uses: divnix/std-action/discover@main
         with: {ffBuildInstructions: true}
         id: discovery

--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1688162727,
-        "narHash": "sha256-FOWPJ4RBnQXL7egQfkNXlBO/Js7Mbq7hULmoR4QE2xY=",
+        "lastModified": 1692005050,
+        "narHash": "sha256-bFhmzmenx3Y/0eH1qAAZGrmFc3siz0BiAJRptdt2QIQ=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "fb34532b5a72f99f9b1f397adb5e18f0fb255d80",
+        "rev": "7ace4d2f29cfcde11ca0bbc549ca73c893b8bd98",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
         (installables "packages" {ci.build = true;})
         (runnables "operables")
         (containers "oci-images" {ci.publish = true;})
+        (kubectl "deployments" {ci.apply = true;})
       ];
     };
 }

--- a/nix/cardano-services/deployments.nix
+++ b/nix/cardano-services/deployments.nix
@@ -1,0 +1,57 @@
+let
+  inherit (inputs.std) dmerge;
+  inherit (inputs.std.inputs) haumea;
+  inherit (inputs.std.lib.ops) readYAML;
+
+  loadYaml = _: _: readYAML;
+
+  baseline = with haumea.lib;
+    load {
+      src = ./deployments;
+      loader = [(matchers.regex ''^.+\.(yaml|yml)'' loadYaml)];
+    };
+in {
+  dev-preview = dmerge baseline {
+    meta.description = "Development Environment on the Cardano Preview Chain (Frankfurt)";
+    backend-deployment = {
+      spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "backend";
+          image = cell.oci-images.cardano-services.image.name;
+        }
+      ];
+    };
+    coingecko-proxy-deployment = {
+      spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "coingecko-proxy";
+          image = cell.oci-images.cardano-services.image.name;
+        }
+      ];
+    };
+    handle-projector-deployment = {
+      spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "handle-projector";
+          image = cell.oci-images.cardano-services.image.name;
+        }
+      ];
+    };
+    pgboss-deployment = {
+      spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "pg-boss-worker";
+          image = cell.oci-images.cardano-services.image.name;
+        }
+      ];
+    };
+    stake-pool-projector-deployment = {
+      spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "stake-pool-projector";
+          image = cell.oci-images.cardano-services.image.name;
+        }
+      ];
+    };
+  };
+}

--- a/nix/cardano-services/deployments/backend-deployment.yaml
+++ b/nix/cardano-services/deployments/backend-deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: backend
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+      network: preview
+      release: dev-preview-cardanojs
+  template:
+    metadata:
+      labels:
+        app: backend
+        network: preview
+        release: dev-preview-cardanojs
+    spec:
+      containers:
+        - args:
+            - start-provider-server
+          env:
+            - name: ALLOWED_ORIGINS
+              value: chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk,chrome-extension://efeiemlfnahiidnjglmehaihacglceia
+            - name: DISABLE_STAKE_POOL_METRIC_APY
+              value: "true"
+            - name: ENABLE_METRICS
+              value: "true"
+            - name: HANDLE_POLICY_IDS
+              value: f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a
+            - name: HANDLE_PROVIDER_SERVER_URL
+              value: https://preview.api.handle.me
+            - name: LOGGER_MIN_SEVERITY
+              value: debug
+            - name: NETWORK
+              value: preview
+            - name: OGMIOS_SRV_SERVICE_NAME
+              value: dev-preview-cardano-stack.dev-preview.svc.cluster.local
+            - name: PAGINATION_PAGE_SIZE_LIMIT
+              value: "5500"
+            - name: POSTGRES_DB_DB_SYNC
+              value: cardano
+            - name: POSTGRES_HOST_DB_SYNC
+              value: dev-preview-dbsync-db
+            - name: POSTGRES_PASSWORD_DB_SYNC
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: cardano-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_POOL_MAX_DB_SYNC
+              value: "50"
+            - name: POSTGRES_PORT_DB_SYNC
+              value: "5432"
+            - name: POSTGRES_SSL_CA_FILE_DB_SYNC
+              value: /tls/ca.crt
+            - name: POSTGRES_SSL_DB_SYNC
+              value: "true"
+            - name: POSTGRES_USER_DB_SYNC
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: cardano-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: SERVICE_NAMES
+              value: asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo
+            - name: TOKEN_METADATA_SERVER_URL
+              value: http://dev-preview-cardano-stack-metadata.dev-preview.svc.cluster.local
+            - name: USE_BLOCKFROST
+              value: "false"
+            - name: USE_KORA_LABS
+              value: "true"
+          image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services-server:aana7a352vdaz0rs41yhfh3s85inw004
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            timeoutSeconds: 5
+          name: backend
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            limits:
+              cpu: 1500m
+              memory: 512Mi
+            requests:
+              cpu: 1000m
+              memory: 350Mi
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+      imagePullSecrets:
+        - name: dockerconfigjson
+      volumes:
+        - csi:
+            driver: csi.cert-manager.io
+            readOnly: true
+            volumeAttributes:
+              csi.cert-manager.io/issuer-kind: ClusterIssuer
+              csi.cert-manager.io/issuer-name: root-ca
+              csi.cert-manager.io/key-usages: client auth
+          name: tls

--- a/nix/cardano-services/deployments/backend-ingress.yaml
+++ b/nix/cardano-services/deployments/backend-ingress.yaml
@@ -1,0 +1,56 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"RedirectConfig":{"Port":"443","Protocol":"HTTPS","StatusCode":"HTTP_301"},"Type":"redirect"}'
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "60"
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "30"
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:eu-central-1:926093910549:regional/webacl/rate-limit-backend/07d554a1-0ac0-4799-9745-9ece4d409889
+    external-dns.alpha.kubernetes.io/aws-region: eu-central-1
+    external-dns.alpha.kubernetes.io/set-identifier: eu-central-1-dev-preview-backend
+  labels:
+    app: backend
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-backend
+spec:
+  ingressClassName: alb
+  rules:
+    - host: backend.dev-preview.eks.lw.iog.io
+      http:
+        paths:
+          - backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+            path: /
+            pathType: Prefix
+          - backend:
+              service:
+                name: dev-preview-cardanojs-backend
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+          - backend:
+              service:
+                name: dev-preview-cardanojs-stake-pool-provider
+                port:
+                  name: http
+            path: /stake-pool
+            pathType: Prefix
+          - backend:
+              service:
+                name: dev-preview-cardanojs-handle-provider
+                port:
+                  name: http
+            path: /handle
+            pathType: Prefix
+  tls:
+    - hosts:
+        - backend.dev-preview.eks.lw.iog.io

--- a/nix/cardano-services/deployments/backend-monitor.yaml
+++ b/nix/cardano-services/deployments/backend-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    instance: primary
+  name: lace-backend-monitor
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 60s
+      path: /metrics
+      port: http
+  namespaceSelector:
+    any: false
+  selector:
+    matchLabels:
+      app: backend

--- a/nix/cardano-services/deployments/backend-service.yaml
+++ b/nix/cardano-services/deployments/backend-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: backend
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-backend
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: backend
+    network: preview
+    release: dev-preview-cardanojs

--- a/nix/cardano-services/deployments/coingecko-proxy-deployment.yaml
+++ b/nix/cardano-services/deployments/coingecko-proxy-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: coingecko-proxy
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-coingecko-proxy
+spec:
+  selector:
+    matchLabels:
+      app: coingecko-proxy
+      network: preview
+      release: dev-preview-cardanojs
+  template:
+    metadata:
+      labels:
+        app: coingecko-proxy
+        network: preview
+        release: dev-preview-cardanojs
+    spec:
+      containers:
+        - image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/coingecko-proxy:qzydqc9866j6hchxkra7v9a70l19g35x
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            timeoutSeconds: 5
+          name: coingecko-proxy
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          startupProbe:
+            failureThreshold: 50
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 1
+      imagePullSecrets:
+        - name: dockerconfigjson

--- a/nix/cardano-services/deployments/coingecko-proxy-ingress.yaml
+++ b/nix/cardano-services/deployments/coingecko-proxy-ingress.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"RedirectConfig":{"Port":"443","Protocol":"HTTPS","StatusCode":"HTTP_301"},"Type":"redirect"}'
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    external-dns.alpha.kubernetes.io/aws-region: eu-central-1
+    external-dns.alpha.kubernetes.io/set-identifier: eu-central-1-dev-preview-proxy
+  labels:
+    app: coingecko-proxy
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-coingecko-proxy
+spec:
+  ingressClassName: alb
+  rules:
+    - host: coingecko.dev-preview.eks.lw.iog.io
+      http:
+        paths:
+          - backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+            path: /
+            pathType: Prefix
+          - backend:
+              service:
+                name: dev-preview-cardanojs-coingecko-proxy
+                port:
+                  name: http
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - coingecko.dev-preview.eks.lw.iog.io

--- a/nix/cardano-services/deployments/coingecko-proxy-service.yaml
+++ b/nix/cardano-services/deployments/coingecko-proxy-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: coingecko-proxy
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-coingecko-proxy
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: coingecko-proxy
+    network: preview
+    release: dev-preview-cardanojs

--- a/nix/cardano-services/deployments/handle-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-projector-deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: handle-projector
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-handle-projector
+spec:
+  selector:
+    matchLabels:
+      app: handle-projector
+      network: preview
+      release: dev-preview-cardanojs
+  template:
+    metadata:
+      labels:
+        app: handle-projector
+        network: preview
+        release: dev-preview-cardanojs
+    spec:
+      containers:
+        - args:
+            - start-projector
+          env:
+            - name: HANDLE_POLICY_IDS
+              value: f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a
+            - name: LOGGER_MIN_SEVERITY
+              value: debug
+            - name: NETWORK
+              value: preview
+            - name: OGMIOS_SRV_SERVICE_NAME
+              value: dev-preview-cardano-stack.dev-preview.svc.cluster.local
+            - name: POSTGRES_DB
+              value: handle
+            - name: POSTGRES_HOST
+              value: dev-preview-dbsync-db
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: handle-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_POOL_MAX
+              value: "2"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_SSL_CA_FILE
+              value: /tls/ca.crt
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: handle-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: PROJECTION_NAMES
+              value: handle
+          image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services-server:aana7a352vdaz0rs41yhfh3s85inw004
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            timeoutSeconds: 5
+          name: handle-projector
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            limits:
+              cpu: 500m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 150Mi
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+      imagePullSecrets:
+        - name: dockerconfigjson
+      volumes:
+        - csi:
+            driver: csi.cert-manager.io
+            readOnly: true
+            volumeAttributes:
+              csi.cert-manager.io/issuer-kind: ClusterIssuer
+              csi.cert-manager.io/issuer-name: root-ca
+              csi.cert-manager.io/key-usages: client auth
+          name: tls

--- a/nix/cardano-services/deployments/handle-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-provider-deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: handle-provider
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-handle-provider
+spec:
+  selector:
+    matchLabels:
+      app: handle-provider
+      network: preview
+      release: dev-preview-cardanojs
+  template:
+    metadata:
+      labels:
+        app: handle-provider
+        network: preview
+        release: dev-preview-cardanojs
+    spec:
+      containers:
+        - args:
+            - start-provider-server
+          env:
+            - name: ALLOWED_ORIGINS
+              value: chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk,chrome-extension://efeiemlfnahiidnjglmehaihacglceia
+            - name: ENABLE_METRICS
+              value: "true"
+            - name: HANDLE_POLICY_IDS
+              value: f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a
+            - name: HANDLE_PROVIDER_SERVER_URL
+              value: https://preview.api.handle.me/
+            - name: LOGGER_MIN_SEVERITY
+              value: debug
+            - name: NETWORK
+              value: preview
+            - name: OGMIOS_SRV_SERVICE_NAME
+              value: dev-preview-cardano-stack.dev-preview.svc.cluster.local
+            - name: POSTGRES_DB
+              value: handle
+            - name: POSTGRES_HOST
+              value: dev-preview-dbsync-db
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: handle-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_POOL_MAX
+              value: "10"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_SSL_CA_FILE
+              value: /tls/ca.crt
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: handle-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: SERVICE_NAMES
+              value: handle
+            - name: USE_KORA_LABS
+              value: "true"
+          image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services-server:aana7a352vdaz0rs41yhfh3s85inw004
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            timeoutSeconds: 5
+          name: handle-provider
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            limits:
+              cpu: 500m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 150Mi
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+      imagePullSecrets:
+        - name: dockerconfigjson
+      volumes:
+        - csi:
+            driver: csi.cert-manager.io
+            readOnly: true
+            volumeAttributes:
+              csi.cert-manager.io/issuer-kind: ClusterIssuer
+              csi.cert-manager.io/issuer-name: root-ca
+              csi.cert-manager.io/key-usages: client auth
+          name: tls

--- a/nix/cardano-services/deployments/handle-provider-monitor.yaml
+++ b/nix/cardano-services/deployments/handle-provider-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    instance: primary
+  name: lace-handle-provider-monitor
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 60s
+      path: /metrics
+      port: http
+  namespaceSelector:
+    any: false
+  selector:
+    matchLabels:
+      app: handle-provider

--- a/nix/cardano-services/deployments/handle-provider-service.yaml
+++ b/nix/cardano-services/deployments/handle-provider-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: handle-provider
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-handle-provider
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: handle-provider
+    network: preview
+    release: dev-preview-cardanojs

--- a/nix/cardano-services/deployments/kustomization.yaml
+++ b/nix/cardano-services/deployments/kustomization.yaml
@@ -1,0 +1,1 @@
+namespace: dev-preview

--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pg-boss-worker
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-pg-boss-worker
+spec:
+  selector:
+    matchLabels:
+      app: pg-boss-worker
+      network: preview
+      release: dev-preview-cardanojs
+  template:
+    metadata:
+      labels:
+        app: pg-boss-worker
+        network: preview
+        release: dev-preview-cardanojs
+    spec:
+      containers:
+        - args:
+            - start-pg-boss-worker
+          env:
+            - name: LOGGER_MIN_SEVERITY
+              value: debug
+            - name: NETWORK
+              value: preview
+            - name: POSTGRES_DB_DB_SYNC
+              value: cardano
+            - name: POSTGRES_DB_STAKE_POOL
+              value: stakepool
+            - name: POSTGRES_HOST_DB_SYNC
+              value: dev-preview-dbsync-db
+            - name: POSTGRES_HOST_STAKE_POOL
+              value: dev-preview-dbsync-db
+            - name: POSTGRES_PASSWORD_DB_SYNC
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: cardano-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_PASSWORD_STAKE_POOL
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_POOL_MAX_DB_SYNC
+              value: "5"
+            - name: POSTGRES_POOL_MAX_STAKE_POOL
+              value: "5"
+            - name: POSTGRES_PORT_DB_SYNC
+              value: "5432"
+            - name: POSTGRES_PORT_STAKE_POOL
+              value: "5432"
+            - name: POSTGRES_SSL_CA_FILE_DB_SYNC
+              value: /tls/ca.crt
+            - name: POSTGRES_SSL_CA_FILE_STAKE_POOL
+              value: /tls/ca.crt
+            - name: POSTGRES_SSL_DB_SYNC
+              value: "true"
+            - name: POSTGRES_SSL_STAKE_POOL
+              value: "true"
+            - name: POSTGRES_USER_DB_SYNC
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: cardano-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_USER_STAKE_POOL
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: QUEUES
+              value: pool-metadata,pool-metrics
+            - name: STAKE_POOL_PROVIDER_URL
+              value: https://dev-preview-stake-pool.dev-preview.svc.cluster.local/stake-pool
+          image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services-server:aana7a352vdaz0rs41yhfh3s85inw004
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+          name: pg-boss-worker
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            limits:
+              cpu: 300m
+              memory: 300Mi
+            requests:
+              cpu: 200m
+              memory: 150Mi
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 3000
+            initialDelaySeconds: 80
+            periodSeconds: 5
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+      imagePullSecrets:
+        - name: dockerconfigjson
+      volumes:
+        - csi:
+            driver: csi.cert-manager.io
+            readOnly: true
+            volumeAttributes:
+              csi.cert-manager.io/issuer-kind: ClusterIssuer
+              csi.cert-manager.io/issuer-name: root-ca
+              csi.cert-manager.io/key-usages: client auth
+          name: tls

--- a/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: stake-pool-projector
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-stake-pool-projector
+spec:
+  selector:
+    matchLabels:
+      app: stake-pool-projector
+      network: preview
+      release: dev-preview-cardanojs
+  template:
+    metadata:
+      labels:
+        app: stake-pool-projector
+        network: preview
+        release: dev-preview-cardanojs
+    spec:
+      containers:
+        - args:
+            - start-projector
+          env:
+            - name: LOGGER_MIN_SEVERITY
+              value: debug
+            - name: NETWORK
+              value: preview
+            - name: OGMIOS_SRV_SERVICE_NAME
+              value: dev-preview-cardano-stack.dev-preview.svc.cluster.local
+            - name: POSTGRES_DB
+              value: stakepool
+            - name: POSTGRES_HOST
+              value: dev-preview-dbsync-db
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_POOL_MAX
+              value: "2"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_SSL
+              value: "true"
+            - name: POSTGRES_SSL_CA_FILE
+              value: /tls/ca.crt
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: PROJECTION_NAMES
+              value: stake-pool,stake-pool-metadata-job,stake-pool-metrics-job
+          image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services-server:aana7a352vdaz0rs41yhfh3s85inw004
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            timeoutSeconds: 5
+          name: stake-pool-projector
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            limits:
+              cpu: 700m
+              memory: 300Mi
+            requests:
+              cpu: 700m
+              memory: 150Mi
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+      imagePullSecrets:
+        - name: dockerconfigjson
+      volumes:
+        - csi:
+            driver: csi.cert-manager.io
+            readOnly: true
+            volumeAttributes:
+              csi.cert-manager.io/issuer-kind: ClusterIssuer
+              csi.cert-manager.io/issuer-name: root-ca
+              csi.cert-manager.io/key-usages: client auth
+          name: tls

--- a/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: stake-pool-provider
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-stake-pool-provider
+spec:
+  selector:
+    matchLabels:
+      app: stake-pool-provider
+      network: preview
+      release: dev-preview-cardanojs
+  template:
+    metadata:
+      labels:
+        app: stake-pool-provider
+        network: preview
+        release: dev-preview-cardanojs
+    spec:
+      containers:
+        - args:
+            - start-provider-server
+          env:
+            - name: ALLOWED_ORIGINS
+              value: chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk,chrome-extension://efeiemlfnahiidnjglmehaihacglceia
+            - name: DISABLE_STAKE_POOL_METRIC_APY
+              value: "true"
+            - name: ENABLE_METRICS
+              value: "true"
+            - name: LOGGER_MIN_SEVERITY
+              value: debug
+            - name: NETWORK
+              value: preview
+            - name: OGMIOS_SRV_SERVICE_NAME
+              value: dev-preview-cardano-stack.dev-preview.svc.cluster.local
+            - name: PAGINATION_PAGE_SIZE_LIMIT
+              value: "5500"
+            - name: POSTGRES_DB_STAKE_POOL
+              value: stakepool
+            - name: POSTGRES_HOST_STAKE_POOL
+              value: dev-preview-dbsync-db
+            - name: POSTGRES_PASSWORD_STAKE_POOL
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: POSTGRES_POOL_MAX_STAKE_POOL
+              value: "10"
+            - name: POSTGRES_PORT_STAKE_POOL
+              value: "5432"
+            - name: POSTGRES_SSL_CA_FILE_STAKE_POOL
+              value: /tls/ca.crt
+            - name: POSTGRES_SSL_STAKE_POOL
+              value: "true"
+            - name: POSTGRES_USER_STAKE_POOL
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
+            - name: SERVICE_NAMES
+              value: stake-pool
+            - name: TOKEN_METADATA_SERVER_URL
+              value: http://dev-preview-cardano-stack-metadata.dev-preview.svc.cluster.local
+            - name: USE_TYPEORM_STAKE_POOL_PROVIDER
+              value: "true"
+          image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services-server:aana7a352vdaz0rs41yhfh3s85inw004
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            timeoutSeconds: 5
+          name: stake-pool-provider
+          ports:
+            - containerPort: 3000
+              name: http
+          resources:
+            limits:
+              cpu: 500m
+              memory: 300Mi
+            requests:
+              cpu: 100m
+              memory: 150Mi
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - mountPath: /tls
+              name: tls
+      imagePullSecrets:
+        - name: dockerconfigjson
+      volumes:
+        - csi:
+            driver: csi.cert-manager.io
+            readOnly: true
+            volumeAttributes:
+              csi.cert-manager.io/issuer-kind: ClusterIssuer
+              csi.cert-manager.io/issuer-name: root-ca
+              csi.cert-manager.io/key-usages: client auth
+          name: tls

--- a/nix/cardano-services/deployments/stake-pool-provider-monitor.yaml
+++ b/nix/cardano-services/deployments/stake-pool-provider-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    instance: primary
+  name: lace-stake-pool-provider-monitor
+spec:
+  endpoints:
+    - honorLabels: true
+      interval: 60s
+      path: /metrics
+      port: http
+  namespaceSelector:
+    any: false
+  selector:
+    matchLabels:
+      app: stake-pool-provider

--- a/nix/cardano-services/deployments/stake-pool-provider-service.yaml
+++ b/nix/cardano-services/deployments/stake-pool-provider-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: stake-pool-provider
+    network: preview
+    release: dev-preview-cardanojs
+  name: dev-preview-cardanojs-stake-pool-provider
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: stake-pool-provider
+    network: preview
+    release: dev-preview-cardanojs


### PR DESCRIPTION
- ci: implement 4th packaging layer & continuous deployment
- debug: provide testbed to evolve nixbuild-action

# Context

Provide a testbed against `nixbuild/nixbuild-action@main` so that it can be developed further to work seamlessly with a hosted github runner
which already has Nix installed in daemon mode.

cc @rickynils

# Proposed Solution

# Important Changes Introduced
