### PR TITLE
ci: fix unskip on releases which are marked with [skip actions]

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -3,14 +3,19 @@ name: STD
 
 on:
   workflow_dispatch:
+
   pull_request:
     branches:
       - develop
       - master
+
   push:
     branches:
       - develop
       - master
+
+  release:
+    types: [published]
 
 env:
   AWS_REGION: us-east-1

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - develop
       - master
+  release:
+    types: [published]
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::926093910549:role/lace-ci


### PR DESCRIPTION
# Context

Github documents here](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs) how commits with `[skip actions]` are skipping actions.

`bot-firmfirm` does automatically create releases with this string in the commit message, such as [this](https://github.com/input-output-hk/cardano-js-sdk/commit/5f05daf2c6756dc6f084ffe47ff6ca63998cea39).

# Proposed Solution

Ensure publishing of tagged artifacts by running this action upon the publishing of a release (and irrespective of `[skip actions]`).

# Important Changes Introduced
