### PR TITLE
feat: add getPubDRepKey to PersonalWallet

### DIFF
--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -32,7 +32,8 @@ export enum KeyAgentType {
 export enum KeyRole {
   External = 0,
   Internal = 1,
-  Stake = 2
+  Stake = 2,
+  DRep = 3
 }
 
 export interface AccountKeyDerivationPath {

--- a/packages/key-management/src/util/key.ts
+++ b/packages/key-management/src/util/key.ts
@@ -8,6 +8,11 @@ export const STAKE_KEY_DERIVATION_PATH: AccountKeyDerivationPath = {
   role: KeyRole.Stake
 };
 
+export const DREP_KEY_DERIVATION_PATH: AccountKeyDerivationPath = {
+  index: 0,
+  role: KeyRole.DRep
+};
+
 export const toEd25519KeyPair = async (
   bip32KeyPair: KeyPair,
   provider: Crypto.Bip32Ed25519

--- a/packages/key-management/test/KeyAgentBase.test.ts
+++ b/packages/key-management/test/KeyAgentBase.test.ts
@@ -128,5 +128,7 @@ describe('KeyAgentBase', () => {
     expect(typeof externalPublicKey).toBe('string');
     const stakePublicKey = await keyAgent.derivePublicKey({ index: 1, role: KeyRole.Stake });
     expect(typeof stakePublicKey).toBe('string');
+    const dRepPublicKey = await keyAgent.derivePublicKey({ index: 0, role: KeyRole.DRep });
+    expect(typeof dRepPublicKey).toBe('string');
   });
 });

--- a/packages/wallet/src/PersonalWallet/PersonalWallet.ts
+++ b/packages/wallet/src/PersonalWallet/PersonalWallet.ts
@@ -64,7 +64,7 @@ import {
   SyncStatus,
   WalletNetworkInfoProvider
 } from '../types';
-import { AsyncKeyAgent, GroupedAddress, cip8 } from '@cardano-sdk/key-management';
+import { AsyncKeyAgent, GroupedAddress, cip8, util as keyManagementUtil } from '@cardano-sdk/key-management';
 import { BehaviorObservable, TrackerSubject, coldObservableProvider } from '@cardano-sdk/util-rxjs';
 import {
   BehaviorSubject,
@@ -91,6 +91,7 @@ import {
   roundRobinRandomImprove
 } from '@cardano-sdk/input-selection';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
+import { Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
 import {
   GenericTxBuilder,
   InitializeTxProps,
@@ -700,5 +701,9 @@ export class PersonalWallet implements ObservableWallet {
         switchMap(() => o$)
       )
     );
+  }
+
+  async getPubDRepKey(): Promise<Ed25519PublicKeyHex> {
+    return this.keyAgent.derivePublicKey(keyManagementUtil.DREP_KEY_DERIVATION_PATH);
   }
 }

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -9,6 +9,7 @@ import {
 } from '@cardano-sdk/core';
 import { BalanceTracker, DelegationTracker, TransactionsTracker, UtxoTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
+import { Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
 import { GroupedAddress, cip8 } from '@cardano-sdk/key-management';
 import { InitializeTxProps, InitializeTxResult, SignedTx, TxBuilder, TxContext } from '@cardano-sdk/tx-construction';
 import { Observable } from 'rxjs';
@@ -70,6 +71,11 @@ export interface ObservableWallet {
   readonly syncStatus: SyncStatus;
 
   getName(): Promise<string>;
+
+  /**
+   * Returns the wallet account's public DRep Key
+   */
+  getPubDRepKey(): Promise<Ed25519PublicKeyHex>;
   /**
    * @deprecated Use `createTxBuilder()` instead.
    * @throws InputSelectionError

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -551,4 +551,9 @@ describe('PersonalWallet methods', () => {
     const response = await wallet.signData({ payload: HexBlob('abc123'), signWith: address });
     expect(response).toHaveProperty('signature');
   });
+
+  it('getPubDRepKey', async () => {
+    const response = await wallet.getPubDRepKey();
+    expect(typeof response).toBe('string');
+  });
 });

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -105,6 +105,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
   finalizeTx: RemoteApiPropertyType.MethodReturningPromise,
   genesisParameters$: RemoteApiPropertyType.HotObservable,
   getName: RemoteApiPropertyType.MethodReturningPromise,
+  getPubDRepKey: RemoteApiPropertyType.MethodReturningPromise,
   handles$: RemoteApiPropertyType.HotObservable,
   initializeTx: RemoteApiPropertyType.MethodReturningPromise,
   protocolParameters$: RemoteApiPropertyType.HotObservable,


### PR DESCRIPTION
# Context
Add support for `DRep` keys introduced in the Conway ledger era

Derivation path: `m / 1852' / 1815' / account' / 3 / address_index`

# Proposed Solution
- Add new `KeyRole.DRep = 3`
- Add `DREP_KEY_DERIVATION_PATH` to `key-management` key util file to be able to derive public DRep keys
- Add new `getPubDRepKey(): Promise<Ed25519PublicKeyHex>` method to `PersonalWallet`
