### PR TITLE
ci: add deploy to preprod on release

### DIFF
--- a/.github/std-unexploded.yml
+++ b/.github/std-unexploded.yml
@@ -168,14 +168,29 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           OWNER_AND_REPO: ${{ github.repository }}
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
-      
 
-  deploy-to-eu:
+  deployments:
+    needs: [discover]
+    name: Perpare deployment data
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+    steps:
+      - name: Group deployment
+        id: group
+        shell: bash
+        run: |
+          dev-preview="$(jq 'map(select(.name == \"dev-preview\"))' <<< ${{ toJSON(fromJSON(needs.discover.outputs.hits).deployments.apply) }})"
+          dev-preprod="$(jq 'map(select(.name == \"dev-preprod\"))' <<< ${{ toJSON(fromJSON(needs.discover.outputs.hits).deployments.apply) }})"
+          printf "%s\n" \
+            "dev-preview=$dev-preview" \
+            "dev-preprod=$dev-preprod" \
+              >> "$GITHUB_OUTPUT"
+
+     
+
+  deploy-dev-preview: &deploy
     <<: *job
-    needs: [discover, images]
-    name: ${{ matrix.target.jobName }} (eu-central-1)
-    env:
-      AWS_REGION: eu-central-1
+    needs: [deployments, images]
+    name: ${{ matrix.target.jobName }}
     permissions:
       id-token: write
       contents: read
@@ -183,26 +198,28 @@ jobs:
     environment:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
-    # Boolean input should be compared with string until https://github.com/actions/runner/issues/2238 resolved
     if: >
-      fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+      needs.deployments.steps.group.dev-preview != '[]'
       && github.event_name == 'push'
       && github.ref == 'refs/heads/master'
     strategy:
       matrix:
-        target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}
+        target: ${{ fromJSON(needs.deployments.outputs.dev-preview) }}
+        region:
+          - eu-central-1
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2.2.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ matrix.region }}
 
       - uses: nixbuild/nix-quick-install-action@v25
       - uses: nixbuild/nixbuild-action@v17
         with:
           nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           generate_summary_for: job
+
       - uses: divnix/std-action/setup-discovery-ssh@main
         with:
           ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -212,13 +229,26 @@ jobs:
       - name: Configure K8S Cluster Access
         shell: bash
         run: |
-          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
-          aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-${{ matrix.region }}'."
+          aws eks update-kubeconfig --name "lace-prod-${{ matrix.region }}"
+
       - name: Show commit
         shell: bash
         run: |
           echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
-      
 
+  deploy-dev-preprod:
+    <<: *deploy
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.deployments.outputs.dev-prod) }}
+        region:
+          - eu-central-1
+    environment:
+      name: dev-preprod
+      url: https://backend.dev-preprod.eks.lw.iog.io
+    if: >
+      needs.deployments.steps.group.dev-preprod != '[]'
+      && github.event_name == 'release'

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -154,12 +154,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           OWNER_AND_REPO: ${{ github.repository }}
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
-  deploy-to-eu:
+  deployments:
+    needs: [discover]
+    name: Perpare deployment data
+    if: fromJSON(needs.discover.outputs.hits).deployments.apply != '{}'
+    steps:
+      - name: Group deployment
+        id: group
+        shell: bash
+        run: |
+          dev-preview="$(jq 'map(select(.name == \"dev-preview\"))' <<< ${{ toJSON(fromJSON(needs.discover.outputs.hits).deployments.apply) }})"
+          dev-preprod="$(jq 'map(select(.name == \"dev-preprod\"))' <<< ${{ toJSON(fromJSON(needs.discover.outputs.hits).deployments.apply) }})"
+          printf "%s\n" \
+            "dev-preview=$dev-preview" \
+            "dev-preprod=$dev-preprod" \
+              >> "$GITHUB_OUTPUT"
+  deploy-dev-preview:
     runs-on: ubuntu-latest
-    needs: [discover, images]
-    name: ${{ matrix.target.jobName }} (eu-central-1)
-    env:
-      AWS_REGION: eu-central-1
+    needs: [deployments, images]
+    name: ${{ matrix.target.jobName }}
     permissions:
       id-token: write
       contents: read
