### PR TITLE
feat: add TypeormAssetProvider to Cardano Services

### DIFF
--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/AssetBuilder.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/AssetBuilder.ts
@@ -1,5 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
-import { LastMintTxModel, MultiAssetHistoryModel, MultiAssetModel } from './types';
+import { LastMintTxModel, MultiAssetModel } from './types';
 import { Logger } from 'ts-log';
 import { Pool } from 'pg';
 import Queries from './queries';
@@ -31,15 +31,5 @@ export class AssetBuilder {
       values: [Buffer.from(policyId, 'hex'), Buffer.from(name, 'hex')]
     });
     return result.rows[0];
-  }
-
-  public async queryMultiAssetHistory(policyId: Cardano.PolicyId, name: Cardano.AssetName) {
-    this.#logger.debug('About to query multi asset history', { name, policyId });
-    const result = await this.#db.query<MultiAssetHistoryModel>({
-      name: 'find_multi_asset_history',
-      text: Queries.findMultiAssetHistory,
-      values: [Buffer.from(policyId, 'hex'), Buffer.from(name, 'hex')]
-    });
-    return result.rows;
   }
 }

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -74,7 +74,6 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
   async getAsset({ assetId, extraData }: GetAssetArgs) {
     const assetInfo = await this.#getAssetInfo(assetId);
 
-    if (extraData?.history) await this.loadHistory(assetInfo);
     if (extraData?.nftMetadata) assetInfo.nftMetadata = await this.#getNftMetadata(assetInfo);
     if (extraData?.tokenMetadata) {
       try {
@@ -133,15 +132,6 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
     return Promise.all(assetIds.map((_) => getAssetInfo(_)));
   }
 
-  private async loadHistory(assetInfo: Asset.AssetInfo) {
-    assetInfo.history = (
-      await this.#builder.queryMultiAssetHistory(assetInfo.policyId, assetInfo.name)
-    ).map<Asset.AssetMintOrBurn>(({ hash, quantity }) => ({
-      quantity: BigInt(quantity),
-      transactionId: hash.toString('hex') as unknown as Cardano.TransactionId
-    }));
-  }
-
   async #getNftMetadata(asset: AssetPolicyIdAndName): Promise<Asset.NftMetadata | null> {
     return this.#cache.get(
       nftMetadataCacheKey(Cardano.AssetId.fromParts(asset.policyId, asset.name)),
@@ -166,9 +156,8 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
       const supply = BigInt(multiAsset.sum);
       // Backwards compatibility
       const quantity = supply;
-      const mintOrBurnCount = Number(multiAsset.count);
 
-      return { assetId, fingerprint, mintOrBurnCount, name, policyId, quantity, supply };
+      return { assetId, fingerprint, name, policyId, quantity, supply };
     });
   }
 }

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -11,7 +11,7 @@ import {
 import { AssetBuilder } from './AssetBuilder';
 import { AssetPolicyIdAndName, NftMetadataService, TokenMetadataService } from '../types';
 import { DB_CACHE_TTL_DEFAULT, InMemoryCache, NoCache } from '../../InMemoryCache';
-import { DbSyncProvider, DbSyncProviderDependencies } from '../../util/DbSyncProvider';
+import { DbSyncProvider, DbSyncProviderDependencies } from '../../util';
 
 /**
  * Properties that are need to create DbSyncAssetProvider

--- a/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
@@ -1,0 +1,145 @@
+import {
+  Asset,
+  AssetProvider,
+  Cardano,
+  GetAssetArgs,
+  GetAssetsArgs,
+  ProviderError,
+  ProviderFailure
+} from '@cardano-sdk/core';
+import { AssetEntity } from '@cardano-sdk/projection-typeorm';
+import { TokenMetadataService } from '../types';
+import { TypeOrmNftMetadataService } from '../TypeOrmNftMetadataService';
+import { TypeormProvider, TypeormProviderDependencies } from '../../util';
+
+interface TypeormAssetProviderProps {
+  paginationPageSizeLimit: number;
+}
+
+interface TypeormAssetProviderDependencies extends TypeormProviderDependencies {
+  tokenMetadataService: TokenMetadataService;
+}
+
+export class TypeormAssetProvider extends TypeormProvider implements AssetProvider {
+  #dependencies: TypeormAssetProviderDependencies;
+  #nftMetadataService: TypeOrmNftMetadataService;
+  #paginationPageSizeLimit: number;
+
+  constructor({ paginationPageSizeLimit }: TypeormAssetProviderProps, dependencies: TypeormAssetProviderDependencies) {
+    const { connectionConfig$, entities, logger } = dependencies;
+    super('TypeormAssetProvider', { connectionConfig$, entities, logger });
+
+    this.#dependencies = dependencies;
+    this.#paginationPageSizeLimit = paginationPageSizeLimit;
+    this.#nftMetadataService = new TypeOrmNftMetadataService({ connectionConfig$, entities, logger });
+  }
+
+  async getAsset({ assetId, extraData }: GetAssetArgs): Promise<Asset.AssetInfo> {
+    const assetInfo = await this.#getAssetInfo(assetId);
+
+    if (extraData?.nftMetadata) assetInfo.nftMetadata = await this.#getNftMetadata(assetInfo);
+    if (extraData?.tokenMetadata) {
+      assetInfo.tokenMetadata = (await this.#fetchTokenMetadataList([assetId]))[0];
+    }
+
+    return assetInfo;
+  }
+
+  async getAssets({ assetIds, extraData }: GetAssetsArgs): Promise<Asset.AssetInfo[]> {
+    if (assetIds.length > this.#paginationPageSizeLimit) {
+      throw new ProviderError(
+        ProviderFailure.BadRequest,
+        undefined,
+        `AssetIds count of ${assetIds.length} can not be greater than ${this.#paginationPageSizeLimit}`
+      );
+    }
+
+    const assetInfoList = await Promise.all(assetIds.map((assetId) => this.#getAssetInfo(assetId)));
+
+    if (extraData?.nftMetadata) {
+      await Promise.all(
+        assetInfoList.map(async (assetInfo) => {
+          assetInfo.nftMetadata = await this.#getNftMetadata(assetInfo);
+        })
+      );
+    }
+
+    if (extraData?.tokenMetadata) {
+      const tokenMetadataList = await this.#fetchTokenMetadataList(assetIds);
+
+      for (const [index, assetInfo] of assetInfoList.entries()) {
+        assetInfo.tokenMetadata = tokenMetadataList[index];
+      }
+    }
+
+    return assetInfoList;
+  }
+
+  async #fetchTokenMetadataList(assetIds: Cardano.AssetId[]) {
+    let tokenMetadataList: (Asset.TokenMetadata | null | undefined)[] = [];
+
+    try {
+      tokenMetadataList = await this.#dependencies.tokenMetadataService.getTokenMetadata(assetIds);
+    } catch (error) {
+      if (error instanceof ProviderError && error.reason === ProviderFailure.Unhealthy) {
+        this.logger.error(`Failed to fetch token metadata for assets ${assetIds} due to: ${error.message}`);
+        tokenMetadataList = Array.from({ length: assetIds.length });
+      } else {
+        throw error;
+      }
+    }
+
+    return tokenMetadataList;
+  }
+
+  async #getNftMetadata(asset: Asset.AssetInfo): Promise<Asset.NftMetadata | null | undefined> {
+    try {
+      return this.#nftMetadataService.getNftMetadata({
+        name: asset.name,
+        policyId: asset.policyId
+      });
+    } catch (error) {
+      this.logger.error('Failed to get nft metadata', asset.assetId, error);
+    }
+  }
+
+  async #getAssetInfo(assetId: Cardano.AssetId): Promise<Asset.AssetInfo> {
+    const assetName = Cardano.AssetId.getAssetName(assetId);
+    const policyId = Cardano.AssetId.getPolicyId(assetId);
+    const fingerprint = Cardano.AssetFingerprint.fromParts(policyId, Cardano.AssetName(assetName));
+
+    return this.withDataSource(async (dataSource) => {
+      const queryRunner = dataSource.createQueryRunner();
+      const assetRepository = queryRunner.manager.getRepository(AssetEntity);
+
+      const asset = await assetRepository.findOneBy({ id: assetId });
+
+      if (!asset) throw new ProviderError(ProviderFailure.NotFound, undefined, `Asset not found '${assetId}'`);
+      const supply = asset.supply!;
+
+      return {
+        assetId,
+        fingerprint,
+        name: assetName,
+        policyId,
+        quantity: supply,
+        supply
+      };
+    });
+  }
+
+  async initializeImpl() {
+    await super.initializeImpl();
+    await this.#nftMetadataService.initialize();
+  }
+
+  async startImpl() {
+    await super.startImpl();
+    await this.#nftMetadataService.start();
+  }
+
+  async shutdownImpl() {
+    await super.shutdownImpl();
+    await this.#nftMetadataService.shutdown();
+  }
+}

--- a/packages/cardano-services/src/Asset/TypeormAssetProvider/index.ts
+++ b/packages/cardano-services/src/Asset/TypeormAssetProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './TypeormAssetProvider';

--- a/packages/cardano-services/src/Asset/index.ts
+++ b/packages/cardano-services/src/Asset/index.ts
@@ -4,4 +4,5 @@ export * from './StubTokenMetadataService';
 export * from './DbSyncNftMetadataService';
 export * from './DbSyncAssetProvider';
 export * from './TypeOrmNftMetadataService';
+export * from './TypeormAssetProvider';
 export * from './types';

--- a/packages/cardano-services/src/Asset/openApi.json
+++ b/packages/cardano-services/src/Asset/openApi.json
@@ -118,9 +118,6 @@
           "fingerprint": {
             "type": "string"
           },
-          "mintOrBurnCount": {
-            "type": "number"
-          },
           "name": {
             "type": "string"
           },
@@ -152,9 +149,6 @@
       "ExtraData": {
         "type": "object",
         "properties": {
-          "history": {
-            "type": "boolean"
-          },
           "nftMetadata": {
             "type": "boolean"
           },

--- a/packages/cardano-services/src/Program/options/postgres.ts
+++ b/packages/cardano-services/src/Program/options/postgres.ts
@@ -32,7 +32,7 @@ export interface BasePosgresProgramOptions {
   postgresSslCaFile?: string;
 }
 
-export type ConnectionNames = 'DbSync' | 'Handle' | 'StakePool' | '';
+export type ConnectionNames = 'DbSync' | 'Handle' | 'StakePool' | 'Asset' | '';
 
 export type PosgresProgramOptions<
   Suffix extends ConnectionNames,

--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -1,14 +1,17 @@
 /* eslint-disable complexity */
 /* eslint-disable sonarjs/cognitive-complexity */
-import { AssetHttpService } from '../../Asset/AssetHttpService';
+import {
+  AssetHttpService,
+  CardanoTokenRegistry,
+  DbSyncAssetProvider,
+  DbSyncNftMetadataService,
+  StubTokenMetadataService
+} from '../../Asset';
 import { CardanoNode, HandleProvider, Seconds } from '@cardano-sdk/core';
-import { CardanoTokenRegistry } from '../../Asset/CardanoTokenRegistry';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider } from '../../ChainHistory';
 import { ConnectionNames, PostgresOptionDescriptions, suffixType2Cli } from '../options/postgres';
 import { DbPools, DbSyncEpochPollService } from '../../util';
