### PR TITLE
LW-7438 Refactor cli providers url

### DIFF
--- a/packages/cardano-services/src/PgBoss/stakePoolMetricsHandler.ts
+++ b/packages/cardano-services/src/PgBoss/stakePoolMetricsHandler.ts
@@ -1,9 +1,16 @@
 import { Cardano, StakePoolProvider } from '@cardano-sdk/core';
-import { CurrentPoolMetricsEntity, StakePoolEntity, StakePoolMetricsUpdateJob } from '@cardano-sdk/projection-typeorm';
+import {
+  CurrentPoolMetricsEntity,
+  STAKE_POOL_METRICS_UPDATE,
+  StakePoolEntity,
+  StakePoolMetricsUpdateJob
+} from '@cardano-sdk/projection-typeorm';
 import { DataSource } from 'typeorm';
 import { Logger } from 'ts-log';
+import { ServiceNames } from '../Program/programs/types';
 import { WorkerHandlerFactory } from './types';
 import { isErrorWithConstraint } from './util';
+import { missingProviderUrlOption } from '../Program/options';
 import { stakePoolHttpProvider } from '@cardano-sdk/cardano-services-client';
 
 interface RefreshPoolMetricsOptions {
@@ -67,6 +74,9 @@ export const refreshPoolMetrics = async (options: RefreshPoolMetricsOptions) => 
 
 export const stakePoolMetricsHandlerFactory: WorkerHandlerFactory = (options) => {
   const { dataSource, logger, stakePoolProviderUrl } = options;
+
+  if (!stakePoolProviderUrl) throw missingProviderUrlOption(STAKE_POOL_METRICS_UPDATE, ServiceNames.StakePool);
+
   const provider = stakePoolHttpProvider({ baseUrl: stakePoolProviderUrl, logger });
 
   return async (data: StakePoolMetricsUpdateJob) => {

--- a/packages/cardano-services/src/PgBoss/types.ts
+++ b/packages/cardano-services/src/PgBoss/types.ts
@@ -1,5 +1,6 @@
 import { DataSource } from 'typeorm';
 import { Logger } from 'ts-log';
+import { PgBossWorkerArgs } from '../Program/services/pgboss';
 import { Pool } from 'pg';
 import { STAKE_POOL_METADATA_QUEUE, STAKE_POOL_METRICS_UPDATE } from '@cardano-sdk/projection-typeorm';
 
@@ -7,12 +8,11 @@ export const workerQueues = [STAKE_POOL_METADATA_QUEUE, STAKE_POOL_METRICS_UPDAT
 
 export type PgBossQueue = typeof workerQueues[number];
 
-export interface WorkerHandlerFactoryOptions {
+export type WorkerHandlerFactoryOptions = {
   dataSource: DataSource;
   db: Pool;
   logger: Logger;
-  stakePoolProviderUrl: string;
-}
+} & PgBossWorkerArgs;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type WorkerHandler = (data: any) => Promise<void>;

--- a/packages/cardano-services/src/Program/options/common.ts
+++ b/packages/cardano-services/src/Program/options/common.ts
@@ -114,6 +114,5 @@ export const withCommonOptions = (command: Command, defaults: { apiUrl: URL }) =
   return command;
 };
 
-export const throwMissingMissingProviderUrlOption = (service: string, provider: ServiceNames) => {
-  throw new MissingProgramOption(service, `${provider} provider URL`);
-};
+export const missingProviderUrlOption = (service: string, provider: ServiceNames) =>
+  new MissingProgramOption(service, `${provider} provider URL`);

--- a/packages/cardano-services/src/Program/programs/pgBossWorker.ts
+++ b/packages/cardano-services/src/Program/programs/pgBossWorker.ts
@@ -1,9 +1,15 @@
-import { CommonProgramOptions, PosgresProgramOptions, PostgresOptionDescriptions } from '../options';
+import {
+  CommonProgramOptions,
+  PosgresProgramOptions,
+  PostgresOptionDescriptions,
+  throwMissingMissingProviderUrlOption
+} from '../options';
 import { HttpServer } from '../../Http/HttpServer';
 import { Logger } from 'ts-log';
 import { MissingProgramOption } from '../errors';
 import { PgBossHttpService, PgBossServiceConfig, PgBossServiceDependencies } from '../services/pgboss';
 import { STAKE_POOL_METRICS_UPDATE } from '@cardano-sdk/projection-typeorm';
+import { ServiceNames } from './types';
 import { SrvRecord } from 'dns';
 import { createDnsResolver } from '../utils';
 import { createLogger } from 'bunyan';
@@ -15,8 +21,7 @@ export const PG_BOSS_WORKER_API_URL_DEFAULT = new URL('http://localhost:3003');
 
 export enum PgBossWorkerOptionDescriptions {
   ParallelJobs = 'Parallel jobs to run',
-  Queues = 'Comma separated queue names',
-  StakePoolProviderUrl = 'Stake pool provider URL'
+  Queues = 'Comma separated queue names'
 }
 
 export type PgBossWorkerArgs = CommonProgramOptions &
@@ -62,7 +67,7 @@ export const loadPgBossWorker = async (args: PgBossWorkerArgs, deps: LoadPgBossW
   if (!db) throw new MissingProgramOption(pgBossWorker, PostgresOptionDescriptions.ConnectionString);
 
   if (args.queues.includes(STAKE_POOL_METRICS_UPDATE) && !args.stakePoolProviderUrl)
-    throw new MissingProgramOption(STAKE_POOL_METRICS_UPDATE, PgBossWorkerOptionDescriptions.StakePoolProviderUrl);
+    throwMissingMissingProviderUrlOption(STAKE_POOL_METRICS_UPDATE, ServiceNames.StakePool);
 
   return new PgBossWorkerHttpServer(args, { connectionConfig$, db, logger });
 };

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -486,11 +486,6 @@ withCommonOptions(
       .argParser((parallelJobs) => Number.parseInt(parallelJobs, 10))
   )
   .addOption(
-    new Option('--stake-pool-provider-url <stakePoolProviderUrl>', PgBossWorkerOptionDescriptions.StakePoolProviderUrl)
-      .env('STAKE_POOL_PROVIDER_URL')
-      .argParser((url) => new URL(url).toString())
-  )
-  .addOption(
     new Option('--queues <queues>', PgBossWorkerOptionDescriptions.Queues)
       .env('QUEUES')
       .argParser((queues) => {

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -60,11 +60,11 @@ import { HttpServer } from './Http';
 import {
   PARALLEL_JOBS_DEFAULT,
   PG_BOSS_WORKER_API_URL_DEFAULT,
-  PgBossWorkerArgs,
   PgBossWorkerOptionDescriptions,
   loadPgBossWorker
 } from './Program/programs/pgBossWorker';
 import { PgBossQueue, isValidQueue } from './PgBoss';
+import { PgBossWorkerArgs } from './Program/services/pgboss';
 import { ProjectionName } from './Projection';
 import { URL } from 'url';
 import { dbCacheValidator } from './util/validators';

--- a/packages/cardano-services/test/Program/services/pgboss.test.ts
+++ b/packages/cardano-services/test/Program/services/pgboss.test.ts
@@ -100,7 +100,10 @@ describe('PgBossHttpService', () => {
   });
 
   it('health check is ok after start with a valid db connection', async () => {
-    service = new PgBossHttpService({ parallelJobs: 3, queues: [] }, { connectionConfig$, db, logger });
+    service = new PgBossHttpService(
+      { apiUrl: new URL('http://unused/'), parallelJobs: 3, queues: [] },
+      { connectionConfig$, db, logger }
+    );
     expect(await service.healthCheck()).toEqual({ ok: false, reason: 'PgBossHttpService not started' });
     await service.initialize();
     await service.start();
@@ -125,7 +128,7 @@ describe('PgBossHttpService', () => {
     });
 
     service = new PgBossHttpService(
-      { parallelJobs: 3, queues: [STAKE_POOL_METADATA_QUEUE] },
+      { apiUrl: new URL('http://unused/'), parallelJobs: 3, queues: [STAKE_POOL_METADATA_QUEUE] },
       { connectionConfig$: config$, db, logger }
     );
     await service.initialize();

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -2605,7 +2605,7 @@ describe('CLI', () => {
       );
       proc.stderr!.on('data', (data) =>
         expect(data.toString()).toMatch(
-          'MissingProgramOption: pool-metrics requires the Stake pool provider URL program option'
+          'MissingProgramOption: pool-metrics requires the stake-pool provider URL program option'
         )
       );
       proc.on('exit', (code) => {

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -2586,7 +2586,6 @@ describe('CLI', () => {
     });
 
     it('exits with code 1 with metrics queue and without a stake pool provider url', (done) => {
-      expect.assertions(2);
       proc = withLogging(
         fork(
           exePath,
@@ -2603,12 +2602,14 @@ describe('CLI', () => {
         ),
         true
       );
-      proc.stderr!.on('data', (data) =>
-        expect(data.toString()).toMatch(
-          'MissingProgramOption: pool-metrics requires the stake-pool provider URL program option'
-        )
-      );
+
+      const chunks: string[] = [];
+
+      proc.stdout!.on('data', (data: Buffer) => chunks.push(data.toString()));
       proc.on('exit', (code) => {
+        expect(chunks.join('')).toMatch(
+          'MissingProgramOption: pool-metrics requires the stake-pool provider URL program option'
+        );
         expect(code).toBe(1);
         done();
       });


### PR DESCRIPTION
# Context

The stake pool rewards job requires the network info provider, so we need to add the network info provider url cli parameter and to propagate it to the job handler.

We had exactly the same problem with the stake pool provider when implementing the stake pool metrics job; in that occasion we introduced the `stakePoolProviderUrl` parameter.

I did this two refactoring rather than _repeating_ what we have for the `stakePoolProviderUrl` parameter to implement the `assetInfoProviderUrl` one; which would have opened the path to an even larger code repetition when adding new provider urls.

# Proposed Solution

- Refactored the `stakePoolProviderUrl` cli parameter into all the provider url parameters.
- Refactored how the configuration is propagated from cli to the job handlers to simply propagate it completely. 

# Important Changes Introduced

The second commit also let us to move the check(s) about the presence of specific provider urls in a more appropriate place.