### PR TITLE
feat: add support for only updating outdated pool metrics at a given …

### DIFF
--- a/packages/cardano-services/src/PgBoss/index.ts
+++ b/packages/cardano-services/src/PgBoss/index.ts
@@ -3,8 +3,6 @@ import { STAKE_POOL_METADATA_QUEUE, STAKE_POOL_METRICS_UPDATE } from '@cardano-s
 import { stakePoolMetadataHandlerFactory } from './stakePoolMetadataHandler';
 import { stakePoolMetricsHandlerFactory } from './stakePoolMetricsHandler';
 
-export * from './stakePoolMetadataHandler';
-export * from './stakePoolMetricsHandler';
 export * from './types';
 export * from './util';
 

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -29,13 +29,15 @@ export enum ServiceNames {
 }
 
 export const POOLS_METRICS_INTERVAL_DEFAULT = 1000;
+export const POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT = 100;
 
 export enum ProjectorOptionDescriptions {
   BlocksBufferLength = 'Chain sync event (blocks) buffer length',
   DropSchema = 'Drop and recreate database schema to project from origin',
   DryRun = 'Initialize the projection, but do not start it',
   ExitAtBlockNo = 'Exit after processing this block. Intended for benchmark testing',
-  PoolsMetricsInterval = 'Interval between two stake pools metrics jobs in number of blocks',
+  PoolsMetricsInterval = 'Interval in number of blocks between two stake pools metrics jobs to update all metrics',
+  PoolsMetricsOutdatedInterval = 'Interval in number of blocks between two stake pools metrics jobs to update only outdated metrics',
   Synchronize = 'Synchronize the schema from the models'
 }
 

--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -29,7 +29,7 @@ import {
 } from '@cardano-sdk/projection-typeorm';
 import { Cardano } from '@cardano-sdk/core';
 import { Mappers as Mapper } from '@cardano-sdk/projection';
-import { POOLS_METRICS_INTERVAL_DEFAULT } from '../Program/programs/types';
+import { POOLS_METRICS_INTERVAL_DEFAULT, POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT } from '../Program/programs/types';
 import { Sorter } from '@hapi/topo';
 import { WithLogger } from '@cardano-sdk/util';
 import { passthrough } from '@cardano-sdk/util-rxjs';
