### PR TITLE
ci/cleanup followup

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -122,7 +122,7 @@ jobs:
     environment:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
-    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == true
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}

--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -7,12 +7,10 @@ on:
 
   pull_request:
     branches:
-      - develop
       - master
 
   push:
     branches:
-      - develop
       - master
 
 env:

--- a/.github/workflows/std-release.yaml
+++ b/.github/workflows/std-release.yaml
@@ -8,4 +8,4 @@ jobs:
   call-std:
     if: startsWith(github.event.release.name, '@cardano-sdk/cardano-services@')
     steps:
-      uses: ./.github/workflows/std.yml
+      - uses: ./.github/workflows/std.yml

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -5,11 +5,9 @@ on:
   workflow_call:
   pull_request:
     branches:
-      - develop
       - master
   push:
     branches:
-      - develop
       - master
 env:
   AWS_REGION: us-east-1

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -111,7 +111,7 @@ jobs:
     environment:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
-    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == true
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}

--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "yants": "yants"
       },
       "locked": {
-        "lastModified": 1692005050,
-        "narHash": "sha256-bFhmzmenx3Y/0eH1qAAZGrmFc3siz0BiAJRptdt2QIQ=",
+        "lastModified": 1692627026,
+        "narHash": "sha256-9t9zsal8sLyDP8QYgUkDynGlFa96VqmauEXPDWojEGk=",
         "owner": "divnix",
         "repo": "std",
-        "rev": "7ace4d2f29cfcde11ca0bbc549ca73c893b8bd98",
+        "rev": "460d53a02f290656926b85d912885496050aa62a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- ci: only deploy on an actual merge to master
- ci: show diff properly and regardless of the deployment actor
- ci: fix oversight; no develop branch here
- ci: fix oversight on release action

# Context

Unduly, the deployment was triggerd on each push to a PR.

Furthermore, with the prior implementation of the kubctl Block Type remote resources deployed via a CI actor wheren't `:diff`-able (and also the diff sometimes didn't work).

# Proposed Solution

This PR implements a filter on the job within the worklow seeking to ensure that the deployment only runs on merge to master.

It also updates `std` incorporating the desired fix and other [minor improvements](https://github.com/divnix/std/compare/9827bd9b8141333086c4a402be3b0643f06b5292...460d53a02f290656926b85d912885496050aa62a).

Two additional trivial fixups where added onto this PR.

# Important Changes Introduced
