### PR TITLE
feat: allow extensions for CIP-30 API

### DIFF
--- a/packages/dapp-connector/package.json
+++ b/packages/dapp-connector/package.json
@@ -53,7 +53,9 @@
   },
   "dependencies": {
     "@cardano-sdk/core": "workspace:~",
+    "@cardano-sdk/crypto": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
+    "lodash": "^4.17.21",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.4",
     "webextension-polyfill": "^0.8.0"

--- a/packages/dapp-connector/src/WalletApi/Cip30Wallet.ts
+++ b/packages/dapp-connector/src/WalletApi/Cip30Wallet.ts
@@ -1,7 +1,63 @@
 import { APIErrorCode, ApiError } from '../errors';
+import { Bytes, Cbor, Paginate, WalletApi, WalletApiExtension, WalletMethod } from './types';
+import { Cardano } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
 import { RemoteAuthenticator } from '../AuthenticatorApi';
-import { WalletApi } from './types';
+import uniq from 'lodash/uniq';
+
+export const CipMethodsMapping: Record<number, WalletMethod[]> = {
+  30: [
+    'getNetworkId',
+    'getUtxos',
+    'getCollateral',
+    'getBalance',
+    'getUsedAddresses',
+    'getUnusedAddresses',
+    'getChangeAddress',
+    'getRewardAddresses',
+    'signTx',
+    'signData',
+    'submitTx'
+  ],
+  95: ['getActivePubStakeKeys', 'getPubDRepKey']
+};
+export const WalletApiMethodNames: WalletMethod[] = Object.values(CipMethodsMapping).flat();
+
+/**
+ * Wrap the proxy API object with a regular javascript object to avoid interop issues with some dApps.
+ *
+ * Only return the allowed API methods.
+ */
+const wrapAndEnableApi = (walletApi: WalletApi, allowedApiMethods: WalletMethod[]): WalletApi => {
+  const objectApi: WalletApi = {
+    getActivePubStakeKeys: () => walletApi.getActivePubStakeKeys(),
+    getBalance: () => walletApi.getBalance(),
+    getChangeAddress: () => walletApi.getChangeAddress(),
+    getCollateral: (params?: { amount?: Cbor }) => walletApi.getCollateral(params),
+    getNetworkId: () => walletApi.getNetworkId(),
+    getPubDRepKey: () => walletApi.getPubDRepKey(),
+    getRewardAddresses: () => walletApi.getRewardAddresses(),
+    getUnusedAddresses: () => walletApi.getUnusedAddresses(),
+    getUsedAddresses: (paginate?: Paginate) => walletApi.getUsedAddresses(paginate),
+    getUtxos: (amount?: Cbor, paginate?: Paginate) => walletApi.getUtxos(amount, paginate),
+    signData: (addr: Cardano.PaymentAddress | Bytes, payload: Bytes) => walletApi.signData(addr, payload),
+    signTx: (tx: Cbor, partialSign?: Boolean) => walletApi.signTx(tx, partialSign),
+    submitTx: (tx: Cbor) => walletApi.submitTx(tx)
+  };
+
+  const enabledApi = Object.fromEntries(
+    Object.entries(objectApi).filter(([methodName, _]) => allowedApiMethods.includes(methodName as WalletMethod))
+  );
+
+  // Add experimental.getCollateral to CIP-30 API
+  if (allowedApiMethods.includes('getCollateral')) {
+    enabledApi.experimental = {
+      getCollateral: (params?: { amount?: Cbor }) => walletApi.getCollateral(params)
+    };
+  }
+
+  return enabledApi as WalletApi;
+};
 
 /**
  * CIP30 API version
@@ -28,6 +84,8 @@ export type WalletDependencies = {
   api: WalletApi;
 };
 
+export type Cip30EnableOptions = { extensions: WalletApiExtension[] };
+
 /**
  * CIP-30 wallet that is injected to page
  */
@@ -35,6 +93,7 @@ export class Cip30Wallet {
   readonly apiVersion: ApiVersion = '0.1.0';
   readonly name: WalletName;
   readonly icon: WalletIcon;
+  readonly supportedExtensions: WalletApiExtension[] = [{ cip: 95 }];
 
   readonly #logger: Logger;
   readonly #api: WalletApi;
@@ -48,6 +107,30 @@ export class Cip30Wallet {
     this.#api = api;
     this.#logger = logger;
     this.#authenticator = authenticator;
+  }
+
+  /**
+   * Receives the array of extensions provided when `wallet.enable` was called and
+   * returns a list of methods names for the CIP-30 API and supported extensions.
+   */
+  #getAllowedApiMethods(extensions: WalletApiExtension[] = []): WalletMethod[] {
+    const enabledExtensions: WalletApiExtension[] = extensions.filter((extension) =>
+      this.supportedExtensions.some(({ cip }) => cip === extension.cip)
+    );
+    return uniq([...CipMethodsMapping[30], ...enabledExtensions.flatMap(({ cip }) => CipMethodsMapping[cip])]);
+  }
+
+  #validateExtensions(extensions: WalletApiExtension[] = []): void {
+    if (
+      !Array.isArray(extensions) ||
+      extensions.some(
+        (extension) =>
+          !extension || typeof extension !== 'object' || !extension.cip || Number.isNaN(Number(extension.cip))
+      )
+    ) {
+      this.#logger.debug(`Invalid extensions: ${extensions}`);
+      throw new ApiError(APIErrorCode.InvalidRequest, `invalid extensions ${extensions}`);
+    }
   }
 
   /**
@@ -78,27 +161,14 @@ export class Cip30Wallet {
    *
    * Errors: `ApiError`
    */
