### PR TITLE
chore(hardware-trezor): update to dedicated trezor node and web packages [LW-7776]

### DIFF
--- a/packages/hardware-trezor/package.json
+++ b/packages/hardware-trezor/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Mappings and integration with Trezor hardware",
   "engines": {
-    "node": ">=14.20.1"
+    "node": ">=16.20.1"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -63,8 +63,9 @@
     "@cardano-sdk/key-management": "workspace:~",
     "@cardano-sdk/tx-construction": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
+    "@trezor/connect": "9.0.11",
+    "@trezor/connect-web": "9.0.11",
     "lodash": "^4.17.21",
-    "trezor-connect": "8.2.11-extended",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.4"
   },

--- a/packages/hardware-trezor/src/TrezorKeyAgent.ts
+++ b/packages/hardware-trezor/src/TrezorKeyAgent.ts
@@ -1,12 +1,23 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
-import * as Trezor from 'trezor-connect';
-import { Cardano, coreToCml } from '@cardano-sdk/core';
-import { CreateTrezorKeyAgentProps } from '@cardano-sdk/key-management/dist/cjs/TrezorKeyAgent';
-import { TrezorKeyAgent as DeprecatedTrezorKeyAgent, KeyAgentDependencies, errors } from '@cardano-sdk/key-management';
+import * as Trezor from '@trezor/connect';
+import { Cardano, NotImplementedError, coreToCml } from '@cardano-sdk/core';
+import {
+  CardanoKeyConst,
+  CommunicationType,
+  KeyAgentBase,
+  KeyAgentDependencies,
+  KeyAgentType,
+  SerializableTrezorKeyAgentData,
+  SignBlobResult,
+  TrezorConfig,
+  errors
+} from '@cardano-sdk/key-management';
 import { ManagedFreeableScope } from '@cardano-sdk/util';
 import { txToTrezor } from './transformers/tx';
-import TrezorConnect from 'trezor-connect';
+import TrezorConnectWeb from '@trezor/connect-web';
+
+const TrezorConnectNode = Trezor.default;
 
 const transportTypedError = (error?: any) =>
   new errors.AuthenticationError(
@@ -14,24 +25,138 @@ const transportTypedError = (error?: any) =>
     new errors.TransportError('Trezor transport failed', error)
   );
 
