### PR TITLE
build/LW-7438 run lint on build only if required

### DIFF
--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build:esm": "tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020",
     "build:cjs": "tsc --build src",
-    "build:version": "node ./scripts/createVersionSource.js && yarn lint:fix && shx cp ./package.json ./dist/package.json",
+    "build:version": "bash -c 'if node ./scripts/createVersionSource.js --check ; then node ./scripts/createVersionSource.js --create && yarn lint:fix ; fi && shx cp ./package.json ./dist/package.json'",
     "build": "yarn build:version && run-s build:cjs build:esm module-fixup",
     "module-fixup": "shx cp ../../build/cjs-package.json ./dist/cjs/package.json && cp ../../build/esm-package.json ./dist/esm/package.json",
     "tscNoEmit": "shx echo typescript --noEmit command not implemented yet",

--- a/packages/cardano-services-client/scripts/createVersionSource.js
+++ b/packages/cardano-services-client/scripts/createVersionSource.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const { argv, exit } = require('process');
+const { deepEqual } = require('assert');
 
 const cardanoServicesSrc = path.join('..', '..', 'cardano-services', 'src');
 
@@ -20,10 +22,31 @@ const apiVersion = Object.fromEntries(
   ])
 );
 
-const version = JSON.stringify(apiVersion, null, 2);
-const contents = `// auto-generated using ../scripts/createVersionSource.js
-export const apiVersion = ${version};
-`;
+const versionFile = path.join(__dirname, '../version.json');
+const create = () => {
+  const version = JSON.stringify(apiVersion, null, 2);
+  const contents = `// auto-generated using ../scripts/createVersionSource.js
+  export const apiVersion = ${version};
+  `;
 
-fs.writeFileSync(path.join(__dirname, '../src/version.ts'), contents, { encoding: 'utf8', flag: 'w' });
-fs.writeFileSync(path.join(__dirname, '../version.json'), `${version}\n`, { encoding: 'utf8', flag: 'w' });
+  fs.writeFileSync(path.join(__dirname, '../src/version.ts'), contents, { encoding: 'utf8', flag: 'w' });
+  fs.writeFileSync(versionFile, `${version}\n`, { encoding: 'utf8', flag: 'w' });
+};
+
+switch (argv[2]) {
+  case '--check':
+    try {
+      deepEqual(JSON.parse(fs.readFileSync(versionFile, { encoding: 'utf8' })), apiVersion);
+      exit(1);
+    } catch {
+      exit(0);
+    }
+  // eslint-disable-next-line no-fallthrough
+  case '--create':
+    create();
+    break;
+  default:
+    // eslint-disable-next-line no-console
+    console.error('Usage: createVersionSource [--check|--create]');
+    exit(1);
+}


### PR DESCRIPTION
# Context

Both `yarn build` and `yarn test` run `yarn build:version` which runs `yarn lint:fix` which takes about a couple of minutes.
Actually `yarn lint:fix` needs to run in this context only when the change reflects in a API version change.

# Proposed Solution

Changed the build script to check if is there a change which requires `yarn lint:fix` to run in order to actually run it.

Applied this change in my local branch a couple of hours ago and it incredibly speed up my job; so I thought this needs to be shared with the rest of the team ASAP.