### PR TITLE
Feat/lw 7403 distribution portfolio locally persisted

### DIFF
--- a/packages/core/src/Cardano/types/DelegationsAndRewards.ts
+++ b/packages/core/src/Cardano/types/DelegationsAndRewards.ts
@@ -44,3 +44,6 @@ export interface Cip17DelegationPortfolio {
   description?: string;
   author?: string;
 }
+
+export type TimeStamp = number;
+export type Cip17DelegationPortfolioUpdate = [TimeStamp, Cip17DelegationPortfolio];

--- a/packages/e2e/test/long-running/delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/delegation-rewards.test.ts
@@ -21,6 +21,7 @@ const submitDelegationTx = async (wallet: PersonalWallet, pools: Cardano.PoolId[
   const { tx: signedTx } = await wallet
     .createTxBuilder()
     .delegatePortfolio({
+      name: 'Tests Portfolio',
       pools: pools.map((poolId) => ({ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolId)), weight: 1 }))
     })
     .build()

--- a/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
@@ -95,7 +95,8 @@ const delegateToMultiplePools = async (
   weights = Array.from({ length: POOLS_COUNT }).map(() => 1)
 ) => {
   const poolIds = await getPoolIds(wallet);
-  const portfolio: Pick<Cardano.Cip17DelegationPortfolio, 'pools'> = {
+  const portfolio: Cardano.Cip17DelegationPortfolio = {
+    name: 'Tests Portfolio',
     pools: poolIds.map(({ hexId: id }, idx) => ({ id, weight: weights[idx] }))
   };
   logger.debug('Delegating portfolio', portfolio);

--- a/packages/tx-construction/src/tx-builder/finalizeTx.ts
+++ b/packages/tx-construction/src/tx-builder/finalizeTx.ts
@@ -30,7 +30,15 @@ const getSignatures = async (
 
 export const finalizeTx = async (
   tx: Cardano.TxBodyWithHash,
-  { ownAddresses, witness, signingOptions, auxiliaryData, isValid, handleResolutions }: TxContext,
+  {
+    ownAddresses,
+    witness,
+    signingOptions,
+    auxiliaryData,
+    isValid,
+    handleResolutions,
+    delegationPortfolioUpdate
+  }: TxContext,
   { inputResolver, keyAgent }: FinalizeTxDependencies,
   stubSign = false
 ): Promise<SignedTx> => {
@@ -58,6 +66,7 @@ export const finalizeTx = async (
   return {
     cbor: TxCBOR.serialize(transaction),
     context: {
+      delegationPortfolioUpdate,
       handleResolutions: handleResolutions ?? []
     },
     tx: transaction

--- a/packages/tx-construction/src/tx-builder/types.ts
+++ b/packages/tx-construction/src/tx-builder/types.ts
@@ -137,6 +137,7 @@ export interface TxContext {
   witness?: InitializeTxWitness;
   isValid?: boolean;
   handleResolutions?: HandleResolution[];
+  delegationPortfolioUpdate?: Cardano.Cip17DelegationPortfolioUpdate;
 }
 
 export type TxInspection = Cardano.TxBodyWithHash &
@@ -148,9 +149,12 @@ export interface SignedTx {
   cbor: TxCBOR;
   tx: Cardano.Tx;
   context: {
+    delegationPortfolioUpdate?: Cardano.Cip17DelegationPortfolioUpdate;
     handleResolutions: HandleResolution[];
   };
 }
+
+export type StoreDelegationPortfolioUpdate = (portfolioUpdate: Cardano.Cip17DelegationPortfolioUpdate | null) => void;
 
 /**
  * Transaction body built with {@link TxBuilder.build}
@@ -269,6 +273,7 @@ export interface TxBuilderDependencies {
   keyAgent: AsyncKeyAgent;
   txBuilderProviders: TxBuilderProviders;
   logger: Logger;
+  storeDelegationPortfolioUpdate?: StoreDelegationPortfolioUpdate;
   outputValidator?: OutputBuilderValidator;
   handleProvider?: HandleProvider;
 }

--- a/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, GroupedAddress, InMemoryKeyAgent, util } from '@cardano-sdk/key-management';
 import { CML, Cardano } from '@cardano-sdk/core';
@@ -146,7 +147,10 @@ describe('TxBuilder/delegatePortfolio', () => {
 
     it('uses random improve input selector when delegating to a single pool', async () => {
       const tx = await txBuilder
-        .delegatePortfolio({ pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }] })
+        .delegatePortfolio({
+          name: 'Tests Portfolio',
+          pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }]
+        })
         .build()
         .inspect();
 
@@ -182,6 +186,7 @@ describe('TxBuilder/delegatePortfolio', () => {
     it('uses roundRobinRandomImprove when only one reward account is registered', async () => {
       await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
@@ -225,6 +230,7 @@ describe('TxBuilder/delegatePortfolio', () => {
         output = { address: groupedAddresses[3].address, value: { coins: 10n } };
         tx = await txBuilder
           .delegatePortfolio({
+            name: 'Tests Portfolio',
             pools: [
               {
                 id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
@@ -305,6 +311,7 @@ describe('TxBuilder/delegatePortfolio', () => {
     it('does not change delegations when portfolio already satisfied, but updates distribution', async () => {
       const tx = await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
@@ -333,6 +340,7 @@ describe('TxBuilder/delegatePortfolio', () => {
         and updates change addresses distribution`, async () => {
       const tx = await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
@@ -365,6 +373,7 @@ describe('TxBuilder/delegatePortfolio', () => {
          and configures change addresses so funds go to the delegated address`, async () => {
       const tx = await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
@@ -384,13 +393,14 @@ describe('TxBuilder/delegatePortfolio', () => {
     });
 
     it('portfolio with empty pools array is not a valid CIP17 portfolio', () => {
-      expect(() => txBuilder.delegatePortfolio({ pools: [] })).toThrow();
+      expect(() => txBuilder.delegatePortfolio({ name: 'Tests Portfolio', pools: [] })).toThrow();
     });
 
     it('derives more stake keys when portfolio has more pools than available keys', async () => {
       const pools = poolIds.slice(0, 3);
       const tx = await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: pools.map((pool) => ({ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(pool)), weight: 1 }))
         })
         .build()
@@ -421,6 +431,7 @@ describe('TxBuilder/delegatePortfolio', () => {
     it('portfolio is superset: adds certificates for the new delegations', async () => {
       const tx = await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
@@ -451,6 +462,7 @@ describe('TxBuilder/delegatePortfolio', () => {
     it('changes delegation and deregisters stake keys that are not delegated', async () => {
       const tx = await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: [
             {
               id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
@@ -474,7 +486,8 @@ describe('TxBuilder/delegatePortfolio', () => {
   });
 
   describe('rewardAccount selection', () => {
-    const portfolio: Pick<Cardano.Cip17DelegationPortfolio, 'pools'> = {
+    const portfolio: Cardano.Cip17DelegationPortfolio = {
+      name: 'Tests Portfolio',
       pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }]
     };
 
@@ -535,6 +548,7 @@ describe('TxBuilder/delegatePortfolio', () => {
 
       const tx = await txBuilder
         .delegatePortfolio({
+          name: 'Tests Portfolio',
           pools: [
             { id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])), weight: 1 },
             { id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[3])), weight: 1 }
@@ -619,7 +633,10 @@ describe('TxBuilder/delegatePortfolio', () => {
 
       await expect(
         txBuilder
-          .delegatePortfolio({ pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }] })
+          .delegatePortfolio({
+            name: 'Tests Portfolio',
+            pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }]
+          })
           .build()
           .inspect()
       ).resolves.toBeTruthy();
@@ -641,7 +658,10 @@ describe('TxBuilder/delegatePortfolio', () => {
 
       await expect(
         txBuilder
-          .delegatePortfolio({ pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }] })
+          .delegatePortfolio({
+            name: 'Tests Portfolio',
+            pools: [{ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])), weight: 1 }]
+          })
           .build()
           .inspect()
       ).rejects.toThrow(OutOfSyncRewardAccounts);

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -26,10 +26,12 @@ export class InMemoryUnspendableUtxoStore extends InMemoryCollectionStore<Cardan
 export class InMemoryRewardsHistoryStore extends InMemoryKeyValueStore<Cardano.RewardAccount, Reward[]> {}
 export class InMemoryStakePoolsStore extends InMemoryKeyValueStore<Cardano.PoolId, Cardano.StakePool> {}
 export class InMemoryRewardsBalancesStore extends InMemoryKeyValueStore<Cardano.RewardAccount, Cardano.Lovelace> {}
+export class InMemoryDelegationPortfolioStore extends InMemoryDocumentStore<Cardano.Cip17DelegationPortfolioUpdate[]> {}
 
 export const createInMemoryWalletStores = (): WalletStores => ({
   addresses: new InMemoryAddressesStore(),
   assets: new InMemoryAssetsStore(),
+  delegationPortfolioUpdates: new InMemoryDelegationPortfolioStore(),
   destroy() {
     if (!this.destroyed) {
       this.destroyed = true;

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -26,6 +26,7 @@ export class PouchDbUtxoStore extends PouchDbCollectionStore<Cardano.Utxo> {}
 export class PouchDbRewardsHistoryStore extends PouchDbKeyValueStore<Cardano.RewardAccount, Reward[]> {}
 export class PouchDbStakePoolsStore extends PouchDbKeyValueStore<Cardano.PoolId, Cardano.StakePool> {}
 export class PouchDbRewardsBalancesStore extends PouchDbKeyValueStore<Cardano.RewardAccount, Cardano.Lovelace> {}
+export class PouchDbDelegationPortfolioStore extends PouchDbDocumentStore<Cardano.Cip17DelegationPortfolioUpdate[]> {}
 
 /**
  * @param {string} walletName used to derive underlying db names
@@ -39,6 +40,7 @@ export const createPouchDbWalletStores = (
   return {
     addresses: new PouchDbAddressesStore(docsDbName, 'addresses', logger),
     assets: new PouchDbAssetsStore(docsDbName, 'assets', logger),
+    delegationPortfolioUpdates: new PouchDbDelegationPortfolioStore(docsDbName, 'DelegationPortfolioUpdates', logger),
     destroy() {
       if (!this.destroyed) {
         // since the database of document stores is shared, destroying any document store destroys all of them

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -79,6 +79,7 @@ export interface WalletStores extends Destroyable {
   rewardsHistory: KeyValueStore<Cardano.RewardAccount, Reward[]>;
   rewardsBalances: KeyValueStore<Cardano.RewardAccount, Cardano.Lovelace>;
   stakePools: KeyValueStore<Cardano.PoolId, Cardano.StakePool>;
+  delegationPortfolioUpdates: DocumentStore<Cardano.Cip17DelegationPortfolioUpdate[]>;
   protocolParameters: DocumentStore<Cardano.ProtocolParameters>;
   genesisParameters: DocumentStore<Cardano.CompactGenesis>;
   eraSummaries: DocumentStore<EraSummary[]>;


### PR DESCRIPTION
# Context

The users staking portfolio preferences need to be locally persisted in the extension storage after submitting delegation txs on-chain, so the wallet can  track what was the user initial distribution choice in order to reduce staking drift 

# Proposed Solution

We need to store/retrieve this portfolio from local storage, but it must match what's actually on chain, otherwise it will produce wrong results (I.E a portfolio that being displayed that doesn't match the users current delegation, or worse, a faulty balancing of change).

This following approach tries to address this in the more robust/tolerant to failure way, while still behaving reasonably well in all cases:

We will store a collection of portfolios with a timestamp (as a Cip17DelegationPortfolioUpdate object), every update just adds to the list, to pick the portfolio for re-balancing (or returning to the client) we just select the most recent portfolio that matches the current delegation of the wallet. This means that:

- If there is a block reorganization and the multi delegation is reverted on chain. We will fall back to the previous portfolio which matches his current delegation.

- if the user is making a transaction right after the multi delegation transaction was issued, and this transaction gets picked up first to be included. We will fall back to the previous portfolio which matches his current delegation.

- if the original multi delegation transaction fails (and the user was switching pools), we will fall back to the previous portfolio which matches his current delegation (effectively rolling back the change which are no longer valid).

- if a transaction fails and the user keeps the same pools but different proportions, the redistribution of balance won't happen, but at least the auto balancing algorithm will follow the user the latest delegation preferences.

- if the transaction succeeds then everything will work as expected.

- If no matching portfolio can be found for users current delegation state, we will create a default portfolio which simply evenly distributes change to all stake addresses.

-  If the wallet is delegating to a single pool, we wont return any portfolio

# Important Changes Introduced
- The PersonalWallet now uses DynamicChangeAddressResolver
- The PersonalWallet now stores the users stake distribution preferences portfolio
