### PR TITLE
ci: print the current commit sha for auditing in all workflows

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -51,6 +51,12 @@ jobs:
       #   with:
       #     nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
       #     generate_summary_for: job
+
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
+
       - uses: divnix/std-action/discover@main
         with: {ffBuildInstructions: true}
         id: discovery
@@ -74,6 +80,10 @@ jobs:
           ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 
@@ -104,6 +114,10 @@ jobs:
           ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 
@@ -144,7 +158,10 @@ jobs:
         run: |
           echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
           aws eks update-kubeconfig --name "lace-prod-eu-central-1"
-
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         env:
           BRANCH: ${{ github.ref_type == 'branch' && github.head_ref }}
@@ -193,7 +210,10 @@ jobs:
         run: |
           echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
           aws eks update-kubeconfig --name "lace-prod-eu-central-1"
-
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
       

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -37,12 +37,17 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      # TODO: uncomment when nixbuild works well together with
-      #       nix daemon mode on hosted runners
-      # - uses: nixbuild/nixbuild-action@v17
-      #   with:
-      #     nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
-      #     generate_summary_for: job
+      - name: Show commit
+        # TODO: uncomment when nixbuild works well together with
+        #       nix daemon mode on hosted runners
+        # - uses: nixbuild/nixbuild-action@v17
+        #   with:
+        #     nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+        #     generate_summary_for: job
+
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/discover@main
         with: {ffBuildInstructions: true}
         id: discovery
@@ -65,6 +70,10 @@ jobs:
           ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
   images:
@@ -94,6 +103,10 @@ jobs:
           ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           user_name: ${{ env.DISCOVERY_USER_NAME }}
           ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
   diff-to-eu:
@@ -131,6 +144,10 @@ jobs:
         run: |
           echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
           aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         env:
           BRANCH: ${{ github.ref_type == 'branch' && github.head_ref }}
@@ -175,5 +192,9 @@ jobs:
         run: |
           echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
           aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}


### PR DESCRIPTION
# Context

It might be surprising to find out that the HEAD of a feature branch is not representing the same commit as is run during CI.

The reason is GitHubs Merge Queue feature which runs CI on a synthetic commit between a branch and the main branch.

# Proposed Solution

Print out the sha explicitly in every step to facilitate auditing and debugging and avoid false assumptions.

ref: LW-8217