-export class TrezorKeyAgent extends DeprecatedTrezorKeyAgent {
+export interface TrezorKeyAgentProps extends Omit<SerializableTrezorKeyAgentData, '__typename'> {
+  isTrezorInitialized?: boolean;
+}
+
+export interface GetTrezorXpubProps {
+  accountIndex: number;
+  communicationType: CommunicationType;
+}
+
+export interface CreateTrezorKeyAgentProps {
+  chainId: Cardano.ChainId;
+  accountIndex?: number;
+  trezorConfig: TrezorConfig;
+}
+
+export type TrezorConnectInstanceType = typeof TrezorConnectNode | typeof TrezorConnectWeb;
+
+const getTrezorConnect = (communicationType: CommunicationType): TrezorConnectInstanceType =>
+  communicationType === CommunicationType.Node ? TrezorConnectNode : TrezorConnectWeb;
+
+export class TrezorKeyAgent extends KeyAgentBase {
+  readonly isTrezorInitialized: Promise<boolean>;
+  readonly #communicationType: CommunicationType;
+
+  constructor({ isTrezorInitialized, ...serializableData }: TrezorKeyAgentProps, dependencies: KeyAgentDependencies) {
+    super({ ...serializableData, __typename: KeyAgentType.Trezor }, dependencies);
+    if (!isTrezorInitialized) {
+      this.isTrezorInitialized = TrezorKeyAgent.initializeTrezorTransport(serializableData.trezorConfig);
+    }
+    this.#communicationType = serializableData.trezorConfig.communicationType;
+  }
+
+  static async initializeTrezorTransport({
+    manifest,
+    communicationType,
+    silentMode = false,
+    lazyLoad = false
+  }: TrezorConfig): Promise<boolean> {
+    const trezorConnect = getTrezorConnect(communicationType);
+    try {
+      await trezorConnect.init({
+        // eslint-disable-next-line max-len
+        // Set to "false" (default) if you want to start communication with bridge on application start (and detect connected device right away)
+        // Set it to "true", then trezor-connect will not be initialized until you call some trezorConnect.method()
+        // This is useful when you don't know if you are dealing with Trezor user
+        lazyLoad: communicationType !== CommunicationType.Node && lazyLoad,
+        // Manifest is required from Trezor Connect 7:
+        // https://github.com/trezor/connect/blob/develop/docs/index.md#trezor-connect-manifest
+        manifest,
+        // Show Trezor Suite popup. Disabled for node based apps
+        popup: communicationType !== CommunicationType.Node && !silentMode
+      });
+      return true;
+    } catch (error: any) {
+      if (error.code === 'Init_AlreadyInitialized') return true;
+      throw transportTypedError(error);
+    }
+  }
+
+  static async checkDeviceConnection(communicationType: CommunicationType): Promise<Trezor.Features> {
+    const trezorConnect = getTrezorConnect(communicationType);
+    try {
+      const deviceFeatures = await trezorConnect.getFeatures();
+      if (!deviceFeatures.success) {
+        throw new errors.TransportError('Failed to get device', deviceFeatures.payload);
+      }
+      if (deviceFeatures.payload.model !== 'T') {
+        throw new errors.TransportError(`Trezor device model "${deviceFeatures.payload.model}" is not supported.`);
+      }
+      return deviceFeatures.payload;
+    } catch (error) {
+      throw transportTypedError(error);
+    }
+  }
+
+  static async getXpub({ accountIndex, communicationType }: GetTrezorXpubProps): Promise<Crypto.Bip32PublicKeyHex> {
+    try {
+      await TrezorKeyAgent.checkDeviceConnection(communicationType);
+      const derivationPath = `m/${CardanoKeyConst.PURPOSE}'/${CardanoKeyConst.COIN_TYPE}'/${accountIndex}'`;
+      const trezorConnect = getTrezorConnect(communicationType);
+      const extendedPublicKey = await trezorConnect.cardanoGetPublicKey({
+        path: derivationPath,
+        showOnTrezor: true
+      });
+      if (!extendedPublicKey.success) {
+        throw new errors.TransportError('Failed to export extended account public key', extendedPublicKey.payload);
+      }
+      return Crypto.Bip32PublicKeyHex(extendedPublicKey.payload.publicKey);
+    } catch (error: any) {
+      throw transportTypedError(error);
+    }
+  }
+
+  static async createWithDevice(
+    { chainId, accountIndex = 0, trezorConfig }: CreateTrezorKeyAgentProps,
+    dependencies: KeyAgentDependencies
+  ) {
+    const isTrezorInitialized = await TrezorKeyAgent.initializeTrezorTransport(trezorConfig);
+    const extendedAccountPublicKey = await TrezorKeyAgent.getXpub({
+      accountIndex,
+      communicationType: trezorConfig.communicationType
+    });
+    return new TrezorKeyAgent(
+      {
+        accountIndex,
+        chainId,
+        extendedAccountPublicKey,
+        isTrezorInitialized,
+        knownAddresses: [],
+        trezorConfig
+      },
+      dependencies
+    );
+  }
+
   /**
    * Gets the mode in which we want to sign the transaction.
    */
-  static getSigningMode(tx: Omit<Trezor.CardanoSignTransaction, 'signingMode'>): Trezor.CardanoTxSigningMode {
+  static getSigningMode(tx: Omit<Trezor.CardanoSignTransaction, 'signingMode'>): Trezor.PROTO.CardanoTxSigningMode {
     if (tx.certificates) {
       for (const cert of tx.certificates) {
         // Represents pool registration from the perspective of a pool owner.
         if (
-          cert.type === Trezor.CardanoCertificateType.STAKE_POOL_REGISTRATION &&
+          cert.type === Trezor.PROTO.CardanoCertificateType.STAKE_POOL_REGISTRATION &&
           cert.poolParameters?.owners.some((owner) => owner.stakingKeyPath)
         )
-          return Trezor.CardanoTxSigningMode.POOL_REGISTRATION_AS_OWNER;
+          return Trezor.PROTO.CardanoTxSigningMode.POOL_REGISTRATION_AS_OWNER;
       }
     }
 
     // Represents an ordinary user transaction transferring funds.
-    return Trezor.CardanoTxSigningMode.ORDINARY_TRANSACTION;
+    return Trezor.PROTO.CardanoTxSigningMode.ORDINARY_TRANSACTION;
   }
 
   async signTransaction(tx: Cardano.TxBodyWithHash): Promise<Cardano.Signatures> {
@@ -50,7 +175,8 @@ export class TrezorKeyAgent extends DeprecatedTrezorKeyAgent {
 
       const signingMode = TrezorKeyAgent.getSigningMode(trezorTxData);
 
-      const result = await TrezorConnect.cardanoSignTransaction({
+      const trezorConnect = getTrezorConnect(this.#communicationType);
+      const result = await trezorConnect.cardanoSignTransaction({
         ...trezorTxData,
         signingMode
       });
@@ -78,25 +204,11 @@ export class TrezorKeyAgent extends DeprecatedTrezorKeyAgent {
     }
   }
 
-  /**
-   * @throws AuthenticationError
-   */
-  static async createWithDevice(
-    { chainId, accountIndex = 0, trezorConfig }: CreateTrezorKeyAgentProps,
-    dependencies: KeyAgentDependencies
-  ) {
-    const isTrezorInitialized = await TrezorKeyAgent.initializeTrezorTransport(trezorConfig);
-    const extendedAccountPublicKey = await TrezorKeyAgent.getXpub({ accountIndex });
-    return new TrezorKeyAgent(
-      {
-        accountIndex,
-        chainId,
-        extendedAccountPublicKey,
-        isTrezorInitialized,
-        knownAddresses: [],
-        trezorConfig
-      },
-      dependencies
-    );
+  async signBlob(): Promise<SignBlobResult> {
+    throw new NotImplementedError('signBlob');
+  }
+
+  async exportRootPrivateKey(): Promise<Crypto.Bip32PrivateKeyHex> {
+    throw new NotImplementedError('Operation not supported!');
   }
 }

--- a/packages/hardware-trezor/src/transformers/additionalWitnessRequests.ts
+++ b/packages/hardware-trezor/src/transformers/additionalWitnessRequests.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { BIP32Path } from '@cardano-sdk/crypto';
 import { TrezorTxTransformerContext } from '../types';
 import { isNotNil } from '@cardano-sdk/util';

--- a/packages/hardware-trezor/src/transformers/assets.ts
+++ b/packages/hardware-trezor/src/transformers/assets.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
 
 const compareAssetNameCanonically = (a: Trezor.CardanoToken, b: Trezor.CardanoToken) => {

--- a/packages/hardware-trezor/src/transformers/auxiliaryData.ts
+++ b/packages/hardware-trezor/src/transformers/auxiliaryData.ts
@@ -1,5 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 
 export const mapAuxiliaryData = (auxiliaryDataHash: Crypto.Hash32ByteBase16): Trezor.CardanoAuxiliaryData => ({
   hash: auxiliaryDataHash

--- a/packages/hardware-trezor/src/transformers/certificates.ts
+++ b/packages/hardware-trezor/src/transformers/certificates.ts
@@ -1,5 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { BIP32Path } from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { GroupedAddress } from '@cardano-sdk/key-management';
@@ -8,8 +8,8 @@ import { TrezorTxTransformerContext } from '../types';
 import { stakeKeyPathFromGroupedAddress } from './keyPaths';
 
 type StakeKeyCertificateType =
-  | Trezor.CardanoCertificateType.STAKE_REGISTRATION
-  | Trezor.CardanoCertificateType.STAKE_DEREGISTRATION;
+  | Trezor.PROTO.CardanoCertificateType.STAKE_REGISTRATION
+  | Trezor.PROTO.CardanoCertificateType.STAKE_DEREGISTRATION;
 
 type TrezorStakeKeyCertificate = {
   type: StakeKeyCertificateType;
@@ -19,7 +19,7 @@ type TrezorStakeKeyCertificate = {
 };
 
 type TrezorDelegationCertificate = {
-  type: Trezor.CardanoCertificateType.STAKE_DELEGATION;
+  type: Trezor.PROTO.CardanoCertificateType.STAKE_DELEGATION;
   path?: BIP32Path;
   scriptHash?: Crypto.Ed25519KeyHashHex;
   pool: string;
@@ -27,7 +27,7 @@ type TrezorDelegationCertificate = {
 
 type TrezorPoolRegistrationCertificate = {
   poolParameters: Trezor.CardanoPoolParameters;
-  type: Trezor.CardanoCertificateType.STAKE_POOL_REGISTRATION;
+  type: Trezor.PROTO.CardanoCertificateType.STAKE_POOL_REGISTRATION;
 };
 
 type ScriptHashCertCredentials = {
@@ -83,7 +83,7 @@ const getStakeDelegationCertificate = (
   return {
     ...credentials,
     pool: poolIdKeyHash,
-    type: Trezor.CardanoCertificateType.STAKE_DELEGATION
+    type: Trezor.PROTO.CardanoCertificateType.STAKE_DELEGATION
   };
 };
 
@@ -128,18 +128,18 @@ export const getPoolRegistrationCertificate = (
               ipv4Address: relay.ipv4,
               ipv6Address: relay.ipv6,
               port: relay.port,
-              type: Trezor.CardanoPoolRelayType.SINGLE_HOST_IP
+              type: Trezor.PROTO.CardanoPoolRelayType.SINGLE_HOST_IP
             };
           case 'RelayByName':
             return {
               hostName: relay.hostname,
               port: relay.port,
-              type: Trezor.CardanoPoolRelayType.SINGLE_HOST_NAME
+              type: Trezor.PROTO.CardanoPoolRelayType.SINGLE_HOST_NAME
             };
           case 'RelayByNameMultihost':
             return {
               hostName: relay.dnsName,
-              type: Trezor.CardanoPoolRelayType.MULTIPLE_HOST_NAME
+              type: Trezor.PROTO.CardanoPoolRelayType.MULTIPLE_HOST_NAME
             };
           default:
             throw new InvalidArgumentError('certificate', 'Unknown relay type.');
@@ -148,16 +148,16 @@ export const getPoolRegistrationCertificate = (
       rewardAccount: certificate.poolParameters.rewardAccount,
       vrfKeyHash: certificate.poolParameters.vrf
     },
-    type: Trezor.CardanoCertificateType.STAKE_POOL_REGISTRATION
+    type: Trezor.PROTO.CardanoCertificateType.STAKE_POOL_REGISTRATION
   };
 };
 
 const toCert = (cert: Cardano.Certificate, context: TrezorTxTransformerContext) => {
   switch (cert.__typename) {
     case Cardano.CertificateType.StakeKeyRegistration:
-      return getStakeAddressCertificate(cert, context, Trezor.CardanoCertificateType.STAKE_REGISTRATION);
+      return getStakeAddressCertificate(cert, context, Trezor.PROTO.CardanoCertificateType.STAKE_REGISTRATION);
     case Cardano.CertificateType.StakeKeyDeregistration:
-      return getStakeAddressCertificate(cert, context, Trezor.CardanoCertificateType.STAKE_DEREGISTRATION);
+      return getStakeAddressCertificate(cert, context, Trezor.PROTO.CardanoCertificateType.STAKE_DEREGISTRATION);
     case Cardano.CertificateType.StakeDelegation:
       return getStakeDelegationCertificate(cert, context);
     case Cardano.CertificateType.PoolRegistration:

--- a/packages/hardware-trezor/src/transformers/tx.ts
+++ b/packages/hardware-trezor/src/transformers/tx.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
 import { TrezorTxTransformerContext } from '../types';
 import { util as deprecatedUtil } from '@cardano-sdk/key-management';

--- a/packages/hardware-trezor/src/transformers/txIn.ts
+++ b/packages/hardware-trezor/src/transformers/txIn.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
 import { Transform } from '@cardano-sdk/util';
 import { TrezorTxTransformerContext } from '../types';

--- a/packages/hardware-trezor/src/transformers/txOut.ts
+++ b/packages/hardware-trezor/src/transformers/txOut.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { InvalidArgumentError, Transform } from '@cardano-sdk/util';
@@ -25,7 +25,7 @@ const toDestination: Transform<Cardano.TxOut, TrezorTxOutputDestination, TrezorT
 
   return {
     addressParameters: {
-      addressType: Trezor.CardanoAddressType.BASE,
+      addressType: Trezor.PROTO.CardanoAddressType.BASE,
       path: paymentPath,
       stakingPath
     }

--- a/packages/hardware-trezor/src/transformers/withdrawals.ts
+++ b/packages/hardware-trezor/src/transformers/withdrawals.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
 import { InvalidArgumentError } from '@cardano-sdk/util';
 import { TrezorTxTransformerContext } from '../types';

--- a/packages/hardware-trezor/src/types.ts
+++ b/packages/hardware-trezor/src/types.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 

--- a/packages/hardware-trezor/test/transformers/certificates.test.ts
+++ b/packages/hardware-trezor/test/transformers/certificates.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
 import { CardanoKeyConst, KeyRole, util } from '@cardano-sdk/key-management';
 import {
@@ -35,7 +35,7 @@ describe('certificates', () => {
               KeyRole.Stake,
               0
             ],
-            type: Trezor.CardanoCertificateType.STAKE_REGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_REGISTRATION
           }
         ]);
       });
@@ -52,7 +52,7 @@ describe('certificates', () => {
               KeyRole.Stake,
               0
             ],
-            type: Trezor.CardanoCertificateType.STAKE_DEREGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DEREGISTRATION
           }
         ]);
       });
@@ -66,7 +66,7 @@ describe('certificates', () => {
         expect(certificates).toEqual([
           {
             keyHash: 'cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f',
-            type: Trezor.CardanoCertificateType.STAKE_REGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_REGISTRATION
           }
         ]);
       });
@@ -80,7 +80,7 @@ describe('certificates', () => {
         expect(certificates).toEqual([
           {
             keyHash: 'cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f',
-            type: Trezor.CardanoCertificateType.STAKE_DEREGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DEREGISTRATION
           }
         ]);
       });
@@ -91,7 +91,7 @@ describe('certificates', () => {
         expect(certificates).toEqual([
           {
             scriptHash: 'cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f',
-            type: Trezor.CardanoCertificateType.STAKE_REGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_REGISTRATION
           }
         ]);
       });
@@ -102,7 +102,7 @@ describe('certificates', () => {
         expect(certificates).toEqual([
           {
             scriptHash: 'cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f',
-            type: Trezor.CardanoCertificateType.STAKE_DEREGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DEREGISTRATION
           }
         ]);
       });
@@ -116,7 +116,7 @@ describe('certificates', () => {
           {
             path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 2, 0],
             pool: '153806dbcd134ddee69a8c5204e38ac80448f62342f8c23cfe4b7edf',
-            type: Trezor.CardanoCertificateType.STAKE_DELEGATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DELEGATION
           }
         ]);
       });
@@ -128,7 +128,7 @@ describe('certificates', () => {
           {
             pool: '153806dbcd134ddee69a8c5204e38ac80448f62342f8c23cfe4b7edf',
             scriptHash: 'cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f',
-            type: Trezor.CardanoCertificateType.STAKE_DELEGATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DELEGATION
           }
         ]);
       });
@@ -140,7 +140,7 @@ describe('certificates', () => {
           {
             keyHash: 'cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f',
             pool: '153806dbcd134ddee69a8c5204e38ac80448f62342f8c23cfe4b7edf',
-            type: Trezor.CardanoCertificateType.STAKE_DELEGATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DELEGATION
           }
         ]);
       });
@@ -192,7 +192,7 @@ describe('certificates', () => {
               rewardAccount: 'stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr',
               vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0'
             },
-            type: Trezor.CardanoCertificateType.STAKE_POOL_REGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_POOL_REGISTRATION
           }
         ]);
       });