-import { DbSyncAssetProvider } from '../../Asset/DbSyncAssetProvider';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../NetworkInfo';
-import { DbSyncNftMetadataService, StubTokenMetadataService } from '../../Asset';
 import { DbSyncRewardsProvider, RewardsHttpService } from '../../Rewards';
 import { DbSyncStakePoolProvider, StakePoolHttpService, createHttpStakePoolMetadataService } from '../../StakePool';
 import { DbSyncUtxoProvider, UtxoHttpService } from '../../Utxo';
@@ -28,6 +31,7 @@ import { Pool } from 'pg';
 import { ProviderServerArgs, ProviderServerOptionDescriptions, ServiceNames } from './types';
 import { SrvRecord } from 'dns';
 import { TxSubmitHttpService } from '../../TxSubmit';
+import { TypeormAssetProvider } from '../../Asset/TypeormAssetProvider';
 import { TypeormStakePoolProvider } from '../../StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider';
 import { URL } from 'url';
 import { createDbSyncMetadataService } from '../../Metadata';
@@ -47,6 +51,7 @@ export const USE_BLOCKFROST_DEFAULT = false;
 export const USE_TYPEORM_STAKE_POOL_PROVIDER_DEFAULT = false;
 export const USE_QUEUE_DEFAULT = false;
 export const HANDLE_PROVIDER_SERVER_URL_DEFAULT = '';
