### PR TITLE
refactor/LW-7438 remove some code repetition

### DIFF
--- a/packages/cardano-services/src/Program/index.ts
+++ b/packages/cardano-services/src/Program/index.ts
@@ -1,4 +1,5 @@
 export * from './errors';
-export * from './programs/';
+export * from './options';
+export * from './programs';
 export * from './utils';
 export * from './services';

--- a/packages/cardano-services/src/Program/options/index.ts
+++ b/packages/cardano-services/src/Program/options/index.ts
@@ -1,4 +1,6 @@
 export * from './common';
 export * from './ogmios';
+export * from './policyIds';
 export * from './postgres';
 export * from './rabbitMq';
+export * from './util';

--- a/packages/cardano-services/src/Program/options/ogmios.ts
+++ b/packages/cardano-services/src/Program/options/ogmios.ts
@@ -1,6 +1,6 @@
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
 import { Ogmios } from '@cardano-sdk/ogmios';
-import { URL } from 'url';
+import { addOptions, newOption } from './util';
 
 const OGMIOS_URL_DEFAULT = (() => {
   const connection = Ogmios.createConnectionObject();
@@ -18,16 +18,17 @@ export interface OgmiosProgramOptions {
 }
 
 export const withOgmiosOptions = (command: Command) =>
-  command
-    .addOption(
-      new Option('--ogmios-srv-service-name <ogmiosSrvServiceName>', OgmiosOptionDescriptions.SrvServiceName).env(
-        'OGMIOS_SRV_SERVICE_NAME'
-      )
-    )
-    .addOption(
-      new Option('--ogmios-url <ogmiosUrl>', OgmiosOptionDescriptions.Url)
-        .env('OGMIOS_URL')
-        .default(new URL(OGMIOS_URL_DEFAULT))
-        .conflicts('ogmiosSrvServiceName')
-        .argParser((url) => new URL(url))
-    );
+  addOptions(command, [
+    newOption(
+      '--ogmios-srv-service-name <ogmiosSrvServiceName>',
+      OgmiosOptionDescriptions.SrvServiceName,
+      'OGMIOS_SRV_SERVICE_NAME'
+    ),
+    newOption(
+      '--ogmios-url <ogmiosUrl>',
+      OgmiosOptionDescriptions.Url,
+      'OGMIOS_URL',
+      (url) => new URL(url),
+      new URL(OGMIOS_URL_DEFAULT)
+    ).conflicts('ogmiosSrvServiceName')
+  ]);

--- a/packages/cardano-services/src/Program/options/policyIds.ts
+++ b/packages/cardano-services/src/Program/options/policyIds.ts
@@ -1,5 +1,6 @@
 import { Cardano, NotImplementedError } from '@cardano-sdk/core';
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
+import { addOptions, newOption } from './util';
 import { readFile } from 'fs/promises';
 
 const handlePolicyIdsParser = (policyIds: string) => policyIds.split(',').map(Cardano.PolicyId);
@@ -25,25 +26,23 @@ export const handlePolicyIdsFromFile = async (args: HandlePolicyIdsProgramOption
 };
 
 export const withHandlePolicyIdsOptions = (command: Command, maxPolicyIdsSupported?: number) =>
-  command
-    .addOption(
-      new Option('--handle-policy-ids <handlePolicyIds>', HandlePolicyIdsOptionDescriptions.HandlePolicyIds)
-        .env('HANDLE_POLICY_IDS')
-        .argParser((policyIds: string) => {
-          const policyIdsArray = handlePolicyIdsParser(policyIds);
+  addOptions(command, [
+    newOption(
+      '--handle-policy-ids <handlePolicyIds>',
+      HandlePolicyIdsOptionDescriptions.HandlePolicyIds,
+      'HANDLE_POLICY_IDS',
+      (policyIds: string) => {
+        const policyIdsArray = handlePolicyIdsParser(policyIds);
 
-          if (maxPolicyIdsSupported && policyIdsArray.length > maxPolicyIdsSupported) {
-            throw new NotImplementedError(`${policyIdsArray.length} policyIds are not supported`);
-          }
+        if (maxPolicyIdsSupported && policyIdsArray.length > maxPolicyIdsSupported)
+          throw new NotImplementedError(`${policyIdsArray.length} policyIds are not supported`);
 
-          return policyIdsArray;
-        })
-    )
-    .addOption(
-      new Option(
-        '--handle-policy-ids-file <handlePolicyIdsFile>',
-        HandlePolicyIdsOptionDescriptions.HandlePolicyIdsFile
-      )
-        .env('HANDLE_POLICY_IDS_FILE')
-        .conflicts('handlePolicyIds')
-    );
+        return policyIdsArray;
+      }
+    ),
+    newOption(
+      '--handle-policy-ids-file <handlePolicyIdsFile>',
+      HandlePolicyIdsOptionDescriptions.HandlePolicyIdsFile,
+      'HANDLE_POLICY_IDS_FILE'
+    ).conflicts('handlePolicyIds')
+  ]);

--- a/packages/cardano-services/src/Program/options/postgres.ts
+++ b/packages/cardano-services/src/Program/options/postgres.ts
@@ -1,4 +1,5 @@
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
+import { addOptions, newOption } from './util';
 import { existingFileValidator } from '../../util/validators';
 
 export enum PostgresOptionDescriptions {
@@ -47,20 +48,20 @@ export const getPostgresOption = <Suffix extends ConnectionNames, Options extend
 
 export const suffixType2Cli = (suffix: ConnectionNames) => suffix.replace(/[A-Z]/g, (_) => `-${_.toLowerCase()}`);
 
-export const withPostgresOptions = (command: Command, suffix: ConnectionNames) => {
-  const cliSuffix = suffix ? suffixType2Cli(suffix) : '';
-  const dscSuffix = suffix ? suffix.replace(/[A-Z]/g, (_) => ` ${_.toLowerCase()}`) : '';
-  const envSuffix = suffix ? suffix.replace(/[A-Z]/g, (_) => `_${_}`).replace(/[a-z]/g, (_) => _.toUpperCase()) : '';
+export const withPostgresOptions = (command: Command, suffixes: ConnectionNames[]) => {
+  for (const suffix of suffixes) {
+    const cliSuffix = suffix ? suffixType2Cli(suffix) : '';
+    const dscSuffix = suffix ? suffix.replace(/[A-Z]/g, (_) => ` ${_.toLowerCase()}`) : '';
+    const envSuffix = suffix ? suffix.replace(/[A-Z]/g, (_) => `_${_}`).replace(/[a-z]/g, (_) => _.toUpperCase()) : '';
 
-  const descSuffix = ` for${dscSuffix}`;
+    const descSuffix = ` for${dscSuffix}`;
 
-  return command
-    .addOption(
-      new Option(
+    addOptions(command, [
+      newOption(
         `--postgres-connection-string${cliSuffix} <postgresConnectionString${suffix}>`,
-        PostgresOptionDescriptions.ConnectionString + descSuffix
+        PostgresOptionDescriptions.ConnectionString + descSuffix,
+        `POSTGRES_CONNECTION_STRING${envSuffix}`
       )
-        .env(`POSTGRES_CONNECTION_STRING${envSuffix}`)
         .conflicts(`postgresSrvServiceName${suffix}`)
         .conflicts(`postgresDb${suffix}`)
         .conflicts(`postgresDbFile${suffix}`)
@@ -69,83 +70,70 @@ export const withPostgresOptions = (command: Command, suffix: ConnectionNames) =
         .conflicts(`postgresPassword${suffix}`)
         .conflicts(`postgresPasswordFile${suffix}`)
         .conflicts(`postgresHost${suffix}`)
-        .conflicts(`postgresPort${suffix}`)
-    )
-    .addOption(
-      new Option(
+        .conflicts(`postgresPort${suffix}`),
+      newOption(
         `--postgres-srv-service-name${cliSuffix} <postgresSrvServiceName${suffix}>`,
-        PostgresOptionDescriptions.SrvServiceName + descSuffix
+        PostgresOptionDescriptions.SrvServiceName + descSuffix,
+        `POSTGRES_SRV_SERVICE_NAME${envSuffix}`
       )
-        .env(`POSTGRES_SRV_SERVICE_NAME${envSuffix}`)
         .conflicts(`postgresHost${suffix}`)
-        .conflicts(`postgresPort${suffix}`)
-    )
-    .addOption(
-      new Option(`--postgres-db${cliSuffix} <postgresDb${suffix}>`, PostgresOptionDescriptions.Db + descSuffix)
-        .env(`POSTGRES_DB${envSuffix}`)
-        .conflicts(`postgresDbFile${suffix}`)
-    )
-    .addOption(
-      new Option(
+        .conflicts(`postgresPort${suffix}`),
+      newOption(
+        `--postgres-db${cliSuffix} <postgresDb${suffix}>`,
+        PostgresOptionDescriptions.Db + descSuffix,
+        `POSTGRES_DB${envSuffix}`
+      ).conflicts(`postgresDbFile${suffix}`),
+      newOption(
         `--postgres-db-file${cliSuffix} <postgresDbFile${suffix}>`,
-        PostgresOptionDescriptions.DbFile + descSuffix
-      )
-        .env(`POSTGRES_DB_FILE${envSuffix}`)
-        .argParser(existingFileValidator)
-    )
-    .addOption(
-      new Option(`--postgres-user${cliSuffix} <postgresUser${suffix}>`, PostgresOptionDescriptions.User + descSuffix)
-        .env(`POSTGRES_USER${envSuffix}`)
-        .conflicts(`postgresUserFile${suffix}`)
-    )
-    .addOption(
-      new Option(
+        PostgresOptionDescriptions.DbFile + descSuffix,
+        `POSTGRES_DB_FILE${envSuffix}`,
+        existingFileValidator
+      ),
+      newOption(
+        `--postgres-user${cliSuffix} <postgresUser${suffix}>`,
+        PostgresOptionDescriptions.User + descSuffix,
+        `POSTGRES_USER${envSuffix}`
+      ).conflicts(`postgresUserFile${suffix}`),
+      newOption(
         `--postgres-user-file${cliSuffix} <postgresUserFile${suffix}>`,
-        PostgresOptionDescriptions.UserFile + descSuffix
-      )
-        .env(`POSTGRES_USER_FILE${envSuffix}`)
-        .argParser(existingFileValidator)
-    )
-    .addOption(
-      new Option(
+        PostgresOptionDescriptions.UserFile + descSuffix,
+        `POSTGRES_USER_FILE${envSuffix}`,
+        existingFileValidator
+      ),
+      newOption(
         `--postgres-password${cliSuffix} <postgresPassword${suffix}>`,
-        PostgresOptionDescriptions.Password + descSuffix
-      )
-        .env(`POSTGRES_PASSWORD${envSuffix}`)
-        .conflicts(`postgresPasswordFile${suffix}`)
-    )
-    .addOption(
-      new Option(
+        PostgresOptionDescriptions.Password + descSuffix,
+        `POSTGRES_PASSWORD${envSuffix}`
+      ).conflicts(`postgresPasswordFile${suffix}`),
+      newOption(
         `--postgres-password-file${cliSuffix} <postgresPasswordFile${suffix}>`,
-        PostgresOptionDescriptions.PasswordFile + descSuffix
-      )
-        .env(`POSTGRES_PASSWORD_FILE${envSuffix}`)
-        .argParser(existingFileValidator)
-    )
-    .addOption(
-      new Option(
+        PostgresOptionDescriptions.PasswordFile + descSuffix,
+        `POSTGRES_PASSWORD_FILE${envSuffix}`,
+        existingFileValidator
+      ),
+      newOption(
         `--postgres-host${cliSuffix} <postgresHost${suffix}>`,
-        PostgresOptionDescriptions.Host + descSuffix
-      ).env(`POSTGRES_HOST${envSuffix}`)
-    )
-    .addOption(
-      new Option(
+        PostgresOptionDescriptions.Host + descSuffix,
+        `POSTGRES_HOST${envSuffix}`
+      ),
+      newOption(
         `--postgres-pool-max${cliSuffix} <postgresPoolMax${suffix}>`,
-        PostgresOptionDescriptions.PoolMax + descSuffix
-      )
-        .env(`POSTGRES_POOL_MAX${envSuffix}`)
-        .argParser((max) => Number.parseInt(max, 10))
-    )
-    .addOption(
-      new Option(
+        PostgresOptionDescriptions.PoolMax + descSuffix,
+        `POSTGRES_POOL_MAX${envSuffix}`,
+        (max) => Number.parseInt(max, 10)
+      ),
+      newOption(
         `--postgres-port${cliSuffix} <postgresPort${suffix}>`,
-        PostgresOptionDescriptions.Port + descSuffix
-      ).env(`POSTGRES_PORT${envSuffix}`)
-    )
-    .addOption(
-      new Option(
+        PostgresOptionDescriptions.Port + descSuffix,
+        `POSTGRES_PORT${envSuffix}`
+      ),
+      newOption(
         `--postgres-ssl-ca-file${cliSuffix} <postgresSslCaFile${suffix}>`,
-        PostgresOptionDescriptions.SslCaFile + descSuffix
-      ).env(`POSTGRES_SSL_CA_FILE${envSuffix}`)
-    );
+        PostgresOptionDescriptions.SslCaFile + descSuffix,
+        `POSTGRES_SSL_CA_FILE${envSuffix}`
+      )
+    ]);
+  }
+
+  return command;
 };

--- a/packages/cardano-services/src/Program/options/rabbitMq.ts
+++ b/packages/cardano-services/src/Program/options/rabbitMq.ts
@@ -1,5 +1,5 @@
-import { Command, Option } from 'commander';
-import { URL } from 'url';
+import { Command } from 'commander';
+import { addOptions, newOption } from './util';
 
 const RABBITMQ_URL_DEFAULT = 'amqp://localhost:5672';
 
@@ -14,16 +14,17 @@ export interface RabbitMqProgramOptions {
 }
 
 export const withRabbitMqOptions = (command: Command) =>
-  command
-    .addOption(
-      new Option('--rabbitmq-srv-service-name <rabbitmqSrvServiceName>', RabbitMqOptionDescriptions.SrvServiceName).env(
-        'RABBITMQ_SRV_SERVICE_NAME'
-      )
-    )
-    .addOption(
-      new Option('--rabbitmq-url <rabbitmqUrl>', RabbitMqOptionDescriptions.Url)
-        .env('RABBITMQ_URL')
-        .default(new URL(RABBITMQ_URL_DEFAULT))
-        .conflicts('rabbitmqSrvServiceName')
-        .argParser((url) => new URL(url))
-    );
+  addOptions(command, [
+    newOption(
+      '--rabbitmq-srv-service-name <rabbitmqSrvServiceName>',
+      RabbitMqOptionDescriptions.SrvServiceName,
+      'RABBITMQ_SRV_SERVICE_NAME'
+    ),
+    newOption(
+      '--rabbitmq-url <rabbitmqUrl>',
+      RabbitMqOptionDescriptions.Url,
+      'RABBITMQ_URL',
+      (url) => new URL(url),
+      new URL(RABBITMQ_URL_DEFAULT)
+    ).conflicts('rabbitmqSrvServiceName')
+  ]);

--- a/packages/cardano-services/src/Program/options/util.ts
+++ b/packages/cardano-services/src/Program/options/util.ts
@@ -1,0 +1,22 @@
+import { Command, Option } from 'commander';
+
+export const addOptions = (command: Command, options: Option[]) => {
+  for (const option of options) command.addOption(option);
+
+  return command;
+};
+
+export const newOption = <T>(
+  flags: string,
+  description: string,
+  envName: string,
+  argParser?: (value: string, previous: T) => T,
+  defaultValue?: unknown
+) => {
+  const option = new Option(flags, description).env(envName);
+
+  if (argParser !== undefined) option.argParser(argParser);
+  if (defaultValue !== undefined) option.default(defaultValue);
+
+  return option;
+};

--- a/packages/cardano-services/src/Program/programs/index.ts
+++ b/packages/cardano-services/src/Program/programs/index.ts
@@ -1,4 +1,6 @@
 export * from './blockfrostWorker';
+export * from './pgBossWorker';
+export * from './projector';
 export * from './providerServer';
 export * from './txWorker';
 export * from './types';

--- a/packages/cardano-services/src/Program/programs/projector.ts
+++ b/packages/cardano-services/src/Program/programs/projector.ts
@@ -13,7 +13,6 @@ import { MissingProgramOption, UnknownServiceName } from '../errors';
 import { ProjectionHttpService, ProjectionName, createTypeormProjection, storeOperators } from '../../Projection';
 import { SrvRecord } from 'dns';
 import { TypeormStabilityWindowBuffer, createStorePoolMetricsUpdateJob } from '@cardano-sdk/projection-typeorm';
-import { URL } from 'url';
 import { createLogger } from 'bunyan';
 import { getConnectionConfig, getOgmiosObservableCardanoNode } from '../services';
 

--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -33,7 +33,6 @@ import { SrvRecord } from 'dns';
 import { TxSubmitHttpService } from '../../TxSubmit';
 import { TypeormAssetProvider } from '../../Asset/TypeormAssetProvider';
 import { TypeormStakePoolProvider } from '../../StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider';
-import { URL } from 'url';
 import { createDbSyncMetadataService } from '../../Metadata';
 import { createLogger } from 'bunyan';
 import { getConnectionConfig, getOgmiosTxSubmitProvider, getRabbitMqTxSubmitProvider } from '../services';

--- a/packages/cardano-services/src/Program/services/index.ts
+++ b/packages/cardano-services/src/Program/services/index.ts
@@ -1,4 +1,5 @@
 export * from './blockfrost';
-export * from './postgres';
 export * from './ogmios';
+export * from './pgboss';
+export * from './postgres';
 export * from './rabbitmq';

--- a/packages/cardano-services/src/Program/services/postgres.ts
+++ b/packages/cardano-services/src/Program/services/postgres.ts
@@ -9,7 +9,6 @@ import { Observable, defer, from, of } from 'rxjs';
 import { PgConnectionConfig } from '@cardano-sdk/projection-typeorm';
 import { Pool, PoolConfig, QueryConfig } from 'pg';
 import { TlsOptions } from 'tls';
-import { URL } from 'url';
 import { isConnectionError, toSerializableObject } from '@cardano-sdk/util';
 import connString from 'pg-connection-string';
 import fs from 'fs';

--- a/packages/cardano-services/test/Program/programs/httpServer.test.ts
+++ b/packages/cardano-services/test/Program/programs/httpServer.test.ts
@@ -20,7 +20,6 @@ import {
 import { Ogmios } from '@cardano-sdk/ogmios';
 import { ProviderError, ProviderFailure, Seconds } from '@cardano-sdk/core';
 import { SrvRecord } from 'dns';
-import { URL } from 'url';
 import {
   createConnectionObjectWithRandomPort,
   createHealthyMockOgmiosServer,

--- a/packages/cardano-services/test/Program/services/rabbitmq.test.ts
+++ b/packages/cardano-services/test/Program/services/rabbitmq.test.ts
@@ -20,7 +20,6 @@ import {
 import { Ogmios, OgmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
 import { RabbitMQContainer } from '../../TxSubmit/rabbitmq/docker';
 import { SrvRecord } from 'dns';
-import { URL } from 'url';
 import { bufferToHexString } from '@cardano-sdk/util';
 import { createMockOgmiosServer } from '../../../../ogmios/test/mocks/mockOgmiosServer';
 import { getRandomPort } from 'get-port-please';


### PR DESCRIPTION
# Context

The CLI argument parsing has some code repetition.

# Proposed Solution

- Introduced `newOption` utility function to remove the repeated block
  ```
    new Option(flags, description)
      .default(defaultValue)
      .env(envName)
      .argParser(argParser)
  ```
- Introduced `addOptions` utility function to remove the repeated `addOption` method chaining.
- Changed
  `withPostgresOptions: (command: Command, suffix: ConnectionNames) => Command`
  into 
  `withPostgresOptions: (command: Command, suffixes: ConnectionNames[]) => Command`
  to call it only once when we need to call it more times for more DBs,