@@ -100,7 +100,10 @@ export const storeOperators = {
   storeHandleMetadata: storeHandleMetadata(),
   storeHandles: storeHandles(),
   storeNftMetadata: storeNftMetadata(),
-  storePoolMetricsUpdateJob: createStorePoolMetricsUpdateJob(POOLS_METRICS_INTERVAL_DEFAULT)(),
+  storePoolMetricsUpdateJob: createStorePoolMetricsUpdateJob(
+    POOLS_METRICS_INTERVAL_DEFAULT,
+    POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT
+  )(),
   storeStakeKeyRegistrations: storeStakeKeyRegistrations(),
   storeStakePoolMetadataJob: storeStakePoolMetadataJob(),
   storeStakePools: storeStakePools(),

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -21,6 +21,7 @@ import {
   PG_BOSS_WORKER_API_URL_DEFAULT,
   POLLING_CYCLE_DEFAULT,
   POOLS_METRICS_INTERVAL_DEFAULT,
+  POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT,
   PROJECTOR_API_URL_DEFAULT,
   PROVIDER_SERVER_API_URL_DEFAULT,
   PgBossWorkerArgs,
@@ -155,6 +156,13 @@ addOptions(withCommonOptions(projectorWithArgs, PROJECTOR_API_URL_DEFAULT), [
     'POOLS_METRICS_INTERVAL',
     (interval) => Number.parseInt(interval, 10),
     POOLS_METRICS_INTERVAL_DEFAULT
+  ),
+  newOption(
+    '--pools-metrics-outdated-interval <poolsMetricsOutdatedInterval>',
+    ProjectorOptionDescriptions.PoolsMetricsOutdatedInterval,
+    'POOLS_METRICS_OUTDATED_INTERVAL',
+    (interval) => Number.parseInt(interval, 10),
+    POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT
   ),
   newOption(
     '--projection-names <projectionNames>',

--- a/packages/cardano-services/test/PgBoss/stakePoolMetadataHandler.test.ts
+++ b/packages/cardano-services/test/PgBoss/stakePoolMetadataHandler.test.ts
@@ -1,4 +1,4 @@
-import * as handler from '../../src/PgBoss';
+import * as handler from '../../src/PgBoss/stakePoolMetadataHandler';
 import { Cardano, NotImplementedError, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { DataMocks } from '../data-mocks';
 import { DataSource } from 'typeorm';

--- a/packages/cardano-services/test/PgBoss/stakePoolMetricsHandler.test.ts
+++ b/packages/cardano-services/test/PgBoss/stakePoolMetricsHandler.test.ts
@@ -1,18 +1,78 @@
 import { Cardano, StakePoolProvider } from '@cardano-sdk/core';
-import { CurrentPoolMetricsEntity } from '@cardano-sdk/projection-typeorm';
+import { CurrentPoolMetricsEntity, StakePoolEntity } from '@cardano-sdk/projection-typeorm';
 import { DataSource } from 'typeorm';
 import { Percent } from '@cardano-sdk/util';
+import { Repository } from 'typeorm/repository/Repository';
+import { getPoolIdsToUpdate, savePoolMetrics } from '../../src/PgBoss/stakePoolMetricsHandler';
 import { initHandlerTest, poolId } from './util';
 import { logger } from '@cardano-sdk/util-dev';
-import { savePoolMetrics } from '../../src/PgBoss';
 
 describe('stakePoolMetricsHandler', () => {
   let dataSource: DataSource;
+  let metricsRepos: Repository<CurrentPoolMetricsEntity>;
+  const metrics: Cardano.StakePoolMetrics = {
+    blocksCreated: 23,
+    delegators: 15,
+    livePledge: 23_000_000n,
+    saturation: Percent(0.002),
+    size: { active: Percent(0.0005), live: Percent(0.0005) },
+    stake: { active: 42_000_000n, live: 42_000_000n }
+  };
 
   beforeAll(async () => {
     const testData = await initHandlerTest();
-
     ({ dataSource } = testData);
+
+    metricsRepos = dataSource.getRepository(CurrentPoolMetricsEntity);
+  });
+
+  describe('getPoolIdsToUpdate', () => {
+    const partialOptions = {
+      dataSource,
+      id: poolId,
+      logger,
+      metrics,
+      provider: null as unknown as StakePoolProvider
+    };
+
+    // Pool id is fixed to 56 chars in the database
+    const outdatedId = 'test_pool_outdated'.padEnd(56, ' ') as Cardano.PoolId;
+
+    beforeAll(async () => {
+      // Override the original undefined value with the one got from initHandlerTest()
+      partialOptions.dataSource = dataSource;
+
+      // database preparation
+
+      await savePoolMetrics({
+        ...partialOptions,
+        slot: Cardano.Slot(1000)
+      });
+
+      const stakePoolRepository = dataSource.getRepository(StakePoolEntity);
+      await stakePoolRepository.insert({ id: outdatedId, status: 'active' });
+
+      await savePoolMetrics({
+        ...partialOptions,
+        id: outdatedId,
+        slot: Cardano.Slot(333)
+      });
+    });
+
+    it('returns only pool ids with outdated metrics', async () => {
+      const pools = await getPoolIdsToUpdate(dataSource, Cardano.Slot(1000));
+      const allMetrics = await metricsRepos.find();
+
+      expect(pools.length).toEqual(1);
+      expect(allMetrics.length).toEqual(2);
+      expect(pools[0].id).toEqual(outdatedId);
+    });
+
+    it('returns all pool ids', async () => {
+      const pools = await getPoolIdsToUpdate(dataSource);
+
+      expect(pools.map((p) => p.id)).toEqual([poolId, outdatedId]);
+    });
   });
 
   describe('savePoolMetrics', () => {
@@ -27,15 +87,6 @@ describe('stakePoolMetricsHandler', () => {
       stakePoolId: 'test_pool                                               '
     };
 
-    const metrics: Cardano.StakePoolMetrics = {
-      blocksCreated: 23,
-      delegators: 15,
-      livePledge: 23_000_000n,
-      saturation: Percent(0.002),
-      size: { active: Percent(0.0005), live: Percent(0.0005) },
-      stake: { active: 42_000_000n, live: 42_000_000n }
-    };
-
     const partialOptions = {
       dataSource,
       id: poolId,
@@ -48,13 +99,12 @@ describe('stakePoolMetricsHandler', () => {
       // Override the original undefined value with the one got from initHandlerTest()
       partialOptions.dataSource = dataSource;
     });
+    beforeEach(async () => {
+      await metricsRepos.clear();
+    });
 
     it('inserts and updates the record', async () => {
-      const metricsRepos = dataSource.getRepository(CurrentPoolMetricsEntity);
       const where = { stakePool: { id: poolId } };
-
-      // No records before insert
-      expect(await metricsRepos.find({ where })).toEqual([]);
 
       // Insert
       await savePoolMetrics({ ...partialOptions, slot: Cardano.Slot(123) });
@@ -74,12 +124,8 @@ describe('stakePoolMetricsHandler', () => {
     });
 
     it('does nothing if stake pool record does not exist', async () => {
-      const metricsRepos = dataSource.getRepository(CurrentPoolMetricsEntity);
       const stakePool = { id: 'does not exist' as Cardano.PoolId };
       const where = { stakePool };
-
-      // No records before insert attempt
-      expect(await metricsRepos.find({ where })).toEqual([]);
 
       // Failing insert attempt
       await savePoolMetrics({ ...partialOptions, ...stakePool, slot: Cardano.Slot(123) });

--- a/packages/cardano-services/test/PgBoss/util.ts
+++ b/packages/cardano-services/test/PgBoss/util.ts
@@ -12,7 +12,7 @@ import { Pool } from 'pg';
 import { logger } from '@cardano-sdk/util-dev';
 
 export const blockId = 'test_block';
-export const poolId = 'test_pool' as Cardano.PoolId;
+export const poolId = 'test_pool'.padEnd(56, ' ') as Cardano.PoolId;
 
 export const initHandlerTest = async () => {
   const connectionConfig = {

--- a/packages/projection-typeorm/src/pgBoss.ts
+++ b/packages/projection-typeorm/src/pgBoss.ts
@@ -24,6 +24,7 @@ export interface PgBossExtension {
 
 export interface StakePoolMetricsUpdateJob {
   slot: Cardano.Slot;
+  outdatedSlot?: Cardano.Slot;
 }
 
 export interface StakePoolMetadataJob {

--- a/packages/projection-typeorm/test/operators/storePoolMetricsUpdateJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storePoolMetricsUpdateJob.test.ts
@@ -7,6 +7,13 @@ const testPromise = () => {
   return [promise, resolvePromise!] as const;
 };
 
+const createEvent = (send: jest.Mock<Promise<void>, []>, blockNo: number, tipSlot?: number) => ({
+  block: { header: { blockNo, slot: blockNo * 10 } },
+  eventType: 0,
+  pgBoss: { send },
+  tip: { slot: tipSlot ?? blockNo * 10 }
+});
+
 describe('createStorePoolMetricsUpdateJob', () => {
   it('sends jobs only at expected blocks', async () => {
     let counter = 0;
@@ -15,31 +22,25 @@ describe('createStorePoolMetricsUpdateJob', () => {
       if (++counter === 3) resolver();
       return Promise.resolve();
     });
-    const createEvent = (blockNo: number, tipSlot?: number) => ({
-      block: { header: { blockNo, slot: blockNo * 10 } },
-      eventType: 0,
-      pgBoss: { send },
-      tip: { slot: tipSlot ?? blockNo * 10 }
-    });
 
     of(
-      createEvent(2, 80),
-      createEvent(3, 80),
-      createEvent(4, 80),
-      createEvent(5, 80), // doesn't generate event since tip is not reached
-      createEvent(6, 80),
-      createEvent(7, 80),
-      createEvent(8), // generates first event once tip is reached
-      createEvent(9),
-      createEvent(10), // generates a std event
-      createEvent(11),
-      createEvent(10), // doesn't generate event due to rollback
-      createEvent(11),
-      createEvent(12),
-      createEvent(13),
-      createEvent(14),
-      createEvent(15), // generates a std event
-      createEvent(16)
+      createEvent(send, 2, 80),
+      createEvent(send, 3, 80),
+      createEvent(send, 4, 80),
+      createEvent(send, 5, 80), // doesn't generate event since tip is not reached
+      createEvent(send, 6, 80),
+      createEvent(send, 7, 80),
+      createEvent(send, 8), // generates first event once tip is reached
+      createEvent(send, 9),
+      createEvent(send, 10), // generates a std event
+      createEvent(send, 11),
+      createEvent(send, 10), // doesn't generate event due to rollback
+      createEvent(send, 11),
+      createEvent(send, 12),
+      createEvent(send, 13),
+      createEvent(send, 14),
+      createEvent(send, 15), // generates a std event
+      createEvent(send, 16)
     )
       .pipe(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,6 +53,49 @@ describe('createStorePoolMetricsUpdateJob', () => {
     expect(send).toBeCalledTimes(3);
     expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 80 }, { slot: 80 });
     expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 100 }, { slot: 100 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 150 }, { slot: 150 });
+  });
+
+  it('sends jobs only at expected blocks for outdated job', async () => {
+    let counter = 0;
+    const [promise, resolver] = testPromise();
+    const send = jest.fn(() => {
+      if (++counter === 5) resolver();
+      return Promise.resolve();
+    });
+
+    of(
+      createEvent(send, 2, 80),
+      createEvent(send, 3, 80), // doesn't generate event since tip is not reached & outdatedSlot is undefined yet
+      createEvent(send, 4, 80),
+      createEvent(send, 5, 80), // doesn't generate event since tip is not reached
+      createEvent(send, 6, 80), // doesn't generate event since tip is not reached & outdatedSlot is undefined yet
+      createEvent(send, 7, 80),
+      createEvent(send, 8), // generates first event once tip is reached
+      createEvent(send, 9), // generates a outdated event
+      createEvent(send, 10), // generates a std event
+      createEvent(send, 11),
+      createEvent(send, 10), // doesn't generate event due to rollback
+      createEvent(send, 11),
+      createEvent(send, 12), // generates a outdated event
+      createEvent(send, 13),
+      createEvent(send, 14),
+      createEvent(send, 15), // generates a std event, doesn't generate outdated event
+      createEvent(send, 16)
+    )
+      .pipe(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createStorePoolMetricsUpdateJob(5, 3)() as OperatorFunction<any, any>
+      )
+      .subscribe();
+
+    await promise;
+
+    expect(send).toBeCalledTimes(5);
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 80 }, { slot: 80 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 80, slot: 90 }, { slot: 90 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 100 }, { slot: 100 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 100, slot: 120 }, { slot: 120 });
     expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 150 }, { slot: 150 });
   });
 });


### PR DESCRIPTION
Add support for only updating outdated pool metrics at a given interval.

# Context

In case of an error during the stake pool metrics job, metrics for a given stake pool might get outdated. This change allows us to run in another interval so that only outdated metrics are updated.


# Proposed Solution
We have modified the existing metrics projector and job to handle outdated metrics as well.

# Important Changes Introduced
None
