### PR TITLE
chore(hardware-trezor): add trezor tx inline datum and datum hash to outputs mapper

### DIFF
--- a/packages/hardware-trezor/src/transformers/txOut.ts
+++ b/packages/hardware-trezor/src/transformers/txOut.ts
@@ -1,7 +1,7 @@
 import * as Trezor from '@trezor/connect';
 import { Cardano, Serialization } from '@cardano-sdk/core';
 import { GroupedAddress, util } from '@cardano-sdk/key-management';
-import { InvalidArgumentError, Transform /* HexBlob*/ } from '@cardano-sdk/util';
+import { InvalidArgumentError, Transform } from '@cardano-sdk/util';
 import { TrezorTxOutputDestination, TrezorTxTransformerContext } from '../types';
 import { mapTokenMap } from './assets';
 

--- a/packages/hardware-trezor/src/transformers/txOut.ts
+++ b/packages/hardware-trezor/src/transformers/txOut.ts
@@ -1,7 +1,7 @@
 import * as Trezor from '@trezor/connect';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Serialization } from '@cardano-sdk/core';
 import { GroupedAddress, util } from '@cardano-sdk/key-management';
-import { InvalidArgumentError, Transform } from '@cardano-sdk/util';
+import { InvalidArgumentError, Transform /* HexBlob*/ } from '@cardano-sdk/util';
 import { TrezorTxOutputDestination, TrezorTxTransformerContext } from '../types';
 import { mapTokenMap } from './assets';
 
@@ -31,17 +31,64 @@ const toDestination: Transform<Cardano.TxOut, TrezorTxOutputDestination, TrezorT
   };
 };
 
+/**
+ * There are currently two types of outputs supported by the ledger:
+ *
+ * legacy_transaction_output =
+ *   [ address
+ *   , amount : value
+ *   , ? datum_hash : $hash32
+ *   ]
+ *
+ * and
+ *
+ * post_alonzo_transaction_output =
+ *   { 0 : address
+ *   , 1 : value
+ *   , ? 2 : datum_option ; New; datum option
+ *   , ? 3 : script_ref   ; New; script reference
+ *   }
+ *
+ * Legacy outputs are definite length arrays of three elements, however the new babbage outputs are definite length maps
+ * of four elements.
+ *
+ * @param out The output to be verified.
+ */
+const isBabbage = (out: Serialization.TransactionOutput): boolean => {
+  const reader = new Serialization.CborReader(out.toCbor());
+  return reader.peekState() === Serialization.CborReaderState.StartMap;
+};
+
+const getInlineDatum = (datum: Cardano.PlutusData): string => Serialization.PlutusData.fromCore(datum).toCbor();
+
 // TODO - use Transform (@cardano-sdk/util) once it is fixed. Even if prop is marked as optional it has to be added to fullfil Transform rules e.g. datumHash
 export const toTxOut = (txOut: Cardano.TxOut, context: TrezorTxTransformerContext): Trezor.CardanoOutput => {
   const destination = toDestination(txOut, context);
-  const trezorTxOut = {
-    ...destination,
-    amount: txOut.value.coins.toString()
-  };
+  const output = Serialization.TransactionOutput.fromCore(txOut);
+
+  const trezorTxOut = isBabbage(output)
+    ? {
+        ...destination,
+        ...(txOut.datumHash
+          ? { datumHash: txOut.datumHash.toString() }
+          : txOut.datum
+          ? { inlineDatum: getInlineDatum(txOut.datum) }
+          : undefined),
+        amount: txOut.value.coins.toString(),
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE
+      }
+    : {
+        ...destination,
+        ...(txOut.datumHash && { datumHash: txOut.datumHash.toString() }),
+        amount: txOut.value.coins.toString(),
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+      };
+
   if (txOut.value.assets) {
     const tokenBundle = mapTokenMap(txOut.value.assets);
     Object.assign(trezorTxOut, { tokenBundle });
   }
+
   return trezorTxOut;
 };
 

--- a/packages/hardware-trezor/test/testData.ts
+++ b/packages/hardware-trezor/test/testData.ts
@@ -56,6 +56,36 @@ export const txOutToOwnedAddress: Cardano.TxOut = {
   }
 };
 
