### PR TITLE
fix(cardano-services): asset provider can now be started with POSTGRES_HOST

### DIFF
--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -62,6 +62,7 @@ export type ProviderServerArgs = CommonProgramOptions &
   PosgresProgramOptions<'DbSync'> &
   PosgresProgramOptions<'Handle'> &
   PosgresProgramOptions<'StakePool'> &
+  PosgresProgramOptions<'Asset'> &
   OgmiosProgramOptions &
   HandlePolicyIdsProgramOptions &
   RabbitMqProgramOptions &

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -333,6 +333,7 @@ addOptions(withOgmiosOptions(withRabbitMqOptions(withHandlePolicyIdsOptions(prov
   runServer('Provider server', () =>
     loadProviderServer({
       ...args,
+      postgresConnectionStringAsset: connectionStringFromArgs(args, 'Asset'),
       postgresConnectionStringDbSync: connectionStringFromArgs(args, 'DbSync'),
       postgresConnectionStringHandle: connectionStringFromArgs(args, 'Handle'),
       postgresConnectionStringStakePool: connectionStringFromArgs(args, 'StakePool'),


### PR DESCRIPTION
# Context

It used to only work with srv or connection string

# Proposed Solution

Add missing cli configuration
