### PR TITLE
fix/LW-8833 return active stake from previous epoch insted

### DIFF
--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -14,11 +14,7 @@ export const findTotalSupply = `
 export const findActiveStake = `
     SELECT CAST(COALESCE(SUM(amount), 0) AS BIGINT) as active_stake
     FROM epoch_stake
-    WHERE epoch_stake.epoch_no = (
-    SELECT no FROM epoch
-        ORDER BY no DESC
-        LIMIT 1
-    )
+    WHERE epoch_stake.epoch_no = (SELECT MAX(no) FROM epoch) - 1
 `;
 
 export const findLatestCompleteEpoch = `


### PR DESCRIPTION
# Context

Due to our wrong interpretation of `epoch_stake` population time, the active stake of our `DbSynNetworkInfoProvider.stake` call is wrong.

# Proposed Temporary Solution

Return active stake from previous epoch.

# Important Changes Introduced

Minor query optimization.