### PR TITLE
feature/LW-8426 - CIP-30 `getExtensions()`

### DIFF
--- a/packages/dapp-connector/src/WalletApi/Cip30Wallet.ts
+++ b/packages/dapp-connector/src/WalletApi/Cip30Wallet.ts
@@ -107,9 +107,7 @@ export class Cip30Wallet {
   readonly #authenticator: RemoteAuthenticator;
 
   constructor(properties: WalletProperties, { api, authenticator, logger }: WalletDependencies) {
-    this.enable = this.enable.bind(this);
     this.icon = properties.icon;
-    this.isEnabled = this.isEnabled.bind(this);
     this.name = properties.walletName;
     this.#api = api;
     this.#logger = logger;

--- a/packages/dapp-connector/src/WalletApi/types.ts
+++ b/packages/dapp-connector/src/WalletApi/types.ts
@@ -33,6 +33,8 @@ export interface Cip30DataSignature {
   signature: CoseSign1CborHex;
 }
 
+export type WalletApiExtension = { cip: number };
+
 /**
  * Returns the network id of the currently connected account.
  * 0 is testnet and 1 is mainnet but other networks can possibly be returned by wallets.
@@ -77,6 +79,14 @@ export type GetCollateral = (params?: { amount?: Cbor }) => Promise<Cbor[] | nul
  * @throws ApiError
  */
 export type GetBalance = () => Promise<Cbor>;
+
+/**
+ * Retrieves the list of extensions enabled by the wallet.
+ * This may be influenced by the set of extensions requested in the initial enable request.
+ *
+ * @throws ApiError
+ */
+export type GetExtensions = () => Promise<WalletApiExtension[]>;
 
 /**
  * Returns a list of all used (included in some on-chain transaction) addresses controlled by the wallet.
@@ -169,6 +179,8 @@ export interface Cip30WalletApi {
 
   getCollateral: GetCollateral;
 
+  getExtensions: GetExtensions;
+
   getUsedAddresses: GetUsedAddresses;
 
   getUnusedAddresses: GetUnusedAddresses;
@@ -193,5 +205,3 @@ export interface Cip95WalletApi {
 export type WalletApi = Cip30WalletApi & Cip95WalletApi;
 
 export type WalletMethod = keyof WalletApi;
-
-export type WalletApiExtension = { cip: number };

--- a/packages/dapp-connector/test/WalletApi/Cip30Wallet.test.ts
+++ b/packages/dapp-connector/test/WalletApi/Cip30Wallet.test.ts
@@ -49,6 +49,7 @@ describe('Wallet', () => {
       const methods = new Set(Object.keys(api));
       expect(methods).toEqual(new Set([...CipMethodsMapping[30], 'experimental']));
       expect(await wallet.isEnabled()).toBe(true);
+      expect(await api.getExtensions()).toEqual([]);
     });
 
     test('with cip95 extension', async () => {
@@ -57,6 +58,7 @@ describe('Wallet', () => {
       const methods = new Set(Object.keys(api));
       expect(methods).toEqual(new Set([...CipMethodsMapping[30], ...CipMethodsMapping[95], 'experimental']));
       expect(await wallet.isEnabled()).toBe(true);
+      expect(await api.getExtensions()).toEqual([{ cip: 95 }]);
     });
 
     test('change extensions after enabling once', async () => {
@@ -64,11 +66,13 @@ describe('Wallet', () => {
       const cip30methods = new Set(Object.keys(cip30api));
       expect(cip30methods).toEqual(new Set([...CipMethodsMapping[30], 'experimental']));
       expect(await wallet.isEnabled()).toBe(true);
+      expect(await cip30api.getExtensions()).toEqual([]);
 
       const cip95api = await wallet.enable({ extensions: [{ cip: 95 }] });
       const cip95methods = new Set(Object.keys(cip95api));
       expect(cip95methods).toEqual(new Set([...CipMethodsMapping[30], ...CipMethodsMapping[95], 'experimental']));
       expect(await wallet.isEnabled()).toBe(true);
+      expect(await cip95api.getExtensions()).toEqual([{ cip: 95 }]);
     });
 
     test('unsupported extensions does not reject and returns cip30 methods', async () => {
@@ -77,6 +81,7 @@ describe('Wallet', () => {
       const methods = new Set(Object.keys(api));
       expect(methods).toEqual(new Set([...CipMethodsMapping[30], 'experimental']));
       expect(await wallet.isEnabled()).toBe(true);
+      expect(await api.getExtensions()).toEqual([]);
     });
 
     test('empty enable options does not reject and returns cip30 methods', async () => {
@@ -85,6 +90,7 @@ describe('Wallet', () => {
       const methods = new Set(Object.keys(api));
       expect(methods).toEqual(new Set([...CipMethodsMapping[30], 'experimental']));
       expect(await wallet.isEnabled()).toBe(true);
+      expect(await api.getExtensions()).toEqual([]);
     });
 
     test('throws if access to wallet api is not authorized', async () => {
@@ -233,6 +239,14 @@ describe('Wallet', () => {
 
       const txId = await api.submitTx('tx');
       expect(txId).toEqual('transactionId');
+    });
+
+    test('getExtensions', async () => {
+      expect(api.getExtensions).toBeDefined();
+      expect(typeof api.getExtensions).toBe('function');
+
+      const extensions = await api.getExtensions();
+      expect(extensions).toEqual([]);
     });
   });
 });

--- a/packages/dapp-connector/test/injectGlobal.test.ts
+++ b/packages/dapp-connector/test/injectGlobal.test.ts
@@ -57,12 +57,14 @@ describe('injectGlobal', () => {
       expect(window.cardano[properties.walletName].name).toBe(properties.walletName);
       expect(typeof window.cardano[properties.walletName].apiVersion).toBe('string');
       expect(window.cardano[properties.walletName].icon).toBe(properties.icon);
+      expect(window.cardano[properties.walletName].isEnabled).toBeDefined();
+      expect(typeof window.cardano[properties.walletName].isEnabled).toBe('function');
+      expect(window.cardano[properties.walletName].enable).toBeDefined();
+      expect(typeof window.cardano[properties.walletName].enable).toBe('function');
       expect(Object.keys(window.cardano[properties.walletName])).toEqual([
         'apiVersion',
         'supportedExtensions',
-        'enable',
         'icon',
-        'isEnabled',
         'name'
       ]);
       expect(window.cardano['another-obj']).toBe(anotherObj);

--- a/packages/dapp-connector/test/testWallet.ts
+++ b/packages/dapp-connector/test/testWallet.ts
@@ -8,6 +8,7 @@ export const api = <WalletApi>{
   getBalance: async () => '100',
   getChangeAddress: async () => 'change-address',
   getCollateral: async () => null,
+  getExtensions: async () => [{ cip: 95 }],
   getNetworkId: async () => 0,
   getPubDRepKey: async () => 'getPubDRepKey' as Ed25519PublicKeyHex,
   getRewardAddresses: async () => ['reward-address-1', 'reward-address-2'],

--- a/packages/e2e/test/web-extension/extension/stubWalletApi.ts
+++ b/packages/e2e/test/web-extension/extension/stubWalletApi.ts
@@ -29,6 +29,7 @@ export const stubWalletApi: WalletApi = {
         }
       ]
     ]),
+  getExtensions: async () => [{ cip: 95 }],
   getNetworkId: async () => 0,
   getPubDRepKey: async () => Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01'),
   getRewardAddresses: async () => ['stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27'],

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -11,7 +11,8 @@ import {
   TxSendErrorCode,
   TxSignError,
   TxSignErrorCode,
-  WalletApi
+  WalletApi,
+  WalletApiExtension
 } from '@cardano-sdk/dapp-connector';
 import { Cardano, Serialization, TxCBOR, coalesceValueQuantities } from '@cardano-sdk/core';
 import { HexBlob, ManagedFreeableScope } from '@cardano-sdk/util';
@@ -337,6 +338,10 @@ const baseCip30WalletApi = (
       }
     }
     return unspendables.map((core) => Serialization.TransactionUnspentOutput.fromCore(core).toCbor());
+  },
+  getExtensions: async (): Promise<WalletApiExtension[]> => {
+    logger.debug('getting enabled extensions');
+    return Promise.resolve([{ cip: 95 }]);
   },
   getNetworkId: async (): Promise<Cardano.NetworkId> => {
     logger.debug('getting networkId');

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -534,6 +534,11 @@ describe('cip30', () => {
           expect.assertions(3);
         });
       });
+
+      test('api.getExtensions', async () => {
+        const extensions = await api.getExtensions();
+        expect(extensions).toEqual([{ cip: 95 }]);
+      });
     });
 
     describe('confirmation callbacks', () => {


### PR DESCRIPTION
# Context

Add support for `getExtensions()` defined in [CIP-30](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0030/README.md#apigetextensions-promiseextension) 

# Proposed Solution
- Add `getExtensions` to `Cip30WalletApi` interface
- Changed return type of `Cip30Wallet.#getAllowedApiMethods` to also include the list of enabled extensions
- Remove unnecessary bindings of `enable` and `isEnabled` in `Cip30Wallet` constructor
