### PR TITLE
chore: bump minimum Node.js version to v16, use v18 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG UBUNTU_VERSION=20.04
 
 FROM ubuntu:${UBUNTU_VERSION} as ubuntu-nodejs
-ARG NODEJS_MAJOR_VERSION=14
+ARG NODEJS_MAJOR_VERSION=18
 ENV DEBIAN_FRONTEND=nonintercative
 RUN apt-get update && apt-get install curl -y
 RUN curl --proto '=https' --tlsv1.2 -sSf -L https://deb.nodesource.com/setup_${NODEJS_MAJOR_VERSION}.x | bash -

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A suite of TypeScript packages suitable for both Node.js and browser-based devel
 
 Packages are distributed as both CommonJS and ESM modules.
 
-- Node.js >=14.20.1
+- Node.js >=16.20.2
   - using with `type="module"` requires `--experimental-specifier-resolution=node` flag
 - Browser via bundlers (see [example webpack config](./packages/e2e/test/web-extension/webpack.config.js))
 
@@ -53,7 +53,7 @@ A Yarn Workspace maintaining a single version across all packages.
 
 - [nvm](https://github.com/nvm-sh/nvm)
 - [yarn](https://yarnpkg.com/getting-started/install)
-- [Node.js](https://nodejs.org/en/download) 14 or later
+- [Node.js](https://nodejs.org/en/download) 16 or later
 - [Docker Desktop] 3.4 or later or a Docker installation that includes Compose V2
 
 #### Clone

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "An SDK for interacting with the Cardano blockchain",
   "engines": {
-    "node": ">=14.20.1"
+    "node": ">=16.20.2"
   },
   "workspaces": [
     "packages/*"

--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.14.0",
   "description": "Cardano Services Client",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0",
   "description": "Cardano GraphQL Services",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.20.0",
   "description": "Core types and libraries for Cardano",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.14",
   "description": "Cryptographic types and functions for Cardano. Warning: The libsodium crypto provider has not yet been audited. Use at this stage is at own risk",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/dapp-connector/package.json
+++ b/packages/dapp-connector/package.json
@@ -3,7 +3,7 @@
   "version": "0.10.0",
   "description": "TypeScript definitions for the dApp Connector standard CIP30",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "0.21.0",
   "description": "End to end tests for the cardano-js-sdk packages.",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.25",
   "description": "Generate golden test files for a range of Cardano concepts",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "bin": "dist/cjs/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "description": "Governance types and utilities for Cardano",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/hardware-ledger/package.json
+++ b/packages/hardware-ledger/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "description": "Mappings and integration with Ledger hardware",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/input-selection/package.json
+++ b/packages/input-selection/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.0",
   "description": "TypeScript definitions for input-selection (Coin Selection Algorithms for Cardano)",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -3,7 +3,7 @@
   "version": "0.11.0",
   "description": "Key management types and utilities for Cardano",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -3,7 +3,7 @@
   "version": "0.13.0",
   "description": "Ogmios Providers",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/projection-typeorm/package.json
+++ b/packages/projection-typeorm/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.0",
   "description": "Project Chain Sync events into PostgreSQL via TypeORM",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/projection/package.json
+++ b/packages/projection/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "description": "Chain Sync event projection",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/tx-construction/package.json
+++ b/packages/tx-construction/package.json
@@ -3,7 +3,7 @@
   "version": "0.12.0",
   "description": "Types and functions for constructing transactions on Cardano",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -3,7 +3,7 @@
   "version": "0.16.0",
   "description": "Utilities for tests in other packages",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/util-rxjs/package.json
+++ b/packages/util-rxjs/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.11",
   "description": "RxJS extensions",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -3,7 +3,7 @@
   "version": "0.14.1",
   "description": "General, not cardano-specific utils",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -3,7 +3,7 @@
   "version": "0.22.0",
   "description": "Wallet modules",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -3,7 +3,7 @@
   "version": "0.15.0",
   "description": "Web extension wallet utilities",
   "engines": {
-    "node": ">=16.20.1"
+    "node": ">=16.20.2"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
# Context
v14 is now depreciated. We still wish to maintaining support for v16 until EOL.

# Important Changes Introduced
- Dockerfile is now being built with v18