### PR TITLE
feat: add 'fresh' option to AssetProvider.getAssets

### DIFF
--- a/packages/cardano-services/src/Asset/openApi.json
+++ b/packages/cardano-services/src/Asset/openApi.json
@@ -166,6 +166,14 @@
           }
         }
       },
+      "FreshOptions": {
+        "type": "object",
+        "properties": {
+          "nftMetadata": {
+            "type": "boolean"
+          }
+        }
+      },
       "ExtraDataAssetIds": {
         "type": "object",
         "properties": {
@@ -201,6 +209,9 @@
           },
           "extraData": {
             "$ref": "#/components/schemas/ExtraDataAssetIds"
+          },
+          "fresh": {
+            "$ref": "#/components/schemas/FreshOptions"
           }
         }
       },

--- a/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/DbSyncAssetProvider.test.ts
@@ -127,6 +127,19 @@ describe('DbSyncAssetProvider', () => {
     ]);
     expect(nftMetadataSpy).toBeCalledTimes(1);
   });
+  it('does not cache nft metadata when fresh.nftMetadata=true', async () => {
+    const assets = await fixtureBuilder.getAssets(1, { with: [AssetWith.CIP25Metadata] });
+    await provider.getAsset({
+      assetId: assets[0].id,
+      extraData: { nftMetadata: true }
+    });
+    await provider.getAssets({
+      assetIds: [assets[0].id],
+      extraData: { nftMetadata: true },
+      fresh: { nftMetadata: true }
+    });
+    expect(nftMetadataSpy).toBeCalledTimes(2);
+  });
   it('returns undefined asset token metadata if the token registry throws a server internal error', async () => {
     const { serverUrl, closeMock } = await mockTokenRegistry(async () => ({ body: {}, code: 500 }));
     const tokenMetadataService = new CardanoTokenRegistry(

--- a/packages/core/src/Provider/AssetProvider/types.ts
+++ b/packages/core/src/Provider/AssetProvider/types.ts
@@ -20,9 +20,17 @@ export interface GetAssetArgs {
   extraData?: AssetExtraData;
 }
 
+export interface GetAssetsFreshOptions {
+  nftMetadata?: boolean;
+}
+
 export interface GetAssetsArgs {
   assetIds: Cardano.AssetId[];
   extraData?: AssetsExtraData;
+  /**
+   * Ask the provider to return fresh (non-cached) response
+   */
+  fresh?: GetAssetsFreshOptions;
 }
 
 export interface AssetProvider extends Provider {


### PR DESCRIPTION
# Context

Wallet sometimes gets old nft metadata

# Proposed Solution

Add a request option to fetch fresh nft metadata. Wallet can then use it when it sees an on-chain transaction that might have changed the nft metadata

# Important Changes Introduced
