### PR TITLE
ci: fix handle provider OCI image reference

### DIFF
--- a/nix/cardano-services/deployments.nix
+++ b/nix/cardano-services/deployments.nix
@@ -24,6 +24,14 @@ in {
         }
       ];
     };
+    handle-provider-deployment = {
+      spec.template.spec.containers = dmerge.updateOn "name" [
+        {
+          name = "handle-provider";
+          image = cell.oci-images.cardano-services.image.name;
+        }
+      ];
+    };
     handle-projector-deployment = {
       spec.template.spec.containers = dmerge.updateOn "name" [
         {


### PR DESCRIPTION
# Context
For the past a while we have handle provider failing due to invalid OCI image name. This is a fix to reduce the amount of alerts

