### PR TITLE
Feat/lw 7585 implement serialization of witness set

### DIFF
--- a/packages/core/src/Serialization/TransactionWitnessSet/BootstrapWitness.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/BootstrapWitness.ts
@@ -1,0 +1,221 @@
+import * as Cardano from '../../Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
+import { Base64Blob, HexBlob, InvalidArgumentError, InvalidStateError } from '@cardano-sdk/util';
+import { CborReader, CborWriter } from '../CBOR';
+import { hexToBytes } from '../../util/misc';
+
+const BOOTSTRAP_WITNESS_ARRAY_SIZE = 4;
+const EMPTY_ATTRIBUTES_CBOR = HexBlob('a0');
+
+/**
+ * The bootstrap witness proves that the transaction has the authority to spend
+ * the value from the associated Byron-era input UTxOs.
+ *
+ * Cardano has transitioned away from this type of witness from Shelley and later eras, BootstrapWitnesses
+ * are currently deprecated.
+ */
+export class BootstrapWitness {
+  #vkey: Crypto.Ed25519PublicKeyHex;
+  #signature: Crypto.Ed25519SignatureHex;
+  #chainCode: HexBlob;
+  #attributes: HexBlob;
+  #originalBytes: HexBlob | undefined = undefined;
+
+  /**
+   * Initializes a new instance of the BootstrapWitness class.
+   *
+   * @param vkey This is the public counterpart to the private key (SKey). It's used to verify the signature.
+   * @param signature This is a cryptographic signature produced by signing the hash of the transaction body with
+   * the corresponding private key (SKey). Anyone can verify this signature using the provided VKey,
+   * ensuring that the transaction was authorized by the holder of the private key.
+   * @param chainCode The chain code is used to compute HD (Hierarchical Deterministic) wallet addresses in the Byron era.
+   * @param attributes Additional attributes that are used for network discrimination.
+   */
+  constructor(
+    vkey: Crypto.Ed25519PublicKeyHex,
+    signature: Crypto.Ed25519SignatureHex,
+    chainCode: HexBlob,
+    attributes: HexBlob
+  ) {
+    this.#vkey = vkey;
+    this.#signature = signature;
+    this.#chainCode = chainCode;
+    this.#attributes = attributes;
+  }
+
+  /**
+   * Serializes a BootstrapWitness into CBOR format.
+   *
+   * @returns The BootstrapWitness in CBOR format.
+   */
+  toCbor(): HexBlob {
+    const writer = new CborWriter();
+
+    if (this.#originalBytes) return this.#originalBytes;
+
+    if (this.#chainCode.length / 2 !== 32)
+      throw new InvalidStateError(`Chaincode must be 32 bytes long, but got ${this.#chainCode.length / 2} bytes long`);
+
+    // CDDL
+    // bootstrap_witness =
+    //   [ public_key : $vkey
+    //   , signature  : $signature
+    //   , chain_code : bytes .size 32
+    //   , attributes : bytes
+    //   ]
+    writer.writeStartArray(BOOTSTRAP_WITNESS_ARRAY_SIZE);
+    writer.writeByteString(hexToBytes(this.#vkey as unknown as HexBlob));
+    writer.writeByteString(hexToBytes(this.#signature as unknown as HexBlob));
+    writer.writeByteString(hexToBytes(this.#chainCode));
+    writer.writeByteString(hexToBytes(this.#attributes));
+
+    return writer.encodeAsHex();
+  }
+
+  /**
+   * Deserializes the BootstrapWitness from a CBOR byte array.
+   *
+   * @param cbor The CBOR encoded BootstrapWitness object.
+   * @returns The new BootstrapWitness instance.
+   */
+  static fromCbor(cbor: HexBlob): BootstrapWitness {
+    const reader = new CborReader(cbor);
+
+    const length = reader.readStartArray();
+
+    if (length !== BOOTSTRAP_WITNESS_ARRAY_SIZE)
+      throw new InvalidArgumentError(
+        'cbor',
+        `Expected an array of ${BOOTSTRAP_WITNESS_ARRAY_SIZE} elements, but got an array of ${length} elements`
+      );
+
+    const vkey = HexBlob.fromBytes(reader.readByteString()) as unknown as Crypto.Ed25519PublicKeyHex;
+    const signature = HexBlob.fromBytes(reader.readByteString()) as unknown as Crypto.Ed25519SignatureHex;
+    const chainCode = HexBlob.fromBytes(reader.readByteString());
+    const attributes = HexBlob.fromBytes(reader.readByteString());
+
+    reader.readEndArray();
+
+    const witness = new BootstrapWitness(vkey, signature, chainCode, attributes);
+    witness.#originalBytes = cbor;
+
+    return witness;
+  }
+
+  /**
+   * Creates a core BootstrapWitness from the BootstrapWitness object.
+   *
+   * @returns The core BootstrapWitness.
+   */
+  toCore(): Cardano.BootstrapWitness {
+    return {
+      addressAttributes: Base64Blob.fromBytes(hexToBytes(this.#attributes)),
+      chainCode: this.#chainCode,
+      key: this.#vkey,
+      signature: this.#signature
+    };
+  }
+
+  /**
+   * Creates a BootstrapWitness object from a core BootstrapWitness.
+   *
+   * @param core A core BootstrapWitness object.
+   */
+  static fromCore(core: Cardano.BootstrapWitness) {
+    // REMARK: there is a quirk with our BootstrapWitness core type related to Ogmios, some fields are mark as optional,
+    // however all fields are required. See https://github.com/CardanoSolutions/ogmios/discussions/285#discussioncomment-4271726.
+    // If chainCode is not present or is not the right size we will throw.
+    // If addressAttributes is not present we will serialize it as an empty byte string.
+
+    if (!core.chainCode) throw new InvalidStateError('Chaincode must be present');
+
+    if (core.chainCode.length / 2 !== 32)
+      throw new InvalidStateError(`Chaincode must be 32 bytes long, but got ${core.chainCode.length / 2} bytes long`);
+
+    return new BootstrapWitness(
+      core.key,
+      core.signature,
+      core.chainCode,
+      core.addressAttributes ? HexBlob.fromBase64(core.addressAttributes) : EMPTY_ATTRIBUTES_CBOR
+    );
+  }
+
+  /**
+   * Gets the public key associated with the provided signature.
+   *
+   * @returns The public key.
+   */
+  vkey(): Crypto.Ed25519PublicKeyHex {
+    return this.#vkey;
+  }
+
+  /**
+   * Sets the public key associated with the provided signature.
+   *
+   * @param vkey The public key.
+   */
+  setVkey(vkey: Crypto.Ed25519PublicKeyHex) {
+    this.#vkey = vkey;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets transaction body signature computed with the private counterpart to the public key (VKey).
+   *
+   * @returns The Ed25519 signature.
+   */
+  signature(): Crypto.Ed25519SignatureHex {
+    return this.#signature;
+  }
+
+  /**
+   * Sets the transaction body signature computed with the private counterpart to the public key (VKey).
+   *
+   * @param signature The Ed25519 signature.
+   */
+  setSignature(signature: Crypto.Ed25519SignatureHex) {
+    this.#signature = signature;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the chaincode of this bootstrap witness.
+   *
+   * @returns The chain code.
+   */
+  chainCode(): HexBlob {
+    return this.#chainCode;
+  }
+
+  /**
+   * Sets the chaincode of this bootstrap witness.
+   *
+   * @param chainCode The chain code.
+   */
+  setChainCode(chainCode: HexBlob) {
+    if (chainCode.length / 2 !== 32)
+      throw new InvalidStateError(`Chaincode must be 32 bytes long, but got ${chainCode.length / 2} bytes long`);
+
+    this.#chainCode = chainCode;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the attributes of this bootstrap witness.
+   *
+   * @returns The attributes.
+   */
+  attributes(): HexBlob {
+    return this.#attributes;
+  }
+
+  /**
+   * Sets the attributes of this bootstrap witness.
+   *
+   * @param attributes The attributes.
+   */
+  setAttributes(attributes: HexBlob) {
+    this.#attributes = attributes;
+    this.#originalBytes = undefined;
+  }
+}

--- a/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/Redeemer.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/Redeemer.ts
@@ -1,0 +1,234 @@
+import * as Cardano from '../../../Cardano';
+import { CborReader, CborWriter } from '../../CBOR';
+import { ExUnits } from '../../Common';
+import { HexBlob, InvalidArgumentError, InvalidStateError } from '@cardano-sdk/util';
+import { PlutusData } from '../../PlutusData';
+import { RedeemerTag } from './RedeemerTag';
+import { hexToBytes } from '../../../util/misc';
+
+const REDEEMER_ARRAY_SIZE = 4;
+
+/**
+ * The Redeemer is an argument provided to a Plutus smart contract (script) when
+ * you are attempting to redeem a UTxO that's protected by that script.
+ */
+export class Redeemer {
+  #tag: RedeemerTag;
+  #index: bigint;
+  #data: PlutusData;
+  #exUnits: ExUnits;
+  #originalBytes: HexBlob | undefined = undefined;
+
+  /**
+   * Initializes a new instance of the Redeemer class.
+   *
+   * @param tag a tag that specifies the purpose of the redeemer in the transaction.
+   * @param index The index of the transaction input this redeemer is intended for. The transaction inputs
+   * are indexed in the map order by their transaction id.
+   * @param data The data that will be provided as an argument to the plutus script.
+   * @param exUnits The computational resources required to execute the Plutus script on the UTxO this redeemer is intended for.
+   */
+  constructor(tag: RedeemerTag, index: bigint, data: PlutusData, exUnits: ExUnits) {
+    this.#tag = tag;
+    this.#index = index;
+    this.#data = data;
+    this.#exUnits = exUnits;
+  }
+
+  /**
+   * Serializes a Redeemer into CBOR format.
+   *
+   * @returns The Redeemer in CBOR format.
+   */
+  toCbor(): HexBlob {
+    const writer = new CborWriter();
+
+    if (this.#originalBytes) return this.#originalBytes;
+
+    // CDDL
+    // redeemer = [ tag: redeemer_tag, index: uint, data: plutus_data, ex_units: ex_units ]
+    writer.writeStartArray(REDEEMER_ARRAY_SIZE);
+    writer.writeInt(this.#tag);
+    writer.writeInt(this.#index);
+    writer.writeEncodedValue(hexToBytes(this.#data.toCbor()));
+    writer.writeEncodedValue(hexToBytes(this.#exUnits.toCbor()));
+
+    return writer.encodeAsHex();
+  }
+
+  /**
+   * Deserializes the Redeemer from a CBOR byte array.
+   *
+   * @param cbor The CBOR encoded Redeemer object.
+   * @returns The new Redeemer instance.
+   */
+  static fromCbor(cbor: HexBlob): Redeemer {
+    const reader = new CborReader(cbor);
+
+    const length = reader.readStartArray();
+
+    if (length !== REDEEMER_ARRAY_SIZE)
+      throw new InvalidArgumentError(
+        'cbor',
+        `Expected an array of ${REDEEMER_ARRAY_SIZE} elements, but got an array of ${length} elements`
+      );
+
+    const tag = Number(reader.readUInt()) as RedeemerTag;
+    const index = reader.readUInt();
+    const data = PlutusData.fromCbor(HexBlob.fromBytes(reader.readEncodedValue()));
+    const exUnits = ExUnits.fromCbor(HexBlob.fromBytes(reader.readEncodedValue()));
+
+    reader.readEndArray();
+
+    const redeemer = new Redeemer(tag, index, data, exUnits);
+    redeemer.#originalBytes = cbor;
+
+    return redeemer;
+  }
+
+  /**
+   * Creates a Core Redeemer object from the current Redeemer object.
+   *
+   * @returns The Core Redeemer object.
+   */
+  toCore(): Cardano.Redeemer {
+    let purpose: Cardano.RedeemerPurpose;
+
+    switch (this.#tag) {
+      case RedeemerTag.Spend:
+        purpose = Cardano.RedeemerPurpose.spend;
+        break;
+      case RedeemerTag.Mint:
+        purpose = Cardano.RedeemerPurpose.mint;
+        break;
+      case RedeemerTag.Cert:
+        purpose = Cardano.RedeemerPurpose.certificate;
+        break;
+      case RedeemerTag.Reward:
+        purpose = Cardano.RedeemerPurpose.withdrawal;
+        break;
+      default:
+        throw new InvalidStateError(`Invalid redeemer type ${this.#tag}`);
+    }
+
+    return {
+      data: this.#data.toCore(),
+      executionUnits: this.#exUnits.toCore(),
+      index: Number(this.#index),
+      purpose
+    };
+  }
+
+  /**
+   * Creates a Redeemer object from the given Core Redeemer object.
+   *
+   * @param redeemer core Redeemer object.
+   */
+  static fromCore(redeemer: Cardano.Redeemer) {
+    let tag: RedeemerTag;
+
+    switch (redeemer.purpose) {
+      case Cardano.RedeemerPurpose.spend:
+        tag = RedeemerTag.Spend;
+        break;
+      case Cardano.RedeemerPurpose.mint:
+        tag = RedeemerTag.Mint;
+        break;
+      case Cardano.RedeemerPurpose.certificate:
+        tag = RedeemerTag.Cert;
+        break;
+      case Cardano.RedeemerPurpose.withdrawal:
+        tag = RedeemerTag.Reward;
+        break;
+      default:
+        throw new InvalidStateError(`Invalid redeemer type ${redeemer.purpose}`);
+    }
+
+    return new Redeemer(
+      tag,
+      BigInt(redeemer.index),
+      PlutusData.fromCore(redeemer.data),
+      ExUnits.fromCore(redeemer.executionUnits)
+    );
+  }
+
+  /**
+   * Gets the tag that specifies the purpose of the redeemer in the transaction.
+   *
+   * @returns The tag with the purpose.
+   */
+  tag(): RedeemerTag {
+    return this.#tag;
+  }
+
+  /**
+   * Sets the tag that specifies the purpose of the redeemer in the transaction.
+   *
+   * @param tag The tag with the purpose.
+   */
+  setTag(tag: RedeemerTag) {
+    this.#tag = tag;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the index of the transaction input this redeemer is intended for.
+   *
+   * @returns The index of the transaction input (the transaction inputs are indexed in the map order
+   * by their transaction id)
+   */
+  index(): bigint {
+    return this.#index;
+  }
+
+  /**
+   * Sets the index of the transaction input this redeemer is intended for.
+   *
+   * @param index The index of the transaction input (the transaction inputs are indexed in the map order
+   * by their transaction id)
+   */
+  setIndex(index: bigint) {
+    this.#index = index;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the data that will be provided as an argument to the plutus script.
+   *
+   * @returns The plutus data.
+   */
+  data(): PlutusData {
+    return this.#data;
+  }
+
+  /**
+   * Sets the data that will be provided as an argument to the plutus script.
+   *
+   * @param data The plutus data.
+   */
+  setData(data: PlutusData) {
+    this.#data = data;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the computational resources required to execute a Plutus script on the
+   * UTxO this redeemer is intended for.
+   *
+   * @returns The computational resources required to execute the Plutus script.
+   */
+  exUnits(): ExUnits {
+    return this.#exUnits;
+  }
+
+  /**
+   * Sets the computational resources required to execute a Plutus script on the
+   * UTxO this redeemer is intended for.
+   *
+   * @param exUnits The computational resources required to execute the Plutus script.
+   */
+  setExUnits(exUnits: ExUnits) {
+    this.#exUnits = exUnits;
+    this.#originalBytes = undefined;
+  }
+}

--- a/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/RedeemerTag.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/RedeemerTag.ts
@@ -1,0 +1,24 @@
+/**
+ * The redeemer tags act as an enumeration to signify the purpose or context of the
+ * redeemer in a transaction. When a Plutus script is executed, the specific action
+ * type related to the redeemer can be identified using these tags, allowing the
+ * script to respond appropriately.
+ */
+export enum RedeemerTag {
+  /**
+   * Indicates the redeemer is for spending a UTxO.
+   */
+  Spend = 0,
+  /**
+   * Indicates the redeemer is associated with a minting action.
+   */
+  Mint = 1,
+  /**
+   * Indicates the redeemer is related to a certificate action within a transaction.
+   */
+  Cert = 2,
+  /**
+   * Indicates the redeemer is for withdrawing rewards from staking.
+   */
+  Reward = 3
+}

--- a/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/index.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/index.ts
@@ -1,0 +1,2 @@
+export * from './RedeemerTag';
+export * from './Redeemer';

--- a/packages/core/src/Serialization/TransactionWitnessSet/TransactionWitnessSet.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/TransactionWitnessSet.ts
@@ -1,0 +1,483 @@
+/* eslint-disable sonarjs/cognitive-complexity, complexity, max-statements */
+
+import * as Cardano from '../../Cardano';
+import { BootstrapWitness } from './BootstrapWitness';
+import { CborReader, CborReaderState, CborWriter } from '../CBOR';
+import { HexBlob } from '@cardano-sdk/util';
+import { NativeScript, PlutusV1Script, PlutusV2Script } from '../Scripts';
+import { PlutusData } from '../PlutusData/PlutusData';
+import { Redeemer } from './Redeemer';
+import { SerializationError, SerializationFailure } from '../../errors';
+import { VkeyWitness } from './VkeyWitness';
+import uniqWith from 'lodash/uniqWith';
+
+/**
+ * This type represents the segregated CDDL scripts.
+ */
+type CddlScripts = {
+  native: Array<NativeScript> | undefined;
+  plutusV1: Array<PlutusV1Script> | undefined;
+  plutusV2: Array<PlutusV2Script> | undefined;
+};
+
+/**
+ * A witness is a piece of information that allows you to efficiently verify the
+ * authenticity of the transaction (also known as proof).
+ *
+ * In Cardano, transactions have multiple types of authentication proofs, these can range
+ * from signatures for spending UTxOs, to scripts (with its arguments, datums and redeemers) for
+ * smart contract execution.
+ */
+export class TransactionWitnessSet {
+  #vkeywitnesses: Array<VkeyWitness> | undefined;
+  #nativeScripts: Array<NativeScript> | undefined;
+  #bootstrapWitnesses: Array<BootstrapWitness> | undefined;
+  #plutusV1Scripts: Array<PlutusV1Script> | undefined;
+  #plutusData: Array<PlutusData> | undefined;
+  #redeemers: Array<Redeemer> | undefined;
+  #plutusV2Scripts: Array<PlutusV2Script> | undefined;
+  #originalBytes: HexBlob | undefined = undefined;
+
+  /**
+   * Serializes a TransactionWitnessSet into CBOR format.
+   *
+   * @returns The TransactionWitnessSet in CBOR format.
+   */
+  toCbor(): HexBlob {
+    const writer = new CborWriter();
+
+    if (this.#originalBytes) return this.#originalBytes;
+
+    // CDDL
+    // transaction_witness_set =
+    //   { ? 0: [* vkeywitness ]
+    //   , ? 1: [* native_script ]
+    //   , ? 2: [* bootstrap_witness ]
+    //   , ? 3: [* plutus_v1_script ]
+    //   , ? 4: [* plutus_data ]
+    //   , ? 5: [* redeemer ]
+    //   , ? 6: [* plutus_v2_script ] ; New
+    //   }
+    writer.writeStartMap(this.#getMapSize());
+
+    if (this.#vkeywitnesses && this.#vkeywitnesses.length > 0) {
+      const uniqueWitnesses = uniqWith(this.#vkeywitnesses, (lhs, rhs) => lhs.vkey() === rhs.vkey());
+
+      writer.writeInt(0n);
+      writer.writeStartArray(uniqueWitnesses.length);
+
+      for (const witness of uniqueWitnesses) {
+        writer.writeEncodedValue(Buffer.from(witness.toCbor(), 'hex'));
+      }
+    }
+
+    if (this.#nativeScripts && this.#nativeScripts.length > 0) {
+      writer.writeInt(1n);
+      writer.writeStartArray(this.#nativeScripts.length);
+
+      for (const script of this.#nativeScripts) {
+        writer.writeEncodedValue(Buffer.from(script.toCbor(), 'hex'));
+      }
+    }
+
+    if (this.#bootstrapWitnesses && this.#bootstrapWitnesses.length > 0) {
+      const uniqueWitnesses = uniqWith(this.#bootstrapWitnesses, (lhs, rhs) => lhs.vkey() === rhs.vkey());
+
+      writer.writeInt(2n);
+      writer.writeStartArray(uniqueWitnesses.length);
+
+      for (const witness of uniqueWitnesses) {
+        writer.writeEncodedValue(Buffer.from(witness.toCbor(), 'hex'));
+      }
+    }
+
+    if (this.#plutusV1Scripts && this.#plutusV1Scripts.length > 0) {
+      writer.writeInt(3n);
+      writer.writeStartArray(this.#plutusV1Scripts.length);
+
+      for (const script of this.#plutusV1Scripts) {
+        writer.writeEncodedValue(Buffer.from(script.toCbor(), 'hex'));
+      }
+    }
+
+    if (this.#plutusData && this.#plutusData.length > 0) {
+      writer.writeInt(4n);
+      writer.writeStartArray(this.#plutusData.length);
+
+      for (const data of this.#plutusData) {
+        writer.writeEncodedValue(Buffer.from(data.toCbor(), 'hex'));
+      }
+    }
+
+    if (this.#redeemers && this.#redeemers.length > 0) {
+      writer.writeInt(5n);
+      writer.writeStartArray(this.#redeemers.length);
+
+      for (const data of this.#redeemers) {
+        writer.writeEncodedValue(Buffer.from(data.toCbor(), 'hex'));
+      }
+    }
+
+    if (this.#plutusV2Scripts && this.#plutusV2Scripts.length > 0) {
+      writer.writeInt(6n);
+      writer.writeStartArray(this.#plutusV2Scripts.length);
+
+      for (const script of this.#plutusV2Scripts) {
+        writer.writeEncodedValue(Buffer.from(script.toCbor(), 'hex'));
+      }
+    }
+
+    return writer.encodeAsHex();
+  }
+
+  /**
+   * Deserializes the TransactionWitnessSet from a CBOR byte array.
+   *
+   * @param cbor The CBOR encoded TransactionWitnessSet object.
+   * @returns The new TransactionWitnessSet instance.
+   */
+  static fromCbor(cbor: HexBlob): TransactionWitnessSet {
+    const reader = new CborReader(cbor);
+
+    const witness = new TransactionWitnessSet();
+
+    reader.readStartMap();
+
+    while (reader.peekState() !== CborReaderState.EndMap) {
+      const key = reader.readInt();
+
+      switch (key) {
+        case 0n:
+          witness.setVkeys(new Array<VkeyWitness>());
+          reader.readStartArray();
+
+          while (reader.peekState() !== CborReaderState.EndArray) {
+            witness.vkeys()!.push(VkeyWitness.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          }
+
+          reader.readEndArray();
+          break;
+        case 1n:
+          witness.setNativeScripts(new Array<NativeScript>());
+          reader.readStartArray();
+
+          while (reader.peekState() !== CborReaderState.EndArray) {
+            witness.nativeScripts()!.push(NativeScript.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          }
+
+          reader.readEndArray();
+          break;
+        case 2n:
+          witness.setBootstraps(new Array<BootstrapWitness>());
+          reader.readStartArray();
+
+          while (reader.peekState() !== CborReaderState.EndArray) {
+            witness.bootstraps()!.push(BootstrapWitness.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          }
+
+          reader.readEndArray();
+          break;
+        case 3n:
+          witness.setPlutusV1Scripts(new Array<PlutusV1Script>());
+          reader.readStartArray();
+
+          while (reader.peekState() !== CborReaderState.EndArray) {
+            witness.plutusV1Scripts()!.push(PlutusV1Script.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          }
+
+          reader.readEndArray();
+          break;
+        case 4n:
+          witness.setPlutusData(new Array<PlutusData>());
+          reader.readStartArray();
+
+          while (reader.peekState() !== CborReaderState.EndArray) {
+            witness.plutusData()!.push(PlutusData.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          }
+
+          reader.readEndArray();
+          break;
+        case 5n:
+          witness.setRedeemers(new Array<Redeemer>());
+          reader.readStartArray();
+
+          while (reader.peekState() !== CborReaderState.EndArray) {
+            witness.redeemers()!.push(Redeemer.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          }
+
+          reader.readEndArray();
+          break;
+        case 6n:
+          witness.setPlutusV2Scripts(new Array<PlutusV2Script>());
+          reader.readStartArray();
+
+          while (reader.peekState() !== CborReaderState.EndArray) {
+            witness.plutusV2Scripts()!.push(PlutusV2Script.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          }
+
+          reader.readEndArray();
+          break;
+      }
+    }
+
+    reader.readEndMap();
+
+    witness.#originalBytes = cbor;
+
+    return witness;
+  }
+
+  /**
+   * Creates a Core Witness object from the current TransactionWitnessSet object.
+   *
+   * @returns The Core TransactionWitnessSet object.
+   */
+  toCore(): Cardano.Witness {
+    const scripts = this.#getCoreScripts();
+    return {
+      bootstrap: this.#bootstrapWitnesses ? this.#bootstrapWitnesses.map((witness) => witness.toCore()) : undefined,
+      datums: this.#plutusData ? this.#plutusData.map((data) => data.toCore()) : undefined,
+      redeemers: this.#redeemers ? this.#redeemers.map((data) => data.toCore()) : undefined,
+      scripts: scripts.length > 0 ? scripts : undefined,
+      signatures: this.#vkeywitnesses ? new Map(this.#vkeywitnesses.map((witness) => witness.toCore())) : new Map()
+    };
+  }
+
+  /**
+   * Creates a TransactionWitnessSet object from the given Core Witness object.
+   *
+   * @param coreWitness The core Witness object.
+   */
+  static fromCore(coreWitness: Cardano.Witness): TransactionWitnessSet {
+    const witness = new TransactionWitnessSet();
+
+    if (coreWitness.signatures) {
+      witness.setVkeys([...coreWitness.signatures].map((vkWitness) => VkeyWitness.fromCore(vkWitness)));
+    }
+
+    if (coreWitness.scripts) {
+      const scripts = TransactionWitnessSet.#getCddlScripts(coreWitness.scripts);
+
+      if (scripts.native) witness.setNativeScripts(scripts.native);
+      if (scripts.plutusV1) witness.setPlutusV1Scripts(scripts.plutusV1);
+      if (scripts.plutusV2) witness.setPlutusV2Scripts(scripts.plutusV2);
+    }
+
+    if (coreWitness.redeemers) {
+      witness.setRedeemers(coreWitness.redeemers.map((data) => Redeemer.fromCore(data)));
+    }
+
+    if (coreWitness.datums) {
+      witness.setPlutusData(coreWitness.datums.map((data) => PlutusData.fromCore(data)));
+    }
+
+    if (coreWitness.bootstrap) {
+      witness.setBootstraps(coreWitness.bootstrap.map((bootstrap) => BootstrapWitness.fromCore(bootstrap)));
+    }
+
+    return witness;
+  }
+
+  /**
+   * Sets the Verification Key Witnesses, used to prove the spending of inputs on the transaction is
+   * authorized by the corresponding private key(s).
+   *
+   * @param vkeys The set of verification key witnesses.
+   */
+  setVkeys(vkeys: Array<VkeyWitness>) {
+    this.#vkeywitnesses = vkeys;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the Verification Key Witnesses, used to prove the spending of inputs on the transaction is
+   * authorized by the corresponding private key(s).
+   *
+   * @returns The set of verification key witnesses.
+   */
+  vkeys(): Array<VkeyWitness> | undefined {
+    return this.#vkeywitnesses;
+  }
+
+  /**
+   * Sets the set of native scripts required by this transaction.
+   *
+   * @param nativeScripts The set of native scripts.
+   */
+  setNativeScripts(nativeScripts: Array<NativeScript>) {
+    this.#nativeScripts = nativeScripts;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the set of native scripts required by this transaction.
+   *
+   * @returns The set of native scripts.
+   */
+  nativeScripts(): Array<NativeScript> | undefined {
+    return this.#nativeScripts;
+  }
+
+  /**
+   * Sets the witnesses for authorizing spending from UTxOs associated with Byron-era addresses.
+   *
+   * @param bootstraps The Bootstrap witnesses for this transaction.
+   */
+  setBootstraps(bootstraps: Array<BootstrapWitness>) {
+    this.#bootstrapWitnesses = bootstraps;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the witnesses for authorizing spending from UTxOs associated with Byron-era addresses.
+   *
+   * @returns The Bootstrap witnesses for this transaction.
+   */
+  bootstraps(): Array<BootstrapWitness> | undefined {
+    return this.#bootstrapWitnesses;
+  }
+
+  /**
+   * Sets the set of plutus v1 scripts required by this transaction.
+   *
+   * @param plutusV1Scripts The set of plutus v1 scripts.
+   */
+  setPlutusV1Scripts(plutusV1Scripts: Array<PlutusV1Script>) {
+    this.#plutusV1Scripts = plutusV1Scripts;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the set of plutus v1 scripts required by this transaction.
+   *
+   * @returns The set of plutus v1 scripts.
+   */
+  plutusV1Scripts(): Array<PlutusV1Script> | undefined {
+    return this.#plutusV1Scripts;
+  }
+
+  /**
+   * Sets the Plutus Data required by the Plutus scripts of this transaction.
+   *
+   * @param plutusData The Plutus Data.
+   */
+  setPlutusData(plutusData: Array<PlutusData>) {
+    this.#plutusData = plutusData;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the Plutus Data required by the Plutus scripts of this transaction.
+   *
+   * @returns The Plutus Data.
+   */
+  plutusData(): Array<PlutusData> | undefined {
+    return this.#plutusData;
+  }
+
+  /**
+   * Sets the redeemers required by the Plutus scripts of this transaction.
+   *
+   * @param redeemers The redeemers.
+   */
+  setRedeemers(redeemers: Array<Redeemer>) {
+    this.#redeemers = redeemers;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the redeemers required by the Plutus scripts of this transaction.
+   *
+   * @returns The redeemers.
+   */
+  redeemers(): Array<Redeemer> | undefined {
+    return this.#redeemers;
+  }
+
+  /**
+   * Sets the set of plutus v2 scripts required by this transaction.
+   *
+   * @param plutusV2Scripts The set of plutus v2 scripts.
+   */
+  setPlutusV2Scripts(plutusV2Scripts: Array<PlutusV2Script>) {
+    this.#plutusV2Scripts = plutusV2Scripts;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets the set of plutus v2 scripts required by this transaction.
+   *
+   * @returns The set of plutus v2 scripts.
+   */
+  plutusV2Scripts(): Array<PlutusV2Script> | undefined {
+    return this.#plutusV2Scripts;
+  }
+
+  /**
+   * Gets all the scripts present in this witness as Core scripts.
+   *
+   * @returns The list of scripts.
+   * @private
+   */
+  #getCoreScripts(): Array<Cardano.Script> {
+    const plutusV1 = this.#plutusV1Scripts ? this.#plutusV1Scripts.map((script) => script.toCore()) : [];
+    const plutusV2 = this.#plutusV2Scripts ? this.#plutusV2Scripts.map((script) => script.toCore()) : [];
+    const native = this.#nativeScripts ? this.#nativeScripts.map((script) => script.toCore()) : [];
+
+    return [...plutusV1, ...plutusV2, ...native];
+  }
+
+  /**
+   * Gets all the scripts present in this witness as CDDL scripts.
+   *
+   * @returns The list of scripts.
+   * @private
+   */
+  static #getCddlScripts(scripts: Array<Cardano.Script>): CddlScripts {
+    const result: CddlScripts = { native: undefined, plutusV1: undefined, plutusV2: undefined };
+
+    for (const script of scripts) {
+      switch (script.__type) {
+        case Cardano.ScriptType.Native:
+          if (!result.native) result.native = new Array<NativeScript>();
+
+          result.native.push(NativeScript.fromCore(script));
+          break;
+        case Cardano.ScriptType.Plutus:
+          if (script.version === Cardano.PlutusLanguageVersion.V1) {
+            if (!result.plutusV1) result.plutusV1 = new Array<PlutusV1Script>();
+
+            result.plutusV1.push(PlutusV1Script.fromCore(script));
+          } else if (script.version === Cardano.PlutusLanguageVersion.V2) {
+            if (!result.plutusV2) result.plutusV2 = new Array<PlutusV2Script>();
+
+            result.plutusV2.push(PlutusV2Script.fromCore(script));
+          }
+          break;
+        default:
+          throw new SerializationError(SerializationFailure.InvalidScriptType, `Script '${script}' is not supported.`);
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Gets the size of the serialized map.
+   *
+   * @private
+   */
+  #getMapSize(): number {
+    let mapSize = 0;
+
+    if (this.#vkeywitnesses !== undefined && this.#vkeywitnesses.length > 0) ++mapSize;
+    if (this.#nativeScripts !== undefined && this.#nativeScripts.length > 0) ++mapSize;
+    if (this.#bootstrapWitnesses !== undefined && this.#bootstrapWitnesses.length > 0) ++mapSize;
+    if (this.#plutusV1Scripts !== undefined && this.#plutusV1Scripts.length > 0) ++mapSize;
+    if (this.#plutusData !== undefined && this.#plutusData.length > 0) ++mapSize;
+    if (this.#redeemers !== undefined && this.#redeemers.length > 0) ++mapSize;
+    if (this.#plutusV2Scripts !== undefined && this.#plutusV2Scripts.length > 0) ++mapSize;
+
+    return mapSize;
+  }
+}

--- a/packages/core/src/Serialization/TransactionWitnessSet/VkeyWitness.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/VkeyWitness.ts
@@ -1,0 +1,133 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { CborReader, CborWriter } from '../CBOR';
+import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { hexToBytes } from '../../util/misc';
+
+const VKEY_ARRAY_SIZE = 2;
+
+/**
+ * VkeyWitness (Verification Key Witness) is a component of a transaction that
+ * provides cryptographic proof that proves that the creator of the transaction
+ * has access to the private keys controlling the UTxOs being spent.
+ */
+export class VkeyWitness {
+  #vkey: Crypto.Ed25519PublicKeyHex;
+  #signature: Crypto.Ed25519SignatureHex;
+  #originalBytes: HexBlob | undefined = undefined;
+
+  /**
+   * Initializes a new instance of the VkeyWitness class.
+   *
+   * @param vkey This is the public counterpart to the private key (SKey). It's used to verify the signature.
+   * @param signature This is a cryptographic signature produced by signing the hash of the transaction body with
+   * the corresponding private key (SKey). Anyone can verify this signature using the provided VKey,
+   * ensuring that the transaction was authorized by the holder of the private key.
+   */
+  constructor(vkey: Crypto.Ed25519PublicKeyHex, signature: Crypto.Ed25519SignatureHex) {
+    this.#vkey = vkey;
+    this.#signature = signature;
+  }
+
+  /**
+   * Serializes a VkeyWitness into CBOR format.
+   *
+   * @returns The VkeyWitness in CBOR format.
+   */
+  toCbor(): HexBlob {
+    const writer = new CborWriter();
+
+    if (this.#originalBytes) return this.#originalBytes;
+
+    // CDDL
+    // vkeywitness = [ $vkey, $signature ]
+    writer.writeStartArray(VKEY_ARRAY_SIZE);
+    writer.writeByteString(hexToBytes(this.#vkey as unknown as HexBlob));
+    writer.writeByteString(hexToBytes(this.#signature as unknown as HexBlob));
+
+    return writer.encodeAsHex();
+  }
+
+  /**
+   * Deserializes the VkeyWitness from a CBOR byte array.
+   *
+   * @param cbor The CBOR encoded VkeyWitness object.
+   * @returns The new VkeyWitness instance.
+   */
+  static fromCbor(cbor: HexBlob): VkeyWitness {
+    const reader = new CborReader(cbor);
+
+    const length = reader.readStartArray();
+
+    if (length !== VKEY_ARRAY_SIZE)
+      throw new InvalidArgumentError(
+        'cbor',
+        `Expected an array of ${VKEY_ARRAY_SIZE} elements, but got an array of ${length} elements`
+      );
+
+    const vkey = HexBlob.fromBytes(reader.readByteString()) as unknown as Crypto.Ed25519PublicKeyHex;
+    const signature = HexBlob.fromBytes(reader.readByteString()) as unknown as Crypto.Ed25519SignatureHex;
+
+    reader.readEndArray();
+
+    const witness = new VkeyWitness(vkey, signature);
+    witness.#originalBytes = cbor;
+
+    return witness;
+  }
+
+  /**
+   * Creates a tuple with the vkey and the signature from the current VkeyWitness object.
+   *
+   * @returns The tuple with the vkey and the signature.
+   */
+  toCore(): [Crypto.Ed25519PublicKeyHex, Crypto.Ed25519SignatureHex] {
+    return [this.#vkey, this.#signature];
+  }
+
+  /**
+   * Creates a VkeyWitness object from a tuple with the vkey and the signature.
+   *
+   * @param signatureEntry A tuple with the vkey and the signature.
+   */
+  static fromCore(signatureEntry: [Crypto.Ed25519PublicKeyHex, Crypto.Ed25519SignatureHex]) {
+    return new VkeyWitness(signatureEntry[0], signatureEntry[1]);
+  }
+
+  /**
+   * Gets the public key associated with the provided signature.
+   *
+   * @returns The public key.
+   */
+  vkey(): Crypto.Ed25519PublicKeyHex {
+    return this.#vkey;
+  }
+
+  /**
+   * Sets the public key associated with the provided signature.
+   *
+   * @param vkey The public key.
+   */
+  setVkey(vkey: Crypto.Ed25519PublicKeyHex) {
+    this.#vkey = vkey;
+    this.#originalBytes = undefined;
+  }
+
+  /**
+   * Gets transaction body signature computed with the private counterpart to the public key (VKey).
+   *
+   * @returns The Ed25519 signature.
+   */
+  signature(): Crypto.Ed25519SignatureHex {
+    return this.#signature;
+  }
+
+  /**
+   * Sets the transaction body signature computed with the private counterpart to the public key (VKey).
+   *
+   * @param signature The Ed25519 signature.
+   */
+  setSignature(signature: Crypto.Ed25519SignatureHex) {
+    this.#signature = signature;
+    this.#originalBytes = undefined;
+  }
+}

--- a/packages/core/src/Serialization/TransactionWitnessSet/index.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/index.ts
@@ -1,0 +1,4 @@
+export * from './Redeemer';
+export * from './BootstrapWitness';
+export * from './TransactionWitnessSet';
+export * from './VkeyWitness';

--- a/packages/core/src/Serialization/index.ts
+++ b/packages/core/src/Serialization/index.ts
@@ -6,3 +6,4 @@ export * from './CBOR';
 export * from './Certificates';
 export * from './Update';
 export * from './TransactionBody';
+export * from './TransactionWitnessSet';

--- a/packages/core/test/Serialization/Transaction.test.ts
+++ b/packages/core/test/Serialization/Transaction.test.ts
@@ -28,14 +28,13 @@ describe('Transaction', () => {
     const tx = Transaction.fromCore(scope, coreTx);
 
     expect(tx.body()).toBeInstanceOf(TransactionBody);
-    const witnessSet = scope.manage(tx.witnessSet());
-    const vKeys = scope.manage(witnessSet.vkeys());
-    const witness = scope.manage(vKeys!.get(0)!);
-    const witnessSignature = scope.manage(witness.signature());
-    const vKey = scope.manage(witness.vkey());
-    const vKeyPublicKey = scope.manage(vKey.public_key());
-    expect(Buffer.from(vKeyPublicKey.as_bytes()).toString('hex')).toBe(vkey);
-    expect(witnessSignature.to_hex()).toBe(signature);
+    const witnessSet = tx.witnessSet();
+    const vKeys = witnessSet.vkeys();
+    const witness = vKeys![0];
+    const witnessSignature = witness.signature();
+    const vKey = witness.vkey();
+    expect(vKey).toBe(vkey);
+    expect(witnessSignature).toBe(signature);
 
     expect(tx.toCore()).toEqual(coreTx);
   });
@@ -78,16 +77,15 @@ describe('Transaction', () => {
   });
 
   it('can set the witness set on the transaction', () => {
-    const scope = new ManagedFreeableScope();
     const tx = Transaction.fromCbor(TxCBOR(TX));
     const tx2 = Transaction.fromCbor(TxCBOR(TX2));
 
-    tx.setWitnessSet(scope.manage(tx2.witnessSet()));
+    tx.setWitnessSet(tx2.witnessSet());
 
     // Perform a round trip serialization.
     const tx3 = Transaction.fromCbor(tx.toCbor());
 
-    expect(scope.manage(tx3.witnessSet()).to_bytes()).toEqual(scope.manage(tx2.witnessSet()).to_bytes());
+    expect(tx3.witnessSet().toCbor()).toEqual(tx2.witnessSet().toCbor());
   });
 
   it('can set the witness set on the transaction', () => {

--- a/packages/core/test/Serialization/TransactionWitnessSet/BootstrapWitness.test.ts
+++ b/packages/core/test/Serialization/TransactionWitnessSet/BootstrapWitness.test.ts
@@ -1,0 +1,93 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
+import { Base64Blob, HexBlob, InvalidStateError } from '@cardano-sdk/util';
+import { BootstrapWitness } from '../../../src/Serialization';
+
+// Test data used in the following tests was generated with the cardano-serialization-lib
+const cbor = HexBlob(
+  '8458203d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c58406291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a5820000000000000000000000000000000000000000000000000000000000000000041a0'
+);
+
+const core: Cardano.BootstrapWitness = {
+  addressAttributes: Base64Blob('oA=='),
+  chainCode: HexBlob('0000000000000000000000000000000000000000000000000000000000000000'),
+  key: Crypto.Ed25519PublicKeyHex('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'),
+  signature: Crypto.Ed25519SignatureHex(
+    '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+  )
+};
+
+describe('BootstrapWitness', () => {
+  it('can decode BootstrapWitness from CBOR', () => {
+    const witness = BootstrapWitness.fromCbor(cbor);
+
+    expect(witness.chainCode()).toEqual('0000000000000000000000000000000000000000000000000000000000000000');
+    expect(witness.signature()).toEqual(
+      '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+    );
+    expect(witness.vkey()).toEqual('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c');
+    expect(witness.attributes()).toEqual('a0');
+  });
+
+  it('can decode BootstrapWitness from Core', () => {
+    const witness = BootstrapWitness.fromCore(core);
+
+    expect(witness.chainCode()).toEqual('0000000000000000000000000000000000000000000000000000000000000000');
+    expect(witness.signature()).toEqual(
+      '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+    );
+    expect(witness.vkey()).toEqual('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c');
+    expect(witness.attributes()).toEqual('a0');
+  });
+
+  it('can encode BootstrapWitness to CBOR', () => {
+    const witness = BootstrapWitness.fromCore(core);
+    expect(witness.toCbor()).toEqual(cbor);
+  });
+
+  it('can encode BootstrapWitness to Core', () => {
+    const witness = BootstrapWitness.fromCbor(cbor);
+    expect(witness.toCore()).toEqual(core);
+  });
+
+  it('encodes attributes as empty byte string if field not present', () => {
+    const witness = BootstrapWitness.fromCore({
+      chainCode: HexBlob('0000000000000000000000000000000000000000000000000000000000000000'),
+      key: Crypto.Ed25519PublicKeyHex('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'),
+      signature: Crypto.Ed25519SignatureHex(
+        '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+      )
+    });
+    expect(witness.toCbor()).toEqual(cbor);
+    expect(witness.chainCode()).toEqual('0000000000000000000000000000000000000000000000000000000000000000');
+    expect(witness.signature()).toEqual(
+      '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+    );
+    expect(witness.vkey()).toEqual('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c');
+    expect(witness.attributes()).toEqual('a0');
+  });
+
+  it('throws if chainCode is not present', () => {
+    expect(() =>
+      BootstrapWitness.fromCore({
+        key: Crypto.Ed25519PublicKeyHex('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'),
+        signature: Crypto.Ed25519SignatureHex(
+          '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+        )
+      })
+    ).toThrowError(InvalidStateError);
+  });
+
+  it('throws if chainCode is not 32 bytes long', () => {
+    expect(() =>
+      BootstrapWitness.fromCore({
+        chainCode: HexBlob('00000000000000000000000000000000000000000000000000000000'),
+        key: Crypto.Ed25519PublicKeyHex('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'),
+        signature: Crypto.Ed25519SignatureHex(
+          '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+        )
+      })
+    ).toThrowError(InvalidStateError);
+  });
+});

--- a/packages/core/test/Serialization/TransactionWitnessSet/Redeemer.test.ts
+++ b/packages/core/test/Serialization/TransactionWitnessSet/Redeemer.test.ts
@@ -1,0 +1,107 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import * as Cardano from '../../../src/Cardano';
+import { HexBlob } from '@cardano-sdk/util';
+import { Redeemer, RedeemerTag } from '../../../src/Serialization';
+import { RedeemerPurpose } from '../../../src/Cardano';
+
+// Test data used in the following tests was generated with the cardano-serialization-lib
+const core = {
+  data: {
+    cbor: HexBlob('d8799f0102030405ff'),
+    constructor: 0n,
+    fields: { cbor: HexBlob('9f0102030405ff'), items: [1n, 2n, 3n, 4n, 5n] }
+  },
+  executionUnits: { memory: 147_852_369_874_563, steps: 369_852_147_852_369 },
+  index: 0,
+  purpose: RedeemerPurpose.spend
+} as Cardano.Redeemer;
+
+describe('Redeemer', () => {
+  it('can decode Redeemer from CBOR', () => {
+    const cbor = HexBlob('840000d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451');
+
+    const redeemer = Redeemer.fromCbor(cbor);
+
+    expect(redeemer.data().toCore()).toEqual({
+      cbor: HexBlob('d8799f0102030405ff'),
+      constructor: 0n,
+      fields: { cbor: HexBlob('9f0102030405ff'), items: [1n, 2n, 3n, 4n, 5n] }
+    });
+    expect(redeemer.exUnits().toCore()).toEqual({ memory: 147_852_369_874_563, steps: 369_852_147_852_369 });
+    expect(redeemer.tag()).toEqual(RedeemerTag.Spend);
+    expect(redeemer.index()).toEqual(0n);
+  });
+
+  it('can decode Redeemer from Core', () => {
+    const redeemer = Redeemer.fromCore(core);
+
+    expect(redeemer.data().toCore()).toEqual({
+      cbor: HexBlob('d8799f0102030405ff'),
+      constructor: 0n,
+      fields: { cbor: HexBlob('9f0102030405ff'), items: [1n, 2n, 3n, 4n, 5n] }
+    });
+    expect(redeemer.exUnits().toCore()).toEqual({ memory: 147_852_369_874_563, steps: 369_852_147_852_369 });
+    expect(redeemer.tag()).toEqual(RedeemerTag.Spend);
+    expect(redeemer.index()).toEqual(0n);
+  });
+
+  describe('Redeemer tag: Spend', () => {
+    const spendCore = { ...core, purpose: RedeemerPurpose.spend };
+    const spendCbor = HexBlob('840000d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451');
+
+    it('can encode Redeemer to CBOR', () => {
+      const redeemer = Redeemer.fromCore(spendCore);
+      expect(redeemer.toCbor()).toEqual(spendCbor);
+    });
+
+    it('can encode Redeemer to Core', () => {
+      const redeemer = Redeemer.fromCbor(spendCbor);
+      expect(redeemer.toCore()).toEqual(spendCore);
+    });
+  });
+
+  describe('Redeemer tag: Mint', () => {
+    const mintCore = { ...core, purpose: RedeemerPurpose.mint };
+    const mintCbor = HexBlob('840100d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451');
+
+    it('can encode Redeemer to CBOR', () => {
+      const redeemer = Redeemer.fromCore(mintCore);
+      expect(redeemer.toCbor()).toEqual(mintCbor);
+    });
+
+    it('can encode Redeemer to Core', () => {
+      const redeemer = Redeemer.fromCbor(mintCbor);
+      expect(redeemer.toCore()).toEqual(mintCore);
+    });
+  });
+
+  describe('Redeemer tag: Cert', () => {
+    const certCore = { ...core, purpose: RedeemerPurpose.certificate };
+    const certCbor = HexBlob('840200d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451');
+
+    it('can encode Redeemer to CBOR', () => {
+      const redeemer = Redeemer.fromCore(certCore);
+      expect(redeemer.toCbor()).toEqual(certCbor);
+    });
+
+    it('can encode Redeemer to Core', () => {
+      const redeemer = Redeemer.fromCbor(certCbor);
+      expect(redeemer.toCore()).toEqual(certCore);
+    });
+  });
+
+  describe('Redeemer tag: Reward', () => {
+    const certCore = { ...core, purpose: RedeemerPurpose.withdrawal };
+    const certCbor = HexBlob('840300d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451');
+
+    it('can encode Redeemer to CBOR', () => {
+      const redeemer = Redeemer.fromCore(certCore);
+      expect(redeemer.toCbor()).toEqual(certCbor);
+    });
+
+    it('can encode Redeemer to Core', () => {
+      const redeemer = Redeemer.fromCbor(certCbor);
+      expect(redeemer.toCore()).toEqual(certCore);
+    });
+  });
+});

--- a/packages/core/test/Serialization/TransactionWitnessSet/TransactionWitnessSet.test.ts
+++ b/packages/core/test/Serialization/TransactionWitnessSet/TransactionWitnessSet.test.ts
@@ -1,0 +1,207 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import * as Crypto from '@cardano-sdk/crypto';
+import { Base64Blob, HexBlob } from '@cardano-sdk/util';
+import { Cardano } from '../../../src';
+import { RedeemerPurpose } from '../../../src/Cardano';
+import { TransactionWitnessSet } from '../../../src/Serialization';
+
+// Test data used in the following tests was generated with the cardano-serialization-lib
+const cbor = HexBlob(
+  'a700838258204a352f53eb4311d552aa9e1c6f0125846a3b607011d691f0e774d893d940b8525840c4f13cc397a50193061ce899b3eda906ad1adf3f3d515b52248ea5aa142781cd9c2ccc52ac62b2e1b5226de890104ec530bda4c38a19b691946da9addb3213f5825820290c08454c58a8c7fad6351e65a652460bd4f80f485f1ccfc350ff6a4d5bd4de5840026f47bab2f24da9690746bdb0e55d53a5eef45a969e3dd2873a3e6bb8ef3316d9f80489bacfd2f543108e284a40847ae7ce33fa358fcfe439a37990ad3107e98258204d953d6a9d556da3f3e26622c725923130f5733d1a3c4013ef8c34d15a070fd75840f9218e5a569c5ace38b1bb81e1f1c0b2d7fea2fe7fb913fdd06d79906436103345347a81494b83f83bf43466b0cebdbbdcef15384f67c255e826c249336ce2c701848204038205098202818200581c3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e830300818200581cb5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f5402828458203d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c58406291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a5820000000000000000000000000000000000000000000000000000000000000000041a08458203d4017c3e863895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c58406291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a5820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff41a00384474601000022001047460100002200114746010000220012474601000022001304833bffffffffffffffff3bffffffffffffffff3bffffffffffffffff0584840000d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451840100d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451840200d8799f0102030405ff821b000086788ffc4e831b00015060e9e46451840300d8799f0102030405ff821b000086788ffc4e831b00015060e9e4645106844746010000220010474601000022001147460100002200124746010000220013'
+);
+
+const simpleWitnessCbor = HexBlob(
+  'a100838258204a352f53eb4311d552aa9e1c6f0125846a3b607011d691f0e774d893d940b8525840c4f13cc397a50193061ce899b3eda906ad1adf3f3d515b52248ea5aa142781cd9c2ccc52ac62b2e1b5226de890104ec530bda4c38a19b691946da9addb3213f5825820290c08454c58a8c7fad6351e65a652460bd4f80f485f1ccfc350ff6a4d5bd4de5840026f47bab2f24da9690746bdb0e55d53a5eef45a969e3dd2873a3e6bb8ef3316d9f80489bacfd2f543108e284a40847ae7ce33fa358fcfe439a37990ad3107e98258204d953d6a9d556da3f3e26622c725923130f5733d1a3c4013ef8c34d15a070fd75840f9218e5a569c5ace38b1bb81e1f1c0b2d7fea2fe7fb913fdd06d79906436103345347a81494b83f83bf43466b0cebdbbdcef15384f67c255e826c249336ce2c7'
+);
+
+const core: Cardano.Witness = {
+  bootstrap: [
+    {
+      addressAttributes: Base64Blob('oA=='),
+      chainCode: HexBlob('0000000000000000000000000000000000000000000000000000000000000000'),
+      key: Crypto.Ed25519PublicKeyHex('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'),
+      signature: Crypto.Ed25519SignatureHex(
+        '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+      )
+    },
+    {
+      addressAttributes: Base64Blob('oA=='),
+      chainCode: HexBlob('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'),
+      key: Crypto.Ed25519PublicKeyHex('3d4017c3e863895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c'),
+      signature: Crypto.Ed25519SignatureHex(
+        '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+      )
+    }
+  ],
+  datums: [-18_446_744_073_709_551_616n, -18_446_744_073_709_551_616n, -18_446_744_073_709_551_616n],
+  redeemers: [
+    {
+      data: {
+        cbor: HexBlob('d8799f0102030405ff'),
+        constructor: 0n,
+        fields: { cbor: HexBlob('9f0102030405ff'), items: [1n, 2n, 3n, 4n, 5n] }
+      },
+      executionUnits: { memory: 147_852_369_874_563, steps: 369_852_147_852_369 },
+      index: 0,
+      purpose: RedeemerPurpose.spend
+    },
+    {
+      data: {
+        cbor: HexBlob('d8799f0102030405ff'),
+        constructor: 0n,
+        fields: { cbor: HexBlob('9f0102030405ff'), items: [1n, 2n, 3n, 4n, 5n] }
+      },
+      executionUnits: { memory: 147_852_369_874_563, steps: 369_852_147_852_369 },
+      index: 0,
+      purpose: RedeemerPurpose.mint
+    },
+    {
+      data: {
+        cbor: HexBlob('d8799f0102030405ff'),
+        constructor: 0n,
+        fields: { cbor: HexBlob('9f0102030405ff'), items: [1n, 2n, 3n, 4n, 5n] }
+      },
+      executionUnits: { memory: 147_852_369_874_563, steps: 369_852_147_852_369 },
+      index: 0,
+      purpose: RedeemerPurpose.certificate
+    },
+    {
+      data: {
+        cbor: HexBlob('d8799f0102030405ff'),
+        constructor: 0n,
+        fields: { cbor: HexBlob('9f0102030405ff'), items: [1n, 2n, 3n, 4n, 5n] }
+      },
+      executionUnits: { memory: 147_852_369_874_563, steps: 369_852_147_852_369 },
+      index: 0,
+      purpose: RedeemerPurpose.withdrawal
+    }
+  ],
+  scripts: [
+    {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('46010000220010'),
+      version: Cardano.PlutusLanguageVersion.V1
+    },
+    {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('46010000220011'),
+      version: Cardano.PlutusLanguageVersion.V1
+    },
+    {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('46010000220012'),
+      version: Cardano.PlutusLanguageVersion.V1
+    },
+    {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('46010000220013'),
+      version: Cardano.PlutusLanguageVersion.V1
+    },
+    {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('46010000220010'),
+      version: Cardano.PlutusLanguageVersion.V2
+    },
+    {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('46010000220011'),
+      version: Cardano.PlutusLanguageVersion.V2
+    },
+    {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('46010000220012'),
+      version: Cardano.PlutusLanguageVersion.V2
+    },
+    { __type: Cardano.ScriptType.Plutus, bytes: HexBlob('46010000220013'), version: Cardano.PlutusLanguageVersion.V2 },
+    { __type: Cardano.ScriptType.Native, kind: 4, slot: Cardano.Slot(3) },
+    { __type: Cardano.ScriptType.Native, kind: 5, slot: Cardano.Slot(9) },
+    {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireAnyOf,
+      scripts: [
+        {
+          __type: Cardano.ScriptType.Native,
+          keyHash: Crypto.Ed25519KeyHashHex('3542acb3a64d80c29302260d62c3b87a742ad14abf855ebc6733081e'),
+          kind: Cardano.NativeScriptKind.RequireSignature
+        }
+      ]
+    },
+    {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireNOf,
+      required: 0,
+      scripts: [
+        {
+          __type: Cardano.ScriptType.Native,
+          keyHash: Crypto.Ed25519KeyHashHex('b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54'),
+          kind: Cardano.NativeScriptKind.RequireSignature
+        }
+      ]
+    }
+  ],
+  signatures: new Map([
+    [
+      Crypto.Ed25519PublicKeyHex('4a352f53eb4311d552aa9e1c6f0125846a3b607011d691f0e774d893d940b852'),
+      Crypto.Ed25519SignatureHex(
+        'c4f13cc397a50193061ce899b3eda906ad1adf3f3d515b52248ea5aa142781cd9c2ccc52ac62b2e1b5226de890104ec530bda4c38a19b691946da9addb3213f5'
+      )
+    ],
+    [
+      Crypto.Ed25519PublicKeyHex('290c08454c58a8c7fad6351e65a652460bd4f80f485f1ccfc350ff6a4d5bd4de'),
+      Crypto.Ed25519SignatureHex(
+        '026f47bab2f24da9690746bdb0e55d53a5eef45a969e3dd2873a3e6bb8ef3316d9f80489bacfd2f543108e284a40847ae7ce33fa358fcfe439a37990ad3107e9'
+      )
+    ],
+    [
+      Crypto.Ed25519PublicKeyHex('4d953d6a9d556da3f3e26622c725923130f5733d1a3c4013ef8c34d15a070fd7'),
+      Crypto.Ed25519SignatureHex(
+        'f9218e5a569c5ace38b1bb81e1f1c0b2d7fea2fe7fb913fdd06d79906436103345347a81494b83f83bf43466b0cebdbbdcef15384f67c255e826c249336ce2c7'
+      )
+    ]
+  ])
+};
+
+const simpleCore: Cardano.Witness = {
+  signatures: new Map([
+    [
+      Crypto.Ed25519PublicKeyHex('4a352f53eb4311d552aa9e1c6f0125846a3b607011d691f0e774d893d940b852'),
+      Crypto.Ed25519SignatureHex(
+        'c4f13cc397a50193061ce899b3eda906ad1adf3f3d515b52248ea5aa142781cd9c2ccc52ac62b2e1b5226de890104ec530bda4c38a19b691946da9addb3213f5'
+      )
+    ],
+    [
+      Crypto.Ed25519PublicKeyHex('290c08454c58a8c7fad6351e65a652460bd4f80f485f1ccfc350ff6a4d5bd4de'),
+      Crypto.Ed25519SignatureHex(
+        '026f47bab2f24da9690746bdb0e55d53a5eef45a969e3dd2873a3e6bb8ef3316d9f80489bacfd2f543108e284a40847ae7ce33fa358fcfe439a37990ad3107e9'
+      )
+    ],
+    [
+      Crypto.Ed25519PublicKeyHex('4d953d6a9d556da3f3e26622c725923130f5733d1a3c4013ef8c34d15a070fd7'),
+      Crypto.Ed25519SignatureHex(
+        'f9218e5a569c5ace38b1bb81e1f1c0b2d7fea2fe7fb913fdd06d79906436103345347a81494b83f83bf43466b0cebdbbdcef15384f67c255e826c249336ce2c7'
+      )
+    ]
+  ])
+};
+
+describe('TransactionWitnessSet', () => {
+  it('can encode TransactionWitnessSet to CBOR', () => {
+    const witness = TransactionWitnessSet.fromCore(core);
+    expect(witness.toCbor()).toEqual(cbor);
+  });
+
+  it('can encode TransactionWitnessSet to Core', () => {
+    const witness = TransactionWitnessSet.fromCbor(cbor);
+    expect(witness.toCore()).toEqual(core);
+  });
+
+  it('can encode simple TransactionWitnessSet to CBOR', () => {
+    const witness = TransactionWitnessSet.fromCore(simpleCore);
+    expect(witness.toCbor()).toEqual(simpleWitnessCbor);
+  });
+
+  it('can encode simple TransactionWitnessSet to Core', () => {
+    const witness = TransactionWitnessSet.fromCbor(simpleWitnessCbor);
+    expect(witness.toCore()).toEqual(simpleCore);
+  });
+});

--- a/packages/core/test/Serialization/TransactionWitnessSet/VkeyWitness.test.ts
+++ b/packages/core/test/Serialization/TransactionWitnessSet/VkeyWitness.test.ts
@@ -1,0 +1,44 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import * as Crypto from '@cardano-sdk/crypto';
+import { HexBlob } from '@cardano-sdk/util';
+import { VkeyWitness } from '../../../src/Serialization';
+
+// Test data used in the following tests was generated with the cardano-serialization-lib
+const cbor = HexBlob(
+  '8258203d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c58406291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+);
+
+const vkey = Crypto.Ed25519PublicKeyHex('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c');
+const signature = Crypto.Ed25519SignatureHex(
+  '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+);
+
+describe('VkeyWitness', () => {
+  it('can decode VkeyWitness from CBOR', () => {
+    const witness = VkeyWitness.fromCbor(cbor);
+
+    expect(witness.vkey()).toEqual('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c');
+    expect(witness.signature()).toEqual(
+      '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+    );
+  });
+
+  it('can decode VkeyWitness from Core', () => {
+    const witness = VkeyWitness.fromCore([vkey, signature]);
+
+    expect(witness.vkey()).toEqual('3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c');
+    expect(witness.signature()).toEqual(
+      '6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a'
+    );
+  });
+
+  it('can encode VkeyWitness to CBOR', () => {
+    const witness = VkeyWitness.fromCore([vkey, signature]);
+    expect(witness.toCbor()).toEqual(cbor);
+  });
+
+  it('can encode VkeyWitness to Core', () => {
+    const witness = VkeyWitness.fromCbor(cbor);
+    expect(witness.toCore()).toEqual([vkey, signature]);
+  });
+});

--- a/packages/tx-construction/test/fees/fees.test.ts
+++ b/packages/tx-construction/test/fees/fees.test.ts
@@ -120,7 +120,7 @@ describe('fees', () => {
     it('calculate the correct min fee for transaction with scripts', () => {
       const prices = { memory: 0.0577, steps: 0.000_007_21 };
       const fee = minFee(babbageTx, prices, MinFeeConstant(155_381), MinFeeCoefficient(44));
-      expect(fee).toBe(218_807n);
+      expect(fee).toBe(218_763n);
     });
   });
 });

--- a/packages/tx-construction/test/input-selection/selectionConstraints.test.ts
+++ b/packages/tx-construction/test/input-selection/selectionConstraints.test.ts
@@ -43,7 +43,7 @@ describe('defaultSelectionConstraints', () => {
 
   it('computeMinimumCost', async () => {
     cmlMock.Value.new.mockImplementation(cmlActual.Value.new);
-    const fee = 218_807n;
+    const fee = 218_763n;
     const buildTx = jest.fn(async () => babbageTx);
     const selectionSkeleton = {} as SelectionSkeleton;
     const constraints = defaultSelectionConstraints({


### PR DESCRIPTION
# Context

In order to use the SDK in the mobile environment is now a priority to replace the CML library with our custom serialization classes.

# Proposed Solution

Implement the serialization natively in Typescript.

# Important Changes Introduced

- Added transaction witness set serialization classes.