### PR TITLE
Feat/remove cml from core package

### DIFF
--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
@@ -4,7 +4,6 @@
 /* eslint-disable max-depth */
 
 import * as Crypto from '@cardano-sdk/crypto';
-import { CML } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 import { HexBlob } from '@cardano-sdk/util';
 import { Logger } from 'ts-log';
@@ -125,7 +124,7 @@ export const createHttpStakePoolMetadataService = (
           const signature = (await axiosClient.get<Crypto.Ed25519SignatureHex>(metadata.extSigUrl)).data;
           const message = HexBlob.fromBytes(Buffer.from(JSON.stringify(extMetadata)));
           const publicKey = Crypto.Ed25519PublicKeyHex(metadata.extVkey);
-          const bip32Ed25519 = new Crypto.CmlBip32Ed25519(CML);
+          const bip32Ed25519 = new Crypto.SodiumBip32Ed25519();
 
           // Verify the signature
           const isSignatureValid = await bip32Ed25519.verify(signature, message, publicKey);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,6 @@
     "@cardano-ogmios/schema": "5.6.0",
     "@cardano-sdk/crypto": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
-    "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1",
     "@foxglove/crc": "^0.0.3",
     "@scure/base": "^1.1.1",
     "fraction.js": "4.0.1",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,3 @@
-import * as CML from '@dcspark/cardano-multiplatform-lib-nodejs';
-export * as CML from '@dcspark/cardano-multiplatform-lib-nodejs';
-export type CardanoMultiplatformLib = typeof CML;
-
 export * as Asset from './Asset';
 export * as Cardano from './Cardano';
 export * from './Provider';

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -94,6 +94,7 @@
     "@cardano-sdk/util-dev": "workspace:~",
     "@cardano-sdk/util-rxjs": "workspace:~",
     "@cardano-sdk/wallet": "workspace:~",
+    "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1",
     "@vespaiach/axios-fetch-adapter": "^0.3.0",
     "axios": "^0.27.2",
     "bunyan": "^1.8.15",

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import * as CML from '@dcspark/cardano-multiplatform-lib-nodejs';
 import * as Crypto from '@cardano-sdk/crypto';
 import {
   AddressDiscovery,
@@ -14,7 +15,6 @@ import {
 } from '@cardano-sdk/wallet';
 import {
   AssetProvider,
-  CML,
   Cardano,
   ChainHistoryProvider,
   HandleProvider,

--- a/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
+++ b/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
@@ -2,7 +2,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import * as Ledger from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { Ada, InvalidDataReason } from '@cardano-foundation/ledgerjs-hw-app-cardano';
-import { CML, Cardano } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { CardanoKeyConst, CommunicationType, util } from '@cardano-sdk/key-management';
 import { LedgerKeyAgent } from '../src';
 import { dummyLogger } from 'ts-log';
@@ -378,7 +378,7 @@ describe('LedgerKeyAgent', () => {
           knownAddresses: []
         },
         {
-          bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+          bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
           inputResolver: {
             resolveInput: jest.fn().mockResolvedValue(null)
           },

--- a/packages/key-management/test/cip8/cip30signData.test.ts
+++ b/packages/key-management/test/cip8/cip30signData.test.ts
@@ -1,7 +1,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, AsyncKeyAgent, GroupedAddress, KeyAgent, KeyRole, cip8 } from '../../src';
-import { CML, Cardano, util } from '@cardano-sdk/core';
 import { COSEKey, COSESign1, SigStructure } from '@emurgo/cardano-message-signing-nodejs';
+import { Cardano, util } from '@cardano-sdk/core';
 import { CoseLabel } from '../../src/cip8/util';
 import { HexBlob } from '@cardano-sdk/util';
 import { testAsyncKeyAgent, testKeyAgent } from '../mocks';
@@ -11,7 +11,7 @@ describe('cip30signData', () => {
   let keyAgent: KeyAgent;
   let asyncKeyAgent: AsyncKeyAgent;
   let address: GroupedAddress;
-  const cryptoProvider = new Crypto.CmlBip32Ed25519(CML);
+  const cryptoProvider = new Crypto.SodiumBip32Ed25519();
 
   beforeAll(async () => {
     const keyAgentReady = testKeyAgent();

--- a/packages/key-management/test/util/ensureStakeKeys.test.ts
+++ b/packages/key-management/test/util/ensureStakeKeys.test.ts
@@ -1,6 +1,6 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, AsyncKeyAgent, InMemoryKeyAgent, util } from '../../src';
-import { CML, Cardano } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { Logger, dummyLogger } from 'ts-log';
 import { firstValueFrom } from 'rxjs';
 
@@ -20,7 +20,7 @@ describe('ensureStakeKeys', () => {
           getPassphrase,
           mnemonicWords
         },
-        { bip32Ed25519: new Crypto.CmlBip32Ed25519(CML), inputResolver, logger: dummyLogger }
+        { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), inputResolver, logger: dummyLogger }
       )
     );
   });

--- a/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
@@ -10,7 +10,7 @@ import {
   util
 } from '@cardano-sdk/key-management';
 import { AssetId, mockProviders as mocks } from '@cardano-sdk/util-dev';
-import { CML, Cardano, Handle, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Cardano, Handle, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import {
   GenericTxBuilder,
   HandleNotFoundError,
@@ -68,7 +68,7 @@ describe('GenericTxBuilder', () => {
         getPassphrase: async () => Buffer.from('passphrase'),
         mnemonicWords: util.generateMnemonicWords()
       },
-      { bip32Ed25519: new Crypto.CmlBip32Ed25519(CML), inputResolver, logger: dummyLogger }
+      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), inputResolver, logger: dummyLogger }
     );
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
     keyAgent.knownAddresses[0].address = mocks.utxo[0][1].address;

--- a/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, GroupedAddress, InMemoryKeyAgent, util } from '@cardano-sdk/key-management';
-import { CML, Cardano } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import {
   GenericTxBuilder,
   OutOfSyncRewardAccounts,
@@ -129,7 +129,7 @@ describe('TxBuilder/delegatePortfolio', () => {
         getPassphrase: async () => Buffer.from('passphrase'),
         mnemonicWords: util.generateMnemonicWords()
       },
-      { bip32Ed25519: new Crypto.CmlBip32Ed25519(CML), inputResolver, logger: dummyLogger }
+      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), inputResolver, logger: dummyLogger }
     );
   });
 

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -3,7 +3,7 @@ import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
 import { AssetId, StubKeyAgent, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
 import { BehaviorSubject, Subscription, firstValueFrom, skip } from 'rxjs';
-import { CML, Cardano, CardanoNodeErrors, ProviderError, ProviderFailure, TxCBOR } from '@cardano-sdk/core';
+import { Cardano, CardanoNodeErrors, ProviderError, ProviderFailure, TxCBOR } from '@cardano-sdk/core';
 import { HexBlob } from '@cardano-sdk/util';
 import { InitializeTxProps, InitializeTxResult } from '@cardano-sdk/tx-construction';
 import { PersonalWallet, TxInFlight, setupWallet } from '../../src';
@@ -73,7 +73,7 @@ describe('PersonalWallet methods', () => {
       type: AddressType.External
     };
     ({ wallet } = await setupWallet({
-      bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+      bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
       createKeyAgent: async (dependencies) => {
         const asyncKeyAgent = await testAsyncKeyAgent([groupedAddress], dependencies);
         asyncKeyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);
@@ -220,7 +220,7 @@ describe('PersonalWallet methods', () => {
       const mockKeyAgent = new StubKeyAgent(inputResolver);
 
       setupWallet({
-        bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+        bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
         createKeyAgent: async () => mockKeyAgent,
         createWallet: async (keyAgent) =>
           new PersonalWallet(
@@ -532,7 +532,7 @@ describe('PersonalWallet methods', () => {
   it('will retry deriving pubDrepKey if one does not exist', async () => {
     let walletKeyAgent: AsyncKeyAgent;
     ({ wallet, keyAgent: walletKeyAgent } = await setupWallet({
-      bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+      bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
       createKeyAgent: async (dependencies) => {
         const asyncKeyAgent = await testAsyncKeyAgent([], dependencies);
         asyncKeyAgent.derivePublicKey = jest.fn().mockRejectedValueOnce('error').mockResolvedValue('string');

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -2,7 +2,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, CommunicationType, SerializableLedgerKeyAgentData, util } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
-import { CML, Cardano, Serialization } from '@cardano-sdk/core';
+import { Cardano, Serialization } from '@cardano-sdk/core';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { InitializeTxProps, InitializeTxResult } from '@cardano-sdk/tx-construction';
@@ -20,7 +20,7 @@ describe('LedgerKeyAgent', () => {
   beforeAll(async () => {
     txSubmitProvider = mocks.mockTxSubmitProvider();
     ({ keyAgent, wallet } = await setupWallet({
-      bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+      bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
       createKeyAgent: async (dependencies) =>
         await LedgerKeyAgent.createWithDevice(
           {

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -14,8 +14,8 @@ import {
 } from '@cardano-sdk/dapp-connector';
 import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
-import { CML, Cardano, CardanoNodeErrors, Serialization, TxCBOR, coalesceValueQuantities } from '@cardano-sdk/core';
 import { CallbackConfirmation, GetCollateralCallbackParams } from '../../src/cip30';
+import { Cardano, CardanoNodeErrors, Serialization, TxCBOR, coalesceValueQuantities } from '@cardano-sdk/core';
 import { HexBlob, ManagedFreeableScope } from '@cardano-sdk/util';
 import { InMemoryUnspendableUtxoStore, createInMemoryWalletStores } from '../../src/persistence';
 import { InitializeTxProps, InitializeTxResult } from '@cardano-sdk/tx-construction';
@@ -673,7 +673,7 @@ describe('cip30', () => {
           type: AddressType.External
         };
         ({ wallet: mockWallet } = await setupWallet({
-          bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+          bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
           createKeyAgent: async (dependencies) => {
             const asyncKeyAgent = await testAsyncKeyAgent([groupedAddress], dependencies);
             asyncKeyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -1,6 +1,6 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';
-import { CML, Cardano } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import {
   PersonalWallet,
   WalletUtilContext,
@@ -103,7 +103,7 @@ describe('WalletUtil', () => {
         type: AddressType.External
       };
       ({ wallet } = await setupWallet({
-        bip32Ed25519: new Crypto.CmlBip32Ed25519(CML),
+        bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
         createKeyAgent: async (dependencies) => {
           const asyncKeyAgent = await testAsyncKeyAgent([groupedAddress], dependencies);
           asyncKeyAgent.deriveAddress = jest.fn().mockResolvedValue(groupedAddress);

--- a/packages/wallet/test/services/addressDiscovery/mockData.ts
+++ b/packages/wallet/test/services/addressDiscovery/mockData.ts
@@ -1,7 +1,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, AsyncKeyAgent, GroupedAddress, KeyRole } from '@cardano-sdk/key-management';
 import { BehaviorSubject } from 'rxjs';
-import { CML, Cardano, ChainHistoryProvider, Paginated, TransactionsByAddressesArgs } from '@cardano-sdk/core';
+import { Cardano, ChainHistoryProvider, Paginated, TransactionsByAddressesArgs } from '@cardano-sdk/core';
 
 const NOT_IMPLEMENTED = 'Not implemented';
 
@@ -19,7 +19,7 @@ const createMockAsyncKeyAgent = (knownAddresses: Array<Array<GroupedAddress>>): 
       return address;
     },
     derivePublicKey: () => Promise.resolve('00' as unknown as Crypto.Ed25519PublicKeyHex),
-    getBip32Ed25519: () => Promise.resolve(new Crypto.CmlBip32Ed25519(CML)),
+    getBip32Ed25519: () => Promise.resolve(new Crypto.SodiumBip32Ed25519()),
     getChainId: () =>
       Promise.resolve({
         networkId: 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3099,7 +3099,6 @@ __metadata:
     "@cardano-ogmios/schema": 5.6.0
     "@cardano-sdk/crypto": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
-    "@dcspark/cardano-multiplatform-lib-nodejs": ^3.1.1
     "@foxglove/crc": ^0.0.3
     "@scure/base": ^1.1.1
     "@types/lodash": ^4.14.182
@@ -3217,6 +3216,7 @@ __metadata:
     "@cardano-sdk/wallet": "workspace:~"
     "@cardano-sdk/web-extension": "workspace:~"
     "@dcspark/cardano-multiplatform-lib-browser": ^3.1.1
+    "@dcspark/cardano-multiplatform-lib-nodejs": ^3.1.1
     "@emurgo/cardano-message-signing-asmjs": ^1.0.1
     "@types/bunyan": ^1.8.8
     "@types/chalk": ^2.2.0


### PR DESCRIPTION
# Context

We must remove the CML library export from core package and clean up all unit tests to use the libsodium crypto provider

# Proposed Solution

Remove the CML core core package

# Important Changes Introduced

The core package no longer exports the CML types.