@@ -167,19 +180,20 @@ jobs:
     environment:
       name: dev-preview
       url: https://backend.dev-preview.eks.lw.iog.io
-    # Boolean input should be compared with string until https://github.com/actions/runner/issues/2238 resolved
     if: >
-      fromJSON(needs.discover.outputs.hits).deployments.apply != '{}' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      needs.deployments.steps.group.dev-preview != '[]' && github.event_name == 'push' && github.ref == 'refs/heads/master'
 
     strategy:
       matrix:
-        target: ${{ fromJSON(needs.discover.outputs.hits).deployments.apply }}
+        target: ${{ fromJSON(needs.deployments.outputs.dev-preview) }}
+        region:
+          - eu-central-1
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2.2.0
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ matrix.region }}
       - uses: nixbuild/nix-quick-install-action@v25
       - uses: nixbuild/nixbuild-action@v17
         with:
@@ -193,11 +207,57 @@ jobs:
       - name: Configure K8S Cluster Access
         shell: bash
         run: |
-          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-eu-central-1'."
-          aws eks update-kubeconfig --name "lace-prod-eu-central-1"
+          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-${{ matrix.region }}'."
+          aws eks update-kubeconfig --name "lace-prod-${{ matrix.region }}"
       - name: Show commit
         shell: bash
         run: |
           echo commit: ${{ github.sha }}
       - uses: divnix/std-action/run@main
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
+  deploy-dev-preprod:
+    runs-on: ubuntu-latest
+    needs: [deployments, images]
+    name: ${{ matrix.target.jobName }}
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2.2.0
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ matrix.region }}
+      - uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nixbuild-action@v17
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
+      - uses: divnix/std-action/setup-discovery-ssh@main
+        with:
+          ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          user_name: ${{ env.DISCOVERY_USER_NAME }}
+          ssh_known_hosts_entry: ${{ env.DISCOVERY_KNOWN_HOSTS_ENTRY }}
+      - name: Configure K8S Cluster Access
+        shell: bash
+        run: |
+          echo "Assuming role '$(aws sts get-caller-identity)' in cluster 'lace-prod-${{ matrix.region }}'."
+          aws eks update-kubeconfig --name "lace-prod-${{ matrix.region }}"
+      - name: Show commit
+        shell: bash
+        run: |
+          echo commit: ${{ github.sha }}
+      - uses: divnix/std-action/run@main
+        with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
+    strategy:
+      matrix:
+        target: ${{ fromJSON(needs.deployments.outputs.dev-prod) }}
+        region:
+          - eu-central-1
+    environment:
+      name: dev-preprod
+      url: https://backend.dev-preprod.eks.lw.iog.io
+    if: >
+      needs.deployments.steps.group.dev-preprod != '[]' && github.event_name == 'release'
+

--- a/nix/cardano-services/deployments.nix
+++ b/nix/cardano-services/deployments.nix
@@ -13,9 +13,9 @@ let
       src = ./deployments;
       loader = [(matchers.regex ''^.+\.(yaml|yml)'' loadYaml)];
     };
