### PR TITLE
[LW-8984] Accept handles with char matching @

### DIFF
--- a/packages/core/src/Asset/util/isValidHandle.ts
+++ b/packages/core/src/Asset/util/isValidHandle.ts
@@ -1,4 +1,4 @@
 export const isValidHandle = (handle: string) => {
-  const pattern = /^[\w.-]+$/;
+  const pattern = /^[\w.@\-]+$/;
   return pattern.test(handle);
 };

--- a/packages/core/test/Asset/util/isValidHandle.test.ts
+++ b/packages/core/test/Asset/util/isValidHandle.test.ts
@@ -8,10 +8,12 @@ const validHandles = [
   'test.handle',
   'test-handle-123',
   'test-handle-123.456',
-  'handle_name'
+  'handle_name',
+  '@alice',
+  'test-@handle'
 ];
 
-const invalidHandles = ['bob!', '$wallet', 'alice@', 'test*handle#2', 'lace&bob', 'ada%1_test'];
+const invalidHandles = ['bob!', '$wallet', 'test*handle#2', 'lace&bob', 'ada%1_test', 'lace ', 'wallet  '];
 
 describe('isValidHandle', () => {
   test('returns false for empty string', () => {
@@ -22,5 +24,11 @@ describe('isValidHandle', () => {
   });
   test.each(invalidHandles)('returns false for invalid handle %s', (handle) => {
     expect(Asset.util.isValidHandle(handle)).toBe(false);
+  });
+  test.each(invalidHandles)('returns false for invalid handle with spaces and tabs', (handle) => {
+    expect(Asset.util.isValidHandle(handle)).toBe(false);
+  });
+  test.each(validHandles)('returns ok for @ symbol', (handle) => {
+    expect(Asset.util.isValidHandle(handle)).toBe(true);
   });
 });


### PR DESCRIPTION
# Context
As a phase 1 of the ADA handle support, we didn't support @ symbols, that were used in sub handles. Currently we will be supporting the character in preparation for further support. 

# Proposed Solution
Allow the projection to add/return this symbols 

# Important Changes Introduced
