### PR TITLE
ci/post diff back to pr

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -107,9 +107,55 @@ jobs:
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 
-  deploy-to-eu:
+  diff-to-eu:
     <<: *job
     needs: [discover, images]
+    name: ${{ matrix.target.jobName }} (eu-central-1)
+    env:
+      AWS_REGION: eu-central-1
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    if: fromJSON(needs.discover.outputs.hits).deployments.diff != '{}'
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.discover.outputs.hits).deployments.diff }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.2.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nixbuild-action@v17
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
+      - uses: divnix/std-action/setup-discovery-ssh@main
+        with:
+          ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          user_name: ${{ env.DISCOVERY_USER_NAME }}
+          ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+
+      - name: Configure K8S Cluster Access
+        shell: bash
+        run: |
+          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
+          aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+
+      - uses: divnix/std-action/run@main
+        env:
+          BRANCH: ${{ github.ref_type == 'branch' && github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
+          OWNER_AND_REPO: ${{ github.repository }}
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
+      
+
+  deploy-to-eu:
+    <<: *job
+    needs: [discover, diff-to-eu]
     name: ${{ matrix.target.jobName }} (eu-central-1)
     env:
       AWS_REGION: eu-central-1

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -96,9 +96,50 @@ jobs:
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
-  deploy-to-eu:
+  diff-to-eu:
     runs-on: ubuntu-latest
     needs: [discover, images]
+    name: ${{ matrix.target.jobName }} (eu-central-1)
+    env:
+      AWS_REGION: eu-central-1
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    if: fromJSON(needs.discover.outputs.hits).deployments.diff != '{}'
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.discover.outputs.hits).deployments.diff }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.2.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+      - uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nixbuild-action@v17
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
+      - uses: divnix/std-action/setup-discovery-ssh@main
+        with:
+          ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          user_name: ${{ env.DISCOVERY_USER_NAME }}
+          ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+      - name: Configure K8S Cluster Access
+        shell: bash
+        run: |
+          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
+          aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+      - uses: divnix/std-action/run@main
+        env:
+          BRANCH: ${{ github.ref_type == 'branch' && github.head_ref }}
+          GH_TOKEN: ${{ github.token }}
+          OWNER_AND_REPO: ${{ github.repository }}
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
+  deploy-to-eu:
+    runs-on: ubuntu-latest
+    needs: [discover, diff-to-eu]
     name: ${{ matrix.target.jobName }} (eu-central-1)
     env:
       AWS_REGION: eu-central-1

--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1692627026,
-        "narHash": "sha256-9t9zsal8sLyDP8QYgUkDynGlFa96VqmauEXPDWojEGk=",
+        "lastModified": 1692787832,
+        "narHash": "sha256-pZ9IC4uBXlzT3L3rX4uLjJFxP16IT84YklKPnM02Nuw=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "460d53a02f290656926b85d912885496050aa62a",
+        "rev": "16edd0fc1e98c28180d845ef1011610f7b800976",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,10 @@
         (installables "packages" {ci.build = true;})
         (runnables "operables")
         (containers "oci-images" {ci.publish = true;})
-        (kubectl "deployments" {ci.apply = true;})
+        (kubectl "deployments" {
+          ci.diff = true;
+          ci.apply = true;
+        })
       ];
     };
 }


### PR DESCRIPTION
# Context

Audit and review on rendered manifests and _actual_ diffs is generally more reliable than on the rendering pipeline itself.

# Proposed Solution

This PR implements diff posting on the effective changes to a manifest so that a review can more easily consider these effective changes to remote state.

# Testing
- [x] Diff working (see post down below by @blaggacao - note also edits [!])
- [x] Initial Post from `GitHub Actions`-user
- [x] Update of Post from `GitHub Actions`-user (see post edit)
- [ ] ~~Post final deploy~~ &mdash; not implemented / not testable &rarr; backlogged for experience gathering and follow up

ref: LW-6727
std: https://github.com/divnix/std/pull/343