### PR TITLE
ci: fix the deployment run on push to master

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -184,7 +184,10 @@ jobs:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
     # Boolean input should be compared with string until https://github.com/actions/runner/issues/2238 resolved
-    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == 'true'
+    if: >
+      fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/master'
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}

--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -131,7 +131,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-    if: fromJSON(needs.discover.outputs.hits).deployments.diff != '{}'
+    if: fromJSON(needs.discover.outputs.hits).deployments.diff != '{}' && github.event_name == 'pull_request'
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.diff }}
@@ -172,7 +172,7 @@ jobs:
 
   deploy-to-eu:
     <<: *job
-    needs: [discover, diff-to-eu]
+    needs: [discover, images]
     name: ${{ matrix.target.jobName }} (eu-central-1)
     env:
       AWS_REGION: eu-central-1

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -119,7 +119,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-    if: fromJSON(needs.discover.outputs.hits).deployments.diff != '{}'
+    if: fromJSON(needs.discover.outputs.hits).deployments.diff != '{}' && github.event_name == 'pull_request'
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.diff }}
@@ -156,7 +156,7 @@ jobs:
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
   deploy-to-eu:
     runs-on: ubuntu-latest
-    needs: [discover, diff-to-eu]
+    needs: [discover, images]
     name: ${{ matrix.target.jobName }} (eu-central-1)
     env:
       AWS_REGION: eu-central-1

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -168,7 +168,9 @@ jobs:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
     # Boolean input should be compared with string until https://github.com/actions/runner/issues/2238 resolved
-    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event.pull_request.merged == 'true'
+    if: >
+      fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+
     strategy:
       matrix:
         target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}


### PR DESCRIPTION
ref: LW-8230

# Context

When someone directly pushes to master, then there's no branch, and hence no pull request that the gh CLI can infer for the purpose of posting a diff back to the PR as comment.

# Proposed Solution

- Run the diff posting job only when the event type is a PR
- Ensure that deploy runs on master regardless of whether it comes from a PR or not (e.g. a bot release directly pushed to master)

# Testing

To test this, a new direct push to master would need to be made.