-  public async enable(): Promise<WalletApi> {
+  public async enable(options?: Cip30EnableOptions): Promise<WalletApi> {
+    this.#validateExtensions(options?.extensions);
+
     if (await this.#authenticator.requestAccess()) {
       this.#logger.debug(`${location.origin} has been granted access to wallet api`);
-      return this.#api;
+      return wrapAndEnableApi(this.#api, this.#getAllowedApiMethods(options?.extensions));
     }
-
     this.#logger.debug(`${location.origin} not authorized to access wallet api`);
     throw new ApiError(APIErrorCode.Refused, 'wallet not authorized.');
   }
 }
-
-export const WalletApiMethodNames: (keyof WalletApi)[] = [
-  'getNetworkId',
-  'getUtxos',
-  'getCollateral',
-  'getBalance',
-  'getUsedAddresses',
-  'getUnusedAddresses',
-  'getChangeAddress',
-  'getRewardAddresses',
-  'signTx',
-  'signData',
-  'submitTx'
-];

--- a/packages/dapp-connector/src/WalletApi/types.ts
+++ b/packages/dapp-connector/src/WalletApi/types.ts
@@ -1,4 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
+import { Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 
 /**
@@ -159,7 +160,7 @@ export type SignData = (addr: Cardano.PaymentAddress | Bytes, payload: Bytes) =>
  */
 export type SubmitTx = (tx: Cbor) => Promise<string>;
 
-export interface WalletApi {
+export interface Cip30WalletApi {
   getNetworkId: GetNetworkId;
 
   getUtxos: GetUtxos;
@@ -183,4 +184,14 @@ export interface WalletApi {
   submitTx: SubmitTx;
 }
 
+export interface Cip95WalletApi {
+  getActivePubStakeKeys: () => Promise<Ed25519PublicKeyHex[]>;
+
+  getPubDRepKey: () => Promise<Ed25519PublicKeyHex>;
+}
+
+export type WalletApi = Cip30WalletApi & Cip95WalletApi;
+
 export type WalletMethod = keyof WalletApi;
+
+export type WalletApiExtension = { cip: number };

--- a/packages/dapp-connector/test/injectGlobal.test.ts
+++ b/packages/dapp-connector/test/injectGlobal.test.ts
@@ -59,6 +59,7 @@ describe('injectGlobal', () => {
       expect(window.cardano[properties.walletName].icon).toBe(properties.icon);
       expect(Object.keys(window.cardano[properties.walletName])).toEqual([
         'apiVersion',
+        'supportedExtensions',
         'enable',
         'icon',
         'isEnabled',

--- a/packages/dapp-connector/test/testWallet.ts
+++ b/packages/dapp-connector/test/testWallet.ts
@@ -4,10 +4,12 @@ import { RemoteAuthenticator } from '../src';
 import { usingAutoFree } from '@cardano-sdk/util';
 
 export const api = <WalletApi>{
+  getActivePubStakeKeys: async () => ['activePubStakeKey-1', 'activePubStakeKey-2'],
   getBalance: async () => '100',
   getChangeAddress: async () => 'change-address',
   getCollateral: async () => null,
   getNetworkId: async () => 0,
+  getPubDRepKey: async () => 'getPubDRepKey',
   getRewardAddresses: async () => ['reward-address-1', 'reward-address-2'],
   getUnusedAddresses: async () => ['unused-address-1', 'unused-address-2', 'unused-address-3'],
   getUsedAddresses: async () => ['used-address-1', 'used-address-2', 'used-address-3'],
@@ -42,7 +44,7 @@ export const properties: WalletProperties = { icon: 'imagelink', walletName: 'te
 export const stubAuthenticator = () => {
   let isEnabled = false;
   return {
-    haveAccess: async () => isEnabled,
-    requestAccess: async () => (isEnabled = true)
-  } as RemoteAuthenticator;
+    haveAccess: jest.fn().mockImplementation(async () => isEnabled),
+    requestAccess: jest.fn().mockImplementation(async () => (isEnabled = true))
+  } as unknown as RemoteAuthenticator;
 };

--- a/packages/e2e/test/web-extension/extension/stubWalletApi.ts
+++ b/packages/e2e/test/web-extension/extension/stubWalletApi.ts
@@ -1,11 +1,15 @@
 import { Cardano, coreToCml } from '@cardano-sdk/core';
 import { Cip30DataSignature, WalletApi } from '@cardano-sdk/dapp-connector';
+import { Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
 import { usingAutoFree } from '@cardano-sdk/util';
 
 const mapUtxos = (utxos: Cardano.Utxo[]) =>
   usingAutoFree((scope) => coreToCml.utxo(scope, utxos).map((utxo) => Buffer.from(utxo.to_bytes()).toString('hex')));
 
 export const stubWalletApi: WalletApi = {
+  getActivePubStakeKeys: async () => [
+    Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01')
+  ],
   getBalance: async () => '100',
   getChangeAddress: async () =>
     'addr_test1qra788mu4sg8kwd93ns9nfdh3k4ufxwg4xhz2r3n064tzfgxu2hyfhlkwuxupa9d5085eunq2qywy7hvmvej456flkns6cy45x',
@@ -27,6 +31,7 @@ export const stubWalletApi: WalletApi = {
       ]
     ]),
   getNetworkId: async () => 0,
+  getPubDRepKey: async () => Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01'),
   getRewardAddresses: async () => ['stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27'],
   getUnusedAddresses: async () => [],
   getUsedAddresses: async () => [

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -13,7 +13,16 @@ import {
   TxSignErrorCode,
   WalletApi
 } from '@cardano-sdk/dapp-connector';
-import { CML, Cardano, Serialization, TxCBOR, cmlToCore, coalesceValueQuantities, coreToCml } from '@cardano-sdk/core';
+import {
+  CML,
+  Cardano,
+  NotImplementedError,
+  Serialization,
+  TxCBOR,
+  cmlToCore,
+  coalesceValueQuantities,
+  coreToCml
+} from '@cardano-sdk/core';
 import { HexBlob, ManagedFreeableScope, usingAutoFree } from '@cardano-sdk/util';
 import { InputSelectionError, InputSelectionFailure } from '@cardano-sdk/input-selection';
 import { Logger } from 'ts-log';
@@ -244,11 +253,11 @@ const getSortedUtxos = async (observableUtxos: Observable<Cardano.Utxo[]>): Prom
   return utxos.sort(compareUtxos);
 };
 
-export const createWalletApi = (
+const baseCip30WalletApi = (
   wallet$: Observable<ObservableWallet>,
   confirmationCallback: CallbackConfirmation,
   { logger }: Cip30WalletDependencies
-): WalletApi => ({
+) => ({
   getBalance: async (): Promise<Cbor> => {
     logger.debug('getting balance');
     try {
@@ -512,4 +521,23 @@ export const createWalletApi = (
       throw new TxSendError(TxSendErrorCode.Refused, 'transaction refused');
     }
   }
+});
+
+// TODO: implement CIP-95 methods
+const extendedCip95WalletApi = () => ({
+  getActivePubStakeKeys: async () => {
+    throw new NotImplementedError('getActivePubStakeKeys');
+  },
+  getPubDRepKey: async () => {
+    throw new NotImplementedError('getPubDRepKey');
+  }
+});
+
+export const createWalletApi = (
+  wallet$: Observable<ObservableWallet>,
+  confirmationCallback: CallbackConfirmation,
+  { logger }: Cip30WalletDependencies
+): WalletApi => ({
+  ...baseCip30WalletApi(wallet$, confirmationCallback, { logger }),
+  ...extendedCip95WalletApi()
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3170,12 +3170,14 @@ __metadata:
   resolution: "@cardano-sdk/dapp-connector@workspace:packages/dapp-connector"
   dependencies:
     "@cardano-sdk/core": "workspace:~"
+    "@cardano-sdk/crypto": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
     "@types/webextension-polyfill": ^0.8.0
     eslint: ^7.32.0
     jest: ^28.1.3
     jest-environment-jsdom: ^28.1.3
     jest-webextension-mock: ^3.7.19
+    lodash: ^4.17.21
     madge: ^5.0.1
     mock-browser: ^0.92.14
     npm-run-all: ^4.1.5


### PR DESCRIPTION
# Context

As a DApp developer, I want to enable the lace DApp connector with an array of extensions, so I can make use of the extensible DApp connector within my DApp.

# Proposed Solution
- Add CIP-95 as a supported extension
- Add `getActivePubStakeKeys` and `getPubDRepKey` to the `WalletApi` interface (without implementation)
- Add a parameter to the `Cip30Wallet.enable` method to be able to pass an array of extensions according to the CIP-30 specification
- Wrap the `Cip30Wallet.api` as a JS object with the allowed methods depending on the extensions array to make `enable` does not return a `Proxy`