### PR TITLE
feat(wallet): active public stake keys tracker support for cip95

### DIFF
--- a/packages/wallet/src/services/ActiveStakePublicKeysTracker.ts
+++ b/packages/wallet/src/services/ActiveStakePublicKeysTracker.ts
@@ -1,0 +1,68 @@
+import { AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
+import { Cardano } from '@cardano-sdk/core';
+import {
+  Observable,
+  OperatorFunction,
+  distinctUntilChanged,
+  filter,
+  from,
+  map,
+  mergeMap,
+  switchMap,
+  toArray
+} from 'rxjs';
+import { TrackerSubject } from '@cardano-sdk/util-rxjs';
+import { deepEquals, isNotNil } from '@cardano-sdk/util';
+
+export interface ActivePubStakeKeysProps {
+  addresses$: Observable<GroupedAddress[]>;
+  rewardAccounts$: Observable<Cardano.RewardAccountInfo[]>;
+  keyAgent: AsyncKeyAgent;
+}
+
+const registeredRewardAccounts: OperatorFunction<Cardano.RewardAccountInfo[], Cardano.RewardAccount[]> = (
+  source$: Observable<Cardano.RewardAccountInfo[]>
+) =>
+  source$.pipe(
+    map((accts: Cardano.RewardAccountInfo[]) =>
+      accts
+        .filter(
+          (acct) =>
+            acct.keyStatus === Cardano.StakeKeyStatus.Registered ||
+            acct.keyStatus === Cardano.StakeKeyStatus.Registering
+        )
+        .map(({ address }) => address)
+    )
+  );
+
+const stakeKeyDerivationPaths =
+  (addresses$: Observable<GroupedAddress[]>) => (source$: Observable<Cardano.RewardAccount[]>) =>
+    source$.pipe(
+      switchMap((rewardAcctAddresses) =>
+        addresses$.pipe(
+          // Get stakeKeyDerivationPath of each reward account
+          map((groupedAddresses) =>
+            rewardAcctAddresses.map(
+              (rewardAddr) =>
+                groupedAddresses.find((groupedAddr) => groupedAddr.rewardAccount === rewardAddr)?.stakeKeyDerivationPath
+            )
+          ),
+          mergeMap((derivationPaths) => from(derivationPaths).pipe(filter(isNotNil), toArray()))
+        )
+      )
+    );
+
+export const createActivePublicStakeKeysTracker = ({
+  addresses$,
+  rewardAccounts$,
+  keyAgent
+}: ActivePubStakeKeysProps) =>
+  new TrackerSubject(
+    rewardAccounts$.pipe(
+      registeredRewardAccounts,
+      stakeKeyDerivationPaths(addresses$),
+      map((derivationPaths) => derivationPaths.map((derivationPath) => keyAgent.derivePublicKey(derivationPath))),
+      mergeMap((publicKeyPromises) => from(Promise.all(publicKeyPromises))),
+      distinctUntilChanged(deepEquals)
+    )
+  );

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,3 +1,4 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import {
   Asset,
   Cardano,
@@ -59,6 +60,7 @@ export interface ObservableWallet {
   readonly currentEpoch$: Observable<EpochInfo>;
   readonly protocolParameters$: Observable<Cardano.ProtocolParameters>;
   readonly addresses$: Observable<GroupedAddress[]>;
+  readonly activePublicStakeKeys$: Observable<Crypto.Ed25519PublicKeyHex[]>;
   readonly handles$: Observable<HandleInfo[]>;
   /** All owned and historical assets */
   readonly assetInfo$: Observable<Assets>;

--- a/packages/wallet/test/PersonalWallet/load.test.ts
+++ b/packages/wallet/test/PersonalWallet/load.test.ts
@@ -56,6 +56,7 @@ const name = 'Test Wallet';
 const address = mocks.utxo[0][0].address!;
 const rewardAccount = mocks.rewardAccount;
 
+const bip32Ed25519 = new Crypto.CmlBip32Ed25519(CML);
 interface Providers {
   rewardsProvider: RewardsProvider;
   utxoProvider: UtxoProvider;
@@ -97,7 +98,7 @@ type CreateWalletProps = {
 
 const createWallet = async (props: CreateWalletProps) => {
   const { wallet } = await setupWallet({
-    bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+    bip32Ed25519,
     createKeyAgent: async (dependencies) => {
       const groupedAddress: GroupedAddress = {
         accountIndex: 0,
@@ -243,6 +244,10 @@ const assertWalletProperties2 = async (wallet: ObservableWallet) => {
   const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
   expect(rewardAccounts).toHaveLength(1);
   expect(rewardAccounts[0].rewardBalance).toBe(mocks.rewardAccountBalance2);
+
+  // activePublicStakeKeys
+  const x = await firstValueFrom(wallet.activePublicStakeKeys$);
+  expect(x.length).toBe(1); // not testing the actual value because the key agent grouped addresses is mocked
 };
 
 /**

--- a/packages/wallet/test/services/ActiveStakePublicKeysTracker.test.ts
+++ b/packages/wallet/test/services/ActiveStakePublicKeysTracker.test.ts
@@ -1,0 +1,163 @@
+import { AccountKeyDerivationPath, AsyncKeyAgent, GroupedAddress, KeyRole } from '@cardano-sdk/key-management';
+import { Cardano } from '@cardano-sdk/core';
+import { ObservableWallet } from '../../src';
+import { createActivePublicStakeKeysTracker } from '../../src/services/ActiveStakePublicKeysTracker';
+import { firstValueFrom, from, lastValueFrom, of, shareReplay, toArray } from 'rxjs';
+import { mockProviders as mocks } from '@cardano-sdk/util-dev';
+
+describe('ActivePublicStakeKeysTracker', () => {
+  let addresses: GroupedAddress[];
+  let rewardAccounts: Cardano.RewardAccountInfo[];
+  let keyAgent: AsyncKeyAgent;
+  let derivePublicKey: jest.Mock;
+
+  /** Assert multiple emissions from stakePubKey$ */
+  const assertEmits = async (
+    stakePubKeys$: ObservableWallet['activePublicStakeKeys$'],
+    expectedEmissions: string[][]
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+  ) => {
+    const publicKeyEmissions = await lastValueFrom(stakePubKeys$.pipe(toArray()));
+    expect(publicKeyEmissions).toEqual(expectedEmissions);
+  };
+
+  beforeEach(() => {
+    addresses = [
+      {
+        rewardAccount: mocks.rewardAccount,
+        stakeKeyDerivationPath: { index: 0, role: KeyRole.Stake }
+      },
+      {
+        rewardAccount: Cardano.RewardAccount('stake_test1upx9faamuf54pm7alg4lna5l7ll08pz833rj45tgr9m2jyceasqjt'),
+        stakeKeyDerivationPath: { index: 1, role: KeyRole.Stake }
+      }
+    ] as GroupedAddress[];
+
+    rewardAccounts = [
+      {
+        address: addresses[0].rewardAccount!,
+        keyStatus: Cardano.StakeKeyStatus.Registered,
+        rewardBalance: 1_000_000n
+      },
+      {
+        address: addresses[1].rewardAccount!,
+        keyStatus: Cardano.StakeKeyStatus.Registered,
+        rewardBalance: 1_000_000n
+      }
+    ];
+
+    derivePublicKey = jest
+      .fn()
+      .mockImplementation((path: AccountKeyDerivationPath) => Promise.resolve(`abc-${path.index}`));
+    keyAgent = {
+      derivePublicKey
+    } as unknown as AsyncKeyAgent;
+  });
+
+  it('empty array when there are no reward accounts', async () => {
+    const addresses$ = of([]);
+    const rewardAccounts$ = of([]);
+
+    const stakePubKeys$ = createActivePublicStakeKeysTracker({
+      addresses$,
+      keyAgent,
+      rewardAccounts$
+    });
+
+    const publicKeys = await firstValueFrom(stakePubKeys$);
+    expect(publicKeys).toEqual([]);
+  });
+
+  it('emits derivation paths for all active keys', async () => {
+    const addresses$ = of(addresses);
+    const rewardAccounts$ = of(rewardAccounts);
+
+    const stakePubKeys$ = createActivePublicStakeKeysTracker({
+      addresses$,
+      keyAgent,
+      rewardAccounts$
+    });
+
+    const publicKeys = await firstValueFrom(stakePubKeys$);
+    expect(publicKeys).toEqual(['abc-0', 'abc-1']);
+    expect(derivePublicKey).toHaveBeenCalledTimes(2);
+    expect(derivePublicKey).toHaveBeenCalledWith(addresses[0].stakeKeyDerivationPath);
+    expect(derivePublicKey).toHaveBeenCalledWith(addresses[1].stakeKeyDerivationPath);
+  });
+
+  it('ignores stake keys that are not registered', async () => {
+    const addresses$ = of(addresses);
+
+    rewardAccounts[0].keyStatus = Cardano.StakeKeyStatus.Unregistered;
+    const rewardAccounts$ = of(rewardAccounts);
+
+    const stakePubKeys$ = createActivePublicStakeKeysTracker({
+      addresses$,
+      keyAgent,
+      rewardAccounts$
+    });
+
+    const publicKeys = await firstValueFrom(stakePubKeys$);
+    expect(publicKeys).toEqual(['abc-1']);
+    expect(derivePublicKey).toHaveBeenCalledTimes(1);
+    expect(derivePublicKey).toHaveBeenCalledWith(addresses[1].stakeKeyDerivationPath);
+  });
+
+  it('ignores reward accounts that are not part of grouped addresses', async () => {
+    addresses[0].rewardAccount = 'something-else' as Cardano.RewardAccount;
+    const addresses$ = of(addresses);
+    const rewardAccounts$ = of(rewardAccounts);
+
+    const stakePubKeys$ = createActivePublicStakeKeysTracker({
+      addresses$,
+      keyAgent,
+      rewardAccounts$
+    });
+
+    const publicKeys = await firstValueFrom(stakePubKeys$);
+    expect(publicKeys).toEqual(['abc-1']);
+    expect(derivePublicKey).toHaveBeenCalledTimes(1);
+    expect(derivePublicKey).toHaveBeenCalledWith(addresses[1].stakeKeyDerivationPath);
+  });
+
+  it('emits when reward accounts change', async () => {
+    const addresses$ = of(addresses);
+    const rewardAccounts$ = from([[rewardAccounts[0]], rewardAccounts]);
+
+    const stakePubKeys$ = createActivePublicStakeKeysTracker({
+      addresses$,
+      keyAgent,
+      rewardAccounts$
+    });
+
+    await assertEmits(stakePubKeys$, [['abc-0'], ['abc-0', 'abc-1']]);
+  });
+
+  it('emits when addresses change', async () => {
+    const addresses$ = from([[addresses[0]], addresses]);
+    const rewardAccounts$ = of(rewardAccounts);
+
+    const stakePubKeys$ = createActivePublicStakeKeysTracker({
+      addresses$,
+      keyAgent,
+      rewardAccounts$
+    });
+
+    await assertEmits(stakePubKeys$, [['abc-0'], ['abc-0', 'abc-1']]);
+  });
+
+  it('does not emit duplicates', async () => {
+    const rewardAccounts$ = from([rewardAccounts, rewardAccounts]);
+    const addresses$ = from([[addresses[0]], addresses, addresses]).pipe(
+      shareReplay({ bufferSize: 1, refCount: true })
+    );
+
+    const stakePubKeys$ = createActivePublicStakeKeysTracker({
+      addresses$,
+      keyAgent,
+      rewardAccounts$
+    });
+
+    await assertEmits(stakePubKeys$, [['abc-0'], ['abc-0', 'abc-1']]);
+  });
+});

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -77,6 +77,7 @@ export const txBuilderProperties: RemoteApiProperties<TxBuilder> = {
 };
 
 export const observableWalletProperties: RemoteApiProperties<ObservableWallet> = {
+  activePublicStakeKeys$: RemoteApiPropertyType.HotObservable,
   addresses$: RemoteApiPropertyType.HotObservable,
   assetInfo$: RemoteApiPropertyType.HotObservable,
   balance: {


### PR DESCRIPTION
Add `ObservableWallet.activePublicStakeKeys$` support.
Will later be used by CIP-95 

# TODO
- [x] e2e test

Below items will be done in a separate PR. This one adds support in ObservableWallet.
- ~~Add web-extension dapp test~~
- ~~integrate with extensions enable work~~