-in {
+in rec {
   dev-preview = dmerge baseline {
-    meta.description = "Development Environment on the Cardano Preview Chain (Frankfurt)";
+    meta.description = "Development Environment on the Cardano Preview Chain (Frankfurt) for every merge to main branch";
     backend-deployment = {
       spec.template.spec.containers = dmerge.updateOn "name" [
         {
@@ -56,5 +56,9 @@ in {
         }
       ];
     };
+  };
+
+  dev-preprod = dmerge dev-preview {
+    meta.description = "Development Environment on the Cardano Preprod Chain (Frankfurt) for every release";
   };
 }

--- a/nix/cardano-services/deployments.nix
+++ b/nix/cardano-services/deployments.nix
@@ -58,7 +58,183 @@ in rec {
     };
   };
 
-  dev-preprod = dmerge dev-preview {
-    meta.description = "Development Environment on the Cardano Preprod Chain (Frankfurt) for every release";
-  };
+  dev-preprod = let
+    namespace = "dev-preprod";
+    ogmiosServiceName = [
+      {
+        name = "OGMIOS_SRV_SERVICE_NAME";
+        value = "${namespace}-cardano-stack";
+      }
+    ];
+    tokenMetadataServerUrl = [
+      {
+        name = "TOKEN_METADATA_SERVER_URL";
+        value = "http://${namespace}-cardano-stack-metadata";
+      }
+    ];
+    stakePoolProviderUrl = [
+      # Stake Pool service
+      {
+        name = "STAKE_POOL_PROVIDER_URL";
+        value = "https://${namespace}-stake-pool/stake-pool";
+      }
+    ];
+    dbSyncDbAccess = [
+      # DB Sync database access
+      {
+        name = "POSTGRES_HOST_DB_SYNC";
+        value = "${namespace}-dbsync-db";
+      }
+      {
+        name = "POSTGRES_PASSWORD_DB_SYNC";
+        valueFrom.secretKeyRef.name = "cardano-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+      {
+        name = "POSTGRES_USER_DB_SYNC";
+        valueFrom.secretKeyRef.name = "cardano-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+    ];
+    stakePoolDbAccess' = [
+      # Stake Pool database access
+      {
+        name = "POSTGRES_HOST_STAKE_POOL";
+        value = "${namespace}-dbsync-db";
+      }
+      {
+        name = "POSTGRES_PASSWORD_STAKE_POOL";
+        valueFrom.secretKeyRef.name = "stakepool-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+      {
+        name = "POSTGRES_USER_STAKE_POOL";
+        valueFrom.secretKeyRef.name = "stakepool-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+    ];
+    stakePoolDbAccess = [
+      # Stake Pool database access (variant)
+      {
+        name = "POSTGRES_HOST";
+        value = "${namespace}-dbsync-db";
+      }
+      {
+        name = "POSTGRES_PASSWORD";
+        valueFrom.secretKeyRef.name = "stakepool-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+      {
+        name = "POSTGRES_USER";
+        valueFrom.secretKeyRef.name = "stakepool-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+    ];
+    handleDbAccess = [
+      # Stake Pool database access (variant)
+      {
+        name = "POSTGRES_HOST";
+        value = "${namespace}-dbsync-db";
+      }
+      {
+        name = "POSTGRES_PASSWORD";
+        valueFrom.secretKeyRef.name = "handle-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+      {
+        name = "POSTGRES_USER";
+        valueFrom.secretKeyRef.name = "handle-owner-user.${namespace}-dbsync-db.credentials.postgresql.acid.zalan.do";
+      }
+    ];
+  in
+    dmerge dev-preview {
+      meta.description = "Development Environment on the Cardano Preprod Chain (Frankfurt) for every release";
+      kustomization = {
+        namespace = "dev-preprod";
+        namePrefix = "dev-preprod-";
+        commonLabels = {
+          network = "preprod";
+        };
+      };
+
+      # Ingress overlays
+      coingecko-proxy-ingress = {
+        metadata.annotations = {
+          "external-dns.alpha.kubernetes.io/set-identifier" = "eu-central-1-${namespace}-proxy";
+        };
+        spec.rules = dmerge.update [0] [
+          {host = "coingecko.${namespace}.eks.lw.iog.io";}
+        ];
+        spec.tls = dmerge.update [0] [
+          {host = "coingecko.${namespace}.eks.lw.iog.io";}
+        ];
+      };
+      backend-ingress = {
+        metadata.annotations = {
+          "external-dns.alpha.kubernetes.io/set-identifier" = "eu-central-1-${namespace}-backend";
+        };
+        spec.rules = dmerge.update [0] [
+          {host = "backend.${namespace}.eks.lw.iog.io";}
+        ];
+        spec.tls = dmerge.update [0] [
+          {host = "backend.${namespace}.eks.lw.iog.io";}
+        ];
+      };
+
+      # Deployment overlays
+      # # Stake Pool Projector + Provider
+      stake-pool-projector-deployment.spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "stake-pool-projector";
+          env = dmerge.updateOn "name" (
+            ogmiosServiceName
+            ++ stakePoolDbAccess'
+          );
+        }
+      ];
+      stake-pool-provider-deployment.spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "stake-pool-provider";
+          env = dmerge.updateOn "name" (
+            ogmiosServiceName
+            ++ tokenMetadataServerUrl
+            ++ stakePoolDbAccess' # variant
+          );
+        }
+      ];
+      # # Handle Projector + Provider
+      handle-projector-deployment.spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "handle-projector";
+          env = dmerge.updateOn "name" (
+            ogmiosServiceName
+            ++ handleDbAccess
+          );
+        }
+      ];
+      handle-provider-deployment.spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "handle-provider";
+          env = dmerge.updateOn "name" (
+            ogmiosServiceName
+            ++ handleDbAccess
+          );
+        }
+      ];
+      # # Backend (?)
+      backend-deployment.spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "backend";
+          env = dmerge.updateOn "name" (
+            ogmiosServiceName
+            ++ tokenMetadataServerUrl
+            ++ dbSyncDbAccess
+          );
+        }
+      ];
+      # # PgBoss Worker
+      pgboss-deployment.spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "pg-boss-worker";
+          env = dmerge.updateOn "name" (
+            stakePoolProviderUrl
+            ++ dbSyncDbAccess
+            ++ stakePoolDbAccess' # variant
+          );
+        }
+      ];
+    };
 }

