### PR TITLE
ci: fix compare boolean to its string value

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -166,7 +166,8 @@ jobs:
     environment:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
-    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == true
+    # Boolean input should be compared with string until https://github.com/actions/runner/issues/2238 resolved
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == 'true'
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -150,7 +150,8 @@ jobs:
     environment:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
-    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == true
+    # Boolean input should be compared with string until https://github.com/actions/runner/issues/2238 resolved
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == 'true'
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}


### PR DESCRIPTION
# Context

It turns out a GH quirk (see code comment) makes booleans stringly typed during expression evaluation

# Proposed Solution

Well, follow suit.

# Testing

This cannot really be tested until the next merge to `master`, i.e. when the event predicate evals true (:crossed_fingers: )

ref: LW-8219
