### PR TITLE
ci: do not require tests to pass when generating coverage report

### DIFF
--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -35,7 +35,7 @@
     "test": "yarn build:version && jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test"
   },

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -31,7 +31,7 @@
     "cli": "ts-node --transpile-only src/cli.ts",
     "compose:up": "docker compose --env-file environments/.env.$NETWORK -p cardano-services-$NETWORK -f docker-compose.yml -f ../../compose/common.yml -f ../../compose/pg-agent.yml ${FILES:-} up",
     "compose:down": "docker compose -p cardano-services-$NETWORK -f docker-compose.yml -f ../../compose/common.yml -f ../../compose/pg-agent.yml down -t 120",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "circular-deps:check": "madge --circular dist/cjs",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -62,7 +62,7 @@
     "cleanup:dist": "shx rm -rf dist",
     "cleanup:nm": "shx rm -rf node_modules",
     "cleanup": "run-s cleanup:dist cleanup:nm",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",
     "prepack": "yarn build",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -34,7 +34,7 @@
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build"
   },
   "devDependencies": {

--- a/packages/hardware-ledger/package.json
+++ b/packages/hardware-ledger/package.json
@@ -34,7 +34,7 @@
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build"
   },
   "devDependencies": {

--- a/packages/hardware-trezor/package.json
+++ b/packages/hardware-trezor/package.json
@@ -34,7 +34,7 @@
     "test": "jest -c test/jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build"
   },
   "devDependencies": {

--- a/packages/input-selection/package.json
+++ b/packages/input-selection/package.json
@@ -34,7 +34,7 @@
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test"
   },

--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -34,7 +34,7 @@
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build"
   },
   "devDependencies": {

--- a/packages/projection-typeorm/package.json
+++ b/packages/projection-typeorm/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js --runInBand",
     "test:build:verify": "tsc --build ./test",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet"

--- a/packages/projection/package.json
+++ b/packages/projection/package.json
@@ -33,7 +33,7 @@
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet"

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -38,7 +38,7 @@
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet"

--- a/packages/util-rxjs/package.json
+++ b/packages/util-rxjs/package.json
@@ -33,7 +33,7 @@
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -34,7 +34,7 @@
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test"
   },

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -29,7 +29,7 @@
     "cleanup:dist": "shx rm -rf dist",
     "cleanup:nm": "shx rm -rf node_modules",
     "cleanup": "run-s cleanup:dist cleanup:nm",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "prepack": "yarn build",

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -34,7 +34,7 @@
     "test": "jest -c ./jest.config.js",
     "test:build:verify": "tsc --build ./test",
     "test:e2e": "shx echo 'test:e2e' command not implemented yet",
-    "coverage": "yarn test --coverage",
+    "coverage": "yarn test --coverage || true",
     "prepack": "yarn build",
     "test:debug": "DEBUG=true yarn test"
   },


### PR DESCRIPTION
# Context

[deploy-docs](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/6576994512) job has been failing for a while now.

# Proposed Solution

It was failing because [one of cardano-services tests](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/6576994512/job/17867630287#step:4:950) is consistently failing (captured in LW-8850). Running the tests is not the purpose of the workflow - it will generate coverage report regardless if tests pass or not.

# Important Changes Introduced
