### PR TITLE
fix(wallet): do not prevent re-submission

### DIFF
--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -442,14 +442,13 @@ describe('PersonalWallet methods', () => {
       });
 
       it('mightBeAlreadySubmitted option interprets ValueNotConservedError as success', async () => {
-        txSubmitProvider.submitTx.mockRejectedValueOnce(
-          new ProviderError(
-            ProviderFailure.BadRequest,
-            new CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError({
-              valueNotConserved: { consumed: 2, produced: 1 }
-            })
-          )
+        const error = new ProviderError(
+          ProviderFailure.BadRequest,
+          new CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError({
+            valueNotConserved: { consumed: 2, produced: 1 }
+          })
         );
+        txSubmitProvider.submitTx.mockRejectedValueOnce(error).mockRejectedValueOnce(error);
         const tx = await wallet.finalizeTx({ tx: await wallet.initializeTx(props) });
         const outgoingTx = toOutgoingTx(tx);
 

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -367,6 +367,13 @@ describe('PersonalWallet methods', () => {
     });
 
     describe('submitTx', () => {
+      const valueNotConservedError = new ProviderError(
+        ProviderFailure.BadRequest,
+        new CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError({
+          valueNotConserved: { consumed: 2, produced: 1 }
+        })
+      );
+
       it('resolves on success', async () => {
         const tx = await wallet.finalizeTx({ tx: await wallet.initializeTx(props) });
         const outgoingTx = toOutgoingTx(tx);
@@ -442,13 +449,9 @@ describe('PersonalWallet methods', () => {
       });
 
       it('mightBeAlreadySubmitted option interprets ValueNotConservedError as success', async () => {
-        const error = new ProviderError(
-          ProviderFailure.BadRequest,
-          new CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError({
-            valueNotConserved: { consumed: 2, produced: 1 }
-          })
-        );
-        txSubmitProvider.submitTx.mockRejectedValueOnce(error).mockRejectedValueOnce(error);
+        txSubmitProvider.submitTx
+          .mockRejectedValueOnce(valueNotConservedError)
+          .mockRejectedValueOnce(valueNotConservedError);
         const tx = await wallet.finalizeTx({ tx: await wallet.initializeTx(props) });
         const outgoingTx = toOutgoingTx(tx);
 
@@ -459,6 +462,20 @@ describe('PersonalWallet methods', () => {
         const txPending = firstValueFrom(wallet.transactions.outgoing.pending$);
         await expect(wallet.submitTx(tx, { mightBeAlreadySubmitted: true })).resolves.not.toThrow();
         expect(await txPending).toEqual(outgoingTx);
+      });
+
+      it('attempts to resubmit the tx that is already in flight', async () => {
+        const tx = await wallet.finalizeTx({ tx: await wallet.initializeTx(props) });
+
+        await wallet.submitTx(tx);
+        expect(await firstValueFrom(wallet.transactions.outgoing.inFlight$)).toHaveLength(1);
+
+        // resubmit the same tx while it's 'in flight'
+        txSubmitProvider.submitTx.mockRejectedValueOnce(valueNotConservedError);
+        await wallet.submitTx(tx, { mightBeAlreadySubmitted: true });
+
+        expect(await firstValueFrom(wallet.transactions.outgoing.inFlight$)).toHaveLength(1);
+        expect(txSubmitProvider.submitTx).toBeCalledTimes(2);
       });
 
       it('resolves on success when submitting a tx when sending coins to a handle', async () => {


### PR DESCRIPTION
# Context

#861 made submitTx idempotent, but also broke internal logic of PersonalWallet preventing it to re-submit transactions

# Proposed Solution

ef64b30c7d02b64746344ea3042ae7b96db888f6
