### PR TITLE
feat: no stability window buffer til volatile

### DIFF
--- a/packages/cardano-services/src/Program/programs/projector.ts
+++ b/packages/cardano-services/src/Program/programs/projector.ts
@@ -1,4 +1,3 @@
-import { Bootstrap } from '@cardano-sdk/projection';
 import { Cardano } from '@cardano-sdk/core';
 import { CommonProgramOptions, OgmiosProgramOptions, PosgresProgramOptions } from '../options';
 import { DnsResolver, createDnsResolver } from '../utils';
@@ -12,8 +11,8 @@ import { Logger } from 'ts-log';
 import { MissingProgramOption, UnknownServiceName } from '../errors';
 import { ProjectionHttpService, ProjectionName, createTypeormProjection, storeOperators } from '../../Projection';
 import { SrvRecord } from 'dns';
-import { TypeormStabilityWindowBuffer, createStorePoolMetricsUpdateJob } from '@cardano-sdk/projection-typeorm';
 import { createLogger } from 'bunyan';
+import { createStorePoolMetricsUpdateJob } from '@cardano-sdk/projection-typeorm';
 import { getConnectionConfig, getOgmiosObservableCardanoNode } from '../services';
 
 export const BLOCKS_BUFFER_LENGTH_DEFAULT = 10;
@@ -50,11 +49,10 @@ const createProjectionHttpService = async (options: ProjectionMapFactoryOptions)
     ogmiosUrl: args.ogmiosUrl
   });
   const connectionConfig$ = getConnectionConfig(dnsResolver, 'projector', '', args);
-  const buffer = new TypeormStabilityWindowBuffer({ logger });
   const { blocksBufferLength, dropSchema, dryRun, exitAtBlockNo, handlePolicyIds, projectionNames, synchronize } = args;
   const projection$ = createTypeormProjection({
     blocksBufferLength,
-    buffer,
+    cardanoNode,
     connectionConfig$,
     devOptions: { dropSchema, synchronize },
     exitAtBlockNo,
@@ -62,12 +60,6 @@ const createProjectionHttpService = async (options: ProjectionMapFactoryOptions)
     projectionOptions: {
       handlePolicyIds
     },
-    projectionSource$: Bootstrap.fromCardanoNode({
-      blocksBufferLength,
-      buffer,
-      cardanoNode,
-      logger
-    }),
     projections: projectionNames
   });
   return new ProjectionHttpService({ dryRun, projection$, projectionNames }, { logger });

--- a/packages/cardano-services/src/Program/services/pgboss.ts
+++ b/packages/cardano-services/src/Program/services/pgboss.ts
@@ -6,6 +6,7 @@ import {
   PoolRegistrationEntity,
   PoolRetirementEntity,
   StakePoolEntity,
+  createDataSource,
   createPgBoss,
   isRecoverableTypeormError
 } from '@cardano-sdk/projection-typeorm';
@@ -32,14 +33,13 @@ import { Pool } from 'pg';
 import { Router } from 'express';
 import { StakePoolMetadataProgramOptions } from '../options/stakePoolMetadata';
 import { contextLogger } from '@cardano-sdk/util';
-import { createObservableDataSource } from '../../Projection/createTypeormProjection';
 import { retryBackoff } from 'backoff-rxjs';
 import PgBoss from 'pg-boss';
 
 /**
  * The entities required by the job handlers
  */