--- a/nix/cardano-services/deployments/backend-deployment.yaml
+++ b/nix/cardano-services/deployments/backend-deployment.yaml
@@ -3,22 +3,19 @@ kind: Deployment
 metadata:
   labels:
     app: backend
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-backend
+
+  name: cardanojs-backend
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: backend
-      network: preview
-      release: dev-preview-cardanojs
+
   template:
     metadata:
       labels:
         app: backend
-        network: preview
-        release: dev-preview-cardanojs
+
     spec:
       containers:
         - args:

--- a/nix/cardano-services/deployments/backend-deployment.yaml
+++ b/nix/cardano-services/deployments/backend-deployment.yaml
@@ -27,9 +27,9 @@ spec:
             - name: ALLOWED_ORIGINS
               value: chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk,chrome-extension://efeiemlfnahiidnjglmehaihacglceia
             - name: DISABLE_STAKE_POOL_METRIC_APY
-              value: "true"
+              value: 'true'
             - name: ENABLE_METRICS
-              value: "true"
+              value: 'true'
             - name: HANDLE_POLICY_IDS
               value: f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a
             - name: HANDLE_PROVIDER_SERVER_URL
@@ -41,7 +41,7 @@ spec:
             - name: OGMIOS_SRV_SERVICE_NAME
               value: dev-preview-cardano-stack.dev-preview.svc.cluster.local
             - name: PAGINATION_PAGE_SIZE_LIMIT
-              value: "5500"
+              value: '5500'
             - name: POSTGRES_DB_DB_SYNC
               value: cardano
             - name: POSTGRES_HOST_DB_SYNC
@@ -52,13 +52,13 @@ spec:
                   key: password
                   name: cardano-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
             - name: POSTGRES_POOL_MAX_DB_SYNC
-              value: "50"
+              value: '50'
             - name: POSTGRES_PORT_DB_SYNC
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_SSL_CA_FILE_DB_SYNC
               value: /tls/ca.crt
             - name: POSTGRES_SSL_DB_SYNC
-              value: "true"
+              value: 'true'
             - name: POSTGRES_USER_DB_SYNC
               valueFrom:
                 secretKeyRef:
@@ -69,9 +69,9 @@ spec:
             - name: TOKEN_METADATA_SERVER_URL
               value: http://dev-preview-cardano-stack-metadata.dev-preview.svc.cluster.local
             - name: USE_BLOCKFROST
-              value: "false"
+              value: 'false'
             - name: USE_KORA_LABS
-              value: "true"
+              value: 'true'
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:

--- a/nix/cardano-services/deployments/backend-ingress.yaml
+++ b/nix/cardano-services/deployments/backend-ingress.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   annotations:
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"RedirectConfig":{"Port":"443","Protocol":"HTTPS","StatusCode":"HTTP_301"},"Type":"redirect"}'
-    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "60"
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '60'
     alb.ingress.kubernetes.io/healthcheck-path: /v1.0.0/health
-    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "30"
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '30'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip

--- a/nix/cardano-services/deployments/backend-ingress.yaml
+++ b/nix/cardano-services/deployments/backend-ingress.yaml
@@ -14,9 +14,8 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: eu-central-1-dev-preview-backend
   labels:
     app: backend
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-backend
+
+  name: cardanojs-backend
 spec:
   ingressClassName: alb
   rules:
