### PR TITLE
chore: use separate images for node and ogmios

### DIFF
--- a/.github/workflows/continuous-integration-e2e.yaml
+++ b/.github/workflows/continuous-integration-e2e.yaml
@@ -64,7 +64,7 @@ jobs:
           CARDANO_NODE_CHAINDB_LOG_LEVEL: 'Warning'
           CARDANO_NODE_LOG_LEVEL: 'Warning'
           OGMIOS_PORT: '1340'
-          OGMIOS_URL: 'ws://cardano-node-ogmios:1340'
+          OGMIOS_URL: 'ws://ogmios:1340'
           POSTGRES_PORT: '5435'
 
       - name: Wait for some epochs

--- a/compose/common.yml
+++ b/compose/common.yml
@@ -19,7 +19,7 @@ x-projector: &projector
     context: ../../
     target: projector
   depends_on:
-    cardano-node-ogmios:
+    ogmios:
       condition: service_healthy
 
 x-provider-server: &provider-server
@@ -71,7 +71,7 @@ x-provider-server-environment: &provider-server-environment
 x-sdk-environment: &sdk-environment
   LOGGER_MIN_SEVERITY: ${LOGGER_MIN_SEVERITY:-info}
   NETWORK_INFO_PROVIDER_URL: http://provider-server:3000/
-  OGMIOS_URL: ws://cardano-node-ogmios:1337
+  OGMIOS_URL: ws://ogmios:1337
   POSTGRES_DB_FILE_ASSET: /run/secrets/postgres_db_asset
   POSTGRES_DB_FILE_DB_SYNC: /run/secrets/postgres_db_db_sync
   POSTGRES_DB_FILE_HANDLE: /run/secrets/postgres_db_handle
@@ -106,7 +106,7 @@ services:
       RESTORE_SNAPSHOT: ${RESTORE_SNAPSHOT:-}
       RESTORE_RECREATE_DB: N
     depends_on:
-      cardano-node-ogmios:
+      ogmios:
         condition: service_healthy
     healthcheck:
       test: ['CMD', '/scripts/is-db-synced.sh']
@@ -138,22 +138,41 @@ services:
     healthcheck:
       test: ['CMD-SHELL', 'curl -s --fail http://localhost:3100/api/v1/status']
 
-  cardano-node-ogmios:
+  cardano-node:
     <<: *logging
+    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.5}
+    command:
+      [
+        'run',
+        '--config',
+        '/config/config.json',
+        '--database-path',
+        '/db',
+        '--socket-path',
+        '/ipc/node.socket',
+        '--topology',
+        '/config/topology.json'
+      ]
+    restart: on-failure
+    volumes:
+      - node-db:/db
+      - node-ipc:/ipc
+
+  ogmios:
+    <<: *logging
+    image: cardanosolutions/ogmios:v${OGMIOS_VERSION:-5.6.0}
+    command:
+      ['--host', '0.0.0.0', '--node-socket', '/ipc/node.socket', '--node-config', '/config/cardano-node/config.json']
     healthcheck:
       retries: 2000
     ports:
       - ${OGMIOS_PORT:-1337}:1337
     restart: on-failure
     volumes:
-      - node-db:/db
       - node-ipc:/ipc
 
   cardano-submit-api:
     command: --config /config/cardano-submit-api/config.json --listen-address 0.0.0.0 --socket-path /ipc/node.socket $SUBMIT_API_ARGS
-    depends_on:
-      cardano-node-ogmios:
-        condition: service_healthy
     image: inputoutput/cardano-submit-api:${CARDANO_NODE_VERSION:-1.35.5}
     ports:
       - 8090:8090

