### PR TITLE
chore: include conway-era branch in std workflow

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - master
+      - conway-era
   push:
     branches:
       - master
+      - conway-era
 env:
   AWS_REGION: us-east-1
   AWS_ROLE_ARN: arn:aws:iam::926093910549:role/lace-ci


### PR DESCRIPTION
This is needed to build and push OCI images for the sanchonet ENV

We can already trigger the build manually, but this is tedious
![image](https://github.com/input-output-hk/cardano-js-sdk/assets/303881/4a4326d1-e3a1-4023-a3e6-6a2d666f0d7f)