@@ -32,21 +31,21 @@ spec:
             pathType: Prefix
           - backend:
               service:
-                name: dev-preview-cardanojs-backend
+                name: cardanojs-backend
                 port:
                   name: http
             path: /
             pathType: Prefix
           - backend:
               service:
-                name: dev-preview-cardanojs-stake-pool-provider
+                name: cardanojs-stake-pool-provider
                 port:
                   name: http
             path: /v1.0.0/stake-pool
             pathType: Prefix
           - backend:
               service:
-                name: dev-preview-cardanojs-handle-provider
+                name: cardanojs-handle-provider
                 port:
                   name: http
             path: /v1.0.0/handle

--- a/nix/cardano-services/deployments/backend-service.yaml
+++ b/nix/cardano-services/deployments/backend-service.yaml
@@ -3,9 +3,8 @@ kind: Service
 metadata:
   labels:
     app: backend
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-backend
+
+  name: cardanojs-backend
 spec:
   ports:
     - name: http
@@ -14,5 +13,3 @@ spec:
       targetPort: 3000
   selector:
     app: backend
-    network: preview
-    release: dev-preview-cardanojs

--- a/nix/cardano-services/deployments/coingecko-proxy-deployment.yaml
+++ b/nix/cardano-services/deployments/coingecko-proxy-deployment.yaml
@@ -3,21 +3,18 @@ kind: Deployment
 metadata:
   labels:
     app: coingecko-proxy
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-coingecko-proxy
+
+  name: cardanojs-coingecko-proxy
 spec:
   selector:
     matchLabels:
       app: coingecko-proxy
-      network: preview
-      release: dev-preview-cardanojs
+
   template:
     metadata:
       labels:
         app: coingecko-proxy
-        network: preview
-        release: dev-preview-cardanojs
+
     spec:
       containers:
         - image: 926093910549.dkr.ecr.us-east-1.amazonaws.com/coingecko-proxy:qzydqc9866j6hchxkra7v9a70l19g35x

--- a/nix/cardano-services/deployments/coingecko-proxy-ingress.yaml
+++ b/nix/cardano-services/deployments/coingecko-proxy-ingress.yaml
@@ -11,9 +11,8 @@ metadata:
     external-dns.alpha.kubernetes.io/set-identifier: eu-central-1-dev-preview-proxy
   labels:
     app: coingecko-proxy
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-coingecko-proxy
+
+  name: cardanojs-coingecko-proxy
 spec:
   ingressClassName: alb
   rules:
@@ -29,7 +28,7 @@ spec:
             pathType: Prefix
           - backend:
               service:
-                name: dev-preview-cardanojs-coingecko-proxy
+                name: cardanojs-coingecko-proxy
                 port:
                   name: http
             path: /

--- a/nix/cardano-services/deployments/coingecko-proxy-service.yaml
+++ b/nix/cardano-services/deployments/coingecko-proxy-service.yaml
@@ -3,9 +3,8 @@ kind: Service
 metadata:
   labels:
     app: coingecko-proxy
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-coingecko-proxy
+
+  name: cardanojs-coingecko-proxy
 spec:
   ports:
     - name: http
@@ -14,5 +13,3 @@ spec:
       targetPort: http
   selector:
     app: coingecko-proxy
-    network: preview
-    release: dev-preview-cardanojs

--- a/nix/cardano-services/deployments/handle-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-projector-deployment.yaml
@@ -3,21 +3,18 @@ kind: Deployment
 metadata:
   labels:
     app: handle-projector
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-handle-projector
+
+  name: cardanojs-handle-projector
 spec:
   selector:
     matchLabels:
       app: handle-projector
-      network: preview
-      release: dev-preview-cardanojs
+
   template:
     metadata:
       labels:
         app: handle-projector
-        network: preview
-        release: dev-preview-cardanojs
+
     spec:
       containers:
         - args:

--- a/nix/cardano-services/deployments/handle-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-projector-deployment.yaml
@@ -41,11 +41,11 @@ spec:
                   key: password
                   name: handle-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
             - name: POSTGRES_POOL_MAX
-              value: "2"
+              value: '2'
             - name: POSTGRES_PORT
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_SSL
-              value: "true"
+              value: 'true'
             - name: POSTGRES_SSL_CA_FILE
               value: /tls/ca.crt
             - name: POSTGRES_USER