-export const pgBossEntities = [
+export const pgBossEntities: Function[] = [
   CurrentPoolMetricsEntity,
   BlockEntity,
   PoolMetadataEntity,
@@ -49,13 +49,28 @@ export const pgBossEntities = [
 ];
 
 export const createPgBossDataSource = (connectionConfig$: Observable<PgConnectionConfig>, logger: Logger) =>
-  createObservableDataSource({
-    connectionConfig$,
-    entities: pgBossEntities,
-    extensions: {},
-    logger,
-    migrationsRun: false
-  });
+  // TODO: use createObservableDataSource from projection-typeorm package.
+  // A challenge in doing that is that we call subscriber.error on retryable errors in order to reconnect.
+  // Doing that with createObservableDataSource will 'destroy' the data source that's currently used,
+  // so pg-boss is then unable to update job status and it stays 'active', not available for the newly
+  // recreated worker to be picked up.
+  // TODO: this raises another question - what happens when database connection drops while working on a job?
+  // Will it stay 'active' forever, or will pg-boss eventually update it due to some sort of timeout?
+  connectionConfig$.pipe(
+    switchMap((connectionConfig) =>
+      from(
+        (async () => {
+          const dataSource = createDataSource({
+            connectionConfig,
+            entities: pgBossEntities,
+            logger
+          });
+          await dataSource.initialize();
+          return dataSource;
+        })()
+      )
+    )
+  );
 
 export type PgBossWorkerArgs = CommonProgramOptions &
   StakePoolMetadataProgramOptions &
@@ -140,6 +155,7 @@ export class PgBossHttpService extends HttpService {
         // This ensures that if an error which can't be retried arrives here is handled as a FATAL error
         shouldRetry: (error: unknown) => {
           const retry = isRecoverableError(error);
+          this.logger.debug('work() shouldRetry', retry, error);
 
           this.#health = {
             ok: false,

--- a/packages/cardano-services/src/Projection/createTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/createTypeormProjection.ts
@@ -1,14 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable prefer-spread */
-import { Cardano } from '@cardano-sdk/core';
+import { Bootstrap, ProjectionEvent, logProjectionProgress, requestNext } from '@cardano-sdk/projection';
+import { Cardano, ObservableCardanoNode } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
-import { Observable, takeWhile } from 'rxjs';
+import { Observable, concat, defer, take, takeWhile } from 'rxjs';
 import {
   PgConnectionConfig,
   TypeormDevOptions,
+  TypeormOptions,
   TypeormStabilityWindowBuffer,
   WithTypeormContext,
   createObservableConnection,
+  createTypeormTipTracker,
   isRecoverableTypeormError,
   typeormTransactionCommit,
   withTypeormTransaction
@@ -19,19 +22,22 @@ import {
   ProjectionOptions,
   prepareTypeormProjection
 } from './prepareTypeormProjection';
-import { ProjectionEvent, logProjectionProgress, requestNext } from '@cardano-sdk/projection';
+import { ReconnectionConfig, passthrough, shareRetryBackoff, toEmpty } from '@cardano-sdk/util-rxjs';
 import { migrations } from './migrations';
-import { passthrough, shareRetryBackoff } from '@cardano-sdk/util-rxjs';
+
+const reconnectionConfig: ReconnectionConfig = {
+  initialInterval: 50,
+  maxInterval: 5000
+};
 
 export interface CreateTypeormProjectionProps {
   projections: ProjectionName[];
   blocksBufferLength: number;
-  buffer?: TypeormStabilityWindowBuffer;
-  projectionSource$: Observable<ProjectionEvent>;
   connectionConfig$: Observable<PgConnectionConfig>;
   devOptions?: TypeormDevOptions;
   exitAtBlockNo?: Cardano.BlockNo;
   logger: Logger;
+  cardanoNode: ObservableCardanoNode;
   projectionOptions?: ProjectionOptions;
 }
 
@@ -54,12 +60,11 @@ const applyStores =
 export const createTypeormProjection = ({
   blocksBufferLength,
   projections,
-  projectionSource$,
   connectionConfig$,
   logger,
-  devOptions,
+  devOptions: requestedDevOptions,
+  cardanoNode,
   exitAtBlockNo,
-  buffer,
   projectionOptions
 }: CreateTypeormProjectionProps) => {
   const { handlePolicyIds } = { handlePolicyIds: [], ...projectionOptions };
@@ -69,32 +74,65 @@ export const createTypeormProjection = ({
 
   const { mappers, entities, stores, extensions } = prepareTypeormProjection(
     {
-      buffer,
       options: projectionOptions,
       projections
     },
     { logger }
   );
-  const connection$ = createObservableConnection({
-    connectionConfig$,
-    devOptions,
-    entities,
-    extensions,
-    logger,
-    options: {
-      installExtensions: true,
-      migrations: migrations.filter(({ entity }) => entities.includes(entity as any)),
-      migrationsRun: !devOptions?.synchronize
-    }
+  const connect = (options?: TypeormOptions, devOptions?: TypeormDevOptions) =>
+    createObservableConnection({
+      connectionConfig$,
+      devOptions,
+      entities,
+      extensions,
+      logger,
+      options
+    });
+
+  const tipTracker = createTypeormTipTracker({
+    connection$: connect(),
+    reconnectionConfig
   });
-  return projectionSource$.pipe(
-    applyMappers(mappers),
-    shareRetryBackoff(
-      (evt$) => evt$.pipe(withTypeormTransaction({ connection$ }), applyStores(stores), typeormTransactionCommit()),
-      { shouldRetry: isRecoverableTypeormError }
-    ),
-    requestNext(),
-    logProjectionProgress(logger),
-    exitAtBlockNo ? takeWhile((event) => event.block.header.blockNo < exitAtBlockNo) : passthrough()
+  const buffer = new TypeormStabilityWindowBuffer({
+    connection$: connect(),
+    logger,
+    reconnectionConfig
+  });
+  const projectionSource$ = Bootstrap.fromCardanoNode({
+    blocksBufferLength,
+    buffer,
+    cardanoNode,
+    logger,
+    projectedTip$: tipTracker.tip$
+  });
+  return concat(
+    // initialize database before starting the projector
+    connect(
+      {
+        installExtensions: true,
+        migrations: migrations.filter(({ entity }) => entities.includes(entity as any)),
+        migrationsRun: !requestedDevOptions?.synchronize
+      },
+      requestedDevOptions
+    ).pipe(take(1), toEmpty),
+    defer(() =>
+      projectionSource$.pipe(
+        applyMappers(mappers),
+        shareRetryBackoff(
+          (evt$) =>
+            evt$.pipe(
+              withTypeormTransaction({ connection$: connect() }),
+              applyStores(stores),
+              buffer.storeBlockData(),
+              typeormTransactionCommit()
+            ),
+          { shouldRetry: isRecoverableTypeormError }
+        ),
+        tipTracker.trackProjectedTip(),
+        requestNext(),
+        logProjectionProgress(logger),
+        exitAtBlockNo ? takeWhile((event) => event.block.header.blockNo < exitAtBlockNo) : passthrough()
+      )
+    )
   );
 };

--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -15,7 +15,6 @@ import {
   StakeKeyRegistrationEntity,
   StakePoolEntity,
   TokensEntity,
-  TypeormStabilityWindowBuffer,
   createStorePoolMetricsUpdateJob,
   storeAddresses,
   storeAssets,
@@ -139,7 +138,7 @@ type Entity = Entities[EntityName];
 const storeEntities: Partial<Record<StoreName, EntityName[]>> = {
   storeAddresses: ['address'],
   storeAssets: ['asset'],
-  storeBlock: ['block'],
+  storeBlock: ['block', 'blockData'],
   storeHandleMetadata: ['handleMetadata', 'output'],
   storeHandles: ['handle', 'asset', 'tokens', 'output'],
   storeNftMetadata: ['asset'],
@@ -303,7 +302,6 @@ const keyOf = <T extends {}>(obj: T, value: unknown): keyof T | null => {
 
 export interface PrepareTypeormProjectionProps {
   projections: ProjectionName[];
-  buffer?: TypeormStabilityWindowBuffer;
   options?: ProjectionOptions;
 }
 
@@ -312,7 +310,7 @@ export interface PrepareTypeormProjectionProps {
  * based on 'projections' and presence of 'buffer':
  */
 export const prepareTypeormProjection = (
-  { projections, buffer, options = {} }: PrepareTypeormProjectionProps,
+  { projections, options = {} }: PrepareTypeormProjectionProps,
   dependencies: WithLogger
 ) => {
   const mapperSorter = new Sorter<MapperOperator>();
@@ -329,10 +327,6 @@ export const prepareTypeormProjection = (
   const selectedEntities = entitySorter.nodes;
   const selectedMappers = mapperSorter.nodes;
   const selectedStores = storeSorter.nodes;
-  if (buffer) {
-    selectedEntities.push(BlockDataEntity);
-    selectedStores.push(buffer.storeBlockData());
-  }
   const extensions = requiredExtensions(projections);
   return {
     __debug: {

--- a/packages/cardano-services/test/Projection/createTypeormProjection.test.ts
+++ b/packages/cardano-services/test/Projection/createTypeormProjection.test.ts
@@ -1,11 +1,4 @@
-import {
-  AssetEntity,
-  OutputEntity,
-  TokensEntity,
-  TypeormStabilityWindowBuffer,
-  createDataSource
-} from '@cardano-sdk/projection-typeorm';
-import { Bootstrap } from '@cardano-sdk/projection';
+import { AssetEntity, OutputEntity, TokensEntity, createDataSource } from '@cardano-sdk/projection-typeorm';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { ProjectionName, createTypeormProjection, prepareTypeormProjection } from '../../src';
 import { lastValueFrom } from 'rxjs';
@@ -13,44 +6,37 @@ import { projectorConnectionConfig, projectorConnectionConfig$ } from '../util';
 
 describe('createTypeormProjection', () => {
   it('creates a projection to PostgreSQL based on requested projection names', async () => {
-    // Setup
+    // Setup projector
     const projections = [ProjectionName.UTXO];
-    const buffer = new TypeormStabilityWindowBuffer({ allowNonSequentialBlockHeights: true, logger });
-    const { entities } = prepareTypeormProjection({ buffer, projections }, { logger });
-    const dataSource = createDataSource({
-      connectionConfig: projectorConnectionConfig,
-      devOptions: { dropSchema: true, synchronize: true },
-      entities,
-      logger
-    });
-    await dataSource.initialize();
-    const queryRunner = dataSource.createQueryRunner();
-    await queryRunner.connect();
     const data = chainSyncData(ChainSyncDataSet.WithMint);
-    await buffer.initialize(queryRunner);
-
     const projection$ = createTypeormProjection({
       blocksBufferLength: 10,
-      buffer,
+      cardanoNode: data.cardanoNode,
       connectionConfig$: projectorConnectionConfig$,
-      devOptions: { dropSchema: true, synchronize: true },
+      devOptions: { dropSchema: true },
       logger,
-      projectionSource$: Bootstrap.fromCardanoNode({
-        blocksBufferLength: 10,
-        buffer,
-        cardanoNode: data.cardanoNode,
-        logger
-      }),
       projections
     });
 
     // Project
     await lastValueFrom(projection$);
 
+    // Setup query runner for assertions
+    const { entities } = prepareTypeormProjection({ projections }, { logger });
+    const dataSource = createDataSource({
+      connectionConfig: projectorConnectionConfig,
+      entities,
+      logger
+    });
+    await dataSource.initialize();
+    const queryRunner = dataSource.createQueryRunner();
+    await queryRunner.connect();
+
     // Check data in the database
     expect(await queryRunner.manager.count(AssetEntity)).toBeGreaterThan(0);
     expect(await queryRunner.manager.count(TokensEntity)).toBeGreaterThan(0);
     expect(await queryRunner.manager.count(OutputEntity)).toBeGreaterThan(0);
+
     await queryRunner.release();
     await dataSource.destroy();
   });

--- a/packages/cardano-services/test/Projection/prepareTypeormProjection.test.ts
+++ b/packages/cardano-services/test/Projection/prepareTypeormProjection.test.ts
@@ -1,40 +1,30 @@
 import { ProjectionName, prepareTypeormProjection } from '../../src';
-import { TypeormStabilityWindowBuffer } from '@cardano-sdk/projection-typeorm';
 import { dummyLogger } from 'ts-log';
 
-const prepare = (projections: ProjectionName[], useBuffer?: boolean) => {
-  const { __debug } = prepareTypeormProjection(
-    {
-      buffer: useBuffer ? new TypeormStabilityWindowBuffer({ logger: dummyLogger }) : undefined,
-      projections
-    },
-    { logger: dummyLogger }
-  );
-  return __debug;
-};
+const prepare = (projections: ProjectionName[]) =>
+  prepareTypeormProjection({ projections }, { logger: dummyLogger }).__debug;
 
 describe('prepareTypeormProjection', () => {
   describe('computes required entities, mappers and stores based on selected projections and presence of a buffer', () => {
-    test('utxo (without buffer)', () => {
+    test('utxo', () => {
       const { entities, mappers, stores } = prepare([ProjectionName.UTXO]);
-      expect(new Set(entities)).toEqual(new Set(['tokens', 'block', 'asset', 'nftMetadata', 'output']));
-      expect(mappers).toEqual(['withMint', 'withUtxo']);
-      expect(stores).toEqual(['storeBlock', 'storeAssets', 'storeUtxo']);
-    });
-
-    test('utxo (with buffer)', () => {
-      const { entities, mappers, stores } = prepare([ProjectionName.UTXO], true);
       expect(new Set(entities)).toEqual(new Set(['tokens', 'block', 'asset', 'nftMetadata', 'output', 'blockData']));
       expect(mappers).toEqual(['withMint', 'withUtxo']);
-      // 'null' is expected here because buffer.storeBlockData is not a common operator,
-      // but is a method of the buffer. As a result it's not part of the predefined operators object.
-      expect(stores).toEqual(['storeBlock', 'storeAssets', 'storeUtxo', null]);
+      expect(stores).toEqual(['storeBlock', 'storeAssets', 'storeUtxo']);
     });
 
     test('stake-pool,stake-pool-metadata', () => {
       const { entities, mappers, stores } = prepare([ProjectionName.StakePool, ProjectionName.StakePoolMetadataJob]);
       expect(new Set(entities)).toEqual(
-        new Set(['block', 'stakePool', 'poolRegistration', 'poolRetirement', 'poolMetadata', 'currentPoolMetrics'])
+        new Set([
+          'block',
+          'blockData',
+          'stakePool',
+          'poolRegistration',
+          'poolRetirement',
+          'poolMetadata',
+          'currentPoolMetrics'
+        ])
       );
       expect(mappers).toEqual(['withCertificates', 'withStakePools']);
       expect(stores).toEqual(['storeBlock', 'storeStakePools', 'storeStakePoolMetadataJob']);

--- a/packages/e2e/test/projection/single-tenant-utxo.test.ts
+++ b/packages/e2e/test/projection/single-tenant-utxo.test.ts
@@ -4,7 +4,7 @@ import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/p
 import { Cardano, ObservableCardanoNode } from '@cardano-sdk/core';
 import { ConnectionConfig } from '@cardano-ogmios/client';
 import { DataSource, QueryRunner } from 'typeorm';
-import { Observable, filter, firstValueFrom, lastValueFrom, of, scan, takeWhile } from 'rxjs';
+import { Observable, defer, filter, firstValueFrom, lastValueFrom, of, scan, takeWhile } from 'rxjs';
 import { OgmiosObservableCardanoNode } from '@cardano-sdk/ogmios';
 import { createDatabase, dropDatabase } from 'typeorm-extension';
 import { getEnv } from '../../src';
@@ -104,7 +104,7 @@ describe('single-tenant utxo projection', () => {
     Bootstrap.fromCardanoNode({ blocksBufferLength: 10, buffer, cardanoNode, logger }).pipe(
       Mappers.withMint(),
       Mappers.withUtxo(),
-      Postgres.withTypeormTransaction({ dataSource$: of(dataSource), logger }),
+      Postgres.withTypeormTransaction({ connection$: defer(() => of({ queryRunner })) }),
       Postgres.storeBlock(),
       Postgres.storeAssets(),
       Postgres.storeUtxo(),
@@ -115,7 +115,7 @@ describe('single-tenant utxo projection', () => {
 
   const storeUtxo = (evt$: Observable<ProjectionEvent<Mappers.WithMint & Mappers.WithUtxo>>) =>
     evt$.pipe(
-      Postgres.withTypeormTransaction({ dataSource$: of(dataSource), logger }),
+      Postgres.withTypeormTransaction({ connection$: defer(() => of({ queryRunner })) }),
       Postgres.storeBlock(),
       Postgres.storeAssets(),
       Postgres.storeUtxo(),

--- a/packages/e2e/test/tsconfig.json
+++ b/packages/e2e/test/tsconfig.json
@@ -27,6 +27,9 @@
       "path": "../../util-dev/src"
     },
     {
+      "path": "../../util-rxjs/src"
+    },
+    {
       "path": "../../wallet/src"
     },
     {

--- a/packages/golden-test-generator/src/ChainSyncEvents/chainSyncEvents.ts
+++ b/packages/golden-test-generator/src/ChainSyncEvents/chainSyncEvents.ts
@@ -96,6 +96,7 @@ export const getChainSyncEvents = async (
             const header = ogmiosToCore.blockHeader(block);
             if (!header) return;
             currentBlock = header.blockNo;
+
             if (onBlock !== undefined) {
               onBlock(currentBlock);
             }

--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -41,6 +41,7 @@
     "@cardano-ogmios/schema": "5.6.0",
     "@cardano-sdk/cardano-services-client": "workspace:~",
     "@cardano-sdk/util-dev": "workspace:~",
+    "@cardano-sdk/util-rxjs": "workspace:~",
     "@types/lodash": "^4.14.182",
     "delay": "^5.0.0",
     "eslint": "^7.32.0",

--- a/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/createObservableInteractionContext.ts
+++ b/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/createObservableInteractionContext.ts
@@ -6,10 +6,9 @@ import {
   createInteractionContext
 } from '@cardano-ogmios/client';
 import { Observable, switchMap } from 'rxjs';
-import { RetryBackoffConfig, retryBackoff } from 'backoff-rxjs';
 import { WithLogger, contextLogger, isConnectionError } from '@cardano-sdk/util';
-
-export type ReconnectionConfig = Omit<RetryBackoffConfig, 'shouldRetry'>;
+import { retryBackoff } from 'backoff-rxjs';
+import type { ReconnectionConfig } from '@cardano-sdk/util-rxjs';
 
 const defaultReconnectionConfig: ReconnectionConfig = { initialInterval: 10, maxInterval: 5000 };
 

--- a/packages/ogmios/src/tsconfig.json
+++ b/packages/ogmios/src/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "../../core/src"
     },
     {
+      "path": "../../util-rxjs/src"
+    },
+    {
       "path": "../../crypto/src"
     }
   ]

--- a/packages/projection-typeorm/package.json
+++ b/packages/projection-typeorm/package.json
@@ -43,6 +43,7 @@
     "@cardano-sdk/projection": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
     "@cardano-sdk/util-rxjs": "workspace:~",
+    "backoff-rxjs": "^7.0.0",
     "lodash": "^4.17.21",
     "pg": "^8.9.0",
     "pg-boss": "8.4.2",

--- a/packages/projection-typeorm/src/createDataSource.ts
+++ b/packages/projection-typeorm/src/createDataSource.ts
@@ -1,8 +1,10 @@
 import 'reflect-metadata';
 import { DataSource, DataSourceOptions, DefaultNamingStrategy, NamingStrategyInterface, QueryRunner } from 'typeorm';
 import { Logger } from 'ts-log';
-import { contextLogger, patchObject } from '@cardano-sdk/util';
-import { createPgBoss } from './pgBoss';
+import { NEVER, Observable, concat, from, share, switchMap } from 'rxjs';
+import { PgBossExtension, createPgBoss, createPgBossExtension } from './pgBoss';
+import { WithLogger, contextLogger, patchObject } from '@cardano-sdk/util';
+import { finalizeWithLatest } from '@cardano-sdk/util-rxjs';
 import { typeormLogger } from './logger';
 import snakeCase from 'lodash/snakeCase';
 
@@ -157,3 +159,87 @@ export const createDataSource = ({
     }
   });
 };
+
+export type CreateObservableDataSourceProps = Omit<CreateDataSourceProps, 'connectionConfig'> & {
+  connectionConfig$: Observable<PgConnectionConfig>;
+};
+
+export const createObservableDataSource = ({ connectionConfig$, ...rest }: CreateObservableDataSourceProps) =>
+  connectionConfig$.pipe(
+    switchMap((connectionConfig) =>
+      concat(
+        from(
+          (async () => {
+            const dataSource = createDataSource({
+              connectionConfig,
+              ...rest
+            });
+            await dataSource.initialize();
+            return dataSource;
+          })()
+        ),
+        NEVER
+      ).pipe(
+        finalizeWithLatest(async (dataSource) => {
+          try {
+            await dataSource?.destroy();
+          } catch (error) {
+            rest.logger.error('Failed to destroy data source', error);
+          }
+        })
+      )
+    )
+  );
+
+export interface TypeormConnection {
+  queryRunner: QueryRunner;
+  pgBoss?: PgBossExtension;
+}
+
+const releaseConnection =
+  ({ logger }: WithLogger) =>
+  async (connection: TypeormConnection | null) => {
+    if (!connection) return;
+    if (connection.queryRunner.isTransactionActive) {
+      try {
+        await connection.queryRunner.rollbackTransaction();
+      } catch (error) {
+        logger.error('Failed to rollback transaction', error);
+      }
+    }
+    if (!connection.queryRunner.isReleased) {
+      try {
+        await connection.queryRunner.release();
+      } catch (error) {
+        logger.error('Failed to "release" query runner', error);
+      }
+    }
+  };
+
+export type ConnectProps = Pick<CreateObservableDataSourceProps, 'extensions' | 'logger'>;
+
+const createConnection = async (dataSource: DataSource, { logger, extensions }: ConnectProps) => {
+  const queryRunner = dataSource.createQueryRunner('master');
+  await queryRunner.connect();
+  if (extensions?.pgBoss) {
+    const pgBoss = createPgBossExtension(queryRunner, logger);
+    return { pgBoss, queryRunner };
+  }
+  return { queryRunner };
+};
+
+export const connect =
+  ({ logger, extensions }: ConnectProps) =>
+  (dataSource$: Observable<DataSource>) => {
+    const sharedSource$ = dataSource$.pipe(share());
+    return sharedSource$.pipe(
+      switchMap((dataSource) =>
+        concat(from(createConnection(dataSource, { extensions, logger })), NEVER).pipe(
+          finalizeWithLatest(releaseConnection({ logger }))
+        )
+      )
+    );
+  };
+
+export const createObservableConnection = (props: CreateObservableDataSourceProps): Observable<TypeormConnection> =>
+  createObservableDataSource(props).pipe(connect(props));

--- a/packages/projection-typeorm/src/createTypeormTipTracker.ts
+++ b/packages/projection-typeorm/src/createTypeormTipTracker.ts
@@ -1,0 +1,82 @@
+import { BaseProjectionEvent } from '@cardano-sdk/projection';
+import { BlockEntity } from './entity';
+import { ChainSyncEventType, TipOrOrigin } from '@cardano-sdk/core';
+import { Observable, ReplaySubject, from, map, of, switchMap, take, tap } from 'rxjs';
+import { ReconnectionConfig } from '@cardano-sdk/util-rxjs';
+import { RetryBackoffConfig, retryBackoff } from 'backoff-rxjs';
+import { TypeormConnection } from './createDataSource';
+import { isRecoverableTypeormError } from './isRecoverableTypeormError';
+
+export interface CreateTypeormTipTrackerProps {
+  connection$: Observable<TypeormConnection>;
+  /**
+   * Retry strategy for tip query. Tracker will re-subscribe to connection$ on each retry.
+   */
+  reconnectionConfig: ReconnectionConfig;
+}
+
+export const createTypeormTipTracker = ({ connection$, reconnectionConfig }: CreateTypeormTipTrackerProps) => {
+  const retryBackoffConfig: RetryBackoffConfig = {
+    ...reconnectionConfig,
+    shouldRetry: isRecoverableTypeormError
+  };
+  const queryLocalTip$ = connection$.pipe(
+    switchMap(({ queryRunner }) => {
+      const blockRepo = queryRunner.manager.getRepository(BlockEntity);
+      return from(
+        (async (): Promise<TipOrOrigin> => {
+          // findOne fails without `where:`, so using find().
+          // It makes 2 queries so is not very efficient,
+          // but it should be fine for `initialize` and rollbacks.
+          const tipQueryResult = await blockRepo.find({
+            order: { slot: 'DESC' },
+            take: 1
+          });
+          if (tipQueryResult.length === 0) {
+            return 'origin';
+          }
+          return {
+            blockNo: tipQueryResult[0].height!,
+            hash: tipQueryResult[0].hash!,
+            slot: tipQueryResult[0].slot!
+          };
+        })()
+      );
+    }),
+    take(1),
+    retryBackoff(retryBackoffConfig)
+  );
+  const tip$ = new ReplaySubject<TipOrOrigin>(1);
+  const trackProjectedTip =
+    <T extends BaseProjectionEvent>() =>
+    (evt$: Observable<T>) =>
+      evt$.pipe(
+        switchMap((evt) => {
+          if (evt.eventType === ChainSyncEventType.RollForward) {
+            tip$.next(evt.block.header);
+            return of(evt);
+          }
+          return queryLocalTip$.pipe(
+            tap((tip) => tip$.next(tip)),
+            map(() => evt)
+          );
+        })
+      );
+  return {
+    shutdown: tip$.complete.bind(tip$),
+    tip$: (() => {
+      let initialized = false;
+      return new Observable<TipOrOrigin>((subscriber) => {
+        if (!initialized) {
+          // Lazily initialize on 1st subscription
+          queryLocalTip$.subscribe((next) => tip$.next(next));
+          initialized = true;
+        }
+        return tip$.subscribe(subscriber);
+      });
+    })(),
+    trackProjectedTip
+  };
+};
+
+export type TypeormTipTracker = ReturnType<typeof createTypeormTipTracker>;

--- a/packages/projection-typeorm/src/index.ts
+++ b/packages/projection-typeorm/src/index.ts
@@ -5,6 +5,7 @@ export * from './entity';
 export * from './operators';
 export * from './TypeormStabilityWindowBuffer';
 export * from './isRecoverableTypeormError';
+export * from './createTypeormTipTracker';
 export {
   STAKE_POOL_METADATA_QUEUE,
   STAKE_POOL_METRICS_UPDATE,

--- a/packages/projection-typeorm/src/operators/withTypeormTransaction.ts
+++ b/packages/projection-typeorm/src/operators/withTypeormTransaction.ts
@@ -1,5 +1,5 @@
 /* eslint-disable func-style */
-import { Observable, Subject, defer, from, map, mergeMap, tap } from 'rxjs';
+import { Observable, Subject, defer, from, map, mergeMap } from 'rxjs';
 import { PgBossExtension } from '../pgBoss';
 import {
   ProjectionEvent,
@@ -18,7 +18,6 @@ export interface WithTypeormTransactionDependencies {
 
 export interface WithTypeormContext {
   queryRunner: QueryRunner;
-  transactionCommitted$: Subject<void>;
 }
 
 export interface WithPgBoss {
@@ -26,7 +25,7 @@ export interface WithPgBoss {
 }
 
 type TypeormContextProp = keyof (WithTypeormContext & WithPgBoss);
-const WithTypeormTransactionProps: Array<TypeormContextProp> = ['queryRunner', 'transactionCommitted$', 'pgBoss'];
+const WithTypeormTransactionProps: Array<TypeormContextProp> = ['queryRunner', 'pgBoss'];
 
 export function withTypeormTransaction<Props>(
   dependencies: WithTypeormTransactionDependencies & { pgBoss?: false }
@@ -74,7 +73,6 @@ export const typeormTransactionCommit =
     evt$.pipe(
       mergeMap((evt) =>
         from(evt.queryRunner.commitTransaction()).pipe(
-          tap(() => evt.transactionCommitted$.next()),
           map(() => {
             // The explicit cast is (probably) needed because typecript can't check that
             // we're not removing any properties overlapping with T

--- a/packages/projection-typeorm/src/operators/withTypeormTransaction.ts
+++ b/packages/projection-typeorm/src/operators/withTypeormTransaction.ts
@@ -1,8 +1,6 @@
 /* eslint-disable func-style */
-import { DataSource, QueryRunner } from 'typeorm';
-import { DataSourceExtensions } from '../createDataSource';
-import { NEVER, Observable, Subject, concat, defer, from, map, mergeMap, switchMap, tap } from 'rxjs';
-import { PgBossExtension, createPgBossExtension } from '../pgBoss';
+import { Observable, Subject, defer, from, map, mergeMap, tap } from 'rxjs';
+import { PgBossExtension } from '../pgBoss';
 import {
   ProjectionEvent,
   UnifiedExtChainSyncObservable,
@@ -10,12 +8,12 @@ import {
   withEventContext,
   withStaticContext
 } from '@cardano-sdk/projection';
-import { WithLogger } from '@cardano-sdk/util';
-import { finalizeWithLatest } from '@cardano-sdk/util-rxjs';
+import { QueryRunner } from 'typeorm';
+import { TypeormConnection } from '../createDataSource';
 import omit from 'lodash/omit';
 
-export interface WithTypeormTransactionDependencies extends WithLogger {
-  dataSource$: Observable<DataSource>;
+export interface WithTypeormTransactionDependencies {
+  connection$: Observable<TypeormConnection>;
 }
 
 export interface WithTypeormContext {
@@ -31,68 +29,28 @@ type TypeormContextProp = keyof (WithTypeormContext & WithPgBoss);
 const WithTypeormTransactionProps: Array<TypeormContextProp> = ['queryRunner', 'transactionCommitted$', 'pgBoss'];
 
 export function withTypeormTransaction<Props>(
-  dependencies: WithTypeormTransactionDependencies
+  dependencies: WithTypeormTransactionDependencies & { pgBoss?: false }
 ): UnifiedExtChainSyncOperator<Props, Props & WithTypeormContext>;
+
 export function withTypeormTransaction<Props>(
-  dependencies: WithTypeormTransactionDependencies,
-  extensions: { pgBoss: true }
+  dependencies: WithTypeormTransactionDependencies & { pgBoss: true }
 ): UnifiedExtChainSyncOperator<Props, Props & WithTypeormContext & WithPgBoss>;
-export function withTypeormTransaction<Props>(
-  dependencies: WithTypeormTransactionDependencies,
-  extensions: DataSourceExtensions
-): UnifiedExtChainSyncOperator<Props, Props & WithTypeormContext>;
+
 /**
  * Start a PostgreSQL transaction for each event.
  *
  * {pgBoss: true} also adds {@link WithPgBoss} context.
  */
-export function withTypeormTransaction<Props>(
-  { dataSource$, logger }: WithTypeormTransactionDependencies,
-  extensions?: DataSourceExtensions
-): UnifiedExtChainSyncOperator<Props, Props & WithTypeormContext & Partial<WithPgBoss>> {
+export function withTypeormTransaction<Props>({
+  connection$
+}: WithTypeormTransactionDependencies & { pgBoss?: boolean }): UnifiedExtChainSyncOperator<
+  Props,
+  Props & WithTypeormContext & Partial<WithPgBoss>
+> {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   return (evt$: UnifiedExtChainSyncObservable<Props>) =>
     evt$.pipe(
-      withStaticContext(
-        defer(() =>
-          dataSource$.pipe(
-            switchMap((dataSource) =>
-              concat(
-                from(
-                  (async () => {
-                    const queryRunner = dataSource.createQueryRunner('master');
-                    await queryRunner.connect();
-                    if (extensions?.pgBoss) {
-                      const pgBoss = createPgBossExtension(queryRunner, logger);
-                      return { pgBoss, queryRunner };
-                    }
-                    return { queryRunner };
-                  })()
-                ),
-                NEVER
-              ).pipe(
-                finalizeWithLatest(async (evt) => {
-                  if (!evt) return;
-                  if (evt.queryRunner.isTransactionActive) {
-                    try {
-                      await evt.queryRunner.rollbackTransaction();
-                    } catch (error) {
-                      logger.error('Failed to rollback transaction', error);
-                    }
-                  }
-                  if (!evt.queryRunner.isReleased) {
-                    try {
-                      await evt.queryRunner.release();
-                    } catch (error) {
-                      logger.error('Failed to "release" query runner', error);
-                    }
-                  }
-                })
-              )
-            )
-          )
-        )
-      ),
+      withStaticContext(defer(() => connection$)),
       withEventContext(({ queryRunner }) =>
         from(
           // - transactionCommitted$.next is called after COMMIT, it is

--- a/packages/projection-typeorm/test/TypeormStabilityWindowBuffer.test.ts
+++ b/packages/projection-typeorm/test/TypeormStabilityWindowBuffer.test.ts
@@ -2,30 +2,26 @@ import {
   BlockDataEntity,
   BlockEntity,
   TypeormStabilityWindowBuffer,
-  createObservableConnection,
-  storeBlock,
-  typeormTransactionCommit,
-  withTypeormTransaction
+  WithTypeormContext,
+  createObservableConnection
 } from '../src';
-import { Bootstrap, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
-import { DataSource, QueryRunner } from 'typeorm';
-import {
-  Observable,
-  combineLatest,
-  defer,
-  filter,
-  firstValueFrom,
-  lastValueFrom,
-  of,
-  take,
-  takeWhile,
-  toArray
-} from 'rxjs';
-import { connectionConfig$, initializeDataSource } from './util';
+import { DataSource, NoConnectionForRepositoryError, QueryRunner, Repository } from 'typeorm';
+import { ProjectionEvent } from '@cardano-sdk/projection';
+import { connectionConfig$, createBlockEntity, createBlockHeader, initializeDataSource } from './util';
+import { createStubObservable, logger } from '@cardano-sdk/util-dev';
+import { firstValueFrom, of, throwError } from 'rxjs';
 
-const { cardanoNode, networkInfo } = chainSyncData(ChainSyncDataSet.WithStakeKeyDeregistration);
+const createBlock = (height: number): Cardano.Block =>
+  ({
+    header: createBlockHeader(height)
+  } as Cardano.Block);
+
+const createBlockDataEntity = (block: Cardano.Block, blockEntity: BlockEntity): BlockDataEntity => ({
+  block: blockEntity,
+  blockHeight: blockEntity.height,
+  data: block
+});
 
 describe('TypeormStabilityWindowBuffer', () => {
   const entities = [BlockEntity, BlockDataEntity];
@@ -34,129 +30,144 @@ describe('TypeormStabilityWindowBuffer', () => {
 
   let dataSource: DataSource;
   let queryRunner: QueryRunner;
+  let blockDataRepo: Repository<BlockDataEntity>;
+  let blockRepo: Repository<BlockEntity>;
   let buffer: TypeormStabilityWindowBuffer;
-  let project$: Observable<Omit<ProjectionEvent, 'requestNext'>>;
 
-  const getBufferSize = () => queryRunner.manager.count(BlockDataEntity);
-  const getNumBlocks = () => queryRunner.manager.count(BlockEntity);
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  const getHeader = (tipOrTail: Cardano.Block | 'origin') => (tipOrTail as Cardano.Block).header;
+  const insertBlock = async (header: Cardano.PartialBlockHeader) => {
+    const blockEntity = createBlockEntity(header);
+    await blockRepo.insert(blockEntity);
+    return blockEntity;
+  };
+
+  const insertBlockAndData = async (block: Cardano.Block) => {
+    const blockEntity = await insertBlock(block.header);
+    const blockDataEntity = createBlockDataEntity(block, blockEntity);
+    await blockDataRepo.insert(blockDataEntity);
+    return { blockDataEntity, blockEntity };
+  };
+
+  const queryBlockData = (height: number) => blockDataRepo.findOne({ where: { blockHeight: height } });
+
+  const getBlockFromBuffer = (id: Cardano.BlockId) => firstValueFrom(buffer.getBlock(id));
+  const storeBlockDataToBuffer = (evt: ProjectionEvent<WithTypeormContext>) =>
+    firstValueFrom(of(evt).pipe(buffer.storeBlockData()));
 
   beforeEach(async () => {
     dataSource = await initializeDataSource({ entities });
     queryRunner = dataSource.createQueryRunner();
-    buffer = new TypeormStabilityWindowBuffer({
-      allowNonSequentialBlockHeights: false,
-      compactBufferEveryNBlocks,
-      logger
-    });
-    await buffer.initialize(queryRunner);
-    project$ = defer(() =>
-      Bootstrap.fromCardanoNode({
-        blocksBufferLength: 10,
-        buffer,
-        cardanoNode: {
-          ...cardanoNode,
-          genesisParameters$: of({
-            ...networkInfo.genesisParameters,
-            securityParameter
-          })
-        },
-        logger
-      }).pipe(
-        withTypeormTransaction({ connection$: createObservableConnection({ connectionConfig$, entities, logger }) }),
-        storeBlock(),
-        buffer.storeBlockData(),
-        typeormTransactionCommit(),
-        requestNext()
-      )
-    );
+    blockDataRepo = queryRunner.manager.getRepository(BlockDataEntity);
+    blockRepo = queryRunner.manager.getRepository(BlockEntity);
   });
 
   afterEach(async () => {
-    buffer.shutdown();
     await queryRunner.release();
     await dataSource.destroy();
   });
 
-  it("calling initialize() again does not reemit tip and tail if they haven't changed", async () => {
-    const tips = firstValueFrom(buffer.tip$.pipe(toArray()));
-    const tails = firstValueFrom(buffer.tail$.pipe(toArray()));
-    await buffer.initialize(queryRunner);
-    buffer.shutdown();
-    expect(await tips).toHaveLength(1);
-    expect(await tails).toHaveLength(1);
-  });
+  describe('with successful connection', () => {
+    beforeEach(() => {
+      const connection$ = createObservableConnection({
+        connectionConfig$,
+        entities,
+        logger
+      });
+      buffer = new TypeormStabilityWindowBuffer({
+        compactBufferEveryNBlocks,
+        connection$,
+        logger,
+        reconnectionConfig: { initialInterval: 1 }
+      });
+    });
 
-  // eslint-disable-next-line unicorn/consistent-function-scoping
-  describe('when there are no blocks in the buffer', () => {
-    it('emits "origin" for both tip and tail', async () => {
-      const [tip, tail] = await firstValueFrom(combineLatest([buffer.tip$, buffer.tail$]));
-      expect(tip).toEqual('origin');
-      expect(tail).toEqual('origin');
+    describe('getBlock', () => {
+      describe('when block data is found', () => {
+        it('emits the block', async () => {
+          const block = createBlock(1);
+          await insertBlockAndData(block);
+          await expect(getBlockFromBuffer(block.header.hash)).resolves.toEqual(block);
+        });
+      });
+
+      describe('when block data is not found', () => {
+        it('emits the null', async () => {
+          const { hash } = createBlockHeader(1);
+          await expect(getBlockFromBuffer(hash)).resolves.toBeNull();
+        });
+      });
+    });
+
+    describe('storeBlockData', () => {
+      const tip = createBlockHeader(securityParameter * 20);
+      const createEvent = (height: number) =>
+        ({
+          block: createBlock(height),
+          eventType: ChainSyncEventType.RollForward,
+          genesisParameters: { securityParameter },
+          queryRunner,
+          tip
+        } as ProjectionEvent<WithTypeormContext>);
+
+      describe('when block is within stability window', () => {
+        it('inserts block data', async () => {
+          const event = createEvent(tip.blockNo - securityParameter);
+          await insertBlock(event.block.header);
+          await storeBlockDataToBuffer(event);
+          await expect(queryBlockData(event.block.header.blockNo)).resolves.toBeTruthy();
+        });
+
+        describe('when block height is a multiple of compactBufferEveryNBlocks parameter', () => {
+          it('deletes block data that is outside of stability window', async () => {
+            await insertBlockAndData(createBlock(tip.blockNo - securityParameter - 1));
+            await insertBlockAndData(createBlock(tip.blockNo - securityParameter));
+            await insertBlockAndData(createBlock(tip.blockNo - securityParameter + 1));
+
+            expect(tip.blockNo % compactBufferEveryNBlocks).toBe(0);
+            const event = createEvent(tip.blockNo);
+
+            await insertBlock(event.block.header);
+            await storeBlockDataToBuffer(event);
+
+            await expect(queryBlockData(tip.blockNo - securityParameter - 1)).resolves.not.toBeTruthy();
+            await expect(queryBlockData(tip.blockNo - securityParameter)).resolves.toBeTruthy();
+            await expect(queryBlockData(tip.blockNo - securityParameter + 1)).resolves.toBeTruthy();
+          });
+        });
+      });
+
+      describe('when block is outside stability window', () => {
+        it('does not insert block data', async () => {
+          const event = createEvent(tip.blockNo - securityParameter - 1);
+          await insertBlock(event.block.header);
+          await storeBlockDataToBuffer(event);
+          await expect(queryBlockData(event.block.header.blockNo)).resolves.not.toBeTruthy();
+        });
+      });
     });
   });
 
-  describe('with 1 block in the buffer', () => {
-    it('emits that block as both tip$ and tail$', async () => {
-      await firstValueFrom(project$);
-      const lastTipAndTail = firstValueFrom(combineLatest([buffer.tip$, buffer.tail$]));
-      const [tip, tail] = await lastTipAndTail;
-      expect(typeof tip).toEqual('object');
-      expect(tail).toEqual(tip);
+  describe('with failing connection', () => {
+    describe('getBlock', () => {
+      it('reconnects and eventually emits the block', async () => {
+        const connection$ = createStubObservable(
+          throwError(() => new NoConnectionForRepositoryError('conn')),
+          createObservableConnection({
+            connectionConfig$,
+            entities,
+            logger
+          })
+        );
+        buffer = new TypeormStabilityWindowBuffer({
+          compactBufferEveryNBlocks,
+          connection$,
+          logger,
+          reconnectionConfig: { initialInterval: 1 }
+        });
+
+        const block = createBlock(1);
+        await insertBlockAndData(block);
+        await expect(getBlockFromBuffer(block.header.hash)).resolves.toEqual(block);
+      });
     });
-  });
-
-  describe('with 3 blocks in the buffer', () => {
-    it('emits tip$ for every new block, tail$ only for origin and the 1st block', async () => {
-      const tipsReady = firstValueFrom(buffer.tip$.pipe(toArray()));
-      const tailsReady = firstValueFrom(buffer.tail$.pipe(toArray()));
-      await lastValueFrom(project$.pipe(take(3)));
-      expect(await getBufferSize()).toEqual(3);
-      buffer.shutdown();
-      const tips = await tipsReady;
-      expect(tips.length).toEqual(4);
-      expect(tips[0]).toEqual('origin');
-      expect(getHeader(tips[1]).hash).not.toEqual(getHeader(tips[2]).hash);
-      expect(getHeader(tips[2]).hash).not.toEqual(getHeader(tips[3]).hash);
-      const tails = await tailsReady;
-      expect(tails.length).toEqual(2);
-      expect(tails[0]).toEqual('origin');
-      expect(getHeader(tails[1]).hash).toEqual(getHeader(tips[1]).hash);
-    });
-  });
-
-  it('rollback pops the tip$', async () => {
-    const tipsReady = firstValueFrom(buffer.tip$.pipe(toArray()));
-    await firstValueFrom(project$.pipe(filter(({ eventType }) => eventType === ChainSyncEventType.RollBackward)));
-    buffer.shutdown();
-    const tips = await tipsReady;
-    expect(getHeader(tips[tips.length - 1]).blockNo).toBeLessThan(getHeader(tips[tips.length - 2]).blockNo);
-  });
-
-  it('clears old block_data every 100 blocks and emits new tail$', async () => {
-    await lastValueFrom(
-      project$.pipe(
-        // stop one block before the expected clear
-        takeWhile(
-          ({
-            block: {
-              header: { blockNo }
-            }
-          }) => (blockNo + 1) % compactBufferEveryNBlocks !== 0
-        )
-      )
-    );
-    const preClearTail = firstValueFrom(buffer.tail$);
-    const preClearBufferSize = await getBufferSize();
-    const preClearNumBlocks = await getNumBlocks();
-    // next event should trigger the clear
-    await firstValueFrom(project$);
-    const postClearTail = firstValueFrom(buffer.tail$);
-    expect(await getBufferSize()).toBeLessThan(preClearBufferSize);
-    expect(await getNumBlocks()).toEqual(preClearNumBlocks + 1);
-    const preClearTailHeight = getHeader(await preClearTail).blockNo;
-    const postClearTailHeight = getHeader(await postClearTail).blockNo;
-    expect(postClearTailHeight).toBeGreaterThan(preClearTailHeight);
   });
 });

--- a/packages/projection-typeorm/test/createTypeormTipTracker.test.ts
+++ b/packages/projection-typeorm/test/createTypeormTipTracker.test.ts
@@ -1,0 +1,153 @@
+import { BaseProjectionEvent } from '@cardano-sdk/projection';
+import {
+  BlockEntity,
+  TypeormConnection,
+  TypeormTipTracker,
+  createObservableConnection,
+  createTypeormTipTracker
+} from '../src';
+import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { DataSource, NoConnectionForRepositoryError, QueryRunner, Repository } from 'typeorm';
+import { Observable, firstValueFrom, of, throwError } from 'rxjs';
+import { RetryBackoffConfig } from 'backoff-rxjs';
+import { connectionConfig$, createBlockEntity, createBlockHeader, initializeDataSource } from './util';
+import { createStubObservable, logger } from '@cardano-sdk/util-dev';
+
+const stubSingleEventProjection = (eventType: ChainSyncEventType, header: Cardano.PartialBlockHeader) =>
+  of({
+    block: { header },
+    eventType
+  } as BaseProjectionEvent);
+
+describe('createTypeormTipTracker', () => {
+  const entities = [BlockEntity];
+  const retryBackoffConfig: RetryBackoffConfig = { initialInterval: 1 };
+
+  let dataSource: DataSource;
+  let queryRunner: QueryRunner;
+  let connection$: Observable<TypeormConnection>;
+  let blockRepo: Repository<BlockEntity>;
+  let tipTracker: TypeormTipTracker;
+
+  beforeEach(async () => {
+    dataSource = await initializeDataSource({ entities });
+    queryRunner = dataSource.createQueryRunner();
+    blockRepo = queryRunner.manager.getRepository(BlockEntity);
+  });
+
+  afterEach(async () => {
+    await queryRunner.release();
+    await dataSource.destroy();
+  });
+
+  describe('with successful connection', () => {
+    beforeEach(() => {
+      connection$ = createObservableConnection({
+        connectionConfig$,
+        entities,
+        logger
+      });
+    });
+
+    describe('when there are no blocks in the buffer', () => {
+      beforeEach(() => {
+        tipTracker = createTypeormTipTracker({ connection$, reconnectionConfig: retryBackoffConfig });
+      });
+
+      it('tip$ emits "origin"', async () => {
+        await expect(firstValueFrom(tipTracker.tip$)).resolves.toBe('origin');
+      });
+
+      describe('piping a block through returned operator', () => {
+        it('tip$ emits new block', async () => {
+          const header = createBlockHeader(1);
+          await firstValueFrom(
+            stubSingleEventProjection(ChainSyncEventType.RollForward, header).pipe(tipTracker.trackProjectedTip())
+          );
+          await expect(firstValueFrom(tipTracker.tip$)).resolves.toEqual(header);
+        });
+      });
+    });
+
+    describe('with 1 block in the buffer', () => {
+      let header: Cardano.PartialBlockHeader;
+
+      beforeEach(async () => {
+        header = createBlockHeader(1);
+        await blockRepo.insert(createBlockEntity(header));
+        tipTracker = createTypeormTipTracker({ connection$, reconnectionConfig: retryBackoffConfig });
+      });
+
+      it('tip$ emits that block', async () => {
+        await expect(firstValueFrom(tipTracker.tip$)).resolves.toEqual(header);
+      });
+
+      describe('rolling back that block', () => {
+        it('tip$ emits "origin"', async () => {
+          await blockRepo.delete(header.slot);
+          await firstValueFrom(
+            stubSingleEventProjection(ChainSyncEventType.RollBackward, header).pipe(tipTracker.trackProjectedTip())
+          );
+          await expect(firstValueFrom(tipTracker.tip$)).resolves.toBe('origin');
+        });
+      });
+
+      describe('piping a block through returned operator', () => {
+        it('tip$ emits new block', async () => {
+          const newBlockHeader = createBlockHeader(2);
+          await firstValueFrom(
+            of({
+              block: { header: newBlockHeader },
+              eventType: ChainSyncEventType.RollForward
+            } as BaseProjectionEvent).pipe(tipTracker.trackProjectedTip())
+          );
+          await expect(firstValueFrom(tipTracker.tip$)).resolves.toEqual(newBlockHeader);
+        });
+      });
+    });
+
+    describe('with 2 blocks in the buffer', () => {
+      let header1: Cardano.PartialBlockHeader;
+      let header2: Cardano.PartialBlockHeader;
+
+      beforeEach(async () => {
+        header1 = createBlockHeader(1);
+        header2 = createBlockHeader(2);
+        await blockRepo.insert([createBlockEntity(header1), createBlockEntity(header2)]);
+        tipTracker = createTypeormTipTracker({ connection$, reconnectionConfig: retryBackoffConfig });
+      });
+
+      it('tip$ emits latest block', async () => {
+        await expect(firstValueFrom(tipTracker.tip$)).resolves.toEqual(header2);
+      });
+
+      describe('rolling back latest block', () => {
+        it('tip$ emits first block', async () => {
+          await blockRepo.delete(header2.slot);
+          await firstValueFrom(
+            stubSingleEventProjection(ChainSyncEventType.RollBackward, header2).pipe(tipTracker.trackProjectedTip())
+          );
+          await expect(firstValueFrom(tipTracker.tip$)).resolves.toEqual(header1);
+        });
+      });
+    });
+  });
+
+  describe('with failing connection', () => {
+    it('reconnects and eventually emits the tip', async () => {
+      connection$ = createStubObservable(
+        throwError(() => new NoConnectionForRepositoryError('conn')),
+        createObservableConnection({
+          connectionConfig$,
+          entities,
+          logger
+        })
+      );
+      const header = createBlockHeader(1);
+      await blockRepo.insert(createBlockEntity(header));
+      tipTracker = createTypeormTipTracker({ connection$, reconnectionConfig: retryBackoffConfig });
+
+      await expect(firstValueFrom(tipTracker.tip$)).resolves.toEqual(header);
+    });
+  });
+});

--- a/packages/projection-typeorm/test/operators/storeHandleMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeHandleMetadata.test.ts
@@ -7,6 +7,7 @@ import {
   OutputEntity,
   TokensEntity,
   TypeormStabilityWindowBuffer,
+  TypeormTipTracker,
   createObservableConnection,
   storeAssets,
   storeBlock,
@@ -21,7 +22,12 @@ import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { Observable, firstValueFrom } from 'rxjs';
 import { QueryRunner, Repository } from 'typeorm';
 import { connectionConfig$, initializeDataSource } from '../util';
-import { createProjectorTilFirst, createRollBackwardEventFor, createStubProjectionSource } from './util';
+import {
+  createProjectorContext,
+  createProjectorTilFirst,
+  createRollBackwardEventFor,
+  createStubProjectionSource
+} from './util';
 
 describe('storeHandleMetadata', () => {
   const eventsWithCip68Handle = chainSyncData(ChainSyncDataSet.WithInlineDatum);
@@ -31,6 +37,7 @@ describe('storeHandleMetadata', () => {
 
   let queryRunner: QueryRunner;
   let buffer: TypeormStabilityWindowBuffer;
+  let tipTracker: TypeormTipTracker;
   const entities = [
     BlockEntity,
     BlockDataEntity,
@@ -63,11 +70,18 @@ describe('storeHandleMetadata', () => {
       Mappers.withNftMetadata({ logger }),
       Mappers.withHandleMetadata({ policyIds }, logger),
       storeData,
+      tipTracker.trackProjectedTip(),
       requestNext()
     );
 
   const project$ = (cardanoNode: ObservableCardanoNode) => () =>
-    Bootstrap.fromCardanoNode({ blocksBufferLength: 1, buffer, cardanoNode, logger }).pipe(applyOperators());
+    Bootstrap.fromCardanoNode({
+      blocksBufferLength: 1,
+      buffer,
+      cardanoNode,
+      logger,
+      projectedTip$: tipTracker.tip$
+    }).pipe(applyOperators());
 
   const projectTilFirst = (cardanoNode: ObservableCardanoNode) => createProjectorTilFirst(project$(cardanoNode));
   let repository: Repository<HandleMetadataEntity>;
@@ -75,14 +89,12 @@ describe('storeHandleMetadata', () => {
   beforeEach(async () => {
     const dataSource = await initializeDataSource({ entities });
     queryRunner = dataSource.createQueryRunner();
-    buffer = new TypeormStabilityWindowBuffer({ allowNonSequentialBlockHeights: true, logger });
+    ({ buffer, tipTracker } = createProjectorContext(entities));
     repository = queryRunner.manager.getRepository(HandleMetadataEntity);
-    await buffer.initialize(queryRunner);
   });
 
   afterEach(async () => {
     await queryRunner.release();
-    buffer.shutdown();
   });
 
   const testRollForwardAndBackward = async (

--- a/packages/projection-typeorm/test/operators/storeHandles/util.ts
+++ b/packages/projection-typeorm/test/operators/storeHandles/util.ts
@@ -24,8 +24,8 @@ import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/p
 import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger, mockProviders } from '@cardano-sdk/util-dev';
 import { Observable } from 'rxjs';
+import { ProjectorContext, createProjectorTilFirst, createStubProjectionSource } from '../util';
 import { connectionConfig$ } from '../../util';
-import { createProjectorTilFirst, createStubProjectionSource } from '../util';
 
 export const stubEvents = chainSyncData(ChainSyncDataSet.WithHandle);
 export const policyId = Cardano.PolicyId('f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a');
@@ -107,13 +107,20 @@ const applyMappers = (evt$: Observable<ProjectionEvent<{}>>) =>
     Mappers.withHandles({ policyIds }, logger)
   );
 
-// eslint-disable-next-line unicorn/consistent-function-scoping
-export const applyOperators = (buffer: TypeormStabilityWindowBuffer) => (evt$: Observable<ProjectionEvent<{}>>) =>
-  evt$.pipe(applyMappers, storeData(buffer), requestNext());
+export const mapAndStore =
+  ({ buffer }: ProjectorContext) =>
+  (evt$: Observable<ProjectionEvent<{}>>) =>
+    evt$.pipe(applyMappers, storeData(buffer));
 
-export const project$ = (buffer: TypeormStabilityWindowBuffer) => () =>
-  Bootstrap.fromCardanoNode({ blocksBufferLength: 10, buffer, cardanoNode: stubEvents.cardanoNode, logger }).pipe(
-    applyOperators(buffer)
-  );
+export const project$ =
+  ({ buffer, tipTracker }: ProjectorContext) =>
+  () =>
+    Bootstrap.fromCardanoNode({
+      blocksBufferLength: 10,
+      buffer,
+      cardanoNode: stubEvents.cardanoNode,
+      logger,
+      projectedTip$: tipTracker.tip$
+    }).pipe(mapAndStore({ buffer, tipTracker }), tipTracker.trackProjectedTip(), requestNext());
 
-export const projectTilFirst = (buffer: TypeormStabilityWindowBuffer) => createProjectorTilFirst(project$(buffer));
+export const projectTilFirst = (context: ProjectorContext) => createProjectorTilFirst(project$(context));

--- a/packages/projection-typeorm/test/operators/storeHandles/util.ts
+++ b/packages/projection-typeorm/test/operators/storeHandles/util.ts
@@ -10,6 +10,7 @@ import {
   StakeKeyRegistrationEntity,
   TokensEntity,
   TypeormStabilityWindowBuffer,
+  createObservableConnection,
   storeAddresses,
   storeAssets,
   storeBlock,
@@ -22,9 +23,9 @@ import {
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger, mockProviders } from '@cardano-sdk/util-dev';
-import { Observable, defer, from } from 'rxjs';
+import { Observable } from 'rxjs';
+import { connectionConfig$ } from '../../util';
 import { createProjectorTilFirst, createStubProjectionSource } from '../util';
-import { initializeDataSource } from '../../util';
 
 export const stubEvents = chainSyncData(ChainSyncDataSet.WithHandle);
 export const policyId = Cardano.PolicyId('f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a');
@@ -70,10 +71,6 @@ export const entities = [
   NftMetadataEntity
 ];
 
-const dataSource$ = defer(() =>
-  from(initializeDataSource({ devOptions: { dropSchema: false, synchronize: false }, entities }))
-);
-
 const storeData =
   (buffer: TypeormStabilityWindowBuffer) =>
   (
@@ -84,7 +81,9 @@ const storeData =
     >
   ) =>
     evt$.pipe(
-      withTypeormTransaction({ dataSource$, logger }),
+      withTypeormTransaction({
+        connection$: createObservableConnection({ connectionConfig$, entities, logger })
+      }),
       storeBlock(),
       storeAssets(),
       storeUtxo(),

--- a/packages/projection-typeorm/test/operators/storeUtxo.test.ts
+++ b/packages/projection-typeorm/test/operators/storeUtxo.test.ts
@@ -6,6 +6,7 @@ import {
   OutputEntity,
   TokensEntity,
   TypeormStabilityWindowBuffer,
+  TypeormTipTracker,
   createObservableConnection,
   storeAssets,
   storeBlock,
@@ -13,23 +14,23 @@ import {
   typeormTransactionCommit,
   withTypeormTransaction
 } from '../../src';
-import { Bootstrap, Mappers, requestNext } from '@cardano-sdk/projection';
+import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { IsNull, Not, QueryRunner } from 'typeorm';
+import { Observable } from 'rxjs';
 import { connectionConfig$, initializeDataSource } from '../util';
-import { createProjectorTilFirst } from './util';
+import { createProjectorContext, createProjectorTilFirst } from './util';
 
 describe('storeUtxo', () => {
   const stubEvents = chainSyncData(ChainSyncDataSet.WithMint);
   let queryRunner: QueryRunner;
   let buffer: TypeormStabilityWindowBuffer;
+  let tipTracker: TypeormTipTracker;
   const entities = [BlockEntity, BlockDataEntity, AssetEntity, NftMetadataEntity, TokensEntity, OutputEntity];
 
-  const project$ = () =>
-    Bootstrap.fromCardanoNode({ blocksBufferLength: 10, buffer, cardanoNode: stubEvents.cardanoNode, logger }).pipe(
-      Mappers.withMint(),
-      Mappers.withUtxo(),
+  const storeData = <T extends Mappers.WithUtxo & Mappers.WithMint>(evt$: Observable<ProjectionEvent<T>>) =>
+    evt$.pipe(
       withTypeormTransaction({
         connection$: createObservableConnection({ connectionConfig$, entities, logger })
       }),
@@ -37,22 +38,28 @@ describe('storeUtxo', () => {
       storeAssets(),
       storeUtxo(),
       buffer.storeBlockData(),
-      typeormTransactionCommit(),
-      requestNext()
+      typeormTransactionCommit()
     );
+
+  const project$ = () =>
+    Bootstrap.fromCardanoNode({
+      blocksBufferLength: 10,
+      buffer,
+      cardanoNode: stubEvents.cardanoNode,
+      logger,
+      projectedTip$: tipTracker.tip$
+    }).pipe(Mappers.withMint(), Mappers.withUtxo(), storeData, tipTracker.trackProjectedTip(), requestNext());
 
   const projectTilFirst = createProjectorTilFirst(project$);
 
   beforeEach(async () => {
     const dataSource = await initializeDataSource({ entities });
     queryRunner = dataSource.createQueryRunner();
-    buffer = new TypeormStabilityWindowBuffer({ allowNonSequentialBlockHeights: true, logger });
-    await buffer.initialize(queryRunner);
+    ({ buffer, tipTracker } = createProjectorContext(entities));
   });
 
   afterEach(async () => {
     await queryRunner.release();
-    buffer.shutdown();
   });
 
   it('hydrates event object with storedProducedUtxo map', async () => {

--- a/packages/projection-typeorm/test/operators/storeUtxo.test.ts
+++ b/packages/projection-typeorm/test/operators/storeUtxo.test.ts
@@ -6,6 +6,7 @@ import {
   OutputEntity,
   TokensEntity,
   TypeormStabilityWindowBuffer,
+  createObservableConnection,
   storeAssets,
   storeBlock,
   storeUtxo,
@@ -16,9 +17,8 @@ import { Bootstrap, Mappers, requestNext } from '@cardano-sdk/projection';
 import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { IsNull, Not, QueryRunner } from 'typeorm';
+import { connectionConfig$, initializeDataSource } from '../util';
 import { createProjectorTilFirst } from './util';
-import { defer, from } from 'rxjs';
-import { initializeDataSource } from '../util';
 
 describe('storeUtxo', () => {
   const stubEvents = chainSyncData(ChainSyncDataSet.WithMint);
@@ -31,8 +31,7 @@ describe('storeUtxo', () => {
       Mappers.withMint(),
       Mappers.withUtxo(),
       withTypeormTransaction({
-        dataSource$: defer(() => from(initializeDataSource({ entities }))),
-        logger
+        connection$: createObservableConnection({ connectionConfig$, entities, logger })
       }),
       storeBlock(),
       storeAssets(),

--- a/packages/projection-typeorm/test/operators/withTypeormTransaction.test.ts
+++ b/packages/projection-typeorm/test/operators/withTypeormTransaction.test.ts
@@ -3,6 +3,7 @@ import {
   BlockDataEntity,
   BlockEntity,
   TypeormStabilityWindowBuffer,
+  connect,
   isRecoverableTypeormError,
   storeBlock,
   typeormTransactionCommit,
@@ -64,8 +65,7 @@ describe('withTypeormTransaction', () => {
     jest.fn((evt$: Observable<ProjectionEvent>) =>
       evt$.pipe(
         withTypeormTransaction({
-          dataSource$,
-          logger
+          connection$: dataSource$.pipe(connect({ logger }))
         }),
         storeBlock(),
         buffer.storeBlockData(),

--- a/packages/projection-typeorm/test/operators/withTypeormTransaction.test.ts
+++ b/packages/projection-typeorm/test/operators/withTypeormTransaction.test.ts
@@ -3,6 +3,7 @@ import {
   BlockDataEntity,
   BlockEntity,
   TypeormStabilityWindowBuffer,
+  TypeormTipTracker,
   connect,
   isRecoverableTypeormError,
   storeBlock,
@@ -18,7 +19,8 @@ import {
 } from '@cardano-sdk/projection';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { ConnectionNotFoundError, DataSource, QueryFailedError, QueryRunner } from 'typeorm';
-import { Observable, defer, firstValueFrom, lastValueFrom, map, of, take } from 'rxjs';
+import { Observable, defer, firstValueFrom, lastValueFrom, map, of, take, toArray } from 'rxjs';
+import { createProjectorContext } from './util';
 import { initializeDataSource } from '../util';
 import { patchObject } from '@cardano-sdk/util';
 import { shareRetryBackoff } from '@cardano-sdk/util-rxjs';
@@ -56,8 +58,10 @@ const mockDataSource = (dataSources: DataSource[]) => {
 };
 
 describe('withTypeormTransaction', () => {
+  const entities = [BlockEntity, BlockDataEntity];
   let project$: Observable<Omit<ProjectionEvent, 'requestNext'>>;
   let buffer: TypeormStabilityWindowBuffer;
+  let tipTracker: TypeormTipTracker;
   let dataSource: DataSource;
   let queryRunner: QueryRunner;
 
@@ -69,17 +73,17 @@ describe('withTypeormTransaction', () => {
         }),
         storeBlock(),
         buffer.storeBlockData(),
-        typeormTransactionCommit()
+        typeormTransactionCommit(),
+        tipTracker.trackProjectedTip()
       )
     );
 
   beforeEach(async () => {
-    dataSource = await initializeDataSource({ entities: [BlockEntity, BlockDataEntity] });
+    dataSource = await initializeDataSource({ entities });
     queryRunner = dataSource.createQueryRunner();
   });
 
   afterEach(async () => {
-    buffer.shutdown();
     await queryRunner.release();
     await dataSource.destroy();
   });
@@ -88,8 +92,7 @@ describe('withTypeormTransaction', () => {
     let numChainSyncSubscriptions: number;
 
     beforeEach(async () => {
-      buffer = new TypeormStabilityWindowBuffer({ logger });
-      await buffer.initialize(queryRunner);
+      ({ buffer, tipTracker } = createProjectorContext(entities));
     });
 
     const project = <PropsOut>(projection: ProjectionOperator<BootstrapExtraProps, PropsOut>) =>
@@ -110,7 +113,8 @@ describe('withTypeormTransaction', () => {
                 )
               )
           }),
-          logger
+          logger,
+          projectedTip$: tipTracker.tip$
         }).pipe(projection, requestNext())
       );
 
@@ -135,13 +139,15 @@ describe('withTypeormTransaction', () => {
 
   describe('with a successful database connection', () => {
     beforeEach(async () => {
-      buffer = new TypeormStabilityWindowBuffer({
-        allowNonSequentialBlockHeights: false,
-        logger
-      });
-      await buffer.initialize(queryRunner);
+      ({ buffer, tipTracker } = createProjectorContext(entities));
       project$ = defer(() =>
-        Bootstrap.fromCardanoNode({ blocksBufferLength: 10, buffer, cardanoNode, logger }).pipe(
+        Bootstrap.fromCardanoNode({
+          blocksBufferLength: 10,
+          buffer,
+          cardanoNode,
+          logger,
+          projectedTip$: tipTracker.tip$
+        }).pipe(
           shareRetryBackoff(createProjection(of(dataSource)), { shouldRetry: isRecoverableTypeormError }),
           requestNext()
         )
@@ -163,11 +169,10 @@ describe('withTypeormTransaction', () => {
     });
 
     it('does not retry unrecoverable errors', async () => {
-      const lastEvent = await lastValueFrom(project$.pipe(take(2)));
-      // deleting last block from the buffer creates an inconsistency: resumed projection will
+      const [previousTip] = await lastValueFrom(project$.pipe(take(2), toArray()));
+      // setting local tip to tip-1 creates an inconsistency: resumed projection will
       // try to insert a 'block' with an already existing 'height' which has a unique constraint.
-      await queryRunner.manager.getRepository(BlockDataEntity).delete(lastEvent.block.header.blockNo);
-      await buffer.initialize(queryRunner);
+      await firstValueFrom(tipTracker.trackProjectedTip()(of(previousTip)));
       // ADP-2807
       await expect(firstValueFrom(project$)).rejects.toThrowError(QueryFailedError);
     });

--- a/packages/projection-typeorm/test/util.ts
+++ b/packages/projection-typeorm/test/util.ts
@@ -1,6 +1,7 @@
-import { CreateDataSourceProps, createDataSource } from '../src';
+import { BlockEntity, CreateDataSourceProps, createDataSource } from '../src';
+import { Cardano } from '@cardano-sdk/core';
 import { NEVER, concat, of } from 'rxjs';
-import { logger } from '@cardano-sdk/util-dev';
+import { generateRandomHexString, logger } from '@cardano-sdk/util-dev';
 
 export const connectionConfig = {
   database: 'projection',
@@ -24,3 +25,15 @@ export const initializeDataSource = async (
   await dataSource.initialize();
   return dataSource;
 };
+
+export const createBlockHeader = (height: number): Cardano.PartialBlockHeader => ({
+  blockNo: Cardano.BlockNo(height),
+  hash: Cardano.BlockId(generateRandomHexString(64)),
+  slot: Cardano.Slot(height * 20)
+});
+
+export const createBlockEntity = (header: Cardano.PartialBlockHeader): BlockEntity => ({
+  hash: header.hash,
+  height: header.blockNo,
+  slot: header.slot
+});

--- a/packages/projection-typeorm/test/util.ts
+++ b/packages/projection-typeorm/test/util.ts
@@ -1,4 +1,5 @@
 import { CreateDataSourceProps, createDataSource } from '../src';
+import { NEVER, concat, of } from 'rxjs';
 import { logger } from '@cardano-sdk/util-dev';
 
 export const connectionConfig = {
@@ -8,6 +9,8 @@ export const connectionConfig = {
   port: 5432,
   username: 'postgres'
 };
+
+export const connectionConfig$ = concat(of(connectionConfig), NEVER);
 
 export const initializeDataSource = async (
   props: Pick<CreateDataSourceProps, 'entities' | 'extensions' | 'devOptions'>

--- a/packages/projection/src/InMemory/types.ts
+++ b/packages/projection/src/InMemory/types.ts
@@ -7,8 +7,8 @@ export type InMemoryStore = {
   stakePools: Map<
     Cardano.PoolId,
     {
-      updates: Mappers.PoolUpdate[];
-      retirements: Mappers.PoolRetirement[];
+      updates: Array<Mappers.PoolUpdate>;
+      retirements: Array<Mappers.PoolRetirement>;
     }
   >;
 };

--- a/packages/projection/src/operators/withRolledBackBlock.ts
+++ b/packages/projection/src/operators/withRolledBackBlock.ts
@@ -1,26 +1,69 @@
-import { Cardano, ChainSyncEvent, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano, ChainSyncEvent, ChainSyncEventType, TipOrOrigin } from '@cardano-sdk/core';
+import {
+  EMPTY,
+  Observable,
+  concatMap,
+  filter,
+  finalize,
+  map,
+  mergeMap,
+  noop,
+  of,
+  switchMap,
+  take,
+  takeWhile
+} from 'rxjs';
 import { ExtChainSyncOperator, StabilityWindowBuffer, WithBlock } from '../types';
-import { Observable, concatMap, finalize, map, noop, of, takeWhile } from 'rxjs';
+
+const syncFromOrigin = (chainSyncEvent: ChainSyncEvent, projectedTip$: Observable<TipOrOrigin>) =>
+  projectedTip$.pipe(
+    take(1),
+    mergeMap((tip) => {
+      if (tip !== 'origin') {
+        // TODO: replace with a ChainSyncError after reworking CardanoNodeErrors
+        throw new Error('Rollback to origin: wrong network?');
+      } else {
+        // Rollback to origin while local tip is at origin is a no-op
+        chainSyncEvent.requestNext();
+        return EMPTY;
+      }
+    })
+  );
 
 /**
  * Transforms rollback event into a stream of granular rollback events, each containing a single rolled back block.
  * Intended to be used as the 1st projection operator.
  */
 export const withRolledBackBlock =
-  (buffer: StabilityWindowBuffer): ExtChainSyncOperator<{}, {}, {}, WithBlock> =>
+  (
+    projectedTip$: Observable<TipOrOrigin>,
+    buffer: StabilityWindowBuffer
+  ): ExtChainSyncOperator<{}, {}, {}, WithBlock> =>
   (evt$: Observable<ChainSyncEvent>) =>
     evt$.pipe(
       concatMap((chainSyncEvent) => {
         switch (chainSyncEvent.eventType) {
           case ChainSyncEventType.RollForward:
             return of(chainSyncEvent);
-          case ChainSyncEventType.RollBackward:
-            return buffer.tip$.pipe(
+          case ChainSyncEventType.RollBackward: {
+            const rollbackPoint = chainSyncEvent.point;
+            if (rollbackPoint === 'origin') {
+              return syncFromOrigin(chainSyncEvent, projectedTip$);
+            }
+            return projectedTip$.pipe(
               takeWhile(
-                (block): block is Cardano.Block =>
-                  block !== 'origin' &&
-                  (chainSyncEvent.point === 'origin' || chainSyncEvent.point.hash !== block.header.hash)
+                (tip): tip is Cardano.PartialBlockHeader => tip !== 'origin' && tip.hash !== rollbackPoint.hash
               ),
+              switchMap((tip) => buffer.getBlock(tip.hash)),
+              filter((block): block is Cardano.Block => {
+                if (!block) {
+                  // TODO: replace with a ChainSyncError after reworking CardanoNodeErrors
+                  throw new Error(
+                    `Could not rollback to ${rollbackPoint.hash}: tip block not found in stability window buffer`
+                  );
+                }
+                return true;
+              }),
               map((block) => ({
                 ...chainSyncEvent,
                 block,
@@ -29,6 +72,7 @@ export const withRolledBackBlock =
               // Call requestNext() once all rolled back blocks are processed
               finalize(chainSyncEvent.requestNext)
             );
+          }
         }
       })
     );

--- a/packages/projection/src/types.ts
+++ b/packages/projection/src/types.ts
@@ -74,16 +74,9 @@ export type ProjectionOperator<ExtraPropsIn, ExtraPropsOut = {}> = UnifiedExtCha
  */
 export interface StabilityWindowBuffer {
   /**
-   * Observable that emits current tip stored in stability window buffer.
-   * 'origin' when buffer is empty.
-   * Calling methods of the buffer should make this observable to emit.
+   * @returns an Observable that emits once and completes
    */
-  tip$: Observable<Cardano.Block | 'origin'>;
-  /**
-   * Observable that emits current tail (the first block) stored in stability window buffer.
-   * 'origin' when buffer is empty.
-   */
-  tail$: Observable<Cardano.Block | 'origin'>;
+  getBlock(id: Cardano.BlockId): Observable<Cardano.Block | null>;
 }
 
 export type BaseProjectionEvent =

--- a/packages/projection/test/InMemory/InMemoryStabilityWindowBuffer.test.ts
+++ b/packages/projection/test/InMemory/InMemoryStabilityWindowBuffer.test.ts
@@ -1,6 +1,6 @@
 import { Cardano, ChainSyncEventType, Seconds } from '@cardano-sdk/core';
 import { InMemory, UnifiedExtChainSyncEvent, WithNetworkInfo } from '../../src';
-import { firstValueFrom, from, take, toArray } from 'rxjs';
+import { firstValueFrom, from } from 'rxjs';
 import { genesisToEraSummary } from '@cardano-sdk/util-dev';
 import { stubBlockId } from '../util';
 
@@ -32,36 +32,19 @@ describe('InMemory.InMemoryStabilityWindowBuffer', () => {
     buffer = new InMemory.InMemoryStabilityWindowBuffer();
   });
 
-  it('emits tip$ and tail$ when adding and deleting blocks', async () => {
-    const tips = firstValueFrom(buffer.tip$.pipe(take(10), toArray()));
-    const tails = firstValueFrom(buffer.tail$.pipe(take(5), toArray()));
-    buffer
-      .handleEvents()(
-        from([
-          event(1, ChainSyncEventType.RollForward),
-          event(1, ChainSyncEventType.RollBackward),
-          event(1, ChainSyncEventType.RollForward),
-          event(2, ChainSyncEventType.RollForward),
-          event(2, ChainSyncEventType.RollBackward),
-          event(2, ChainSyncEventType.RollForward),
-          event(3, ChainSyncEventType.RollForward),
-          event(4, ChainSyncEventType.RollForward),
-          event(5, ChainSyncEventType.RollForward)
-        ])
-      )
-      .subscribe();
-    expect(await tips).toEqual([
-      'origin',
-      event(1).block,
-      'origin',
-      event(1).block,
-      event(2).block,
-      event(1).block,
-      event(2).block,
-      event(3).block,
-      event(4).block,
-      event(5).block
-    ]);
-    expect(await tails).toEqual(['origin', event(1).block, 'origin', event(1).block, event(2).block]);
+  describe('getBlock', () => {
+    it('emits the block when it exists in the buffer', async () => {
+      buffer
+        .handleEvents()(from([event(1, ChainSyncEventType.RollForward)]))
+        .subscribe();
+      await expect(firstValueFrom(buffer.getBlock(stubBlockId(1)))).resolves.not.toBeNull();
+    });
+
+    it('emits `null` when block does not exist in the buffer', async () => {
+      buffer
+        .handleEvents()(from([event(1, ChainSyncEventType.RollForward), event(1, ChainSyncEventType.RollBackward)]))
+        .subscribe();
+      await expect(firstValueFrom(buffer.getBlock(stubBlockId(1)))).resolves.toBeNull();
+    });
   });
 });

--- a/packages/projection/test/operators/withRolledBackBlock.test.ts
+++ b/packages/projection/test/operators/withRolledBackBlock.test.ts
@@ -1,13 +1,18 @@
-import { Cardano, ChainSyncEventType, ChainSyncRollBackward } from '@cardano-sdk/core';
+import { Cardano, ChainSyncEventType, ChainSyncRollBackward, TipOrOrigin } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, createTestScheduler } from '@cardano-sdk/util-dev';
 import { InMemory, UnifiedExtChainSyncEvent, withNetworkInfo, withRolledBackBlock } from '../../src';
 import { stubBlockId } from '../util';
 
 const dataWithStakeKeyDeregistration = chainSyncData(ChainSyncDataSet.WithPoolRetirement);
 
+const createBlockHeader = (slot: number): Cardano.PartialBlockHeader => ({
+  blockNo: Cardano.BlockNo(slot),
+  hash: stubBlockId(slot),
+  slot: Cardano.Slot(slot)
+});
 const createEvent = (eventType: ChainSyncEventType, slot: number, tipSlot = slot) =>
   ({
-    block: { header: { blockNo: Cardano.BlockNo(slot), hash: stubBlockId(slot), slot: Cardano.Slot(slot) } },
+    block: { header: createBlockHeader(slot) },
     eventType,
     point:
       eventType === ChainSyncEventType.RollForward
@@ -17,7 +22,7 @@ const createEvent = (eventType: ChainSyncEventType, slot: number, tipSlot = slot
     tip: { blockNo: Cardano.BlockNo(tipSlot), hash: stubBlockId(tipSlot), slot: Cardano.Slot(tipSlot) }
   } as UnifiedExtChainSyncEvent<{}>);
 
-const sourceRollback = (slot: number): ChainSyncRollBackward => {
+const sourceRollbackToPoint = (slot: number): ChainSyncRollBackward => {
   const point = { hash: stubBlockId(slot), slot: Cardano.Slot(slot) };
   return {
     eventType: ChainSyncEventType.RollBackward,
@@ -27,16 +32,28 @@ const sourceRollback = (slot: number): ChainSyncRollBackward => {
   };
 };
 
-describe('withRolledBackBlocks', () => {
+const sourceRollbackToOrigin = (): ChainSyncRollBackward => ({
+  eventType: ChainSyncEventType.RollBackward,
+  point: 'origin',
+  requestNext: jest.fn(),
+  tip: 'origin'
+});
+
+describe('withRolledBackBlock', () => {
   let buffer: InMemory.InMemoryStabilityWindowBuffer;
 
   beforeEach(() => {
     buffer = new InMemory.InMemoryStabilityWindowBuffer();
   });
 
-  it('re-emits rolled back blocks one by one and calls requestNext on original event', () => {
-    createTestScheduler().run(({ hot, expectObservable, expectSubscriptions, flush }) => {
-      const originalRollbackEvent = sourceRollback(1);
+  it('re-emits rolled back blocks til rollback point one by one and calls requestNext on original event', () => {
+    createTestScheduler().run(({ cold, hot, expectObservable, expectSubscriptions, flush }) => {
+      const originalRollbackEvent = sourceRollbackToPoint(1);
+      const projectedTip$ = cold('dcb', {
+        b: createBlockHeader(1),
+        c: createBlockHeader(2),
+        d: createBlockHeader(3)
+      });
       const source$ = hot('abcde', {
         a: createEvent(ChainSyncEventType.RollForward, 0),
         b: createEvent(ChainSyncEventType.RollForward, 1),
@@ -46,11 +63,11 @@ describe('withRolledBackBlocks', () => {
       });
       expectObservable(
         source$.pipe(
-          withRolledBackBlock(buffer),
+          withRolledBackBlock(projectedTip$, buffer),
           withNetworkInfo(dataWithStakeKeyDeregistration.cardanoNode),
           buffer.handleEvents()
         )
-      ).toBe('abcd(ef)', {
+      ).toBe('abcdef', {
         a: { ...createEvent(ChainSyncEventType.RollForward, 0), ...dataWithStakeKeyDeregistration.networkInfo },
         b: { ...createEvent(ChainSyncEventType.RollForward, 1), ...dataWithStakeKeyDeregistration.networkInfo },
         c: { ...createEvent(ChainSyncEventType.RollForward, 2), ...dataWithStakeKeyDeregistration.networkInfo },
@@ -61,6 +78,66 @@ describe('withRolledBackBlocks', () => {
       expectSubscriptions(source$.subscriptions).toBe('^');
       flush();
       expect(originalRollbackEvent.requestNext).toBeCalledTimes(1);
+    });
+  });
+
+  describe('rollback to origin', () => {
+    describe('when local tip at origin', () => {
+      it('calls requestNext without emitting', () => {
+        createTestScheduler().run(({ cold, hot, expectObservable, expectSubscriptions, flush }) => {
+          const rollbackEvent = sourceRollbackToOrigin();
+          const projectedTip$ = cold<TipOrOrigin>('a', {
+            a: 'origin'
+          });
+          const source$ = hot('a|', {
+            a: rollbackEvent
+          });
+          expectObservable(source$.pipe(withRolledBackBlock(projectedTip$, buffer))).toBe('-|');
+          expectSubscriptions(source$.subscriptions).toBe('^!');
+          flush();
+          expect(rollbackEvent.requestNext).toBeCalledTimes(1);
+        });
+      });
+    });
+
+    describe('when local tip is not at origin', () => {
+      it('assumes we connected to the wrong network and throws', () => {
+        createTestScheduler().run(({ cold, hot, expectObservable, flush }) => {
+          const rollbackEvent = sourceRollbackToOrigin();
+          const projectedTip$ = cold<TipOrOrigin>('a', {
+            a: createBlockHeader(1)
+          });
+          const source$ = hot('a|', {
+            a: rollbackEvent
+          });
+          expectObservable(source$.pipe(withRolledBackBlock(projectedTip$, buffer))).toBe(
+            '#',
+            {},
+            new Error('Rollback to origin: wrong network?')
+          );
+          flush();
+        });
+      });
+    });
+  });
+
+  it('throws when block is not found in the buffer', () => {
+    createTestScheduler().run(({ cold, hot, expectObservable, flush }) => {
+      const rollbackEvent = sourceRollbackToPoint(1);
+      const projectedTip$ = cold<TipOrOrigin>('a', {
+        a: createBlockHeader(2)
+      });
+      const source$ = hot('a|', {
+        a: rollbackEvent
+      });
+      expectObservable(source$.pipe(withRolledBackBlock(projectedTip$, buffer))).toBe(
+        '#',
+        {},
+        new Error(
+          'Could not rollback to 0000000000000000000000000000000000000000000000000000000000000001: tip block not found in stability window buffer'
+        )
+      );
+      flush();
     });
   });
 });

--- a/packages/util-dev/src/createStubObservable.ts
+++ b/packages/util-dev/src/createStubObservable.ts
@@ -1,0 +1,13 @@
+import { Observable } from 'rxjs';
+
+/**
+ * @returns an Observable that proxies subscriptions to observables provided as arguments.
+ * Arguments are subscribed to in order they are provided.
+ */
+export const createStubObservable = <T>(...calls: Observable<T>[]) => {
+  let numCall = 0;
+  return new Observable<T>((subscriber) => {
+    const sub = calls[numCall++].subscribe(subscriber);
+    return () => sub.unsubscribe();
+  });
+};

--- a/packages/util-dev/src/index.ts
+++ b/packages/util-dev/src/index.ts
@@ -7,6 +7,7 @@ export * from './util';
 export * from './createStubStakePoolProvider';
 export * from './testScheduler';
 export * from './createStubUtxoProvider';
+export * from './createStubObservable';
 export * from './createGenericMockServer';
 export * from './dataGeneration';
 export * from './eraSummaries';

--- a/packages/util-dev/test/createStubObservable.test.ts
+++ b/packages/util-dev/test/createStubObservable.test.ts
@@ -1,0 +1,15 @@
+import { concat } from 'rxjs';
+import { createStubObservable, createTestScheduler } from '../src';
+
+describe('createStubObservable', () => {
+  it('returns an observable that subscribes to observables provided as arguments in order', () => {
+    createTestScheduler().run(({ cold, expectObservable, expectSubscriptions }) => {
+      const a$ = cold('a|');
+      const b$ = cold('b|');
+      const target$ = createStubObservable(a$, b$);
+      expectObservable(concat(target$, target$)).toBe('ab|');
+      expectSubscriptions(a$.subscriptions).toBe('^!');
+      expectSubscriptions(b$.subscriptions).toBe('-^!');
+    });
+  });
+});

--- a/packages/util-rxjs/src/types.ts
+++ b/packages/util-rxjs/src/types.ts
@@ -1,3 +1,6 @@
 import { Observable } from 'rxjs';
+import { RetryBackoffConfig } from 'backoff-rxjs';
 
 export type ObservableType<O> = O extends Observable<infer T> ? T : unknown;
+
+export type ReconnectionConfig = Omit<RetryBackoffConfig, 'shouldRetry'>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3464,6 +3464,7 @@ __metadata:
     "@cardano-sdk/crypto": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
     "@cardano-sdk/util-dev": "workspace:~"
+    "@cardano-sdk/util-rxjs": "workspace:~"
     "@types/lodash": ^4.14.182
     backoff-rxjs: ^7.0.0
     buffer: 5.7.1
@@ -3495,6 +3496,7 @@ __metadata:
     "@cardano-sdk/util": "workspace:~"
     "@cardano-sdk/util-dev": "workspace:~"
     "@cardano-sdk/util-rxjs": "workspace:~"
+    backoff-rxjs: ^7.0.0
     eslint: ^7.32.0
     jest: ^28.1.3
     lodash: ^4.17.21


### PR DESCRIPTION
# Context

Projector is inserting block data into the database even when it's far away from the tip and there is no chance of a fork/rollback happening.

LW-6953

# Proposed Solution

Projector no longer inserts block data until it reaches `tip-securityParameter` block height. This is implemented by extracting Tip tracking capabilities out of StabilityWindowBuffer interface.

Preliminary performance testing of utxo projection on my computer resulted in
- ~3x projector speed on empty blocks
- ~2x projector speed on non-empty blocks

# Important Changes Introduced

See commit log
