### PR TITLE
fix(dapp-connector): re-implement initial cip-30 api

### DIFF
--- a/packages/dapp-connector/src/WalletApi/Cip30Wallet.ts
+++ b/packages/dapp-connector/src/WalletApi/Cip30Wallet.ts
@@ -120,6 +120,8 @@ export class Cip30Wallet {
     this.#api = api;
     this.#logger = logger;
     this.#authenticator = authenticator;
+    this.enable = this.enable.bind(this);
+    this.isEnabled = this.isEnabled.bind(this);
   }
 
   #validateExtensions(extensions: WalletApiExtension[] = []): void {

--- a/packages/dapp-connector/test/WalletApi/Cip30Wallet.test.ts
+++ b/packages/dapp-connector/test/WalletApi/Cip30Wallet.test.ts
@@ -41,6 +41,16 @@ describe('Wallet', () => {
     expect(typeof wallet.enable).toBe('function');
   });
 
+  it('should return initial api as plain javascript object', () => {
+    // Verbose to enable easy detection of which are missing
+    expect(wallet.hasOwnProperty('apiVersion')).toBe(true);
+    expect(wallet.hasOwnProperty('enable')).toBe(true);
+    expect(wallet.hasOwnProperty('icon')).toBe(true);
+    expect(wallet.hasOwnProperty('isEnabled')).toBe(true);
+    expect(wallet.hasOwnProperty('name')).toBe(true);
+    expect(wallet.hasOwnProperty('supportedExtensions')).toBe(true);
+  });
+
   describe('enable', () => {
     test('no extensions', async () => {
       expect(await wallet.isEnabled()).toBe(false);

--- a/packages/dapp-connector/test/injectGlobal.test.ts
+++ b/packages/dapp-connector/test/injectGlobal.test.ts
@@ -65,7 +65,9 @@ describe('injectGlobal', () => {
         'apiVersion',
         'supportedExtensions',
         'icon',
-        'name'
+        'name',
+        'enable',
+        'isEnabled'
       ]);
       expect(window.cardano['another-obj']).toBe(anotherObj);
     });


### PR DESCRIPTION
# Context

The initial and full APIs should remain POJOs to ensure compatability with dApps
LW-9080

# Proposed Solution
revert removal of initial bind, introduce test to guard against change

# Important Changes Introduced
