### PR TITLE
ci: call std as release process only for specific release prefix

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -3,6 +3,7 @@ name: STD
 
 on:
   workflow_dispatch:
+  workflow_call:
 
   pull_request:
     branches:
@@ -13,9 +14,6 @@ on:
     branches:
       - develop
       - master
-
-  release:
-    types: [published]
 
 env:
   AWS_REGION: us-east-1

--- a/.github/workflows/std-release.yaml
+++ b/.github/workflows/std-release.yaml
@@ -1,0 +1,11 @@
+name: STD-on-release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  call-std:
+    if: startsWith(github.event.release.name, '@cardano-sdk/cardano-services@')
+    steps:
+      uses: ./.github/workflows/std.yml


### PR DESCRIPTION
# Context

The current setup triggers multiple STD pipelines, one for _each_ release tag.
But we only need the pipeline to run once for `cardano-sdk/cardano-services`.

# Proposed Solution

- Make it a call workflow
- Call it form a release workflow
  - Which is in turn able to filter on a broader spectrum of the available event data.

# Testing
- create a new release after merge (?)

ref: LW-8058
