### PR TITLE
fix: pgboss url configuration

### DIFF
--- a/nix/cardano-services/deployments/pgboss-deployment.yaml
+++ b/nix/cardano-services/deployments/pgboss-deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: QUEUES
               value: pool-metadata,pool-metrics
             - name: STAKE_POOL_PROVIDER_URL
-              value: https://dev-preview-cardanojs-backend.dev-preview.svc.cluster.local/v1.0.0/stake-pool
+              value: http://dev-preview-cardanojs-backend.dev-preview.svc.cluster.local
           image: FIXME-ADD-LATEST-IMAGE-REFERENCE
           livenessProbe:
             httpGet:


### PR DESCRIPTION
# Context

The application adds the path suffix all on its own, furthermore no https (port 443) is configured _within_ the cluster network.

# Proposed Solutioni
- remove the path suffix
- change https to http

# Testing
- [x] `dev-preview` is still not working and this gets us one step closer, see [comment](https://github.com/input-output-hk/cardano-js-sdk/pull/915#pullrequestreview-1622325439)