### PR TITLE
feat(wallet): re-fetch cip68 nft metadata

### DIFF
--- a/packages/wallet/src/services/TransactionsTracker.ts
+++ b/packages/wallet/src/services/TransactionsTracker.ts
@@ -198,7 +198,7 @@ const createHistoricalTransactionsTrackerSubject = (
     )
   );
 
-const newTransactions$ = (transactions$: Observable<Cardano.HydratedTx[]>) =>
+export const newTransactions$ = <T extends Pick<Cardano.Tx, 'id'>>(transactions$: Observable<T[]>) =>
   transactions$.pipe(
     take(1),
     map((transactions) => transactions.map(({ id }) => id)),


### PR DESCRIPTION
# Context

Currently, PersonalWallet only fetches asset metadata once when it is started. Metadata of some of the CIP-68 NFTs is updated in a transaction made by the owner of the user NFT (e.g. adahandle personalization).

LW-8332

# Proposed Solution

PersonalWallet will re-fetch CIP-68 NFT metadata when it sees an on-chain transaction with a corresponding reference NFT

# Important Changes Introduced