+export const txOutWithDatumHash: Cardano.TxOut = {
+  address: Cardano.PaymentAddress(
+    'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+  ),
+  datumHash: Crypto.Hash32ByteBase16('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5'),
+  value: {
+    coins: 10n
+  }
+};
+
+export const txOutWithDatumHashAndOwnedAddress: Cardano.TxOut = {
+  ...txOutToOwnedAddress,
+  datumHash: Crypto.Hash32ByteBase16('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+};
+
+export const txOutWithInlineDatum: Cardano.TxOut = {
+  address: Cardano.PaymentAddress(
+    'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+  ),
+  datum: 123n,
+  value: {
+    coins: 10n
+  }
+};
+
+export const txOutWithInlineDatumAndOwnedAddress: Cardano.TxOut = {
+  ...txOutToOwnedAddress,
+  datum: 123n
+};
+
 export const rewardKey = 'stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr';
 export const rewardScript = 'stake178phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcccycj5';
 export const rewardAccount = Cardano.RewardAccount(rewardKey);
@@ -188,7 +218,7 @@ export const txBody: Cardano.TxBody = {
   fee: 10n,
   inputs: [txIn],
   mint: mintTokenMap,
-  outputs: [txOutWithAssets, txOutWithAssetsToOwnedAddress],
+  outputs: [txOutWithAssets, txOutWithAssetsToOwnedAddress, txOutWithDatumHash],
   validityInterval: {
     invalidBefore: Cardano.Slot(100),
     invalidHereafter: Cardano.Slot(1000)

--- a/packages/hardware-trezor/test/transformers/tx.test.ts
+++ b/packages/hardware-trezor/test/transformers/tx.test.ts
@@ -36,7 +36,8 @@ describe('tx', () => {
           {
             address:
               'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
-            amount: '10'
+            amount: '10',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
           }
         ],
         protocolMagic: 999,
@@ -98,6 +99,7 @@ describe('tx', () => {
             address:
               'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
             amount: '10',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY,
             tokenBundle: [
               {
                 policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
@@ -139,6 +141,7 @@ describe('tx', () => {
               stakingPath: knownAddressStakeKeyPath
             },
             amount: '10',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY,
             tokenBundle: [
               {
                 policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
@@ -172,6 +175,13 @@ describe('tx', () => {
                 ]
               }
             ]
+          },
+          {
+            address:
+              'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+            amount: '10',
+            datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
           }
         ],
         protocolMagic: 999,

--- a/packages/hardware-trezor/test/transformers/txOut.test.ts
+++ b/packages/hardware-trezor/test/transformers/txOut.test.ts
@@ -6,7 +6,11 @@ import {
   txOut,
   txOutToOwnedAddress,
   txOutWithAssets,
-  txOutWithAssetsToOwnedAddress
+  txOutWithAssetsToOwnedAddress,
+  txOutWithDatumHash,
+  txOutWithDatumHashAndOwnedAddress,
+  txOutWithInlineDatum,
+  txOutWithInlineDatumAndOwnedAddress
 } from '../testData';
 import { mapTxOuts, toTxOut } from '../../src/transformers/txOut';
 
@@ -16,12 +20,12 @@ describe('txOut', () => {
       const txOuts = mapTxOuts([txOut, txOut, txOut], contextWithKnownAddresses);
 
       expect(txOuts.length).toEqual(3);
-
       for (const out of txOuts) {
         expect(out).toEqual({
           address:
             'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
-          amount: '10'
+          amount: '10',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
         });
       }
     });
@@ -36,6 +40,7 @@ describe('txOut', () => {
           address:
             'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
           amount: '10',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY,
           tokenBundle: [
             {
               policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
@@ -88,7 +93,8 @@ describe('txOut', () => {
             path: knownAddressKeyPath,
             stakingPath: knownAddressStakeKeyPath
           },
-          amount: '10'
+          amount: '10',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
         });
       }
     });
@@ -109,6 +115,7 @@ describe('txOut', () => {
             stakingPath: knownAddressStakeKeyPath
           },
           amount: '10',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY,
           tokenBundle: [
             {
               policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
@@ -153,7 +160,8 @@ describe('txOut', () => {
       expect(out).toEqual({
         address:
           'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
-        amount: '10'
+        amount: '10',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
       });
     });
 
@@ -163,6 +171,7 @@ describe('txOut', () => {
         address:
           'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
         amount: '10',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY,
         tokenBundle: [
           {
             policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
@@ -208,7 +217,8 @@ describe('txOut', () => {
           path: knownAddressKeyPath,
           stakingPath: knownAddressStakeKeyPath
         },
-        amount: '10'
+        amount: '10',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
       });
     });
 
@@ -222,6 +232,7 @@ describe('txOut', () => {
           stakingPath: knownAddressStakeKeyPath
         },
         amount: '10',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY,
         tokenBundle: [
           {
             policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
@@ -255,6 +266,60 @@ describe('txOut', () => {
             ]
           }
         ]
+      });
+    });
+
+    it('can map simple transaction output with datum hash', async () => {
+      const out = toTxOut(txOutWithDatumHash, contextWithKnownAddresses);
+
+      expect(out).toEqual({
+        address:
+          'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+        amount: '10',
+        datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+      });
+    });
+
+    it('can map simple transaction output with datum hash to owned address', async () => {
+      const out = toTxOut(txOutWithDatumHashAndOwnedAddress, contextWithKnownAddresses);
+
+      expect(out).toEqual({
+        addressParameters: {
+          addressType: Trezor.PROTO.CardanoAddressType.BASE,
+          path: knownAddressKeyPath,
+          stakingPath: knownAddressStakeKeyPath
+        },
+        amount: '10',
+        datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+      });
+    });
+
+    it('can map simple transaction with inline datum', async () => {
+      const out = toTxOut(txOutWithInlineDatum, contextWithKnownAddresses);
+
+      expect(out).toEqual({
+        address:
+          'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+        amount: '10',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+        inlineDatum: '187b'
+      });
+    });
+
+    it('can map simple transaction with inline datum to owned address', async () => {
+      const out = toTxOut(txOutWithInlineDatumAndOwnedAddress, contextWithKnownAddresses);
+
+      expect(out).toEqual({
+        addressParameters: {
+          addressType: Trezor.PROTO.CardanoAddressType.BASE,
+          path: knownAddressKeyPath,
+          stakingPath: knownAddressStakeKeyPath
+        },
+        amount: '10',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+        inlineDatum: '187b'
       });
     });
   });


### PR DESCRIPTION
This PR introduces additional outputs mapper data where we added `inlineDatum` and `datumHash`.

# Context

Add trezor tx inline datum and datum hash to outputs mapper