### PR TITLE
fix(hardware-trezor): Trezor connect web import LW-6514

### DIFF
--- a/packages/hardware-trezor/src/TrezorKeyAgent.ts
+++ b/packages/hardware-trezor/src/TrezorKeyAgent.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
 import * as Trezor from '@trezor/connect';
+import * as TrezorWeb from '@trezor/connect-web';
 import { Cardano, NotImplementedError } from '@cardano-sdk/core';
 import {
   CardanoKeyConst,
@@ -14,9 +15,9 @@ import {
   errors
 } from '@cardano-sdk/key-management';
 import { txToTrezor } from './transformers/tx';
-import TrezorConnectWeb from '@trezor/connect-web';
 
 const TrezorConnectNode = Trezor.default;
+const TrezorConnectWeb = TrezorWeb.default;
 
 const transportTypedError = (error?: any) =>
   new errors.AuthenticationError(


### PR DESCRIPTION
# Context

This PR fixes an issue related to importing the `@trezor/connect-web` package. The previous version (seemingly correct) causes an import issue in Lace.
