### PR TITLE
Fix/lw 8951 reject tx submit errors

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -28,6 +28,12 @@ export const providerFailureToStatusCodeMap: { [key in ProviderFailure]: number 
   [ProviderFailure.ServerUnavailable]: 500
 };
 
+const isProviderFailure = (reason: string): reason is ProviderFailure =>
+  Object.values(ProviderFailure).includes(reason as ProviderFailure);
+
+export const reasonToProviderFailure = (reason: string): ProviderFailure =>
+  isProviderFailure(reason) ? reason : ProviderFailure.Unknown;
+
 export class ProviderError<InnerError = unknown> extends ComposableError<InnerError> {
   constructor(public reason: ProviderFailure, innerError?: InnerError, public detail?: string) {
     super(formatErrorMessage(reason, detail), innerError);

--- a/packages/util-dev/src/handleProvider.ts
+++ b/packages/util-dev/src/handleProvider.ts
@@ -2,9 +2,9 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { toSerializableObject } from '@cardano-sdk/util';
 
-export const axiosError = (bodyError = new Error('error')) => {
+export const axiosError = (bodyError: Error | null = new Error('error'), reason = ProviderFailure.BadRequest) => {
   const response = {
-    data: toSerializableObject(new ProviderError(ProviderFailure.BadRequest, bodyError))
+    data: toSerializableObject(new ProviderError(reason, bodyError))
   } as AxiosResponse;
   const error = new AxiosError(undefined, undefined, undefined, undefined, response);
   Object.defineProperty(error, 'response', { value: response });

--- a/packages/wallet/src/services/SmartTxSubmitProvider.ts
+++ b/packages/wallet/src/services/SmartTxSubmitProvider.ts
@@ -89,9 +89,7 @@ export class SmartTxSubmitProvider implements TxSubmitProvider {
           ...this.#retryBackoffConfig,
           shouldRetry: (error) =>
             error instanceof ProviderError &&
-            [ProviderFailure.Unhealthy, ProviderFailure.ConnectionFailure, ProviderFailure.Unknown].includes(
-              error.reason
-            )
+            [ProviderFailure.Unhealthy, ProviderFailure.ConnectionFailure].includes(error.reason)
         })
       )
     );

--- a/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
+++ b/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
@@ -69,17 +69,22 @@ describe('SmartTxSubmitProvider', () => {
       it('re-submits transactions that failed to submit due to a recoverable provider failure', async () => {
         underlyingProvider.submitTx
           .mockRejectedValueOnce(new ProviderError(ProviderFailure.ConnectionFailure))
-          .mockRejectedValueOnce(new ProviderError(ProviderFailure.Unhealthy))
-          .mockRejectedValueOnce(new ProviderError(ProviderFailure.Unknown));
+          .mockRejectedValueOnce(new ProviderError(ProviderFailure.Unhealthy));
         await provider.submitTx({ signedTransaction: txWithValidityIntervalHex });
-        expect(underlyingProvider.submitTx).toBeCalledTimes(4);
+        expect(underlyingProvider.submitTx).toBeCalledTimes(3);
       });
 
       it('rejects with any non-recoverable provider error', async () => {
-        const error = new ProviderError(ProviderFailure.BadRequest);
-        underlyingProvider.submitTx.mockRejectedValueOnce(error);
-        await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(error);
-        expect(underlyingProvider.submitTx).toBeCalledTimes(1);
+        const errorBadRequest = new ProviderError(ProviderFailure.BadRequest);
+        const errorUnknown = new ProviderError(ProviderFailure.Unknown);
+        underlyingProvider.submitTx.mockRejectedValueOnce(errorBadRequest).mockRejectedValueOnce(errorUnknown);
+        await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(
+          errorBadRequest
+        );
+        await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(
+          errorUnknown
+        );
+        expect(underlyingProvider.submitTx).toBeCalledTimes(2);
       });
     });
 


### PR DESCRIPTION
# Context

cardano-submit-api tx provider does not emit innerError with code and data like ogmios does.
When innerError is missing or is not parsable in to a known txSubmitError, the error is reported as ProviderFailure.Unknown.
Furthermore, SmartTxSubmitProvider is retrying Unknown errors, but shouldn't.

# Proposed Solution

TxSubmit errors without innerError will be mapped to a ProviderFailure based on the response reason.
Update SmartTxSubmitProvider to retry only Unhealthy or ConnectionFailure unreachable errors

# Important Changes Introduced