@@ -232,7 +232,7 @@ describe('certificates', () => {
               rewardAccount: 'stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr',
               vrfKeyHash: '8dd154228946bd12967c12bedb1cb6038b78f8b84a1760b1a788fa72a4af3db0'
             },
-            type: Trezor.CardanoCertificateType.STAKE_POOL_REGISTRATION
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_POOL_REGISTRATION
           }
         ]);
       });

--- a/packages/hardware-trezor/test/transformers/txOut.test.ts
+++ b/packages/hardware-trezor/test/transformers/txOut.test.ts
@@ -1,4 +1,4 @@
-import * as Trezor from 'trezor-connect';
+import * as Trezor from '@trezor/connect';
 import {
   contextWithKnownAddresses,
   knownAddressKeyPath,
@@ -84,7 +84,7 @@ describe('txOut', () => {
       for (const out of txOuts) {
         expect(out).toEqual({
           addressParameters: {
-            addressType: Trezor.CardanoAddressType.BASE,
+            addressType: Trezor.PROTO.CardanoAddressType.BASE,
             path: knownAddressKeyPath,
             stakingPath: knownAddressStakeKeyPath
           },
@@ -104,7 +104,7 @@ describe('txOut', () => {
       for (const out of txOuts) {
         expect(out).toEqual({
           addressParameters: {
-            addressType: Trezor.CardanoAddressType.BASE,
+            addressType: Trezor.PROTO.CardanoAddressType.BASE,
             path: knownAddressKeyPath,
             stakingPath: knownAddressStakeKeyPath
           },
@@ -204,7 +204,7 @@ describe('txOut', () => {
 
       expect(out).toEqual({
         addressParameters: {
-          addressType: Trezor.CardanoAddressType.BASE,
+          addressType: Trezor.PROTO.CardanoAddressType.BASE,
           path: knownAddressKeyPath,
           stakingPath: knownAddressStakeKeyPath
         },
@@ -217,7 +217,7 @@ describe('txOut', () => {
 
       expect(out).toEqual({
         addressParameters: {
-          addressType: Trezor.CardanoAddressType.BASE,
+          addressType: Trezor.PROTO.CardanoAddressType.BASE,
           path: knownAddressKeyPath,
           stakingPath: knownAddressStakeKeyPath
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,13 +3379,14 @@ __metadata:
     "@cardano-sdk/key-management": "workspace:~"
     "@cardano-sdk/tx-construction": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
+    "@trezor/connect": 9.0.11
+    "@trezor/connect-web": 9.0.11
     eslint: ^7.32.0
     jest: ^28.1.3
     lodash: ^4.17.21
     madge: ^5.0.1
     npm-run-all: ^4.1.5
     shx: ^0.3.3
-    trezor-connect: 8.2.11-extended
     ts-custom-error: ^3.2.0
     ts-jest: ^28.0.7
     ts-log: 2.2.4


### PR DESCRIPTION
# Context

This PR replaces the legacy `trezor-connect` package with `@trezor/connect` and `@trezor/connect-web` and refactors the new `TrezorKeyAgent` in our `hardware-trezor` package to not extend the legacy key agent from the `key-management` package (this made the switch to the new Trezor packages easier)