+export const USE_TYPEORM_ASSET_PROVIDER_DEFAULT = false;
 
 export interface LoadProviderServerDependencies {
   dnsResolver?: (serviceName: string) => Promise<SrvRecord>;
@@ -189,36 +194,56 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
     return sharedHandleProvider;
   };
 
-  return {
-    [ServiceNames.Asset]: withDbSyncProvider(async (dbPools, cardanoNode) => {
-      const ntfMetadataService = new DbSyncNftMetadataService({
-        db: dbPools.main,
-        logger,
-        metadataService: createDbSyncMetadataService(dbPools.main, logger)
-      });
-      const tokenMetadataService = args.tokenMetadataServerUrl?.startsWith('stub:')
-        ? new StubTokenMetadataService()
-        : new CardanoTokenRegistry({ logger }, args);
-      const assetProvider = new DbSyncAssetProvider(
-        {
-          cacheTTL: args.assetCacheTTL,
-          disableDbCache: args.disableDbCache,
-          paginationPageSizeLimit: Math.min(args.paginationPageSizeLimit! * 10, PAGINATION_PAGE_SIZE_LIMIT_ASSETS)
-        },
-        {
-          cache: {
-            healthCheck: healthCheckCache
-          },
-          cardanoNode,
-          dbPools,
-          logger,
-          ntfMetadataService,
-          tokenMetadataService
-        }
-      );
+  const getTypeormAssetProvider = withTypeOrmProvider('Asset', (connectionConfig$) => {
+    const tokenMetadataService = args.tokenMetadataServerUrl?.startsWith('stub:')
+      ? new StubTokenMetadataService()
+      : new CardanoTokenRegistry({ logger }, args);
 
+    return new TypeormAssetProvider(
+      { paginationPageSizeLimit: args.paginationPageSizeLimit! },
+      {
+        connectionConfig$,
+        entities: getEntities(['asset']),
+        logger,
+        tokenMetadataService
+      }
+    );
+  });
+
+  const getDbSyncAssetProvider = withDbSyncProvider((dbPools, cardanoNode) => {
+    const ntfMetadataService = new DbSyncNftMetadataService({
+      db: dbPools.main,
+      logger,
+      metadataService: createDbSyncMetadataService(dbPools.main, logger)
+    });
+
+    const tokenMetadataService = args.tokenMetadataServerUrl?.startsWith('stub:')
+      ? new StubTokenMetadataService()
+      : new CardanoTokenRegistry({ logger }, args);
+    return new DbSyncAssetProvider(
+      {
+        cacheTTL: args.assetCacheTTL,
+        disableDbCache: args.disableDbCache,
+        paginationPageSizeLimit: Math.min(args.paginationPageSizeLimit! * 10, PAGINATION_PAGE_SIZE_LIMIT_ASSETS)
+      },
+      {
+        cache: {
+          healthCheck: healthCheckCache
+        },
+        cardanoNode,
+        dbPools,
+        logger,
+        ntfMetadataService,
+        tokenMetadataService
+      }
+    );
+  }, ServiceNames.Asset);
+
+  return {
+    [ServiceNames.Asset]: async () => {
+      const assetProvider = args.useTypeormAssetProvider ? getTypeormAssetProvider() : getDbSyncAssetProvider();
       return new AssetHttpService({ assetProvider, logger });
-    }, ServiceNames.Asset),
+    },
     [ServiceNames.StakePool]: async () => {
       const stakePoolProvider = args.useTypeormStakePoolProvider
         ? getTypeormStakePoolProvider()

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -1,9 +1,6 @@
-import { CommonProgramOptions } from '../options/common';
+import { CommonProgramOptions, OgmiosProgramOptions, PosgresProgramOptions, RabbitMqProgramOptions } from '../options';
 import { HandlePolicyIdsProgramOptions } from '../options/policyIds';
 import { Milliseconds, Seconds } from '@cardano-sdk/core';
-import { OgmiosProgramOptions } from '../options/ogmios';
-import { PosgresProgramOptions } from '../options/postgres';
-import { RabbitMqProgramOptions } from '../options/rabbitMq';
 
 /**
  * cardano-services programs
@@ -56,7 +53,8 @@ export enum ProviderServerOptionDescriptions {
   UseKoraLabsProvider = 'Use the KoraLabs handle provider',
   UseQueue = 'Enables RabbitMQ',
   PaginationPageSizeLimit = 'Pagination page size limit shared across all providers',
-  HandleProviderServerUrl = 'URL for the Handle provider server'
+  HandleProviderServerUrl = 'URL for the Handle provider server',
+  UseTypeormAssetProvider = 'Use the TypeORM Asset Provider (default is db-sync)'
 }
 
 export type ProviderServerArgs = CommonProgramOptions &
@@ -79,6 +77,7 @@ export type ProviderServerArgs = CommonProgramOptions &
     dbCacheTtl: Seconds | 0;
     useBlockfrost?: boolean;
     useKoraLabs?: boolean;
+    useTypeormAssetProvider?: boolean;
     useQueue?: boolean;
     useTypeormStakePoolProvider?: boolean;
     paginationPageSizeLimit?: number;

--- a/packages/cardano-services/src/Program/utils.ts
+++ b/packages/cardano-services/src/Program/utils.ts
@@ -64,7 +64,7 @@ export const stringOptionToBoolean = (value: string, program: Programs, option: 
 // If typeorm provider is enabled we establish a DB connection though the TypeORM data source
 // Should be refactored when implement many typeorm providers and integrate with IOC dependency injection
 export const getDbPools = async (dnsResolver: DnsResolver, logger: Logger, args: ProviderServerArgs) =>
-  args.useTypeormStakePoolProvider
+  args.useTypeormStakePoolProvider || args.useTypeormAssetProvider
     ? {}
     : {
         healthCheck: await getPool(dnsResolver, logger, args),
@@ -72,11 +72,13 @@ export const getDbPools = async (dnsResolver: DnsResolver, logger: Logger, args:
       };
 
 export const getCardanoNode = async (dnsResolver: DnsResolver, logger: Logger, args: ProviderServerArgs) =>
-  serviceSetHas(args.serviceNames, cardanoNodeDependantServices) && !args.useTypeormStakePoolProvider
+  serviceSetHas(args.serviceNames, cardanoNodeDependantServices) &&
+  !args.useTypeormStakePoolProvider &&
+  !args.useTypeormAssetProvider
     ? await getOgmiosCardanoNode(dnsResolver, logger, args)
     : undefined;
 
 export const getGenesisData = async (args: ProviderServerArgs) =>
-  args.cardanoNodeConfigPath && !args.useTypeormStakePoolProvider
+  args.cardanoNodeConfigPath && !args.useTypeormStakePoolProvider && !args.useTypeormAssetProvider
     ? await loadGenesisData(args.cardanoNodeConfigPath)
     : undefined;

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -34,6 +34,7 @@ import {
   TxWorkerOptionDescriptions,
   USE_BLOCKFROST_DEFAULT,
   USE_QUEUE_DEFAULT,
+  USE_TYPEORM_ASSET_PROVIDER_DEFAULT,
   USE_TYPEORM_STAKE_POOL_PROVIDER_DEFAULT,
   availableNetworks,
   connectionStringFromArgs,
@@ -193,19 +194,25 @@ withCommonOptions(
     withPostgresOptions(
       withPostgresOptions(
         withPostgresOptions(
-          withRabbitMqOptions(
-            withHandlePolicyIdsOptions(
-              program
-                .command('start-provider-server')
-                .description('Start the Provider Server')
-                .argument('[serviceNames...]', `List of services to attach: ${Object.values(ServiceNames).toString()}`)
-            )
+          withPostgresOptions(
+            withRabbitMqOptions(
+              withHandlePolicyIdsOptions(
+                program
+                  .command('start-provider-server')
+                  .description('Start the Provider Server')
+                  .argument(
+                    '[serviceNames...]',
+                    `List of services to attach: ${Object.values(ServiceNames).toString()}`
+                  )
+              )
+            ),
+            'StakePool'
           ),
-          'StakePool'
+          'Handle'
         ),
-        'Handle'
+        'DbSync'
       ),
-      'DbSync'
+      'Asset'
     )
   ),
   {
@@ -360,6 +367,18 @@ withCommonOptions(
       .env('HANDLE_PROVIDER_SERVER_URL')
       .default(HANDLE_PROVIDER_SERVER_URL_DEFAULT)
       .argParser((serverUrl: string) => serverUrl)
+  )
+  .addOption(
+    new Option('--use-typeorm-asset-provider <true/false>', ProviderServerOptionDescriptions.UseTypeormAssetProvider)
+      .env('USE_TYPEORM_ASSET_PROVIDER')
+      .default(USE_TYPEORM_ASSET_PROVIDER_DEFAULT)
+      .argParser((useTypeormAssetProvider) =>
+        stringOptionToBoolean(
+          useTypeormAssetProvider,
+          Programs.ProviderServer,
+          ProviderServerOptionDescriptions.UseTypeormAssetProvider
+        )
+      )
   )
   .action(async (serviceNames: ServiceNames[], args: ProviderServerArgs) =>
     runServer('Provider server', () =>

--- a/packages/cardano-services/test/Asset/AssetBuilder.test.ts
+++ b/packages/cardano-services/test/Asset/AssetBuilder.test.ts
@@ -55,19 +55,4 @@ describe('AssetBuilder', () => {
       expect(result).toBeUndefined();
     });
   });
-
-  describe('queryMultiAssetHistory', () => {
-    test('query multi_asset transactions history', async () => {
-      const assets = await fixtureBuilder.getAssets(1);
-      const history = await fixtureBuilder.getHistory(assets[0].policyId, assets[0].name);
-      const result = await builder.queryMultiAssetHistory(assets[0].policyId, assets[0].name);
-      expect(result[0].quantity).toEqual(history[0].quantity.toString());
-      expect(result[0].hash).toEqual(Buffer.from(history[0].transactionId, 'hex'));
-    });
-
-    test('return empty array when not found', async () => {
-      const result = await builder.queryMultiAssetHistory(notValidPolicyId, notValidAssetName);
-      expect(result).toStrictEqual([]);
-    });
-  });
 });

--- a/packages/cardano-services/test/Asset/AssetHttpService.test.ts
+++ b/packages/cardano-services/test/Asset/AssetHttpService.test.ts
@@ -205,12 +205,10 @@ describe('AssetHttpService', () => {
         const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
         const res = await provider.getAsset({
           assetId: assets[0].id,
-          extraData: { history: true, nftMetadata: true, tokenMetadata: true }
+          extraData: { nftMetadata: true, tokenMetadata: true }
         });
-        const expectedHistory = await fixtureBuilder.getHistory(assets[0].policyId, assets[0].name);
-        const { history, nftMetadata, tokenMetadata } = res;
+        const { nftMetadata, tokenMetadata } = res;
 
-        expect(history).toEqual(expectedHistory);
         expect(nftMetadata).toEqual(assets[0].metadata);
         expect(tokenMetadata).toBeDefined();
       });

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -87,7 +87,6 @@ describe('DbSyncAssetProvider', () => {
     expect(await provider.getAsset({ assetId: assets[0].id })).toMatchShapeOf({
       assetId: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb6d616361726f6e2d63616b65',
       fingerprint: 'asset1f0azzptnr8dghzjh7egqvdjmt33e3lz5uy59th',
-      mintOrBurnCount: 1,
       name: '6d616361726f6e2d63616b65',
       policyId: '50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb',
       quantity: 1n,
@@ -98,11 +97,9 @@ describe('DbSyncAssetProvider', () => {
     const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
     const asset = await provider.getAsset({
       assetId: assets[0].id,
-      extraData: { history: true, nftMetadata: true, tokenMetadata: true }
+      extraData: { nftMetadata: true, tokenMetadata: true }
     });
-    const history = await fixtureBuilder.getHistory(assets[0].policyId, assets[0].name);
 
-    expect(asset.history).toEqual(history);
     // TODO: review test data, this is false positive right now
     expect(asset.nftMetadata).toBeTruthy();
     expect(asset.nftMetadata).toStrictEqual(assets[0].metadata);

--- a/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetFixtureBuilder.ts
+++ b/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetFixtureBuilder.ts
@@ -1,0 +1,77 @@
+import { Asset, Cardano } from '@cardano-sdk/core';
+import { AssetEntity, NftMetadataEntity } from '@cardano-sdk/projection-typeorm';
+import { IsNull, Not } from 'typeorm';
+import { Logger } from 'ts-log';
+import { TypeormProvider, TypeormProviderDependencies } from '../../../src/util';
+
+export enum TypeormAssetWith {
+  metadata = 'metadata'
+}
+
+export class TypeormAssetFixtureBuilder extends TypeormProvider {
+  #logger: Logger;
+
+  constructor({ connectionConfig$, entities, logger }: TypeormProviderDependencies) {
+    super('TypeormAssetFixtureBuilder', { connectionConfig$, entities, logger });
+    this.#logger = logger;
+  }
+
+  public async getAssets(desiredQty: number, options?: { with?: TypeormAssetWith[] }): Promise<Asset.AssetInfo[]> {
+    this.#logger.debug(`About to fetch up to ${desiredQty} assets`);
+
+    const assets = await this.#getAssetsQuery(desiredQty, !!options?.with?.includes(TypeormAssetWith.metadata));
+
+    const resultQty = assets.length;
+
+    if (assets.length === 0) {
+      throw new Error('No assets found');
+    } else if (resultQty < desiredQty) {
+      this.#logger.warn(`${desiredQty} assets desired, only ${resultQty} results found`);
+    }
+
+    const assetsInfo: Asset.AssetInfo[] = assets.map((row) => {
+      const assetId = row.id!;
+      const policyId = Cardano.AssetId.getPolicyId(assetId);
+      const assetName = Cardano.AssetId.getAssetName(assetId);
+      const fingerprint = Cardano.AssetFingerprint.fromParts(policyId, Cardano.AssetName(assetName));
+      const supply = row.supply!;
+      return { assetId, fingerprint, name: assetName, policyId, quantity: supply, supply };
+    });
+
+    if (options?.with?.includes(TypeormAssetWith.metadata)) {
+      await Promise.all(
+        assetsInfo.map(async (assetInfo) => {
+          const assetMetadata = await this.#getNftMetadataQuery(assetInfo.assetId);
+          assetInfo.nftMetadata = assetMetadata
+            ? ({
+                image: assetMetadata.image,
+                name: assetMetadata.name,
+                ...(assetMetadata.description && { description: assetMetadata.description }),
+                ...(assetMetadata.files && { files: assetMetadata.files }),
+                ...(assetMetadata.mediaType && { mediaType: assetMetadata.mediaType }),
+                ...(assetMetadata.otherProperties && {
+                  otherProperties: assetMetadata.otherProperties
+                })
+              } as Asset.NftMetadata)
+            : null;
+        })
+      );
+    }
+
+    return assetsInfo;
+  }
+
+  async #getAssetsQuery(limit: number, withNftMetadata: boolean): Promise<AssetEntity[]> {
+    return this.withDataSource((dataSource) => {
+      const assetRepository = dataSource.getRepository(AssetEntity);
+      return assetRepository.find({ take: limit, where: { nftMetadata: withNftMetadata ? Not(IsNull()) : undefined } });
+    });
+  }
+
+  async #getNftMetadataQuery(assetId: Cardano.AssetId): Promise<NftMetadataEntity | null> {
+    return this.withDataSource((dataSource) => {
+      const nftMetadataRepository = dataSource.getRepository(NftMetadataEntity);
+      return nftMetadataRepository.findOneBy({ userTokenAsset: { id: assetId } });
+    });
+  }
+}

--- a/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetProvider.test.ts
@@ -1,0 +1,144 @@
+import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Observable } from 'rxjs';
+import {
+  PAGINATION_PAGE_SIZE_LIMIT_ASSETS,
+  TokenMetadataService,
+  TypeormAssetProvider,
+  createDnsResolver,
+  getConnectionConfig,
+  getEntities
+} from '../../../src';
+import { PgConnectionConfig } from '@cardano-sdk/projection-typeorm';
+import { TypeormAssetFixtureBuilder, TypeormAssetWith } from './TypeormAssetFixtureBuilder';
+import { logger } from '@cardano-sdk/util-dev';
+
+const tokenMetadata = {
+  assetId: '4abc',
+  decimals: 8,
+  desc: 'SingularityNET',
+  icon: 'testLogo',
+  name: 'SingularityNet AGIX Token',
+  ticker: 'AGIX',
+  url: 'https://singularitynet.io/'
+};
+
+describe('TypeormAssetProvider', () => {
+  let provider: TypeormAssetProvider;
+  let fixtureBuilder: TypeormAssetFixtureBuilder;
+  let connectionConfig$: Observable<PgConnectionConfig>;
+  let tokenMetadataService: jest.Mocked<TokenMetadataService>;
+
+  beforeEach(async () => {
+    const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
+    const entities = getEntities(['asset']);
+    connectionConfig$ = getConnectionConfig(dnsResolver, 'test', 'Handle', {
+      postgresConnectionStringHandle: process.env.POSTGRES_CONNECTION_STRING_HANDLE!
+    });
+    tokenMetadataService = {
+      getTokenMetadata: jest.fn().mockResolvedValue([tokenMetadata]),
+      shutdown: jest.fn()
+    };
+
+    provider = new TypeormAssetProvider(
+      {
+        paginationPageSizeLimit: PAGINATION_PAGE_SIZE_LIMIT_ASSETS
+      },
+      { connectionConfig$, entities, logger, tokenMetadataService }
+    );
+    fixtureBuilder = new TypeormAssetFixtureBuilder({ connectionConfig$, entities, logger });
+
+    await provider.initialize();
+    await provider.start();
+    await fixtureBuilder.initialize();
+    await fixtureBuilder.start();
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+
+    await provider.shutdown();
+    await fixtureBuilder.shutdown();
+  });
+
+  describe('getAsset', () => {
+    it('should return asset info for a given asset id', async () => {
+      const assetQuery = await fixtureBuilder.getAssets(1);
+      const testAsset = assetQuery[0];
+      const asset = await provider.getAsset({ assetId: testAsset.assetId });
+      expect(asset).toEqual(testAsset);
+    });
+
+    it('should throw an error if the asset does not exist', async () => {
+      const assetId = Cardano.AssetId('64190c10b567ad4bcf254ad0f76eb374d749d0b25fd82786af6a839a48656c6c6f48616e646c65');
+      await expect(provider.getAsset({ assetId })).rejects.toThrowError(ProviderError);
+    });
+
+    it('should return metadata if the asset has metadata', async () => {
+      const assetQuery = await fixtureBuilder.getAssets(1, { with: [TypeormAssetWith.metadata] });
+      const testAsset = assetQuery[0];
+      const asset = await provider.getAsset({ assetId: testAsset.assetId, extraData: { nftMetadata: true } });
+      expect(asset).toEqual(testAsset);
+    });
+
+    it('should return both nftMetadata and tokenMetadata if the asset has both', async () => {
+      const assetQuery = await fixtureBuilder.getAssets(1, { with: [TypeormAssetWith.metadata] });
+      const testAsset = assetQuery[0];
+      const asset = await provider.getAsset({
+        assetId: testAsset.assetId,
+        extraData: { nftMetadata: true, tokenMetadata: true }
+      });
+      expect(asset.tokenMetadata).toEqual(tokenMetadata);
+      expect(asset.nftMetadata).toEqual(testAsset.nftMetadata);
+    });
+
+    it('should return undefined asset token metadata if the token registry throws a server error', async () => {
+      tokenMetadataService.getTokenMetadata.mockRejectedValue(new ProviderError(ProviderFailure.Unhealthy));
+
+      const assetQuery = await fixtureBuilder.getAssets(1, { with: [TypeormAssetWith.metadata] });
+      const testAsset = assetQuery[0];
+
+      const asset = await provider.getAsset({
+        assetId: testAsset.assetId,
+        extraData: { tokenMetadata: true }
+      });
+
+      expect(asset.tokenMetadata).toBeUndefined();
+    });
+  });
+
+  describe('getAssets', () => {
+    it('should return multiple asset info for every assetId in a given array', async () => {
+      const testAssets = await fixtureBuilder.getAssets(4);
+      const assetIds = testAssets.map((asset) => asset.assetId);
+      const assets = await provider.getAssets({ assetIds });
+      expect(assets).toEqual(testAssets);
+    });
+
+    it('Should return multiple asset info with nftMetadata for every assetId in a given array', async () => {
+      const testAssets = await fixtureBuilder.getAssets(3, { with: [TypeormAssetWith.metadata] });
+      const assetIds = testAssets.map((asset) => asset.assetId);
+      const assets = await provider.getAssets({ assetIds, extraData: { nftMetadata: true } });
+      expect(assets).toEqual(testAssets);
+    });
+
+    it('Should throw error when one of the assetIds does not exist', async () => {
+      const testAssets = await fixtureBuilder.getAssets(1);
+      const invalidAssetId = Cardano.AssetId(
+        '64190c10b567ad4bcf254ad0f76eb374d749d0b25fd82786af6a839a48656c6c6f48616e646c65'
+      );
+      const assetIds = [...testAssets.map((asset) => asset.assetId), invalidAssetId];
+      await expect(provider.getAssets({ assetIds })).rejects.toThrowError(ProviderError);
+    });
+
+    it('should fetch multiple token metadata for multiple assetIds', async () => {
+      const testAssets = await fixtureBuilder.getAssets(4);
+      const assetIds = testAssets.map((asset) => asset.assetId);
+      const asset = await provider.getAssets({
+        assetIds,
+        extraData: { tokenMetadata: true }
+      });
+      expect(asset).toHaveLength(testAssets.length);
+      expect(asset[0].tokenMetadata).toBeTruthy();
+    });
+  });
+});

--- a/packages/cardano-services/test/Asset/fixtures/FixtureBuilder.ts
+++ b/packages/cardano-services/test/Asset/fixtures/FixtureBuilder.ts
@@ -35,19 +35,6 @@ export class AssetFixtureBuilder {
     return result.rows[0];
   }
 
-  public async getHistory(policyId: Cardano.PolicyId, name: Cardano.AssetName) {
-    this.#logger.debug('About to query multi asset history', { name, policyId });
-    const result: QueryResult<{
-      hash: Buffer;
-      quantity: string;
-    }> = await this.#db.query(Queries.findMultiAssetHistory, [Buffer.from(policyId, 'hex'), Buffer.from(name, 'hex')]);
-
-    return result.rows.map(({ hash, quantity }) => ({
-      quantity: BigInt(quantity),
-      transactionId: bufferToHexString(hash) as unknown as Cardano.TransactionId
-    }));
-  }
-
   public async getAssets(desiredQty: number, options?: { with?: AssetWith[] }): Promise<AssetData[]> {
     this.#logger.debug(`About to fetch up to ${desiredQty} assets`);
 

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -2136,6 +2136,30 @@ describe('CLI', () => {
           const res = await axios.post(`${apiUrl}/${ServiceNames.StakePool}/health`, { headers });
           expect(res.status).toBe(200);
         });
+
+        it('asset provider server', async () => {
+          proc = withLogging(
+            fork(
+              exePath,
+              [
+                ...baseArgs,
+                '--api-url',
+                apiUrl,
+                '--postgres-connection-string-asset',
+                postgresConnectionStringHandle,
+                '--use-typeorm-asset-provider',
+                'true',
+                '--service-names',
+                ServiceNames.Asset
+              ],
+              { env: {}, stdio: 'pipe' }
+            )
+          );
+          await serverStarted(apiUrl);
+          const headers = { 'Content-Type': 'application/json' };
+          const res = await axios.post(`${apiUrl}/${ServiceNames.Asset}/health`, { headers });
+          expect(res.status).toBe(200);
+        });
       });
     });
   });

--- a/packages/core/src/Asset/types/AssetInfo.ts
+++ b/packages/core/src/Asset/types/AssetInfo.ts
@@ -21,11 +21,6 @@ export interface AssetInfo {
    */
   quantity: bigint;
   supply: bigint;
-  mintOrBurnCount: number;
-  /**
-   * Sorted by slot
-   */
-  history?: AssetMintOrBurn[];
   /**
    * CIP-0035. `undefined` if not loaded, `null` if no metadata found
    */

--- a/packages/core/src/Provider/AssetProvider/types.ts
+++ b/packages/core/src/Provider/AssetProvider/types.ts
@@ -5,19 +5,9 @@ export interface AssetsExtraData {
   tokenMetadata?: boolean;
 }
 
-/**
- * @deprecated Use `AssetsExtraData` with `getAssets` instead
- */
-export interface AssetExtraData extends AssetsExtraData {
-  history?: boolean;
-}
-
-/**
- * @deprecated Use `GetAssetsArgs` with `getAssets` instead
- */
 export interface GetAssetArgs {
   assetId: Cardano.AssetId;
-  extraData?: AssetExtraData;
+  extraData?: AssetsExtraData;
 }
 
 export interface GetAssetsArgs {
@@ -27,16 +17,15 @@ export interface GetAssetsArgs {
 
 export interface AssetProvider extends Provider {
   /**
-   * @deprecated Use `getAssets` instead
    * @param assetId asset ID (concatenated hex values of policyId + assetName)
-   * @param extraData optional extra data to be provided - nftMetadata, tokenMetadata or history
+   * @param extraData optional extra data to be provided - nftMetadata or tokenMetadata
    * @throws ProviderError
    */
   getAsset: (args: GetAssetArgs) => Promise<Asset.AssetInfo>;
 
   /**
    * @param assetIds asset IDs (concatenated hex values of policyId + assetName)
-   * @param extraData optional extra data to be provided - nftMetadata, tokenMetadata or history
+   * @param extraData optional extra data to be provided - nftMetadata or tokenMetadata
    * @throws ProviderError
    */
   getAssets: (args: GetAssetsArgs) => Promise<Asset.AssetInfo[]>;

--- a/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
@@ -195,7 +195,6 @@ describe('PersonalWallet.assets/nft', () => {
     expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_2_INDEX])).toMatchObject({
       assetId: assetIds[TOKEN_METADATA_2_INDEX],
       fingerprint: fingerprints[TOKEN_METADATA_2_INDEX],
-      mintOrBurnCount: expect.anything(),
       name: assetNames[TOKEN_METADATA_2_INDEX],
       nftMetadata: {
         image: 'ipfs://some_hash1',
@@ -222,7 +221,6 @@ describe('PersonalWallet.assets/nft', () => {
     expect(nfts.find((nft) => nft.assetId === assetIds[TOKEN_METADATA_1_INDEX])).toMatchObject({
       assetId: assetIds[TOKEN_METADATA_1_INDEX],
       fingerprint: fingerprints[TOKEN_METADATA_1_INDEX],
-      mintOrBurnCount: expect.anything(),
       name: assetNames[TOKEN_METADATA_1_INDEX],
       nftMetadata: {
         description: 'NFT with different types of files',
@@ -356,7 +354,6 @@ describe('PersonalWallet.assets/nft', () => {
         expect(nfts.find((nft) => nft.assetId === assetId)).toMatchObject({
           assetId,
           fingerprint,
-          mintOrBurnCount: expect.anything(),
           name: assetNameHex,
           nftMetadata: {
             image: 'ipfs://some_hash1',

--- a/packages/util-dev/src/mockProviders/mockAssetProvider.ts
+++ b/packages/util-dev/src/mockProviders/mockAssetProvider.ts
@@ -4,13 +4,6 @@ import { handleAssetId, handleAssetName, handleFingerprint, handlePolicyId } fro
 export const asset: Asset.AssetInfo = {
   assetId: Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41'),
   fingerprint: Cardano.AssetFingerprint('asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3'),
-  history: [
-    {
-      quantity: 1000n,
-      transactionId: Cardano.TransactionId('886206542d63b23a047864021fbfccf291d78e47c1e59bd4c75fbc67b248c5e8')
-    }
-  ],
-  mintOrBurnCount: 5,
   name: Cardano.AssetName('54534c41'),
   nftMetadata: null,
   policyId: Cardano.PolicyId('7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373'),
@@ -22,7 +15,6 @@ export const asset: Asset.AssetInfo = {
 export const handleAssetInfo: Asset.AssetInfo = {
   assetId: handleAssetId,
   fingerprint: handleFingerprint,
-  mintOrBurnCount: 1,
   name: handleAssetName,
   policyId: handlePolicyId,
   quantity: 1n,

--- a/packages/wallet/test/services/HandlesTracker.test.ts
+++ b/packages/wallet/test/services/HandlesTracker.test.ts
@@ -39,7 +39,6 @@ const expectedHandleInfo: HandleInfo = {
   fingerprint: handleFingerprint,
   handle,
   hasDatum: !!handleOutput.datum,
-  mintOrBurnCount: handleAssetInfo.mintOrBurnCount,
   name: handleAssetName,
   policyId: handlePolicyId,
   quantity: 1n,

--- a/packages/wallet/test/services/ProviderTracker/TrackedAssetProvider.test.ts
+++ b/packages/wallet/test/services/ProviderTracker/TrackedAssetProvider.test.ts
@@ -14,9 +14,6 @@ describe('TrackedAssetProvider', () => {
 
   describe('wraps underlying provider functions, tracks # of calls/responses and resets on stats.reset()', () => {
     const assetId = Cardano.AssetId('b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a76e7574636f696e');
-    const extraData = {
-      history: false
-    };
 
     const testFunctionStats =
       <T>(
@@ -48,9 +45,9 @@ describe('TrackedAssetProvider', () => {
     test(
       'getAsset',
       testFunctionStats(
-        (provider) => provider.getAsset({ assetId, extraData }),
+        (provider) => provider.getAsset({ assetId }),
         (stats) => stats.getAsset$,
-        () => expect(assetProvider.getAsset).toBeCalledWith({ assetId, extraData })
+        () => expect(assetProvider.getAsset).toBeCalledWith({ assetId })
       )
     );
 


### PR DESCRIPTION
# Context

This PR explores using `TypeORM` as an alternative asset provider to `DbSync` and added a CLI option `--use-typeorm-asset-provider` to enable this provider.

# Proposed Solution
Create `TypeormAssetProvider` to resolve asset info and `TypeormNftMetadataService` to fetch NFT metadata and refactor the provider server to use this new provider

# Important Changes Introduced
- remove AssetInfo.mintOrBurnCount and AssetInfo.history some fields from Cardano.AssetInfo [breaking change]
- remove `history` from `extraData` property of `AssetProvider` interface [breaking change]
- add `TypeormAssetProvider`
- add `--use-typeorm-asset-provider `CLI argument