--- a/demo/README.md
+++ b/demo/README.md
@@ -7,7 +7,7 @@ An example of [projection](../packages/projection/) into PostgreSQL database ([p
 ```sh
 cd /path/to/cardano-js-sdk/ # monorepo root
 yarn && yarn build
-yarn preprod:up cardano-node-ogmios postgres # or preview:up/mainnet:up
+yarn preprod:up cardano-node ogmios postgres # or preview:up/mainnet:up
 ```
 
 ### Configuration

--- a/demo/projection-typeorm.js
+++ b/demo/projection-typeorm.js
@@ -1,4 +1,4 @@
-// Runtime dependency: `yarn preprod:up cardano-node-ogmios postgres` (can be any network)
+// Runtime dependency: `yarn preprod:up cardano-node ogmios postgres` (can be any network)
 /* eslint-disable import/no-extraneous-dependencies */
 const { Bootstrap, Mappers, requestNext, logProjectionProgress } = require('@cardano-sdk/projection');
 const {

--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -8,8 +8,12 @@ x-logging: &logging
       max-file: '20'
 
 services:
-  cardano-node-ogmios:
-    image: cardanosolutions/cardano-node-ogmios:v${OGMIOS_VERSION:-5.6.0}_${CARDANO_NODE_VERSION:-1.35.5}-${NETWORK:-mainnet}
+  cardano-node:
+    volumes:
+      - ./config/network/${NETWORK:-mainnet}/cardano-node:/config
+      - ./config/network/${NETWORK:-mainnet}/genesis:/genesis
+
+  ogmios:
     volumes:
       - ./config/network/${NETWORK:-mainnet}:/config
 

--- a/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
+++ b/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
@@ -22,7 +22,7 @@ TL_LEVEL="${TL_LEVEL:=info}" node "$SCRIPT_DIR/mint-handles.js"
 yarn --cwd "$PACKAGES_DIR"/e2e test:local-network register-pool.test.ts
 
 echo 'Stop providing data to projectors'
-docker compose -p local-network-e2e stop cardano-node-ogmios
+docker compose -p local-network-e2e stop cardano-node ogmios
 sleep 2
 
 echo 'Creating snapshots...'

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -39,12 +39,19 @@ services:
       test: ['CMD-SHELL', 'wget -O /dev/null http://localhost || exit 1']
       timeout: 10s
 
-  cardano-node-ogmios:
-    entrypoint: ['/tini', '-g', '--', '/scripts/cardano-node-ogmios.sh']
-    image: cardanosolutions/cardano-node-ogmios:v${OGMIOS_VERSION:-5.6.0}_${CARDANO_NODE_VERSION:-1.35.5}
+  cardano-node:
     depends_on:
       local-testnet:
         condition: service_healthy
+    volumes:
+      - ./local-network/config/network/cardano-node:/config
+      - ./local-network/config/network/genesis:/genesis
+
+  ogmios:
+    depends_on:
+      local-testnet:
+        condition: service_healthy
+    entrypoint: ['bin/sh', '/scripts/ogmios-start.sh']
     volumes:
       - ./local-network/config/network:/config
       - ./local-network/scripts:/scripts

--- a/packages/e2e/local-network/scripts/ogmios-start.sh
+++ b/packages/e2e/local-network/scripts/ogmios-start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Simple scripts which overrides the original cardano-node-ogmios.sh file from the
-# cardano-node-ogmios docker image.
+# Simple script which overrides will run instead of the `/bin/ogmios` binary in the original
+# ogmios docker image. It delays starting ogmios based on a sentinel file.
 
 # Used to support the e2e test to check the projector is able to
 # connect / reconnect to the ogmios server.
@@ -9,5 +9,5 @@
 # If the test set the file, wait for its removal before starting the container
 while [ -f /sdk-ipc/prevent_ogmios ]; do sleep 10; done
 
-# Start the cardano-node-ogmios as normal
-/root/cardano-node-ogmios.sh
+# Start the ogmios as normal
+/bin/ogmios "$@"

--- a/packages/e2e/test/long-running/projector-ogmios-connection.test.ts
+++ b/packages/e2e/test/long-running/projector-ogmios-connection.test.ts
@@ -10,7 +10,7 @@ const preventOgmiosStartFile = path.join(__dirname, '..', '..', 'local-network',
 
 const docker = new Dockerode();
 
-const ogmiosContainer = docker.getContainer('local-network-e2e-cardano-node-ogmios-1');
+const ogmiosContainer = docker.getContainer('local-network-e2e-ogmios-1');
 const stakePoolProjectorContainer = docker.getContainer('local-network-e2e-stake-pool-projector-1');
 
 const createPrevent = async () => {

--- a/scripts/preprod-network.sh
+++ b/scripts/preprod-network.sh
@@ -16,7 +16,7 @@ echo "
 
 export NETWORK="preprod"
 # Init only the minimum services needed for getting started
-SERVICES="postgres cardano-node-ogmios cardano-db-sync provider-server"
+SERVICES="postgres cardano-node ogmios cardano-db-sync provider-server"
 
 # Check for the correct number of arguments
 if [ "$#" -ne 1 ]; then


### PR DESCRIPTION
# Context

Cardano Node and Ogmios are bundled as a single image by the ogmios project.
This creates a connection between compatible versions.
However, we may want to start versions that are not tested/bundled together for experimental purposes or just to get a preview of them running together.

# Proposed Solution

Use separate services for `cardano-node` and `ogmios`.

# Important Changes Introduced
