### PR TITLE
fix(ogmios): don't parse alonzo datum hashes as inline datums

### DIFF
--- a/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/OgmiosObservableCardanoNode.ts
+++ b/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/OgmiosObservableCardanoNode.ts
@@ -144,7 +144,7 @@ export class OgmiosObservableCardanoNode implements ObservableCardanoNode {
                 subscriber.next({
                   chainSync$: createObservableChainSyncClient(
                     { intersectionPoint: intersection.point },
-                    { interactionContext$: this.#interactionContext$ }
+                    { interactionContext$: this.#interactionContext$, logger: this.#logger }
                   ),
                   intersection
                 });

--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -277,7 +277,10 @@ const mapDatumHash = (datum: Schema.TxOut['datumHash']) => {
 
 const mapTxOut = (txOut: Schema.TxOut): Cardano.TxOut => ({
   address: Cardano.PaymentAddress(txOut.address),
-  datum: mapInlineDatum(txOut.datum),
+  // From ogmios v5.5.0 release notes:
+  // Similarly, Alonzo transaction outputs will now contain a datumHash field, carrying the datum hash digest.
+  // However, they will also contain a datum field with the exact same value for backward compatibility reason.
+  datum: txOut.datum === txOut.datumHash ? undefined : mapInlineDatum(txOut.datum),
   datumHash: mapDatumHash(txOut.datumHash),
   scriptReference: txOut.script ? mapScript(txOut.script) : undefined,
   value: {

--- a/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
+++ b/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
@@ -528,7 +528,7 @@ Object {
           Object {
             "address": "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc",
             "datum": undefined,
-            "datumHash": undefined,
+            "datumHash": "c5dfa8c3cbd5a959829618a7b46e163078cb3f1b39f152514d0c3686d553529a",
             "scriptReference": undefined,
             "value": Object {
               "assets": Map {},

--- a/packages/ogmios/test/ogmiosToCore/testData.ts
+++ b/packages/ogmios/test/ogmiosToCore/testData.ts
@@ -121,8 +121,8 @@ export const mockAlonzoBlock: Ogmios.Schema.Alonzo = {
             },
             {
               address: 'addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc',
-              datum: null,
-              datumHash: null,
+              datum: 'c5dfa8c3cbd5a959829618a7b46e163078cb3f1b39f152514d0c3686d553529a',
+              datumHash: 'c5dfa8c3cbd5a959829618a7b46e163078cb3f1b39f152514d0c3686d553529a',
               value: { assets: {}, coins: 8_286_924_731n }
             }
           ],


### PR DESCRIPTION
# Context

Asset projector fails on mainnet with
```
2023-10-23 22:44:51.999 | at /nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/ogmios/dist/cjs/ogmiosToCore/tx.js:332:72 |  
-- | -- | --
  |   | 2023-10-23 22:44:51.999 | at mapCommonTx (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/ogmios/dist/cjs/ogmiosToCore/tx.js:301:38) |  
  |   | 2023-10-23 22:44:51.999 | at Array.map (<anonymous>) |  
  |   | 2023-10-23 22:44:51.999 | at mapTxOut (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/ogmios/dist/cjs/ogmiosToCore/tx.js:265:12) |  
  |   | 2023-10-23 22:44:51.999 | at mapInlineDatum (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/ogmios/dist/cjs/ogmiosToCore/tx.js:256:44) |  
  |   | 2023-10-23 22:44:51.999 | at PlutusData.fromCbor (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/core/dist/cjs/Serialization/PlutusData/PlutusData.js:153:129) |  
  |   | 2023-10-23 22:44:51.999 | at CborReader.readEncodedValue (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/core/dist/cjs/Serialization/CBOR/CborReader.js:55:104) |  
  |   | 2023-10-23 22:44:51.999 | at CborReader._CborReader_skipNextNode (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/core/dist/cjs/Serialization/CBOR/CborReader.js:574:18) |  
  |   | 2023-10-23 22:44:51.999 | at CborReader.readTextString (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/core/dist/cjs/Serialization/CBOR/CborReader.js:264:98) |  
  |   | 2023-10-23 22:44:51.999 | at CborReader._CborReader_ensureReadCapacity (/nix/store/242nx3dy5l3xq05wvnk9m0kxiszi6y1h-cardano-sdk/libexec/incl/packages/core/dist/cjs/Serialization/CBOR/CborReader.js:394:15) |  
  |   | 2023-10-23 22:44:51.999 | CborContentException: Unexpected end of buffer


```

# Proposed Solution

- Ogmios sets both 'datum' and 'datumHash' for backwards compatibility in alonzo blocks. This is likely the cause of the error (not confirmed). Fix the mapper to not parse the hashes as inline datums.
- Logs are missing some important context: improve logging when ogmios mapping fails