### PR TITLE
fix(cardano-services): throw a 404 on a request of a handle not found

### DIFF
--- a/packages/cardano-services/src/Handle/TypeOrmHandleProvider.ts
+++ b/packages/cardano-services/src/Handle/TypeOrmHandleProvider.ts
@@ -26,6 +26,9 @@ const handleSelect = <{ [k in HandleFields]: true }>Object.fromEntries(handleFie
 export const emptyStringHandleResolutionRequestError = () =>
   new ProviderError(ProviderFailure.BadRequest, undefined, "Empty string handle can't be resolved");
 
+export const handleResolutionNotFoundRequestError = () =>
+  new ProviderError(ProviderFailure.NotFound, undefined, 'Handle not found');
+
 export class TypeOrmHandleProvider extends TypeormProvider implements HandleProvider {
   inMemoryCache: InMemoryCache;
 
@@ -47,7 +50,7 @@ export class TypeOrmHandleProvider extends TypeormProvider implements HandleProv
       await queryRunner.release();
 
       const mapEntity = (entity: PartialHandleEntity | undefined): HandleResolution | null => {
-        if (!entity) return null;
+        if (!entity) throw handleResolutionNotFoundRequestError();
 
         const { cardanoAddress, handle, hasDatum, policyId } = entity;
 

--- a/packages/cardano-services/test/Handle/TypeOrmHandleProvider.test.ts
+++ b/packages/cardano-services/test/Handle/TypeOrmHandleProvider.test.ts
@@ -28,6 +28,11 @@ describe('TypeOrmHandleProvider', () => {
       "BAD_REQUEST (Empty string handle can't be resolved)"
     ));
 
+  it('throws a 404 if handle not found', async () =>
+    expect(provider.resolveHandles({ handles: ['testingHandles', '', 'test'] })).rejects.toThrow(
+      'NOT_FOUND (Handle not found)'
+    ));
+
   it('resolve method correctly resolves handles', async () => {
     const result = await provider.resolveHandles({ handles: ['none', 'TestHandle'] });
 


### PR DESCRIPTION
# Context
Currently we are sending null for non found handles, we want to return a 404. 

# Proposed Solution
Instead of returning null, throw a 404. 

# Important Changes Introduced
