### PR TITLE
feat!: delegation distribution portfolio is now persisted on chain an…

### DIFF
--- a/packages/core/src/Cardano/types/DelegationsAndRewards.ts
+++ b/packages/core/src/Cardano/types/DelegationsAndRewards.ts
@@ -1,6 +1,8 @@
 import { Lovelace } from './Value';
+import { Metadatum } from './AuxiliaryData';
 import { PoolId, PoolIdHex, StakePool } from './StakePool';
 import { RewardAccount } from '../Address';
+import { metadatumToJson } from '../../util/metadatum';
 
 export interface DelegationsAndRewards {
   delegate?: PoolId;
@@ -44,3 +46,31 @@ export interface Cip17DelegationPortfolio {
   description?: string;
   author?: string;
 }
+
+// On chain portfolio metadata
+export const DelegationMetadataLabel = 6862n; // 0x1ace
+export type DelegationPortfolioMetadata = Exclude<Cip17DelegationPortfolio, 'pools'> & {
+  pools: Pick<Cip17Pool, 'id' | 'weight'>[];
+};
+
+export const portfolioMetadataFromCip17 = (cip17: Cip17DelegationPortfolio): DelegationPortfolioMetadata => {
+  const portfolio = { ...cip17 };
+
+  portfolio.pools = cip17.pools.map((pool) => ({
+    id: pool.id,
+    weight: pool.weight
+  }));
+
+  return portfolio as DelegationPortfolioMetadata;
+};
+
+export const cip17FromMetadatum = (portfolio: Metadatum): Cip17DelegationPortfolio => {
+  const cip17 = metadatumToJson(portfolio);
+
+  for (const pool of cip17.pools) {
+    // Metadatum serializes/deserializes numbers as bigints
+    pool.weight = Number(pool.weight);
+  }
+
+  return cip17 as Cip17DelegationPortfolio;
+};

--- a/packages/core/test/Cardano/types/DelegationAndRewards.test.ts
+++ b/packages/core/test/Cardano/types/DelegationAndRewards.test.ts
@@ -1,0 +1,98 @@
+import * as Cardano from '../../../src/Cardano';
+
+describe('portfolioMetadataFromCip17', () => {
+  const poolIds: Cardano.PoolId[] = [
+    Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh'),
+    Cardano.PoolId('pool1t9xlrjyk76c96jltaspgwcnulq6pdkmhnge8xgza8ku7qvpsy9r'),
+    Cardano.PoolId('pool1la4ghj4w4f8p4yk4qmx0qvqmzv6592ee9rs0vgla5w6lc2nc8w5')
+  ];
+
+  const portfolio = {
+    // eslint-disable-next-line sonarjs/no-duplicate-string
+    name: 'Tests Portfolio',
+    pools: [
+      {
+        id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
+        name: 'A',
+        ticker: 'At',
+        weight: 1
+      },
+      {
+        id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+        name: 'B',
+        ticker: 'Bt',
+        weight: 1
+      },
+      {
+        id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
+        name: 'C',
+        ticker: 'Ct',
+        weight: 1
+      }
+    ]
+  };
+
+  it('can get portfolio metadata from CIP-17', () => {
+    const portfolioMetadata = Cardano.portfolioMetadataFromCip17(portfolio);
+
+    expect(portfolioMetadata).toEqual({
+      name: 'Tests Portfolio',
+      pools: [
+        {
+          id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
+          weight: 1
+        },
+        {
+          id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+          weight: 1
+        },
+        {
+          id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
+          weight: 1
+        }
+      ]
+    });
+  });
+
+  it('can get portfolio metadata from CIP-17', () => {
+    const metadatum: Cardano.Metadatum = new Map<Cardano.Metadatum, Cardano.Metadatum>([
+      ['name', 'Tests Portfolio'],
+      [
+        'pools',
+        [
+          new Map<Cardano.Metadatum, Cardano.Metadatum>([
+            ['id', Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0]))],
+            ['weight', 1n]
+          ]),
+          new Map<Cardano.Metadatum, Cardano.Metadatum>([
+            ['id', Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1]))],
+            ['weight', 1n]
+          ]),
+          new Map<Cardano.Metadatum, Cardano.Metadatum>([
+            ['id', Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2]))],
+            ['weight', 1n]
+          ])
+        ]
+      ]
+    ]);
+
+    const cip17 = Cardano.cip17FromMetadatum(metadatum);
+    expect(cip17).toEqual({
+      name: 'Tests Portfolio',
+      pools: [
+        {
+          id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[0])),
+          weight: 1
+        },
+        {
+          id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[1])),
+          weight: 1
+        },
+        {
+          id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolIds[2])),
+          weight: 1
+        }
+      ]
+    });
+  });
+});

