### PR TITLE
test(cardano-services): increase the dealy of flaky test

### DIFF
--- a/packages/core/test/CardanoNode/util/bufferChainSyncEvent.test.ts
+++ b/packages/core/test/CardanoNode/util/bufferChainSyncEvent.test.ts
@@ -158,7 +158,7 @@ describe('bufferChainSyncEvent', () => {
     consumer.consumeTill(3);
     await sleep(10);
     producer.produceTill(16);
-    await sleep(20);
+    await sleep(40);
     consumer.consumeTill(4);
     await sleep(10);
   };


### PR DESCRIPTION
# Context

A too short delay is often cause of CI unit tests failures.

# Proposed Solution

Increased the delay to reduce the probability of this error.