--- a/nix/cardano-services/deployments/handle-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-provider-deployment.yaml
@@ -26,7 +26,7 @@ spec:
             - name: ALLOWED_ORIGINS
               value: chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk,chrome-extension://efeiemlfnahiidnjglmehaihacglceia
             - name: ENABLE_METRICS
-              value: "true"
+              value: 'true'
             - name: HANDLE_POLICY_IDS
               value: f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a
             - name: HANDLE_PROVIDER_SERVER_URL
@@ -47,11 +47,11 @@ spec:
                   key: password
                   name: handle-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
             - name: POSTGRES_POOL_MAX
-              value: "10"
+              value: '10'
             - name: POSTGRES_PORT
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_SSL
-              value: "true"
+              value: 'true'
             - name: POSTGRES_SSL_CA_FILE
               value: /tls/ca.crt
             - name: POSTGRES_USER
@@ -62,7 +62,7 @@ spec:
             - name: SERVICE_NAMES
               value: handle
             - name: USE_KORA_LABS
-              value: "true"
+              value: 'true'
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:

--- a/nix/cardano-services/deployments/handle-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-provider-deployment.yaml
@@ -3,21 +3,18 @@ kind: Deployment
 metadata:
   labels:
     app: handle-provider
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-handle-provider
+
+  name: cardanojs-handle-provider
 spec:
   selector:
     matchLabels:
       app: handle-provider
-      network: preview
-      release: dev-preview-cardanojs
+
   template:
     metadata:
       labels:
         app: handle-provider
-        network: preview
-        release: dev-preview-cardanojs
+
     spec:
       containers:
         - args:

--- a/nix/cardano-services/deployments/handle-provider-service.yaml
+++ b/nix/cardano-services/deployments/handle-provider-service.yaml
@@ -3,9 +3,8 @@ kind: Service
 metadata:
   labels:
     app: handle-provider
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-handle-provider
+
+  name: cardanojs-handle-provider
 spec:
   ports:
     - name: http
@@ -14,5 +13,3 @@ spec:
       targetPort: 3000
   selector:
     app: handle-provider
-    network: preview
-    release: dev-preview-cardanojs

--- a/nix/cardano-services/deployments/kustomization.yaml
+++ b/nix/cardano-services/deployments/kustomization.yaml
@@ -5,3 +5,6 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: 'true'
 namespace: dev-preview
+namePrefix: dev-preview-
+commonLabels:
+  network: preview

--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -46,21 +46,21 @@ spec:
                   key: password
                   name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
             - name: POSTGRES_POOL_MAX_DB_SYNC
-              value: "5"
+              value: '5'
             - name: POSTGRES_POOL_MAX_STAKE_POOL
-              value: "5"
+              value: '5'
             - name: POSTGRES_PORT_DB_SYNC
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_PORT_STAKE_POOL
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_SSL_CA_FILE_DB_SYNC
               value: /tls/ca.crt
             - name: POSTGRES_SSL_CA_FILE_STAKE_POOL
               value: /tls/ca.crt
             - name: POSTGRES_SSL_DB_SYNC
-              value: "true"
+              value: 'true'
             - name: POSTGRES_SSL_STAKE_POOL
-              value: "true"
+              value: 'true'
             - name: POSTGRES_USER_DB_SYNC
               valueFrom:
                 secretKeyRef:

--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -3,21 +3,18 @@ kind: Deployment
 metadata:
   labels:
     app: pg-boss-worker
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-pg-boss-worker
+
+  name: cardanojs-pg-boss-worker
 spec:
   selector:
     matchLabels:
       app: pg-boss-worker
-      network: preview
-      release: dev-preview-cardanojs
+
   template:
     metadata:
       labels:
         app: pg-boss-worker
-        network: preview
-        release: dev-preview-cardanojs
+
     spec:
       containers:
         - args:

--- a/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
@@ -39,11 +39,11 @@ spec:
                   key: password
                   name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
             - name: POSTGRES_POOL_MAX
-              value: "2"
+              value: '2'
             - name: POSTGRES_PORT
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_SSL
-              value: "true"
+              value: 'true'
             - name: POSTGRES_SSL_CA_FILE
               value: /tls/ca.crt
             - name: POSTGRES_USER