--- a/packages/e2e/test/long-running/delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/delegation-rewards.test.ts
@@ -21,6 +21,7 @@ const submitDelegationTx = async (wallet: PersonalWallet, pools: Cardano.PoolId[
   const { tx: signedTx } = await wallet
     .createTxBuilder()
     .delegatePortfolio({
+      name: 'Test Portfolio',
       pools: pools.map((poolId) => ({ id: Cardano.PoolIdHex(Cardano.PoolId.toKeyHash(poolId)), weight: 1 }))
     })
     .build()

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -116,4 +116,5 @@ export interface DelegationTracker {
   rewardsHistory$: Observable<RewardsHistory>;
   rewardAccounts$: Observable<Cardano.RewardAccountInfo[]>;
   distribution$: Observable<Map<Cardano.PoolId, DelegatedStake>>;
+  portfolio$: Observable<Cardano.Cip17DelegationPortfolio | null>;
 }

--- a/packages/wallet/test/services/DelegationTracker/stub-tx.ts
+++ b/packages/wallet/test/services/DelegationTracker/stub-tx.ts
@@ -1,8 +1,14 @@
 import { Cardano } from '@cardano-sdk/core';
+import { TxWithEpoch } from '../../../src/services/DelegationTracker/types';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const createStubTxWithCertificates = (certificates?: Cardano.Certificate[], commonCertProps?: any) =>
+export const createStubTxWithCertificates = (
+  certificates?: Cardano.Certificate[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  commonCertProps?: any,
+  auxData?: Cardano.AuxiliaryData
+) =>
   ({
+    auxiliaryData: auxData,
     blockHeader: {
       slot: Cardano.Slot(37_834_496)
     },
@@ -10,3 +16,21 @@ export const createStubTxWithCertificates = (certificates?: Cardano.Certificate[
       certificates: certificates?.map((cert) => ({ ...cert, ...commonCertProps }))
     }
   } as Cardano.HydratedTx);
+
+export const createStubTxWithEpoch = (
+  epoch: number,
+  certificates?: Cardano.Certificate[],
+  auxData?: Cardano.AuxiliaryData
+) =>
+  ({
+    epoch: Cardano.EpochNo(epoch),
+    tx: {
+      auxiliaryData: auxData,
+      blockHeader: {
+        slot: Cardano.Slot(37_834_496)
+      },
+      body: {
+        certificates: certificates?.map((cert) => ({ ...cert }))
+      }
+    } as Cardano.HydratedTx
+  } as TxWithEpoch);

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -98,6 +98,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
   currentEpoch$: RemoteApiPropertyType.HotObservable,
   delegation: {
     distribution$: RemoteApiPropertyType.HotObservable,
+    portfolio$: RemoteApiPropertyType.HotObservable,
     rewardAccounts$: RemoteApiPropertyType.HotObservable,
     rewardsHistory$: RemoteApiPropertyType.HotObservable
   },


### PR DESCRIPTION
# Context

The users staking portfolio preferences need to be persisted after submitting delegation txs on-chain, so the wallet can track what was the user initial distribution choice in order to maintain the portfolio balance

# Proposed Solution

Store the users preference as transaction metadata in the delegation transaction. Then the personal wallet can track using the tx history the delegation preference changes.

# Important Changes Introduced
- The PersonalWallet now uses DynamicChangeAddressResolver
- The DelegationTracker now exposes a new observable `portfolio$` that tracks the current portfolio.
- The TxBuilder now takes a whole CIP-17 portfolio object.
