### PR TITLE
fix: service name url mismatch

### DIFF
--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: QUEUES
               value: pool-metadata,pool-metrics
             - name: STAKE_POOL_PROVIDER_URL
-              value: https://dev-preview-cardanojs-backend.dev-preview.svc.cluster.local/stake-pool
+              value: https://dev-preview-cardanojs-backend.dev-preview.svc.cluster.local/v1.0.0/stake-pool
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:
@@ -96,7 +96,7 @@ spec:
             runAsUser: 0
           startupProbe:
             httpGet:
-              path: /ready
+              path: /v1.0.0/ready
               port: 3000
             initialDelaySeconds: 80
             periodSeconds: 5

--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: QUEUES
               value: pool-metadata,pool-metrics
             - name: STAKE_POOL_PROVIDER_URL
-              value: https://dev-preview-cardanojs-stake-pool-provider.dev-preview.svc.cluster.local/stake-pool
+              value: https://dev-preview-cardanojs-backend.dev-preview.svc.cluster.local/stake-pool
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:

--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -46,21 +46,21 @@ spec:
                   key: password
                   name: stakepool-owner-user.dev-preview-dbsync-db.credentials.postgresql.acid.zalan.do
             - name: POSTGRES_POOL_MAX_DB_SYNC
-              value: "5"
+              value: '5'
             - name: POSTGRES_POOL_MAX_STAKE_POOL
-              value: "5"
+              value: '5'
             - name: POSTGRES_PORT_DB_SYNC
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_PORT_STAKE_POOL
-              value: "5432"
+              value: '5432'
             - name: POSTGRES_SSL_CA_FILE_DB_SYNC
               value: /tls/ca.crt
             - name: POSTGRES_SSL_CA_FILE_STAKE_POOL
               value: /tls/ca.crt
             - name: POSTGRES_SSL_DB_SYNC
-              value: "true"
+              value: 'true'
             - name: POSTGRES_SSL_STAKE_POOL
-              value: "true"
+              value: 'true'
             - name: POSTGRES_USER_DB_SYNC
               valueFrom:
                 secretKeyRef:
@@ -74,7 +74,7 @@ spec:
             - name: QUEUES
               value: pool-metadata,pool-metrics
             - name: STAKE_POOL_PROVIDER_URL
-              value: https://dev-preview-stake-pool.dev-preview.svc.cluster.local/stake-pool
+              value: https://dev-preview-cardanojs-stake-pool-provider.dev-preview.svc.cluster.local/stake-pool
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:


### PR DESCRIPTION
# Context

The url link from pg-boss-worker needs to point to the correct service name.

# Solution

Without really understanding how they are rendered and if the actual service name would be rendered as expceted, ensure that they are both rendered the same way (either right or wrong).

# Testing

This is currently a root cause for a failure in `dev-preview` deployment.

- [x] As per: https://github.com/input-output-hk/wallet-world/pull/2854