--- a/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
@@ -3,21 +3,18 @@ kind: Deployment
 metadata:
   labels:
     app: stake-pool-projector
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-stake-pool-projector
+
+  name: cardanojs-stake-pool-projector
 spec:
   selector:
     matchLabels:
       app: stake-pool-projector
-      network: preview
-      release: dev-preview-cardanojs
+
   template:
     metadata:
       labels:
         app: stake-pool-projector
-        network: preview
-        release: dev-preview-cardanojs
+
     spec:
       containers:
         - args:

--- a/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
@@ -26,9 +26,9 @@ spec:
             - name: ALLOWED_ORIGINS
               value: chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk,chrome-extension://efeiemlfnahiidnjglmehaihacglceia
             - name: DISABLE_STAKE_POOL_METRIC_APY
-              value: "true"
+              value: 'true'
             - name: ENABLE_METRICS
-              value: "true"
+              value: 'true'
             - name: LOGGER_MIN_SEVERITY
               value: debug
             - name: NETWORK
@@ -36,7 +36,7 @@ spec:
             - name: OGMIOS_SRV_SERVICE_NAME
               value: dev-preview-cardano-stack.dev-preview.svc.cluster.local
             - name: PAGINATION_PAGE_SIZE_LIMIT
-              value: "5500"
+              value: '5500'
             - name: POSTGRES_DB_STAKE_POOL
               value: stakepool
             - name: POSTGRES_HOST_STAKE_POOL
@@ -47,13 +47,13 @@ spec:
                   key: password
                   name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
             - name: POSTGRES_POOL_MAX_STAKE_POOL
-              value: "10"
+              value: '10'
             - name: POSTGRES_PORT_STAKE_POOL
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_SSL_CA_FILE_STAKE_POOL
               value: /tls/ca.crt
             - name: POSTGRES_SSL_STAKE_POOL
-              value: "true"
+              value: 'true'
             - name: POSTGRES_USER_STAKE_POOL
               valueFrom:
                 secretKeyRef:
@@ -64,7 +64,7 @@ spec:
             - name: TOKEN_METADATA_SERVER_URL
               value: http://dev-preview-cardano-stack-metadata.dev-preview.svc.cluster.local
             - name: USE_TYPEORM_STAKE_POOL_PROVIDER
-              value: "true"
+              value: 'true'
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:

--- a/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
@@ -3,21 +3,18 @@ kind: Deployment
 metadata:
   labels:
     app: stake-pool-provider
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-stake-pool-provider
+
+  name: cardanojs-stake-pool-provider
 spec:
   selector:
     matchLabels:
       app: stake-pool-provider
-      network: preview
-      release: dev-preview-cardanojs
+
   template:
     metadata:
       labels:
         app: stake-pool-provider
-        network: preview
-        release: dev-preview-cardanojs
+
     spec:
       containers:
         - args:

--- a/nix/cardano-services/deployments/stake-pool-provider-service.yaml
+++ b/nix/cardano-services/deployments/stake-pool-provider-service.yaml
@@ -3,9 +3,8 @@ kind: Service
 metadata:
   labels:
     app: stake-pool-provider
-    network: preview
-    release: dev-preview-cardanojs
-  name: dev-preview-cardanojs-stake-pool-provider
+
+  name: cardanojs-stake-pool-provider
 spec:
   ports:
     - name: http
@@ -14,5 +13,3 @@ spec:
       targetPort: 3000
   selector:
     app: stake-pool-provider
-    network: preview
-    release: dev-preview-cardanojs


### PR DESCRIPTION
ref: LW-8119

WIP: this implementation also depends on corresponding changes to the cluster RBACs.

# Context

After our CD-to-`dev-preview` pipeline is working in principle, it's time to evaluate how it can be extended.

The immediate increment would be "deploy to `dev-preprod` automatically on every release".

# Proposed Solution

- This PR prototypes this capability in the GitHub Actions
- It also speccs out `dev-preprod` with a mix of `kustomize` and `dmerge` (for the cases not covered by stock `kustomize`) overlay approaches

# Testing

Unfortunately, final testing can only be done in the real scenario (e.g. during the next release cycle).

Therefore, special care is necessary during the review to reduce the need for fixups.
