### PR TITLE
Adds live endpoint and fixes DbSyncProvider ready endpoint

### DIFF
--- a/nix/cardano-services/deployments/backend-deployment.yaml
+++ b/nix/cardano-services/deployments/backend-deployment.yaml
@@ -75,7 +75,7 @@ spec:
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:
-              path: /v1.0.0/health
+              path: /v1.0.0/live
               port: 3000
             timeoutSeconds: 5
           name: backend

--- a/nix/cardano-services/deployments/backend-ingress.yaml
+++ b/nix/cardano-services/deployments/backend-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"RedirectConfig":{"Port":"443","Protocol":"HTTPS","StatusCode":"HTTP_301"},"Type":"redirect"}'
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "60"
-    alb.ingress.kubernetes.io/healthcheck-path: /v1.0.0/health
+    alb.ingress.kubernetes.io/healthcheck-path: /v1.0.0/live
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "30"
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing

--- a/nix/cardano-services/deployments/handle-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-projector-deployment.yaml
@@ -58,7 +58,7 @@ spec:
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:
-              path: /v1.0.0/health
+              path: /v1.0.0/live
               port: 3000
             timeoutSeconds: 5
           name: handle-projector

--- a/nix/cardano-services/deployments/handle-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/handle-provider-deployment.yaml
@@ -66,7 +66,7 @@ spec:
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:
-              path: /v1.0.0/health
+              path: /v1.0.0/live
               port: 3000
             timeoutSeconds: 5
           name: handle-provider

--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -78,7 +78,7 @@ spec:
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:
-              path: /v1.0.0/health
+              path: /v1.0.0/live
               port: 3000
           name: pg-boss-worker
           ports:

--- a/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-projector-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:
-              path: /v1.0.0/health
+              path: /v1.0.0/live
               port: 3000
             timeoutSeconds: 5
           name: stake-pool-projector

--- a/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
+++ b/nix/cardano-services/deployments/stake-pool-provider-deployment.yaml
@@ -68,7 +68,7 @@ spec:
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:
-              path: /v1.0.0/health
+              path: /v1.0.0/live
               port: 3000
             timeoutSeconds: 5
           name: stake-pool-provider

--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -137,6 +137,10 @@ export class HttpServer extends RunnableModule {
 
     const handlers = {
       health: healthCheckHandler(() => 200),
+      live: async (req: express.Request, res: express.Response) => {
+        this.logger.debug('/live', { ip: req.ip });
+        return res.sendStatus(200);
+      },
       meta: serverMetadataHandler,
       ready: healthCheckHandler(({ ok }) => (ok ? 200 : 503))
     };

--- a/packages/cardano-services/src/Http/openApi.json
+++ b/packages/cardano-services/src/Http/openApi.json
@@ -55,6 +55,32 @@
           }
         }
       }
+    },
+    "/v1.0.0/ready": {
+      "get": {
+        "summary": "HTTP Server ready GET",
+        "operationId": "server-ready-get",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "503": {
+            "description": "Service Unavailable"
+          }
+        }
+      },
+      "post": {
+        "summary": "HTTP Server ready POST",
+        "operationId": "server-ready-post",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "503": {
+            "description": "Service Unavailable"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/packages/cardano-services/src/Http/openApi.json
+++ b/packages/cardano-services/src/Http/openApi.json
@@ -9,6 +9,26 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/v1.0.0/live": {
+      "get": {
+        "summary": "HTTP Server live GET",
+        "operationId": "server-live-get",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "summary": "HTTP Server live POST",
+        "operationId": "server-live-post",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/v1.0.0/meta": {
       "post": {
         "summary": "HTTP Server metadata POST",

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -472,9 +472,7 @@ describe('HttpServer', () => {
       await httpServer.initialize();
       await httpServer.start();
       await serverStarted(apiUrlBase);
-      const res = await axios.post(`${apiUrlBase}/health`, {
-        headers: { [CONTENT_TYPE]: 'application/json' }
-      });
+      const res = await axios.get(`${apiUrlBase}/health`);
       const readyRes = await axios.get(`${apiUrlBase}/ready`);
       expect(res.status).toBe(200);
       expect(readyRes.status).toBe(200);

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -390,6 +390,34 @@ describe('HttpServer', () => {
       expect(response.data.includes('healthcheck 0')).toEqual(true);
     });
   });
+
+  describe('live endpoint', () => {
+    afterEach(async () => {
+      await httpServer.shutdown();
+    });
+
+    it('/live endpoint returns a 200 coded response, if the server is running, for GET and POST requests', async () => {
+      httpServer = new HttpServer(
+        { listen: { host: 'localhost', port } },
+        {
+          logger,
+          runnableDependencies: [cardanoNode],
+          services: [new SomeHttpService(ServiceNames.StakePool, provider, logger)]
+        }
+      );
+
+      await httpServer.initialize();
+      await httpServer.start();
+      await serverStarted(apiUrlBase);
+
+      const resGet = await axios.get(`${apiUrlBase}/live`);
+      const resPost = await axios.post(`${apiUrlBase}/live`);
+
+      expect(resGet.status).toBe(200);
+      expect(resPost.status).toBe(200);
+    });
+  });
+
   describe('Service health check', () => {
     const shouldFail = true;
     beforeEach(async () => {

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -2160,10 +2160,8 @@ describe('CLI', () => {
 
     const assertServerAlive = async () => {
       await serverStarted(apiUrl);
-      const headers = { 'Content-Type': 'application/json' };
-      const res = await axios.post(`${apiUrl}${baseVersionPath}/health`, { headers });
+      const res = await axios.get(`${apiUrl}${baseVersionPath}/live`);
       expect(res.status).toBe(200);
-      expect(res.data.ok).toBe(false);
     };
 
     beforeAll(async () => {


### PR DESCRIPTION
# Context
Services need to report when they are live and also when they are ready, which can be used to interpret the service health. Orchestration logic can be tied to the live result, to determine if a restart is required, or the ready result for starting up dependent services.

# Proposed Solution
- Adds `/live` endpoint that simply returns a `200` if the server is reachable.
- `DbSyncProvider` now only as to access both the node and database to be considered ready.

# Important Changes Introduced
`/ready` endpoint no longer returns the health check response, and it's been included in the `HttpServer` OpenApi document 