### PR TITLE
Feat/Add separate withdrawals to implicit coin

### DIFF
--- a/packages/core/src/Cardano/util/computeImplicitCoin.ts
+++ b/packages/core/src/Cardano/util/computeImplicitCoin.ts
@@ -7,7 +7,11 @@ import { CertificateType, HydratedTxBody, Lovelace } from '../types';
  */
 export interface ImplicitCoin {
   /**
-   * Reward withdrawals + deposit reclaims
+   * Reward withdrawals
+   */
+  withdrawals?: Lovelace;
+  /**
+   * Reward withdrawals + deposit reclaims (total return)
    */
   input?: Lovelace;
   /**
@@ -44,6 +48,7 @@ export const computeImplicitCoin = (
   );
   return {
     deposit,
-    input: withdrawalsTotal + reclaimTotal
+    input: withdrawalsTotal + reclaimTotal,
+    withdrawals: withdrawalsTotal
   };
 };

--- a/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
+++ b/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
@@ -24,5 +24,6 @@ describe('Cardano.util.computeImplicitCoin', () => {
     const coin = Cardano.util.computeImplicitCoin(protocolParameters, { certificates, withdrawals });
     expect(coin.deposit).toBe(2n + 2n);
     expect(coin.input).toBe(2n + 3n + 5n);
+    expect(coin.withdrawals).toBe(5n);
   });
 });

--- a/packages/input-selection/src/util.ts
+++ b/packages/input-selection/src/util.ts
@@ -54,7 +54,8 @@ export const preProcessArgs = (
   const outputs = [...outputSet];
   const implicitCoin: Required<Cardano.util.ImplicitCoin> = {
     deposit: partialImplicitValue?.coin?.deposit || 0n,
-    input: partialImplicitValue?.coin?.input || 0n
+    input: partialImplicitValue?.coin?.input || 0n,
+    withdrawals: partialImplicitValue?.coin?.withdrawals || 0n
   };
   const mintMap: Cardano.TokenMap = partialImplicitValue?.mint || new Map();
   const { implicitTokensInput, implicitTokensSpend } = mintToImplicitTokens(mintMap);


### PR DESCRIPTION
# Context

Currently there's no way of knowing whether the value in `implicitCoin`'s `input` comes from rewards, stake key de-registration, or a combination of them. With this change, this is solved.

# Proposed Solution

Add a `withdrawals` prop to the return object, which contains only the user's rewards. This is a non-breaking change, and by `diff`ing `input` and `withdrawals`, it's possible to also determine what the stake key deregistration return is.

# Important Changes Introduced


