### PR TITLE
Test/multisig wallet poc

### DIFF
--- a/packages/cardano-services-client/src/version.ts
+++ b/packages/cardano-services-client/src/version.ts
@@ -1,7 +1,7 @@
 // auto-generated using ../scripts/createVersionSource.js
 export const apiVersion = {
   assetInfo: '1.0.0',
-  chainHistory: '2.0.0',
+  chainHistory: '3.0.0',
   handle: '1.0.0',
   networkInfo: '1.0.0',
   rewards: '1.0.0',

--- a/packages/cardano-services-client/version.json
+++ b/packages/cardano-services-client/version.json
@@ -1,6 +1,6 @@
 {
   "assetInfo": "1.0.0",
-  "chainHistory": "2.0.0",
+  "chainHistory": "3.0.0",
   "handle": "1.0.0",
   "networkInfo": "1.0.0",
   "rewards": "1.0.0",

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -1,3 +1,4 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { BigIntMath } from '@cardano-sdk/util';
 import {
   BlockModel,
@@ -147,10 +148,15 @@ export const mapCertificate = (
   if (isStakeCertModel(certModel))
     return {
       __typename: certModel.registration
-        ? Cardano.CertificateType.StakeKeyRegistration
-        : Cardano.CertificateType.StakeKeyDeregistration,
+        ? Cardano.CertificateType.StakeRegistration
+        : Cardano.CertificateType.StakeDeregistration,
       cert_index: certModel.cert_index,
-      stakeKeyHash: Cardano.RewardAccount.toHash(Cardano.RewardAccount(certModel.address))
+      stakeCredential: {
+        hash: Cardano.RewardAccount.toHash(
+          Cardano.RewardAccount(certModel.address)
+        ) as unknown as Crypto.Hash28ByteBase16,
+        type: Cardano.CredentialType.KeyHash
+      }
     } as WithCertIndex<Cardano.StakeAddressCertificate>;
 
   if (isDelegationCertModel(certModel))
@@ -158,7 +164,12 @@ export const mapCertificate = (
       __typename: Cardano.CertificateType.StakeDelegation,
       cert_index: certModel.cert_index,
       poolId: certModel.pool_id as unknown as Cardano.PoolId,
-      stakeKeyHash: Cardano.RewardAccount.toHash(Cardano.RewardAccount(certModel.address))
+      stakeCredential: {
+        hash: Cardano.RewardAccount.toHash(
+          Cardano.RewardAccount(certModel.address)
+        ) as unknown as Crypto.Hash28ByteBase16,
+        type: Cardano.CredentialType.KeyHash
+      }
     } as WithCertIndex<Cardano.StakeDelegationCertificate>;
 
   return null;

--- a/packages/cardano-services/src/ChainHistory/openApi.json
+++ b/packages/cardano-services/src/ChainHistory/openApi.json
@@ -6,13 +6,13 @@
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "2.0.0"
+    "version": "3.0.0"
   },
   "paths": {
-    "/v2.0.0/chain-history/health": {
+    "/v3.0.0/chain-history/health": {
       "$ref": "../Http/schema.json#/paths/Health"
     },
-    "/v2.0.0/chain-history/blocks/by-hashes": {
+    "/v3.0.0/chain-history/blocks/by-hashes": {
       "post": {
         "summary": "block history by hashes",
         "operationId": "blocksByHashes",
@@ -50,7 +50,7 @@
         }
       }
     },
-    "/v2.0.0/chain-history/txs/by-hashes": {
+    "/v3.0.0/chain-history/txs/by-hashes": {
       "post": {
         "summary": "transaction history by hashes",
         "operationId": "transactionsByHashes",
@@ -88,7 +88,7 @@
         }
       }
     },
-    "/v2.0.0/chain-history/txs/by-addresses": {
+    "/v3.0.0/chain-history/txs/by-addresses": {
       "post": {
         "summary": "transaction history by addresses",
         "operationId": "transactionsByAddresses",

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -25,7 +25,7 @@ import {
   WithdrawalModel
 } from '../../../src/ChainHistory/DbSyncChainHistory/types';
 import { Cardano } from '@cardano-sdk/core';
-import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
+import { Hash28ByteBase16, Hash32ByteBase16 } from '@cardano-sdk/crypto';
 
 const blockHash = '7a48b034645f51743550bbaf81f8a14771e58856e031eb63844738ca8ad72298';
 const poolId = 'pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh';
@@ -253,14 +253,24 @@ describe('chain history mappers', () => {
         registration: false
       } as WithCertType<StakeCertModel>);
       expect(registrationResult).toEqual<WithCertIndex<Cardano.StakeAddressCertificate>>({
-        __typename: Cardano.CertificateType.StakeKeyRegistration,
+        __typename: Cardano.CertificateType.StakeRegistration,
         cert_index: 0,
-        stakeKeyHash: Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(
+            Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+          ),
+          type: Cardano.CredentialType.KeyHash
+        }
       });
       expect(deregistrationResult).toEqual<WithCertIndex<Cardano.StakeAddressCertificate>>({
-        __typename: Cardano.CertificateType.StakeKeyDeregistration,
+        __typename: Cardano.CertificateType.StakeDeregistration,
         cert_index: 0,
-        stakeKeyHash: Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(
+            Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+          ),
+          type: Cardano.CredentialType.KeyHash
+        }
       });
     });
     test('map DelegationCertModel to Cardano.StakeDelegationCertificate', () => {
@@ -274,7 +284,12 @@ describe('chain history mappers', () => {
         __typename: Cardano.CertificateType.StakeDelegation,
         cert_index: 0,
         poolId: Cardano.PoolId(poolId),
-        stakeKeyHash: Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(
+            Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+          ),
+          type: Cardano.CredentialType.KeyHash
+        }
       });
     });
   });
@@ -321,8 +336,13 @@ describe('chain history mappers', () => {
 
     const certificates: Cardano.Certificate[] = [
       {
-        __typename: Cardano.CertificateType.StakeKeyRegistration,
-        stakeKeyHash: Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+        __typename: Cardano.CertificateType.StakeRegistration,
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(
+            Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))
+          ),
+          type: Cardano.CredentialType.KeyHash
+        }
       }
     ];
 

--- a/packages/cardano-services/test/data-mocks/tx.ts
+++ b/packages/cardano-services/test/data-mocks/tx.ts
@@ -1,5 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
-import { Ed25519KeyHashHex, Hash32ByteBase16 } from '@cardano-sdk/crypto';
+import { Hash28ByteBase16, Hash32ByteBase16 } from '@cardano-sdk/crypto';
 
 import merge from 'lodash/merge';
 
@@ -100,7 +100,10 @@ export const withAuxiliaryData: Cardano.HydratedTx = merge(withAssets, {
 export const delegationCertificate: Cardano.StakeDelegationCertificate = {
   __typename: Cardano.CertificateType.StakeDelegation,
   poolId: Cardano.PoolId('pool1cjm567pd9eqj7wlpuq2mnsasw2upewq0tchg4n8gktq5k7eepvr'),
-  stakeKeyHash: Ed25519KeyHashHex('f15db05f56035465bf8900a09bdaa16c3d8b8244fea686524408dd80')
+  stakeCredential: {
+    hash: Hash28ByteBase16('f15db05f56035465bf8900a09bdaa16c3d8b8244fea686524408dd80'),
+    type: Cardano.CredentialType.KeyHash
+  }
 };
 
 export const collateralInputs = [
@@ -216,7 +219,10 @@ export const withdrawal = {
 export const certificate = {
   __typename: 'StakeDelegationCertificate',
   poolId: 'pool19yv4rswp06fdnwg5zq0uk876gttewt86kytqrlt3ermnq3reky0',
-  stakeKeyHash: '9394c5bb6bc96115c9dc4468d020a99abff4aa2deda81b4bc6665bea'
+  stakeCredential: {
+    hash: '9394c5bb6bc96115c9dc4468d020a99abff4aa2deda81b4bc6665bea',
+    type: 0
+  }
 };
 
 export const redeemer = {

--- a/packages/core/src/Cardano/Address/BaseAddress.ts
+++ b/packages/core/src/Cardano/Address/BaseAddress.ts
@@ -42,9 +42,9 @@ export class BaseAddress {
   static fromCredentials(networkId: NetworkId, payment: Credential, stake: Credential): BaseAddress {
     let type = AddressType.BasePaymentKeyStakeKey;
 
-    if (payment.type === CredentialType.ScriptHash) type &= 0b0001;
+    if (payment.type === CredentialType.ScriptHash) type |= 0b0001;
 
-    if (stake.type === CredentialType.ScriptHash) type &= 0b0010;
+    if (stake.type === CredentialType.ScriptHash) type |= 0b0010;
 
     return new BaseAddress({
       delegationPart: stake,

--- a/packages/core/src/Cardano/Address/RewardAddress.ts
+++ b/packages/core/src/Cardano/Address/RewardAddress.ts
@@ -35,7 +35,7 @@ export class RewardAddress {
   static fromCredentials(networkId: NetworkId, payment: Credential): RewardAddress {
     let type = AddressType.RewardKey;
 
-    if (payment.type === CredentialType.ScriptHash) type &= 0b0001;
+    if (payment.type === CredentialType.ScriptHash) type |= 0b0001;
 
     return new RewardAddress({
       networkId,

--- a/packages/core/src/Cardano/types/Certificate.ts
+++ b/packages/core/src/Cardano/types/Certificate.ts
@@ -1,13 +1,14 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { Anchor, DelegateRepresentative } from './Governance';
-import { Credential, RewardAccount } from '../Address';
+import { Credential, CredentialType, RewardAccount } from '../Address';
 import { EpochNo } from './Block';
+import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
 import { Lovelace } from './Value';
 import { PoolId, PoolParameters } from './StakePool';
 
 export enum CertificateType {
-  StakeKeyRegistration = 'StakeKeyRegistrationCertificate',
-  StakeKeyDeregistration = 'StakeKeyDeregistrationCertificate',
+  StakeRegistration = 'StakeRegistrationCertificate',
+  StakeDeregistration = 'StakeDeregistrationCertificate',
   PoolRegistration = 'PoolRegistrationCertificate',
   PoolRetirement = 'PoolRetirementCertificate',
   StakeDelegation = 'StakeDelegationCertificate',
@@ -15,8 +16,8 @@ export enum CertificateType {
   GenesisKeyDelegation = 'GenesisKeyDelegationCertificate', // deprecated in conway
 
   // Conway Era Certs
-  Registration = 'RegistrationCertificate', // Replaces StakeKeyRegistration in post-conway era
-  Unregistration = 'UnRegistrationCertificate', // Replaces StakeKeyDeregistration in post-conway era
+  Registration = 'RegistrationCertificate', // Replaces StakeRegistration in post-conway era
+  Unregistration = 'UnRegistrationCertificate', // Replaces StakeDeregistration in post-conway era
   VoteDelegation = 'VoteDelegationCertificate',
   StakeVoteDelegation = 'StakeVoteDelegationCertificate',
   StakeRegistrationDelegation = 'StakeRegistrationDelegateCertificate', // delegate or delegation??
@@ -32,41 +33,41 @@ export enum CertificateType {
 // Conway Certificates
 export interface NewStakeAddressCertificate {
   __typename: CertificateType.Registration | CertificateType.Unregistration;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  stakeCredential: Credential;
   deposit: Lovelace;
 }
 
 // Delegation
 export interface VoteDelegationCertificate {
   __typename: CertificateType.VoteDelegation;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  stakeCredential: Credential;
   dRep: DelegateRepresentative;
 }
 
 export interface StakeVoteDelegationCertificate {
   __typename: CertificateType.StakeVoteDelegation;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  stakeCredential: Credential;
   poolId: PoolId;
   dRep: DelegateRepresentative;
 }
 
 export interface StakeRegistrationDelegationCertificate {
   __typename: CertificateType.StakeRegistrationDelegation;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  stakeCredential: Credential;
   poolId: PoolId;
   deposit: Lovelace;
 }
 
 export interface VoteRegistrationDelegationCertificate {
   __typename: CertificateType.VoteRegistrationDelegation;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  stakeCredential: Credential;
   dRep: DelegateRepresentative;
   deposit: Lovelace;
 }
 
 export interface StakeVoteRegistrationDelegationCertificate {
   __typename: CertificateType.StakeVoteRegistrationDelegation;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  stakeCredential: Credential;
   poolId: PoolId;
   dRep: DelegateRepresentative;
   deposit: Lovelace;
@@ -107,8 +108,8 @@ export interface UpdateDelegateRepresentativeCertificate {
 
 /** To be deprecated in the Era after conway replaced by <NewStakeAddressCertificate> */
 export interface StakeAddressCertificate {
-  __typename: CertificateType.StakeKeyRegistration | CertificateType.StakeKeyDeregistration;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  __typename: CertificateType.StakeRegistration | CertificateType.StakeDeregistration;
+  stakeCredential: Credential;
 }
 
 export interface PoolRegistrationCertificate {
@@ -124,7 +125,7 @@ export interface PoolRetirementCertificate {
 
 export interface StakeDelegationCertificate {
   __typename: CertificateType.StakeDelegation;
-  stakeKeyHash: Crypto.Ed25519KeyHashHex;
+  stakeCredential: Credential;
   poolId: PoolId;
 }
 
@@ -179,9 +180,12 @@ export type Certificate =
  *
  * @param rewardAccount The reward account to be registered.
  */
-export const createStakeKeyRegistrationCert = (rewardAccount: RewardAccount): Certificate => ({
-  __typename: CertificateType.StakeKeyRegistration,
-  stakeKeyHash: RewardAccount.toHash(rewardAccount)
+export const createStakeRegistrationCert = (rewardAccount: RewardAccount): Certificate => ({
+  __typename: CertificateType.StakeRegistration,
+  stakeCredential: {
+    hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+    type: CredentialType.KeyHash
+  }
 });
 
 /**
@@ -189,9 +193,12 @@ export const createStakeKeyRegistrationCert = (rewardAccount: RewardAccount): Ce
  *
  * @param rewardAccount The reward account to be de-registered.
  */
-export const createStakeKeyDeregistrationCert = (rewardAccount: RewardAccount): Certificate => ({
-  __typename: CertificateType.StakeKeyDeregistration,
-  stakeKeyHash: RewardAccount.toHash(rewardAccount)
+export const createStakeDeregistrationCert = (rewardAccount: RewardAccount): Certificate => ({
+  __typename: CertificateType.StakeDeregistration,
+  stakeCredential: {
+    hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+    type: CredentialType.KeyHash
+  }
 });
 
 /**
@@ -203,5 +210,8 @@ export const createStakeKeyDeregistrationCert = (rewardAccount: RewardAccount): 
 export const createDelegationCert = (rewardAccount: RewardAccount, poolId: PoolId): Certificate => ({
   __typename: CertificateType.StakeDelegation,
   poolId,
-  stakeKeyHash: RewardAccount.toHash(rewardAccount)
+  stakeCredential: {
+    hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+    type: CredentialType.KeyHash
+  }
 });

--- a/packages/core/src/Cardano/util/computeImplicitCoin.ts
+++ b/packages/core/src/Cardano/util/computeImplicitCoin.ts
@@ -22,7 +22,7 @@ export const computeImplicitCoin = (
   const deposit = BigIntMath.sum(
     certificates?.map(
       (cert) =>
-        (cert.__typename === CertificateType.StakeKeyRegistration && stakeKeyDepositBigint) ||
+        (cert.__typename === CertificateType.StakeRegistration && stakeKeyDepositBigint) ||
         (cert.__typename === CertificateType.PoolRegistration && poolDepositBigint) ||
         0n
     ) || []
@@ -31,7 +31,7 @@ export const computeImplicitCoin = (
   const reclaimTotal = BigIntMath.sum(
     certificates?.map(
       (cert) =>
-        (cert.__typename === CertificateType.StakeKeyDeregistration && stakeKeyDepositBigint) ||
+        (cert.__typename === CertificateType.StakeDeregistration && stakeKeyDepositBigint) ||
         (cert.__typename === CertificateType.PoolRetirement && poolDepositBigint) ||
         0n
     ) || []

--- a/packages/core/src/Serialization/Certificates/Certificate.ts
+++ b/packages/core/src/Serialization/Certificates/Certificate.ts
@@ -295,10 +295,10 @@ export class Certificate {
     let cert: Certificate;
 
     switch (certificate.__typename) {
-      case Cardano.CertificateType.StakeKeyRegistration:
+      case Cardano.CertificateType.StakeRegistration:
         cert = Certificate.newStakeRegistration(StakeRegistration.fromCore(certificate));
         break;
-      case Cardano.CertificateType.StakeKeyDeregistration:
+      case Cardano.CertificateType.StakeDeregistration:
         cert = Certificate.newStakeDeregistration(StakeDeregistration.fromCore(certificate));
         break;
       case Cardano.CertificateType.StakeDelegation:

--- a/packages/core/src/Serialization/Certificates/Registration.ts
+++ b/packages/core/src/Serialization/Certificates/Registration.ts
@@ -118,7 +118,7 @@ export class Registration {
     return {
       __typename: Cardano.CertificateType.Registration,
       deposit: this.#deposit,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(this.#credential.hash)
+      stakeCredential: this.#credential
     };
   }
 
@@ -128,10 +128,7 @@ export class Registration {
    * @param cert core StakeAddressCertificate object.
    */
   static fromCore(cert: Cardano.NewStakeAddressCertificate) {
-    return new Registration(
-      { hash: Crypto.Hash28ByteBase16(cert.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
-      cert.deposit
-    );
+    return new Registration(cert.stakeCredential, cert.deposit);
   }
 
   /**

--- a/packages/core/src/Serialization/Certificates/StakeDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeDelegation.ts
@@ -113,8 +113,8 @@ export class StakeDelegation {
   toCore(): Cardano.StakeDelegationCertificate {
     return {
       __typename: Cardano.CertificateType.StakeDelegation,
-      poolId: Cardano.PoolId.fromKeyHash(this.#poolKeyHash), // TODO: Core type does not support script hash as credential, fix?;
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(this.#credential.hash)
+      poolId: Cardano.PoolId.fromKeyHash(this.#poolKeyHash),
+      stakeCredential: this.#credential
     };
   }
 
@@ -124,10 +124,7 @@ export class StakeDelegation {
    * @param cert core StakeDelegationCertificate object.
    */
   static fromCore(cert: Cardano.StakeDelegationCertificate) {
-    return new StakeDelegation(
-      { hash: Crypto.Hash28ByteBase16(cert.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
-      Cardano.PoolId.toKeyHash(cert.poolId)
-    ); // TODO: Core type does not support script hash as credential, fix?
+    return new StakeDelegation(cert.stakeCredential, Cardano.PoolId.toKeyHash(cert.poolId));
   }
 
   /**

--- a/packages/core/src/Serialization/Certificates/StakeDeregistration.ts
+++ b/packages/core/src/Serialization/Certificates/StakeDeregistration.ts
@@ -104,8 +104,8 @@ export class StakeDeregistration {
    */
   toCore(): Cardano.StakeAddressCertificate {
     return {
-      __typename: Cardano.CertificateType.StakeKeyDeregistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(this.#credential.hash) // TODO: Core type does not support script hash as credential, fix?
+      __typename: Cardano.CertificateType.StakeDeregistration,
+      stakeCredential: this.#credential
     };
   }
 
@@ -115,10 +115,7 @@ export class StakeDeregistration {
    * @param cert core StakeAddressCertificate object.
    */
   static fromCore(cert: Cardano.StakeAddressCertificate) {
-    return new StakeDeregistration({
-      hash: Crypto.Hash28ByteBase16(cert.stakeKeyHash), // TODO: Core type does not support script hash as credential, fix?
-      type: Cardano.CredentialType.KeyHash
-    });
+    return new StakeDeregistration(cert.stakeCredential);
   }
 
   /**

--- a/packages/core/src/Serialization/Certificates/StakeRegistration.ts
+++ b/packages/core/src/Serialization/Certificates/StakeRegistration.ts
@@ -2,7 +2,6 @@ import * as Cardano from '../../Cardano';
 import * as Crypto from '@cardano-sdk/crypto';
 import { CborReader, CborWriter } from '../CBOR';
 import { CertificateKind } from './CertificateKind';
-import { CredentialType } from '../../Cardano';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -105,8 +104,8 @@ export class StakeRegistration {
    */
   toCore(): Cardano.StakeAddressCertificate {
     return {
-      __typename: Cardano.CertificateType.StakeKeyRegistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(this.#credential.hash) // TODO: Core type does not support script hash as credential, fix?
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential: this.#credential
     };
   }
 
@@ -116,7 +115,7 @@ export class StakeRegistration {
    * @param cert core StakeAddressCertificate object.
    */
   static fromCore(cert: Cardano.StakeAddressCertificate) {
-    return new StakeRegistration({ hash: Crypto.Hash28ByteBase16(cert.stakeKeyHash), type: CredentialType.KeyHash }); // TODO: Core type does not support script hash as credential, fix?
+    return new StakeRegistration(cert.stakeCredential);
   }
 
   /**

--- a/packages/core/src/Serialization/Certificates/StakeRegistrationDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeRegistrationDelegation.ts
@@ -115,7 +115,7 @@ export class StakeRegistrationDelegation {
       __typename: CertificateType.StakeRegistrationDelegation,
       deposit: this.#deposit,
       poolId: Cardano.PoolId.fromKeyHash(this.#poolKeyHash),
-      stakeKeyHash: this.#credential.hash as unknown as Crypto.Ed25519KeyHashHex
+      stakeCredential: this.#credential
     };
   }
 
@@ -126,7 +126,7 @@ export class StakeRegistrationDelegation {
    */
   static fromCore(deleg: Cardano.StakeRegistrationDelegationCertificate) {
     return new StakeRegistrationDelegation(
-      { hash: Crypto.Hash28ByteBase16(deleg.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
+      deleg.stakeCredential,
       deleg.deposit,
       Cardano.PoolId.toKeyHash(deleg.poolId)
     );

--- a/packages/core/src/Serialization/Certificates/StakeVoteDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeVoteDelegation.ts
@@ -120,7 +120,7 @@ export class StakeVoteDelegation {
       __typename: CertificateType.StakeVoteDelegation,
       dRep: this.#dRep.toCore(),
       poolId: Cardano.PoolId.fromKeyHash(this.#poolKeyHash),
-      stakeKeyHash: this.#credential.hash as unknown as Crypto.Ed25519KeyHashHex
+      stakeCredential: this.#credential
     };
   }
 
@@ -131,7 +131,7 @@ export class StakeVoteDelegation {
    */
   static fromCore(deleg: Cardano.StakeVoteDelegationCertificate) {
     return new StakeVoteDelegation(
-      { hash: Crypto.Hash28ByteBase16(deleg.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
+      deleg.stakeCredential,
       DRep.fromCore(deleg.dRep),
       Cardano.PoolId.toKeyHash(deleg.poolId)
     );

--- a/packages/core/src/Serialization/Certificates/StakeVoteRegistrationDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeVoteRegistrationDelegation.ts
@@ -132,7 +132,7 @@ export class StakeVoteRegistrationDelegation {
       dRep: this.#dRep.toCore(),
       deposit: this.#deposit,
       poolId: Cardano.PoolId.fromKeyHash(this.#poolKeyHash),
-      stakeKeyHash: this.#credential.hash as unknown as Crypto.Ed25519KeyHashHex
+      stakeCredential: this.#credential
     };
   }
 
@@ -143,7 +143,7 @@ export class StakeVoteRegistrationDelegation {
    */
   static fromCore(deleg: Cardano.StakeVoteRegistrationDelegationCertificate) {
     return new StakeVoteRegistrationDelegation(
-      { hash: Crypto.Hash28ByteBase16(deleg.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
+      deleg.stakeCredential,
       deleg.deposit,
       DRep.fromCore(deleg.dRep),
       Cardano.PoolId.toKeyHash(deleg.poolId)

--- a/packages/core/src/Serialization/Certificates/Unregistration.ts
+++ b/packages/core/src/Serialization/Certificates/Unregistration.ts
@@ -116,7 +116,7 @@ export class Unregistration {
     return {
       __typename: Cardano.CertificateType.Unregistration,
       deposit: this.#deposit,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(this.#credential.hash)
+      stakeCredential: this.#credential
     };
   }
 
@@ -126,10 +126,7 @@ export class Unregistration {
    * @param cert core StakeAddressCertificate object.
    */
   static fromCore(cert: Cardano.NewStakeAddressCertificate) {
-    return new Unregistration(
-      { hash: Crypto.Hash28ByteBase16(cert.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
-      cert.deposit
-    );
+    return new Unregistration(cert.stakeCredential, cert.deposit);
   }
 
   /**

--- a/packages/core/src/Serialization/Certificates/VoteDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/VoteDelegation.ts
@@ -110,7 +110,7 @@ export class VoteDelegation {
     return {
       __typename: CertificateType.VoteDelegation,
       dRep: this.#dRep.toCore(),
-      stakeKeyHash: this.#credential.hash as unknown as Crypto.Ed25519KeyHashHex
+      stakeCredential: this.#credential
     };
   }
 
@@ -120,10 +120,7 @@ export class VoteDelegation {
    * @param deleg core VoteDelegationCertificate object.
    */
   static fromCore(deleg: Cardano.VoteDelegationCertificate) {
-    return new VoteDelegation(
-      { hash: Crypto.Hash28ByteBase16(deleg.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
-      DRep.fromCore(deleg.dRep)
-    );
+    return new VoteDelegation(deleg.stakeCredential, DRep.fromCore(deleg.dRep));
   }
 
   /**

--- a/packages/core/src/Serialization/Certificates/VoteRegistrationDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/VoteRegistrationDelegation.ts
@@ -117,7 +117,7 @@ export class VoteRegistrationDelegation {
       __typename: CertificateType.VoteRegistrationDelegation,
       dRep: this.#dRep.toCore(),
       deposit: this.#deposit,
-      stakeKeyHash: this.#credential.hash as unknown as Crypto.Ed25519KeyHashHex
+      stakeCredential: this.#credential
     };
   }
 
@@ -127,11 +127,7 @@ export class VoteRegistrationDelegation {
    * @param deleg core VoteRegistrationDelegationCertificate object.
    */
   static fromCore(deleg: Cardano.VoteRegistrationDelegationCertificate) {
-    return new VoteRegistrationDelegation(
-      { hash: Crypto.Hash28ByteBase16(deleg.stakeKeyHash), type: Cardano.CredentialType.KeyHash },
-      deleg.deposit,
-      DRep.fromCore(deleg.dRep)
-    );
+    return new VoteRegistrationDelegation(deleg.stakeCredential, deleg.deposit, DRep.fromCore(deleg.dRep));
   }
 
   /**

--- a/packages/core/src/util/txInspector.ts
+++ b/packages/core/src/util/txInspector.ts
@@ -35,7 +35,7 @@ type TxInspector<T extends Inspectors> = (tx: HydratedTx) => {
 // Inspection result types
 export type SendReceiveValueInspection = Value;
 export type DelegationInspection = StakeDelegationCertificate[];
-export type StakeKeyRegistrationInspection = StakeAddressCertificate[];
+export type StakeRegistrationInspection = StakeAddressCertificate[];
 export type PoolRegistrationInspection = PoolRegistrationCertificate[];
 export type PoolRetirementInspection = PoolRetirementCertificate[];
 
@@ -70,7 +70,7 @@ export type TotalAddressInputsValueInspector = (
 ) => Inspector<SendReceiveValueInspection>;
 export type SendReceiveValueInspector = (ownAddresses: PaymentAddress[]) => Inspector<SendReceiveValueInspection>;
 export type DelegationInspector = Inspector<DelegationInspection>;
-export type StakeKeyRegistrationInspector = Inspector<StakeKeyRegistrationInspection>;
+export type StakeRegistrationInspector = Inspector<StakeRegistrationInspection>;
 export type WithdrawalInspector = Inspector<WithdrawalInspection>;
 export type SignedCertificatesInspector = (
   rewardAccounts: RewardAccount[],
@@ -121,7 +121,6 @@ export const totalAddressOutputsValueInspector: SendReceiveValueInspector = (own
 export const signedCertificatesInspector: SignedCertificatesInspector =
   (rewardAccounts: RewardAccount[], certificateTypes?: CertificateType[]) => (tx) => {
     if (!tx.body.certificates || tx.body.certificates.length === 0) return [];
-    const stakeKeyHashes = rewardAccounts?.map((account) => RewardAccount.toHash(account));
     const certificates = certificateTypes
       ? tx.body.certificates?.filter((certificate) => certificateTypes.includes(certificate.__typename))
       : tx.body.certificates;
@@ -132,7 +131,6 @@ export const signedCertificatesInspector: SignedCertificatesInspector =
         return rewardAccounts.some((account) => RewardAccount.toHash(account) === credHash);
       }
 
-      if ('stakeKeyHash' in certificate) return stakeKeyHashes.includes(certificate.stakeKeyHash);
       if ('poolParameters' in certificate) return rewardAccounts.includes(certificate.poolParameters.rewardAccount);
       return false;
     });
@@ -200,11 +198,7 @@ export const valueReceivedInspector: TotalAddressInputsValueInspector = (ownAddr
  */
 const certificateInspector =
   <
-    T extends
-      | DelegationInspection
-      | StakeKeyRegistrationInspection
-      | PoolRegistrationInspection
-      | PoolRetirementInspection
+    T extends DelegationInspection | StakeRegistrationInspection | PoolRegistrationInspection | PoolRetirementInspection
   >(
     type: CertificateType
   ): Inspector<T> =>
@@ -225,19 +219,19 @@ export const delegationInspector: DelegationInspector = certificateInspector<Del
  * Inspects a transaction for a stake key deregistration certificate.
  *
  * @param {HydratedTx} tx transaction to inspect
- * @returns {StakeKeyRegistrationInspection} array of stake key deregistration certificates
+ * @returns {StakeRegistrationInspection} array of stake key deregistration certificates
  */
-export const stakeKeyDeregistrationInspector: StakeKeyRegistrationInspector =
-  certificateInspector<StakeKeyRegistrationInspection>(CertificateType.StakeKeyDeregistration);
+export const stakeKeyDeregistrationInspector: StakeRegistrationInspector =
+  certificateInspector<StakeRegistrationInspection>(CertificateType.StakeDeregistration);
 
 /**
  * Inspects a transaction for a stake key registration certificate.
  *
  * @param {HydratedTx} tx transaction to inspect
- * @returns {StakeKeyRegistrationInspection} array of stake key registration certificates
+ * @returns {StakeRegistrationInspection} array of stake key registration certificates
  */
-export const stakeKeyRegistrationInspector: StakeKeyRegistrationInspector =
-  certificateInspector<StakeKeyRegistrationInspection>(CertificateType.StakeKeyRegistration);
+export const stakeKeyRegistrationInspector: StakeRegistrationInspector =
+  certificateInspector<StakeRegistrationInspection>(CertificateType.StakeRegistration);
 
 /**
  * Inspects a transaction for pool registration certificates.

--- a/packages/core/test/Cardano/Address/BaseAddress.test.ts
+++ b/packages/core/test/Cardano/Address/BaseAddress.test.ts
@@ -2,12 +2,21 @@ import * as cip19TestVectors from '../../../../util-dev/src/Cip19TestVectors';
 import { Cardano } from '../../../src';
 
 describe('Cardano/Address/BaseAddress', () => {
-  it('fromCredentials can build the correct BaseAddress instance', () => {
+  it('fromCredentials can build the correct BaseAddress instance when given a key hash', () => {
     const address = Cardano.BaseAddress.fromCredentials(
       Cardano.NetworkId.Mainnet,
       cip19TestVectors.KEY_PAYMENT_CREDENTIAL,
       cip19TestVectors.KEY_STAKE_CREDENTIAL
     );
     expect(address.toAddress().toBech32()).toEqual(cip19TestVectors.basePaymentKeyStakeKey);
+  });
+
+  it('fromCredentials can build the correct BaseAddress instance when given a script hash', () => {
+    const address = Cardano.BaseAddress.fromCredentials(
+      Cardano.NetworkId.Mainnet,
+      cip19TestVectors.SCRIPT_CREDENTIAL,
+      cip19TestVectors.SCRIPT_CREDENTIAL
+    );
+    expect(address.toAddress().toBech32()).toEqual(cip19TestVectors.basePaymentScriptStakeScript);
   });
 });

--- a/packages/core/test/Cardano/Address/RewardAddress.test.ts
+++ b/packages/core/test/Cardano/Address/RewardAddress.test.ts
@@ -2,11 +2,19 @@ import * as cip19TestVectors from '../../../../util-dev/src/Cip19TestVectors';
 import { Cardano } from '../../../src';
 
 describe('Cardano/Address/RewardAddress', () => {
-  it('fromCredentials can build the correct RewardAddress instance', () => {
+  it('fromCredentials can build the correct RewardAddress instance when given a key hash', () => {
     const address = Cardano.RewardAddress.fromCredentials(
       Cardano.NetworkId.Mainnet,
       cip19TestVectors.KEY_STAKE_CREDENTIAL
     );
     expect(address.toAddress().toBech32()).toEqual(cip19TestVectors.rewardKey);
+  });
+
+  it('fromCredentials can build the correct RewardAddress instance when given a script hash', () => {
+    const address = Cardano.RewardAddress.fromCredentials(
+      Cardano.NetworkId.Mainnet,
+      cip19TestVectors.SCRIPT_CREDENTIAL
+    );
+    expect(address.toAddress().toBech32()).toEqual(cip19TestVectors.rewardScript);
   });
 });

--- a/packages/core/test/Cardano/types/Certificates.test.ts
+++ b/packages/core/test/Cardano/types/Certificates.test.ts
@@ -1,33 +1,38 @@
+import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import {
   CertificateType,
   PoolId,
   RewardAccount,
   createDelegationCert,
-  createStakeKeyDeregistrationCert,
-  createStakeKeyRegistrationCert
+  createStakeDeregistrationCert,
+  createStakeRegistrationCert
 } from '../../../src/Cardano';
 
 const rewardAccount = RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr');
-const stakeKeyHash = 'cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f';
+const stakeCredential = {
+  hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+  type: Cardano.CredentialType.KeyHash
+};
 const poolId = PoolId('pool1ev8vy6fyj7693ergzty2t0azjvw35tvkt2vcjwpgajqs7z6u2vn');
 
 describe('Certificate', () => {
-  describe('createStakeKeyRegistrationCert', () => {
+  describe('createStakeRegistrationCert', () => {
     it('can create a stake key registration certificate', () => {
-      const cert = createStakeKeyRegistrationCert(rewardAccount);
+      const cert = createStakeRegistrationCert(rewardAccount);
       expect(cert).toEqual({
-        __typename: CertificateType.StakeKeyRegistration,
-        stakeKeyHash
+        __typename: CertificateType.StakeRegistration,
+        stakeCredential
       });
     });
   });
 
-  describe('createStakeKeyDeregistrationCert', () => {
+  describe('createStakeDeregistrationCert', () => {
     it('can create a stake key de-registration certificate', () => {
-      const cert = createStakeKeyDeregistrationCert(rewardAccount);
+      const cert = createStakeDeregistrationCert(rewardAccount);
       expect(cert).toEqual({
-        __typename: CertificateType.StakeKeyDeregistration,
-        stakeKeyHash
+        __typename: CertificateType.StakeDeregistration,
+        stakeCredential
       });
     });
   });
@@ -38,7 +43,7 @@ describe('Certificate', () => {
       expect(cert).toEqual({
         __typename: CertificateType.StakeDelegation,
         poolId: 'pool1ev8vy6fyj7693ergzty2t0azjvw35tvkt2vcjwpgajqs7z6u2vn',
-        stakeKeyHash
+        stakeCredential
       });
     });
   });

--- a/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
+++ b/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
@@ -1,14 +1,18 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '../../../src';
 
 describe('Cardano.util.computeImplicitCoin', () => {
   it('sums registrations for deposit, withdrawals and deregistrations for input', async () => {
     const protocolParameters = { poolDeposit: 3, stakeKeyDeposit: 2 } as Cardano.ProtocolParameters;
     const rewardAccount = Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27');
-    const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
+    const stakeCredential = {
+      hash: Cardano.RewardAccount.toHash(rewardAccount) as unknown as Crypto.Hash28ByteBase16,
+      type: Cardano.CredentialType.KeyHash
+    };
     const certificates: Cardano.Certificate[] = [
-      { __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash },
-      { __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash },
-      { __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash },
+      { __typename: Cardano.CertificateType.StakeRegistration, stakeCredential },
+      { __typename: Cardano.CertificateType.StakeDeregistration, stakeCredential },
+      { __typename: Cardano.CertificateType.StakeRegistration, stakeCredential },
       {
         __typename: Cardano.CertificateType.PoolRetirement,
         epoch: Cardano.EpochNo(500),
@@ -17,7 +21,7 @@ describe('Cardano.util.computeImplicitCoin', () => {
       {
         __typename: Cardano.CertificateType.StakeDelegation,
         poolId: Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh'),
-        stakeKeyHash
+        stakeCredential
       }
     ];
     const withdrawals: Cardano.Withdrawal[] = [{ quantity: 5n, stakeAddress: rewardAccount }];

--- a/packages/core/test/Serialization/Certificates/Certificate.test.ts
+++ b/packages/core/test/Serialization/Certificates/Certificate.test.ts
@@ -49,8 +49,11 @@ describe('Certificate', () => {
 
     it('can decode StakeRegistration from Core', () => {
       const core: Cardano.StakeAddressCertificate = {
-        __typename: Cardano.CertificateType.StakeKeyRegistration,
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        __typename: Cardano.CertificateType.StakeRegistration,
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       };
 
       const certificate = Certificate.fromCore(core);
@@ -69,8 +72,11 @@ describe('Certificate', () => {
 
     it('can encode StakeRegistration to CBOR', () => {
       const core: Cardano.StakeAddressCertificate = {
-        __typename: Cardano.CertificateType.StakeKeyRegistration,
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        __typename: Cardano.CertificateType.StakeRegistration,
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       };
 
       const certificate = Certificate.fromCore(core);
@@ -84,8 +90,11 @@ describe('Certificate', () => {
       const certificate = Certificate.fromCbor(cbor);
 
       expect(certificate.toCore()).toEqual({
-        __typename: Cardano.CertificateType.StakeKeyRegistration,
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        __typename: Cardano.CertificateType.StakeRegistration,
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       });
     });
   });
@@ -110,8 +119,11 @@ describe('Certificate', () => {
 
     it('can decode StakeDeregistration from Core', () => {
       const core: Cardano.StakeAddressCertificate = {
-        __typename: Cardano.CertificateType.StakeKeyDeregistration,
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        __typename: Cardano.CertificateType.StakeDeregistration,
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       };
 
       const certificate = Certificate.fromCore(core);
@@ -130,8 +142,11 @@ describe('Certificate', () => {
 
     it('can encode StakeDeregistration to CBOR', () => {
       const core: Cardano.StakeAddressCertificate = {
-        __typename: Cardano.CertificateType.StakeKeyDeregistration,
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        __typename: Cardano.CertificateType.StakeDeregistration,
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       };
 
       const certificate = Certificate.fromCore(core);
@@ -145,8 +160,11 @@ describe('Certificate', () => {
       const certificate = Certificate.fromCbor(cbor);
 
       expect(certificate.toCore()).toEqual({
-        __typename: Cardano.CertificateType.StakeKeyDeregistration,
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        __typename: Cardano.CertificateType.StakeDeregistration,
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       });
     });
   });
@@ -175,7 +193,10 @@ describe('Certificate', () => {
       const core: Cardano.StakeDelegationCertificate = {
         __typename: Cardano.CertificateType.StakeDelegation,
         poolId: Cardano.PoolId('pool1mpgg03jxj52qwxvvy7cmj58a96vl9pvxcqqvuw0kumheygxmn34'),
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       };
 
       const certificate = Certificate.fromCore(core);
@@ -196,7 +217,10 @@ describe('Certificate', () => {
       const core: Cardano.StakeDelegationCertificate = {
         __typename: Cardano.CertificateType.StakeDelegation,
         poolId: Cardano.PoolId('pool1mpgg03jxj52qwxvvy7cmj58a96vl9pvxcqqvuw0kumheygxmn34'),
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       };
 
       const certificate = Certificate.fromCore(core);
@@ -216,7 +240,10 @@ describe('Certificate', () => {
       expect(certificate.toCore()).toEqual({
         __typename: Cardano.CertificateType.StakeDelegation,
         poolId: Cardano.PoolId('pool1mpgg03jxj52qwxvvy7cmj58a96vl9pvxcqqvuw0kumheygxmn34'),
-        stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+        stakeCredential: {
+          hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+          type: Cardano.CredentialType.KeyHash
+        }
       });
     });
   });

--- a/packages/core/test/Serialization/Certificates/Registration.test.ts
+++ b/packages/core/test/Serialization/Certificates/Registration.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { Registration } from '../../../src/Serialization';
 
@@ -8,7 +9,10 @@ const cbor = HexBlob('83078200581c0000000000000000000000000000000000000000000000
 const core = {
   __typename: 'RegistrationCertificate',
   deposit: 0n,
-  stakeKeyHash: '00000000000000000000000000000000000000000000000000000000'
+  stakeCredential: {
+    hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+    type: Cardano.CredentialType.KeyHash
+  }
 } as Cardano.NewStakeAddressCertificate;
 
 describe('Registration', () => {

--- a/packages/core/test/Serialization/Certificates/StakeDelegation.test.ts
+++ b/packages/core/test/Serialization/Certificates/StakeDelegation.test.ts
@@ -23,7 +23,10 @@ describe('StakeDelegation', () => {
     const core: Cardano.StakeDelegationCertificate = {
       __typename: Cardano.CertificateType.StakeDelegation,
       poolId: Cardano.PoolId('pool1mpgg03jxj52qwxvvy7cmj58a96vl9pvxcqqvuw0kumheygxmn34'),
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
 
     const certificate = StakeDelegation.fromCore(core);
@@ -38,7 +41,10 @@ describe('StakeDelegation', () => {
     const core: Cardano.StakeDelegationCertificate = {
       __typename: Cardano.CertificateType.StakeDelegation,
       poolId: Cardano.PoolId('pool1mpgg03jxj52qwxvvy7cmj58a96vl9pvxcqqvuw0kumheygxmn34'),
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
 
     const certificate = StakeDelegation.fromCore(core);
@@ -58,7 +64,10 @@ describe('StakeDelegation', () => {
     expect(certificate.toCore()).toEqual({
       __typename: Cardano.CertificateType.StakeDelegation,
       poolId: Cardano.PoolId('pool1mpgg03jxj52qwxvvy7cmj58a96vl9pvxcqqvuw0kumheygxmn34'),
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     });
   });
 });

--- a/packages/core/test/Serialization/Certificates/StakeDeregistration.test.ts
+++ b/packages/core/test/Serialization/Certificates/StakeDeregistration.test.ts
@@ -19,8 +19,11 @@ describe('StakeDeregistration', () => {
 
   it('can decode StakeDeregistration from Core', () => {
     const core: Cardano.StakeAddressCertificate = {
-      __typename: Cardano.CertificateType.StakeKeyDeregistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      __typename: Cardano.CertificateType.StakeDeregistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
 
     const certificate = StakeDeregistration.fromCore(core);
@@ -33,8 +36,11 @@ describe('StakeDeregistration', () => {
 
   it('can encode StakeDeregistration to CBOR', () => {
     const core: Cardano.StakeAddressCertificate = {
-      __typename: Cardano.CertificateType.StakeKeyDeregistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      __typename: Cardano.CertificateType.StakeDeregistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
 
     const certificate = StakeDeregistration.fromCore(core);
@@ -48,8 +54,11 @@ describe('StakeDeregistration', () => {
     const certificate = StakeDeregistration.fromCbor(cbor);
 
     expect(certificate.toCore()).toEqual({
-      __typename: Cardano.CertificateType.StakeKeyDeregistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      __typename: Cardano.CertificateType.StakeDeregistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     });
   });
 });

--- a/packages/core/test/Serialization/Certificates/StakeRegistration.test.ts
+++ b/packages/core/test/Serialization/Certificates/StakeRegistration.test.ts
@@ -19,8 +19,11 @@ describe('StakeRegistration', () => {
 
   it('can decode StakeRegistration from Core', () => {
     const core: Cardano.StakeAddressCertificate = {
-      __typename: Cardano.CertificateType.StakeKeyRegistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
 
     const certificate = StakeRegistration.fromCore(core);
@@ -33,8 +36,11 @@ describe('StakeRegistration', () => {
 
   it('can encode StakeRegistration to CBOR', () => {
     const core: Cardano.StakeAddressCertificate = {
-      __typename: Cardano.CertificateType.StakeKeyRegistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
 
     const certificate = StakeRegistration.fromCore(core);
@@ -48,8 +54,11 @@ describe('StakeRegistration', () => {
     const certificate = StakeRegistration.fromCbor(cbor);
 
     expect(certificate.toCore()).toEqual({
-      __typename: Cardano.CertificateType.StakeKeyRegistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f')
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16('cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f'),
+        type: Cardano.CredentialType.KeyHash
+      }
     });
   });
 });

--- a/packages/core/test/Serialization/Certificates/StakeRegistrationDelegation.test.ts
+++ b/packages/core/test/Serialization/Certificates/StakeRegistrationDelegation.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { StakeRegistrationDelegation } from '../../../src/Serialization';
 
@@ -11,7 +12,10 @@ const core = {
   __typename: 'StakeRegistrationDelegateCertificate',
   deposit: 0n,
   poolId: 'pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8a7a2d',
-  stakeKeyHash: '00000000000000000000000000000000000000000000000000000000'
+  stakeCredential: {
+    hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+    type: Cardano.CredentialType.KeyHash
+  }
 } as Cardano.StakeRegistrationDelegationCertificate;
 
 describe('StakeRegistrationDelegation', () => {

--- a/packages/core/test/Serialization/Certificates/StakeVoteDelegation.test.ts
+++ b/packages/core/test/Serialization/Certificates/StakeVoteDelegation.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { StakeVoteDelegation } from '../../../src/Serialization';
 
@@ -14,7 +15,10 @@ const core = {
     type: 0
   },
   poolId: 'pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8a7a2d',
-  stakeKeyHash: '00000000000000000000000000000000000000000000000000000000'
+  stakeCredential: {
+    hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+    type: Cardano.CredentialType.KeyHash
+  }
 } as Cardano.StakeVoteDelegationCertificate;
 
 describe('StakeVoteDelegation', () => {

--- a/packages/core/test/Serialization/Certificates/StakeVoteRegistrationDelegation.test.ts
+++ b/packages/core/test/Serialization/Certificates/StakeVoteRegistrationDelegation.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { StakeVoteRegistrationDelegation } from '../../../src/Serialization';
 
@@ -15,7 +16,10 @@ const core = {
   },
   deposit: 0n,
   poolId: 'pool1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8a7a2d',
-  stakeKeyHash: '00000000000000000000000000000000000000000000000000000000'
+  stakeCredential: {
+    hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+    type: Cardano.CredentialType.KeyHash
+  }
 } as Cardano.StakeVoteRegistrationDelegationCertificate;
 
 describe('StakeVoteRegistrationDelegation', () => {

--- a/packages/core/test/Serialization/Certificates/Unregistration.test.ts
+++ b/packages/core/test/Serialization/Certificates/Unregistration.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { Unregistration } from '../../../src/Serialization';
 
@@ -8,7 +9,10 @@ const cbor = HexBlob('83088200581c0000000000000000000000000000000000000000000000
 const core = {
   __typename: 'UnRegistrationCertificate',
   deposit: 0n,
-  stakeKeyHash: '00000000000000000000000000000000000000000000000000000000'
+  stakeCredential: {
+    hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+    type: Cardano.CredentialType.KeyHash
+  }
 } as Cardano.NewStakeAddressCertificate;
 
 describe('Unregistration', () => {

--- a/packages/core/test/Serialization/Certificates/VoteDelegation.test.ts
+++ b/packages/core/test/Serialization/Certificates/VoteDelegation.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { VoteDelegation } from '../../../src/Serialization';
 
@@ -13,7 +14,10 @@ const core = {
     hash: '00000000000000000000000000000000000000000000000000000000',
     type: 0
   },
-  stakeKeyHash: '00000000000000000000000000000000000000000000000000000000'
+  stakeCredential: {
+    hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+    type: Cardano.CredentialType.KeyHash
+  }
 } as Cardano.VoteDelegationCertificate;
 
 describe('VoteDelegation', () => {

--- a/packages/core/test/Serialization/Certificates/VoteRegistrationDelegation.test.ts
+++ b/packages/core/test/Serialization/Certificates/VoteRegistrationDelegation.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { VoteRegistrationDelegation } from '../../../src/Serialization';
 
@@ -14,7 +15,10 @@ const core = {
     type: 0
   },
   deposit: 0n,
-  stakeKeyHash: '00000000000000000000000000000000000000000000000000000000'
+  stakeCredential: {
+    hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+    type: Cardano.CredentialType.KeyHash
+  }
 } as Cardano.VoteRegistrationDelegationCertificate;
 
 describe('VoteRegistrationDelegation', () => {

--- a/packages/e2e/test/local-network/register-pool.test.ts
+++ b/packages/e2e/test/local-network/register-pool.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../../src';
 import { logger } from '@cardano-sdk/util-dev';
 
+import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, KeyRole } from '@cardano-sdk/key-management';
 import { firstValueFrom } from 'rxjs';
 
@@ -117,13 +118,17 @@ describe('local-network/register-pool', () => {
 
     const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
     const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccounts[0].address);
+    const stakeCredential = {
+      hash: stakeKeyHash as unknown as Crypto.Hash28ByteBase16,
+      type: Cardano.CredentialType.KeyHash
+    };
 
     await submitCertificate(registrationCert, wallet1);
 
     // Register stake key.
     const registerStakeKey: Cardano.StakeAddressCertificate = {
-      __typename: Cardano.CertificateType.StakeKeyRegistration,
-      stakeKeyHash
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential
     };
 
     await submitCertificate(registerStakeKey, wallet1);
@@ -132,7 +137,7 @@ describe('local-network/register-pool', () => {
     const delegationCert: Cardano.StakeDelegationCertificate = {
       __typename: Cardano.CertificateType.StakeDelegation,
       poolId,
-      stakeKeyHash
+      stakeCredential
     };
 
     await submitCertificate(delegationCert, wallet1);
@@ -202,13 +207,17 @@ describe('local-network/register-pool', () => {
 
     const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
     const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccounts[0].address);
+    const stakeCredential = {
+      hash: stakeKeyHash as unknown as Crypto.Hash28ByteBase16,
+      type: Cardano.CredentialType.KeyHash
+    };
 
     await submitCertificate(registrationCert, wallet2);
 
     // Register stake key.
     const registerStakeKey: Cardano.StakeAddressCertificate = {
-      __typename: Cardano.CertificateType.StakeKeyRegistration,
-      stakeKeyHash
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential
     };
 
     await submitCertificate(registerStakeKey, wallet2);
@@ -217,7 +226,7 @@ describe('local-network/register-pool', () => {
     const delegationCert: Cardano.StakeDelegationCertificate = {
       __typename: Cardano.CertificateType.StakeDelegation,
       poolId,
-      stakeKeyHash
+      stakeCredential
     };
 
     await submitCertificate(delegationCert, wallet2);

--- a/packages/e2e/test/long-running/multisig-wallet/MultiSigTx.ts
+++ b/packages/e2e/test/long-running/multisig-wallet/MultiSigTx.ts
@@ -1,0 +1,117 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { Cardano, Serialization, deserializeTx } from '@cardano-sdk/core';
+import { HexBlob } from '@cardano-sdk/util';
+
+/**
+ * Represents a multi-signature transaction for the Cardano blockchain.
+ * This transaction can be serialized and transfer between participants of the multisig wallet.
+ * The transaction carries a bit of extra context, such as the expected signers and the signatures
+ * of the signers who have already signed. this way the participants will know if the transaction is ready to be sent,
+ * or they need to relay the transaction to additional participants (and to whom) for additional signing.
+ */
+export class MultiSigTx {
+  #transaction: Cardano.Tx;
+  #expectedSigners: Array<Crypto.Ed25519PublicKeyHex> = [];
+
+  /**
+   * Initializes a new instance of the MultiSigTx class.
+   *
+   * @param {Cardano.Tx} transaction - The underlying Cardano transaction.
+   * @param {Array<Crypto.Ed25519PublicKeyHex>} expectedSigners - An array of expected signers' public keys.
+   */
+  constructor(transaction: Cardano.Tx, expectedSigners: Array<Crypto.Ed25519PublicKeyHex>) {
+    this.#transaction = transaction;
+    this.#expectedSigners = expectedSigners;
+  }
+
+  /**
+   * Serializes the multi-signature transaction to a CBOR hex blob.
+   *
+   * @returns {HexBlob} The serialized transaction as a hex-encoded string.
+   */
+  toCbor(): HexBlob {
+    const writer = new Serialization.CborWriter();
+
+    writer.writeStartArray(2);
+    writer.writeStartArray(this.#expectedSigners.length);
+
+    for (const signer of this.#expectedSigners) {
+      writer.writeByteString(Buffer.from(signer, 'hex'));
+    }
+
+    writer.writeEncodedValue(Buffer.from(Serialization.Transaction.fromCore(this.#transaction).toCbor(), 'hex'));
+    return writer.encodeAsHex();
+  }
+
+  /**
+   * Deserializes a CBOR hex blob into a MultiSigTx instance.
+   *
+   * @param {HexBlob} cbor - The CBOR hex blob representing the transaction.
+   * @returns {MultiSigTx} The deserialized MultiSigTx instance.
+   */
+  static fromCbor(cbor: HexBlob): MultiSigTx {
+    const reader = new Serialization.CborReader(cbor);
+
+    reader.readStartArray();
+    const length = reader.readStartArray();
+    const expectedSigners: Array<Crypto.Ed25519PublicKeyHex> = [];
+
+    if (length === null || length <= 0) throw new Error('Expected at least one signer');
+
+    for (let i = 0; i < length; i++)
+      expectedSigners.push(Crypto.Ed25519PublicKeyHex(Buffer.from(reader.readByteString()).toString('hex')));
+
+    reader.readEndArray();
+
+    const transaction = deserializeTx(reader.readEncodedValue());
+    reader.readEndArray();
+
+    return new MultiSigTx(transaction, expectedSigners);
+  }
+
+  /**
+   * Checks whether the transaction has been fully signed.
+   *
+   * @returns {boolean} True if the transaction is fully signed, otherwise false.
+   */
+  isFullySigned(): boolean {
+    return this.#expectedSigners.every((signer) => this.#transaction.witness.signatures.has(signer));
+  }
+
+  /**
+   * Retrieves the original Cardano transaction.
+   *
+   * @returns {Cardano.Tx} The Cardano transaction.
+   */
+  getTransaction(): Cardano.Tx {
+    return this.#transaction;
+  }
+
+  /**
+   * Identifies and returns the public keys of signers who have not yet signed the transaction.
+   *
+   * @returns {Array<Crypto.Ed25519PublicKeyHex>} An array of public keys of the missing signers.
+   */
+  getMissingSigners(): Array<Crypto.Ed25519PublicKeyHex> {
+    const missingSigners: Array<Crypto.Ed25519PublicKeyHex> = [];
+
+    for (const signer of this.#expectedSigners)
+      if (!this.#transaction.witness.signatures.has(signer)) missingSigners.push(signer);
+
+    return missingSigners;
+  }
+
+  /**
+   * Identifies and returns the public keys of signers who have signed the transaction.
+   *
+   * @returns {Array<Crypto.Ed25519PublicKeyHex>} An array of public keys of the signers who have already signed.
+   */
+  getAccountedForSigners(): Array<Crypto.Ed25519PublicKeyHex> {
+    const accountedSigners: Array<Crypto.Ed25519PublicKeyHex> = [];
+
+    for (const signer of this.#expectedSigners)
+      if (this.#transaction.witness.signatures.has(signer)) accountedSigners.push(signer);
+
+    return accountedSigners;
+  }
+}

--- a/packages/e2e/test/long-running/multisig-wallet/MultiSigWallet.ts
+++ b/packages/e2e/test/long-running/multisig-wallet/MultiSigWallet.ts
@@ -1,0 +1,491 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { AddressType, GroupedAddress, InMemoryKeyAgent, KeyRole } from '@cardano-sdk/key-management';
+import {
+  Cardano,
+  ChainHistoryProvider,
+  Reward,
+  RewardsProvider,
+  Serialization,
+  TxSubmitProvider,
+  UtxoProvider,
+  coalesceValueQuantities,
+  nativeScriptPolicyId,
+  util
+} from '@cardano-sdk/core';
+import { InputSelector, StaticChangeAddressResolver, roundRobinRandomImprove } from '@cardano-sdk/input-selection';
+import { MultiSigTx } from './MultiSigTx';
+import { Observable, firstValueFrom, interval, map, switchMap } from 'rxjs';
+import { WalletNetworkInfoProvider } from '@cardano-sdk/wallet';
+import { defaultSelectionConstraints } from '@cardano-sdk/tx-construction';
+
+const randomHexChar = () => Math.floor(Math.random() * 16).toString(16);
+const randomPublicKey = () => Crypto.Ed25519PublicKeyHex(Array.from({ length: 64 }).map(randomHexChar).join(''));
+
+// eslint-disable-next-line max-len
+const DUMMY_HEX_BYTES =
+  'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+const DERIVATION_PATH = {
+  index: 0,
+  role: KeyRole.External
+};
+
+export class MultiSigWalletProps {
+  expectedSigners: Array<Crypto.Ed25519PublicKeyHex> = [];
+  inMemoryKeyAgent: InMemoryKeyAgent;
+  utxoProvider: UtxoProvider;
+  chainHistoryProvider: ChainHistoryProvider;
+  rewardsProvider: RewardsProvider;
+  txSubmitProvider: TxSubmitProvider;
+  networkInfoProvider: WalletNetworkInfoProvider;
+  networkId: Cardano.NetworkId;
+  pollingInterval: number;
+}
+
+/** Represents a multi-signature wallet for Cardano blockchain. */
+export class MultiSigWallet {
+  #expectedSigners: Array<Crypto.Ed25519PublicKeyHex> = [];
+  #inMemoryKeyAgent: InMemoryKeyAgent;
+  #multisigScript: Cardano.NativeScript;
+  #inputSelector: InputSelector;
+  #address: GroupedAddress;
+  #utxoProvider: UtxoProvider;
+  #chainHistoryProvider: ChainHistoryProvider;
+  #rewardsProvider: RewardsProvider;
+  #txSubmitProvider: TxSubmitProvider;
+  #networkInfoProvider: WalletNetworkInfoProvider;
+  #pollingInterval: number;
+
+  /** Creates a new MultiSigWallet instance with the specified signers and network configuration. */
+  static async createMultiSigWallet(props: MultiSigWalletProps) {
+    const script = await MultiSigWallet.#buildScript(props.expectedSigners, props.inMemoryKeyAgent);
+    const address = await MultiSigWallet.#getAddress(script, props.networkId);
+
+    const inputSelector = roundRobinRandomImprove({
+      changeAddressResolver: new StaticChangeAddressResolver(() => Promise.resolve([address]))
+    });
+
+    return new MultiSigWallet(props, script, address, inputSelector);
+  }
+
+  /** Constructs a new MultiSigWallet. */
+  constructor(
+    props: MultiSigWalletProps,
+    script: Cardano.NativeScript,
+    address: GroupedAddress,
+    inputSelector: InputSelector
+  ) {
+    this.#multisigScript = script;
+    this.#address = address;
+    this.#inputSelector = inputSelector;
+    this.#expectedSigners = props.expectedSigners;
+    this.#inMemoryKeyAgent = props.inMemoryKeyAgent;
+    this.#utxoProvider = props.utxoProvider;
+    this.#chainHistoryProvider = props.chainHistoryProvider;
+    this.#rewardsProvider = props.rewardsProvider;
+    this.#txSubmitProvider = props.txSubmitProvider;
+    this.#networkInfoProvider = props.networkInfoProvider;
+    this.#pollingInterval = props.pollingInterval;
+  }
+
+  /**
+   * Retrieves the list of signers' public keys.
+   *
+   * @returns {Array<Crypto.Ed25519PublicKeyHex>} An array of signers' public keys.
+   */
+  getSigners(): Array<Crypto.Ed25519PublicKeyHex> {
+    return this.#expectedSigners;
+  }
+
+  /**
+   * Retrieves the payment address of the wallet.
+   *
+   * @returns {Cardano.PaymentAddress} The payment address.
+   */
+  getPaymentAddress(): Cardano.PaymentAddress {
+    return this.#address.address;
+  }
+
+  /**
+   * Retrieves the reward account associated with the wallet.
+   *
+   * @returns {Cardano.RewardAccount} The reward account.
+   */
+  getRewardAccount(): Cardano.RewardAccount {
+    return this.#address.rewardAccount;
+  }
+
+  /**
+   * Delegates the stake to a specified pool.
+   *
+   * @param {Cardano.PoolId} pool - The pool ID to delegate to.
+   * @returns {Promise<MultiSigTx>} A multi-signature transaction object for the delegation.
+   */
+  async delegate(pool: Cardano.PoolId): Promise<MultiSigTx> {
+    const certificates: Cardano.Certificate[] = [];
+
+    certificates.push(
+      {
+        __typename: Cardano.CertificateType.StakeRegistration,
+        stakeCredential: {
+          hash: Cardano.RewardAccount.toHash(this.getRewardAccount()) as unknown as Crypto.Hash28ByteBase16,
+          type: Cardano.CredentialType.ScriptHash
+        }
+      },
+      {
+        __typename: Cardano.CertificateType.StakeDelegation,
+        poolId: pool,
+        stakeCredential: {
+          hash: Cardano.RewardAccount.toHash(this.getRewardAccount()) as unknown as Crypto.Hash28ByteBase16,
+          type: Cardano.CredentialType.ScriptHash
+        }
+      }
+    );
+
+    const { body, id } = await this.#createTransaction(
+      // Add dummy output. This is not needed, but probably ok for POC.
+      new Set<Cardano.TxOut>([
+        {
+          address: this.getPaymentAddress(),
+          value: { coins: 1_000_000n }
+        }
+      ]),
+      certificates
+    );
+
+    return new MultiSigTx(
+      {
+        body,
+        id,
+        witness: {
+          scripts: [this.#multisigScript],
+          signatures: new Map<Crypto.Ed25519PublicKeyHex, Crypto.Ed25519SignatureHex>()
+        }
+      },
+      this.#expectedSigners
+    );
+  }
+
+  /**
+   * Transfers funds to a specified address.
+   *
+   * @param {Cardano.PaymentAddress} address - The address to transfer funds to.
+   * @param {Cardano.Value} value - The amount to be transferred.
+   * @returns {Promise<MultiSigTx>} A multi-signature transaction object for the transfer.
+   */
+  async transferFunds(address: Cardano.PaymentAddress, value: Cardano.Value): Promise<MultiSigTx> {
+    const { body, id } = await this.#createTransaction(
+      new Set<Cardano.TxOut>([
+        {
+          address,
+          value
+        }
+      ])
+    );
+
+    return new MultiSigTx(
+      {
+        body,
+        id,
+        witness: {
+          scripts: [this.#multisigScript],
+          signatures: new Map<Crypto.Ed25519PublicKeyHex, Crypto.Ed25519SignatureHex>()
+        }
+      },
+      this.#expectedSigners
+    );
+  }
+
+  /**
+   * Signs a multi-signature transaction.
+   *
+   * @param {MultiSigTx} multiSigTx - The multi-signature transaction to sign.
+   * @returns {Promise<MultiSigTx>} The signed multi-signature transaction.
+   */
+  async sign(multiSigTx: MultiSigTx): Promise<MultiSigTx> {
+    const currentSignatures = multiSigTx.getTransaction().witness.signatures;
+    const newSignatures = await this.#inMemoryKeyAgent.signTransaction(
+      {
+        body: multiSigTx.getTransaction().body,
+        hash: multiSigTx.getTransaction().id
+      },
+      { additionalKeyPaths: [DERIVATION_PATH] }
+    );
+
+    for (const signature of newSignatures.entries()) {
+      currentSignatures.set(signature[0], signature[1]);
+    }
+
+    multiSigTx.getTransaction().witness.signatures = currentSignatures;
+
+    return multiSigTx;
+  }
+
+  /**
+   * Submits a signed multi-signature transaction to the network.
+   *
+   * @param {MultiSigTx} multiSigTx - The signed multi-signature transaction to submit.
+   * @returns {Promise<Cardano.TransactionId>} The transaction ID of the submitted transaction.
+   */
+  async submit(multiSigTx: MultiSigTx): Promise<Cardano.TransactionId> {
+    const tx = Serialization.Transaction.fromCore(multiSigTx.getTransaction());
+
+    await this.#txSubmitProvider.submitTx({
+      signedTransaction: tx.toCbor()
+    });
+
+    return tx.getId();
+  }
+
+  /**
+   * Retrieves the set of unspent transaction outputs (UTXOs) associated with the wallet.
+   *
+   * @returns {Observable<Cardano.Utxo[]>} A hot observable with the list of  current UTXOs.
+   */
+  getUtxoSet(): Observable<Cardano.Utxo[]> {
+    return interval(this.#pollingInterval).pipe(
+      switchMap(
+        () =>
+          new Observable<Cardano.Utxo[]>((subscriber) => {
+            this.#utxoProvider
+              .utxoByAddresses({ addresses: [this.#address.address] })
+              // eslint-disable-next-line promise/always-return
+              .then((utxos) => {
+                subscriber.next(utxos);
+              })
+              .catch((error) => subscriber.error(error));
+          })
+      )
+    );
+  }
+
+  /**
+   * Calculates and returns the total balance of the wallet.
+   *
+   * @returns {Observable<Cardano.Value>} An observable that emits the wallet's balance.
+   */
+  getBalance(): Observable<Cardano.Value> {
+    return this.getUtxoSet().pipe(map((utxoSet) => coalesceValueQuantities(utxoSet.map((utxo) => utxo[1].value))));
+  }
+
+  /**
+   * Retrieves and emits the transaction history of the wallet at specified polling intervals.
+   *
+   * @returns {Observable<Cardano.HydratedTx[]>} An observable that emits the list of historical transactions.
+   */
+  getTransactionHistory(): Observable<Cardano.HydratedTx[]> {
+    return interval(this.#pollingInterval).pipe(
+      switchMap(
+        () =>
+          new Observable<Cardano.HydratedTx[]>((subscriber) => {
+            this.#chainHistoryProvider
+              .transactionsByAddresses({
+                addresses: [this.#address.address],
+                pagination: {
+                  limit: 25, // Gets only the first 25 transaction. This is probably good enough for the POC.
+                  startAt: 0
+                }
+              })
+              // eslint-disable-next-line promise/always-return
+              .then((paginatedTxs) => {
+                subscriber.next(paginatedTxs.pageResults);
+                subscriber.complete();
+              })
+              .catch((error) => subscriber.error(error));
+          })
+      )
+    );
+  }
+
+  /**
+   * Retrieves and emits the rewards history of the wallet's reward account at specified polling intervals.
+   *
+   * @returns {Observable<Map<Cardano.RewardAccount, Reward[]>>} An observable that emits the rewards history.
+   */
+  getRewardsHistory(): Observable<Map<Cardano.RewardAccount, Reward[]>> {
+    return interval(this.#pollingInterval).pipe(
+      switchMap(
+        () =>
+          new Observable<Map<Cardano.RewardAccount, Reward[]>>((subscriber) => {
+            this.#rewardsProvider
+              .rewardsHistory({
+                rewardAccounts: [this.#address.rewardAccount]
+              })
+              // eslint-disable-next-line promise/always-return
+              .then((rewardsHistory) => {
+                subscriber.next(rewardsHistory);
+                subscriber.complete();
+              })
+              .catch((error) => subscriber.error(error));
+          })
+      )
+    );
+  }
+
+  /**
+   * Retrieves and emits the current balance of the reward account at specified polling intervals.
+   *
+   * @returns {Observable<Cardano.Lovelace>} An observable that emits the balance of the reward account.
+   */
+  getRewardAccountBalance(): Observable<Cardano.Lovelace> {
+    return interval(this.#pollingInterval).pipe(
+      switchMap(
+        () =>
+          new Observable<Cardano.Lovelace>((subscriber) => {
+            this.#rewardsProvider
+              .rewardAccountBalance({
+                rewardAccount: this.#address.rewardAccount
+              })
+              // eslint-disable-next-line promise/always-return
+              .then((rewardAccountBalance) => {
+                subscriber.next(rewardAccountBalance);
+                subscriber.complete();
+              })
+              .catch((error) => subscriber.error(error));
+          })
+      )
+    );
+  }
+
+  /**
+   * Internally used method to build the multi-signature script.
+   *
+   * @param {Array<Crypto.Ed25519PublicKeyHex>} expectedSigners - The public keys expected to sign transactions.
+   * @param {InMemoryKeyAgent} keyAgent - The in-memory key agent.
+   * @returns {Promise<Cardano.NativeScript>} The constructed native script.
+   */
+  static async #buildScript(expectedSigners: Array<Crypto.Ed25519PublicKeyHex>, keyAgent: InMemoryKeyAgent) {
+    const signers = [...expectedSigners];
+
+    // Sorting guarantees that we will always get the same script if the same keys are used.
+    signers.sort();
+
+    // We are going to use RequireAllOf for this POC to keep it simple, but RequireNOf makes more sense.
+    const script: Cardano.NativeScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireAllOf,
+      scripts: []
+    };
+
+    for (const signer of signers) {
+      script.scripts.push({
+        __type: Cardano.ScriptType.Native,
+        keyHash: await keyAgent.bip32Ed25519.getPubKeyHash(signer),
+        kind: Cardano.NativeScriptKind.RequireSignature
+      });
+    }
+
+    return script;
+  }
+
+  /**
+   * Internally used method to derive the wallet's grouped address from the script and network ID.
+   *
+   * @param {Cardano.NativeScript} script - The native script for multi-signature.
+   * @param {Cardano.NetworkId} networkId - The network identifier.
+   * @returns {Promise<GroupedAddress>} The derived grouped address.
+   */
+  static async #getAddress(script: Cardano.NativeScript, networkId: Cardano.NetworkId): Promise<GroupedAddress> {
+    const scriptHash = nativeScriptPolicyId(script) as unknown as Crypto.Hash28ByteBase16;
+
+    const scriptCredential = {
+      hash: scriptHash,
+      type: Cardano.CredentialType.ScriptHash
+    };
+
+    const baseAddress = Cardano.BaseAddress.fromCredentials(
+      Cardano.NetworkId.Testnet,
+      scriptCredential,
+      scriptCredential
+    );
+
+    return {
+      accountIndex: 0,
+      address: baseAddress.toAddress().toBech32() as Cardano.PaymentAddress,
+      index: 0,
+      networkId,
+      rewardAccount: Cardano.RewardAddress.fromCredentials(networkId, scriptCredential)
+        .toAddress()
+        .toBech32() as Cardano.RewardAccount,
+      type: AddressType.External
+    };
+  }
+
+  /**
+   * Internally used method to create a transaction with the given outputs and certificates.
+   *
+   * @param {Set<Cardano.TxOut>?} txOuts - The set of transaction outputs.
+   * @param {Cardano.Certificate[]?} certificates - The list of certificates to include in the transaction.
+   * @returns {Promise<{ body: Cardano.TxBody, id: Cardano.TransactionId }>} The transaction body and ID.
+   */
+  async #createTransaction(txOuts?: Set<Cardano.TxOut>, certificates?: Cardano.Certificate[]) {
+    const [protocolParameters, utxo] = await Promise.all([
+      this.#networkInfoProvider.protocolParameters(),
+      firstValueFrom(this.getUtxoSet())
+    ]);
+
+    const withdrawals: Cardano.Withdrawal[] = [];
+    const rewardsBalance = await firstValueFrom(this.getRewardAccountBalance());
+
+    if (rewardsBalance > 0) {
+      withdrawals.push({ quantity: rewardsBalance, stakeAddress: this.getRewardAccount() });
+    }
+
+    const constraints = defaultSelectionConstraints({
+      buildTx: async (inputSelection) => {
+        const body: Cardano.TxBody = {
+          certificates,
+          fee: inputSelection.fee,
+          inputs: [...inputSelection.inputs].map(([txIn]) => txIn),
+          outputs: txOuts ? [...txOuts.values()] : [],
+          ...(withdrawals.length > 0 ? { withdrawals } : {})
+        };
+
+        const signatureMap = new Map();
+
+        // TODO: There is a small bug here and the fee is off by a few lovelace, this *2 will offset
+        // the error in the meantime.
+        for (let i = 0; i < this.#expectedSigners.length * 2; ++i)
+          signatureMap.set(randomPublicKey(), DUMMY_HEX_BYTES as Crypto.Ed25519SignatureHex);
+
+        return {
+          body,
+          id: '' as Cardano.TransactionId,
+          witness: {
+            scripts: [this.#multisigScript],
+            signatures: signatureMap
+          }
+        };
+      },
+      protocolParameters
+    });
+
+    const implicitCoin = Cardano.util.computeImplicitCoin(protocolParameters, {
+      certificates,
+      withdrawals
+    });
+
+    const { selection: inputSelection } = await this.#inputSelector.select({
+      constraints,
+      implicitValue: { coin: implicitCoin },
+      outputs: txOuts || new Set(),
+      utxo: new Set(utxo)
+    });
+
+    const body = {
+      certificates,
+      fee: inputSelection.fee,
+      inputs: [...inputSelection.inputs].map(([txIn]) => txIn),
+      outputs: txOuts ? [...inputSelection.outputs, ...inputSelection.change] : [],
+      withdrawals
+    };
+
+    const serializableBody = Serialization.TransactionBody.fromCore(body);
+
+    const id = Cardano.TransactionId.fromHexBlob(
+      util.bytesToHex(Crypto.blake2b(Crypto.blake2b.BYTES).update(util.hexToBytes(serializableBody.toCbor())).digest())
+    );
+
+    return { body, id };
+  }
+}

--- a/packages/e2e/test/long-running/multisig-wallet/multisig-delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/multisig-wallet/multisig-delegation-rewards.test.ts
@@ -1,0 +1,308 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { Cardano, EraSummary, StakePoolProvider, createSlotEpochCalc } from '@cardano-sdk/core';
+import { InMemoryKeyAgent, KeyRole } from '@cardano-sdk/key-management';
+import { MultiSigTx } from './MultiSigTx';
+import { MultiSigWallet } from './MultiSigWallet';
+import { Observable, filter, firstValueFrom, map, take } from 'rxjs';
+import { PersonalWallet } from '@cardano-sdk/wallet';
+import { TrackerSubject } from '@cardano-sdk/util-rxjs';
+import { createStandaloneKeyAgent, getEnv, getWallet, waitForEpoch, walletReady, walletVariables } from '../../../src';
+import { isNotNil } from '@cardano-sdk/util';
+import { logger } from '@cardano-sdk/util-dev';
+
+const env = getEnv(walletVariables);
+
+// eslint-disable-next-line max-len
+const aliceMnemonics =
+  'decorate survey empower stairs pledge humble social leisure baby wrap grief exact monster rug dash kiss perfect select science light frame play swallow day';
+
+// eslint-disable-next-line max-len
+const bobMnemonics =
+  'salon zoo engage submit smile frost later decide wing sight chaos renew lizard rely canal coral scene hobby scare step bus leaf tobacco slice';
+
+// eslint-disable-next-line max-len
+const charlotteMnemonics =
+  'phrase raw learn suspect inmate powder combine apology regular hero gain chronic fruit ritual short screen goddess odor keen creek brand today kit machine';
+
+const DERIVATION_PATH = {
+  index: 0,
+  role: KeyRole.External
+};
+
+const getPoolIds = async (stakePoolProvider: StakePoolProvider, count: number) => {
+  const activePools = await stakePoolProvider.queryStakePools({
+    filters: { pledgeMet: true, status: [Cardano.StakePoolStatus.Active] },
+    pagination: { limit: count, startAt: 0 }
+  });
+  expect(activePools.totalResultCount).toBeGreaterThanOrEqual(count);
+  const poolIds = activePools.pageResults.map(({ id }) => id);
+  expect(poolIds.every((poolId) => poolId !== undefined)).toBeTruthy();
+  logger.info('Wallet funds will be staked to pools:', poolIds);
+  return poolIds;
+};
+
+const fundMultiSigWallet = async (sendingWallet: PersonalWallet, address: Cardano.PaymentAddress) => {
+  logger.info(`Funding multisig wallet with address: ${address}`);
+
+  const tAdaToSend = 5_000_000n;
+
+  const txBuilder = sendingWallet.createTxBuilder();
+  const txOut = await txBuilder.buildOutput().address(address).coin(tAdaToSend).build();
+  const { tx: signedTx } = await txBuilder.addOutput(txOut).build().sign();
+  await sendingWallet.submitTx(signedTx);
+};
+
+const getKeyAgent = async (mnemonics: string, faucetWallet: PersonalWallet) => {
+  const genesis = await firstValueFrom(faucetWallet.genesisParameters$);
+
+  const keyAgent = await createStandaloneKeyAgent(
+    mnemonics.split(' '),
+    genesis,
+    await faucetWallet.keyAgent.getBip32Ed25519()
+  );
+
+  const pubKey = await keyAgent.derivePublicKey(DERIVATION_PATH);
+
+  return { keyAgent, pubKey };
+};
+
+const generateTxs = async (sendingWallet: PersonalWallet, receivingWallet: PersonalWallet) => {
+  logger.info('Sending 100 txs to generate reward fees');
+
+  const tAdaToSend = 5_000_000n;
+  const [{ address: receivingAddress }] = await firstValueFrom(receivingWallet.addresses$);
+
+  for (let i = 0; i < 100; i++) {
+    const txBuilder = sendingWallet.createTxBuilder();
+    const txOut = await txBuilder.buildOutput().address(receivingAddress).coin(tAdaToSend).build();
+    const { tx: signedTx } = await txBuilder.addOutput(txOut).build().sign();
+    await sendingWallet.submitTx(signedTx);
+  }
+};
+
+const createMultiSignWallet = async (
+  keyAgent: InMemoryKeyAgent,
+  faucetWallet: PersonalWallet,
+  participants: Array<Crypto.Ed25519PublicKeyHex>
+) => {
+  const props = {
+    chainHistoryProvider: faucetWallet.chainHistoryProvider,
+    expectedSigners: participants,
+    inMemoryKeyAgent: keyAgent,
+    networkId: env.KEY_MANAGEMENT_PARAMS.chainId.networkId,
+    networkInfoProvider: faucetWallet.networkInfoProvider,
+    pollingInterval: 50,
+    rewardsProvider: faucetWallet.rewardsProvider,
+    txSubmitProvider: faucetWallet.txSubmitProvider,
+    utxoProvider: faucetWallet.utxoProvider
+  };
+
+  return await MultiSigWallet.createMultiSigWallet(props);
+};
+
+const getTxConfirmationEpoch = async (
+  history$: Observable<Cardano.HydratedTx[]>,
+  tx: Cardano.Tx<Cardano.TxBody>,
+  eraSummaries$: TrackerSubject<EraSummary[]>
+) => {
+  const txs = await firstValueFrom(history$.pipe(filter((_) => _.some(({ id }) => id === tx.id))));
+  const observedTx = txs.find(({ id }) => id === tx.id);
+  const slotEpochCalc = createSlotEpochCalc(await firstValueFrom(eraSummaries$));
+
+  return slotEpochCalc(observedTx!.blockHeader.slot);
+};
+
+describe('multi signature wallet', () => {
+  let faucetWallet: PersonalWallet;
+  let aliceKeyAgent: InMemoryKeyAgent;
+  let bobKeyAgent: InMemoryKeyAgent;
+  let charlotteKeyAgent: InMemoryKeyAgent;
+  let alicePubKey: Crypto.Ed25519PublicKeyHex;
+  let bobPubKey: Crypto.Ed25519PublicKeyHex;
+  let charlottePubKey: Crypto.Ed25519PublicKeyHex;
+  let faucetAddress: Cardano.PaymentAddress;
+  let aliceMultiSigWallet: MultiSigWallet;
+  let bobMultiSigWallet: MultiSigWallet;
+  let charlotteMultiSigWallet: MultiSigWallet;
+  let multiSigParticipants: Crypto.Ed25519PublicKeyHex[];
+
+  const initializeFaucet = async () => {
+    ({ wallet: faucetWallet } = await getWallet({
+      env,
+      logger,
+      name: 'Faucet Wallet',
+      polling: { interval: 50 }
+    }));
+
+    await walletReady(faucetWallet);
+  };
+
+  beforeAll(async () => {
+    await initializeFaucet();
+    ({ keyAgent: aliceKeyAgent, pubKey: alicePubKey } = await getKeyAgent(aliceMnemonics, faucetWallet));
+    ({ keyAgent: bobKeyAgent, pubKey: bobPubKey } = await getKeyAgent(bobMnemonics, faucetWallet));
+    ({ keyAgent: charlotteKeyAgent, pubKey: charlottePubKey } = await getKeyAgent(charlotteMnemonics, faucetWallet));
+
+    faucetAddress = (await firstValueFrom(faucetWallet.addresses$))[0].address;
+
+    multiSigParticipants = [alicePubKey, bobPubKey, charlottePubKey];
+
+    aliceMultiSigWallet = await createMultiSignWallet(aliceKeyAgent, faucetWallet, multiSigParticipants);
+    bobMultiSigWallet = await createMultiSignWallet(bobKeyAgent, faucetWallet, multiSigParticipants);
+    charlotteMultiSigWallet = await createMultiSignWallet(charlotteKeyAgent, faucetWallet, multiSigParticipants);
+  });
+
+  afterAll(() => {
+    faucetWallet?.shutdown();
+  });
+
+  it('can receive balance and can spend balance', async () => {
+    expect(aliceMultiSigWallet.getPaymentAddress()).toEqual(bobMultiSigWallet.getPaymentAddress());
+    expect(aliceMultiSigWallet.getPaymentAddress()).toEqual(charlotteMultiSigWallet.getPaymentAddress());
+
+    await fundMultiSigWallet(faucetWallet, bobMultiSigWallet.getPaymentAddress());
+
+    const multiSigWalletBalance = await firstValueFrom(
+      bobMultiSigWallet.getBalance().pipe(
+        map((value) => value.coins),
+        filter((value) => value > 0n),
+        take(1)
+      )
+    );
+
+    expect(multiSigWalletBalance).toBeGreaterThan(0n);
+
+    // Alice will initiate the transaction on her wallet.
+    let tx = await aliceMultiSigWallet.transferFunds(faucetAddress, { coins: 2_000_000n });
+
+    // Alice then signs the transaction and relay it to Bob.
+    tx = await aliceMultiSigWallet.sign(tx);
+    const aliceSerializedTx = tx.toCbor();
+
+    // .... Bob receives the transaction and signs it.
+    let bobTx = MultiSigTx.fromCbor(aliceSerializedTx);
+    bobTx = await bobMultiSigWallet.sign(bobTx);
+
+    // Bob can then check if there are any missing signatures. If there are, he can then
+    // check who is missing and send the transaction to them.
+    expect(bobTx.isFullySigned()).toBe(false);
+    expect(bobTx.getMissingSigners()).toEqual([charlottePubKey]);
+
+    const bobSerializedTx = bobTx.toCbor();
+
+    // .... Charlotte receives the transaction and signs it.
+    let charlotteTx = MultiSigTx.fromCbor(bobSerializedTx);
+    charlotteTx = await charlotteMultiSigWallet.sign(charlotteTx);
+
+    // Charlotte can then check if there are any missing signatures. And if all signatures
+    // are complete she can submit it to the network.
+    expect(charlotteTx.getMissingSigners()).toEqual([]);
+    expect(charlotteTx.isFullySigned()).toBe(true);
+    const txId = await charlotteMultiSigWallet.submit(charlotteTx);
+
+    // Search chain history to see if the transaction is there.
+    const txFoundInHistory = await firstValueFrom(
+      faucetWallet.transactions.history$.pipe(
+        map((txs) => txs.find((hTx) => hTx.id === txId)),
+        filter(isNotNil),
+        take(1)
+      )
+    );
+
+    expect(txFoundInHistory).toBeTruthy();
+  });
+
+  // eslint-disable-next-line max-statements
+  it('delegate to a pool and claim rewards', async () => {
+    expect(aliceMultiSigWallet.getRewardAccount()).toEqual(bobMultiSigWallet.getRewardAccount());
+    expect(aliceMultiSigWallet.getRewardAccount()).toEqual(charlotteMultiSigWallet.getRewardAccount());
+
+    await fundMultiSigWallet(faucetWallet, bobMultiSigWallet.getPaymentAddress());
+
+    const multiSigWalletBalance = await firstValueFrom(
+      bobMultiSigWallet.getBalance().pipe(
+        map((value) => value.coins),
+        filter((value) => value > 0n),
+        take(1)
+      )
+    );
+
+    expect(multiSigWalletBalance).toBeGreaterThan(0n);
+
+    const [poolId] = await getPoolIds(faucetWallet.stakePoolProvider, 1);
+
+    // Alice will initiate the delegation transaction on her wallet.
+    let tx = await aliceMultiSigWallet.delegate(poolId);
+    tx = await aliceMultiSigWallet.sign(tx);
+    tx = await bobMultiSigWallet.sign(tx);
+    tx = await charlotteMultiSigWallet.sign(tx);
+
+    const txId = await charlotteMultiSigWallet.submit(tx);
+
+    // Search chain history to see if the transaction is there.
+    const txFoundInHistory = await firstValueFrom(
+      charlotteMultiSigWallet.getTransactionHistory().pipe(
+        map((txs) => txs.find((hTx) => hTx.id === txId)),
+        filter(isNotNil),
+        take(1)
+      )
+    );
+
+    expect(txFoundInHistory).toBeTruthy();
+
+    // Delegation is completed. Now we wait for rewards to be available.
+    const delegationTxConfirmedAtEpoch = await getTxConfirmationEpoch(
+      charlotteMultiSigWallet.getTransactionHistory(),
+      tx.getTransaction(),
+      faucetWallet.eraSummaries$
+    );
+
+    logger.info(`Delegation tx confirmed at epoch #${delegationTxConfirmedAtEpoch}`);
+
+    await waitForEpoch(faucetWallet, delegationTxConfirmedAtEpoch + 2);
+    await generateTxs(faucetWallet, faucetWallet);
+    await waitForEpoch(faucetWallet, delegationTxConfirmedAtEpoch + 4);
+
+    // Check reward
+    const multiSigWalletRewardBalance = await firstValueFrom(
+      bobMultiSigWallet.getRewardAccountBalance().pipe(
+        filter((value) => value > 0n),
+        take(1)
+      )
+    );
+
+    expect(multiSigWalletRewardBalance).toBeGreaterThan(0n);
+
+    logger.info(`Generated rewards: ${multiSigWalletRewardBalance} tLovelace`);
+
+    tx = await aliceMultiSigWallet.transferFunds(faucetAddress, { coins: 2_000_000n });
+    expect(tx.getTransaction().body.withdrawals?.length).toBeGreaterThan(0);
+
+    tx = await aliceMultiSigWallet.sign(tx);
+    tx = await bobMultiSigWallet.sign(tx);
+    tx = await charlotteMultiSigWallet.sign(tx);
+
+    const spendRewardsTx = await charlotteMultiSigWallet.submit(tx);
+
+    // Search chain history to see if the transaction is there.
+    const spendRewardsTxFoundInHistory = await firstValueFrom(
+      faucetWallet.transactions.history$.pipe(
+        map((txs) => txs.find((hTx) => hTx.id === spendRewardsTx)),
+        filter(isNotNil),
+        take(1)
+      )
+    );
+
+    expect(spendRewardsTxFoundInHistory).toBeTruthy();
+
+    // Check reward
+    const finalRewardBalance = await firstValueFrom(
+      bobMultiSigWallet.getRewardAccountBalance().pipe(
+        filter((value) => value === 0n),
+        take(1)
+      )
+    );
+
+    expect(finalRewardBalance).toEqual(0n);
+  });
+});

--- a/packages/e2e/test/projection/offline-fork.test.ts
+++ b/packages/e2e/test/projection/offline-fork.test.ts
@@ -28,7 +28,7 @@ import { ReconnectionConfig } from '@cardano-sdk/util-rxjs';
 import { createDatabase } from 'typeorm-extension';
 import { getEnv } from '../../src';
 
-const dataWithStakeKeyDeregistration = chainSyncData(ChainSyncDataSet.WithStakeKeyDeregistration);
+const dataWithStakeDeregistration = chainSyncData(ChainSyncDataSet.WithStakeKeyDeregistration);
 
 const ogmiosConnectionConfig = ((): ConnectionConfig => {
   const { OGMIOS_URL } = getEnv(['OGMIOS_URL']);
@@ -66,22 +66,22 @@ const createForkProjectionSource = (
   // eslint-disable-next-line sort-keys-fix/sort-keys-fix
   findIntersect: (points) => {
     const intersectionPoint = points[0] as Point;
-    const someEventsWithStakeKeyRegistration = dataWithStakeKeyDeregistration.allEvents
+    const someEventsWithStakeRegistration = dataWithStakeDeregistration.allEvents
       .filter(
         (evt): evt is Omit<ChainSyncRollForward, 'requestNext'> =>
           evt.eventType === ChainSyncEventType.RollForward &&
           evt.block.body.some((tx) =>
-            tx.body.certificates?.some((cert) => cert.__typename === Cardano.CertificateType.StakeKeyRegistration)
+            tx.body.certificates?.some((cert) => cert.__typename === Cardano.CertificateType.StakeRegistration)
           )
       )
       .slice(0, 2);
     return of({
       chainSync$: new Observable<ChainSyncEvent>((subscriber) => {
-        const events = [...someEventsWithStakeKeyRegistration];
+        const events = [...someEventsWithStakeRegistration];
         const next = () => {
           const nextEvt = events.shift();
           if (nextEvt) {
-            const blockOffset = someEventsWithStakeKeyRegistration.length - events.length;
+            const blockOffset = someEventsWithStakeRegistration.length - events.length;
             const slot = Cardano.Slot(intersectionPoint.slot + blockOffset * 20);
             const blockNo = Cardano.BlockNo(lastEvt.block.header.blockNo + blockOffset);
             subscriber.next({
@@ -104,7 +104,7 @@ const createForkProjectionSource = (
       }),
       intersection: {
         point: intersectionPoint,
-        tip: someEventsWithStakeKeyRegistration[someEventsWithStakeKeyRegistration.length - 1].tip
+        tip: someEventsWithStakeRegistration[someEventsWithStakeRegistration.length - 1].tip
       }
     });
   },

--- a/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
+++ b/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
@@ -420,8 +420,10 @@ describe('LedgerKeyAgent', () => {
                 {
                   __typename: Cardano.CertificateType.StakeDelegation,
                   poolId,
-                  stakeKeyHash:
-                    '00000000000000000000000000000000000000000000000000000000' as unknown as Crypto.Ed25519KeyHashHex
+                  stakeCredential: {
+                    hash: '00000000000000000000000000000000000000000000000000000000' as unknown as Crypto.Hash28ByteBase16,
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }
               ],
               fee: 10n,

--- a/packages/hardware-ledger/test/testData.ts
+++ b/packages/hardware-ledger/test/testData.ts
@@ -4,6 +4,10 @@ import { Base64Blob, HexBlob } from '@cardano-sdk/util';
 import { Cardano, Serialization } from '@cardano-sdk/core';
 export const rewardAccount = Cardano.RewardAccount('stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr');
 export const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
+export const stakeCredential = {
+  hash: stakeKeyHash as unknown as Crypto.Hash28ByteBase16,
+  type: Cardano.CredentialType.KeyHash
+};
 export const paymentAddress = Cardano.PaymentAddress(
   'addr1qxdtr6wjx3kr7jlrvrfzhrh8w44qx9krcxhvu3e79zr7497tpmpxjfyhk3vwg6qjezjmlg5nr5dzm9j6nxyns28vsy8stu5lh6'
 );

--- a/packages/hardware-ledger/test/transformers/certificates.test.ts
+++ b/packages/hardware-ledger/test/transformers/certificates.test.ts
@@ -7,7 +7,7 @@ import {
   poolId,
   poolId2,
   poolParameters,
-  stakeKeyHash
+  stakeCredential
 } from '../testData';
 import { Cardano } from '@cardano-sdk/core';
 import { CardanoKeyConst, KeyRole, util } from '@cardano-sdk/key-management';
@@ -26,8 +26,8 @@ describe('certificates', () => {
       const ledgerCerts = mapCerts(
         [
           {
-            __typename: Cardano.CertificateType.StakeKeyRegistration,
-            stakeKeyHash
+            __typename: Cardano.CertificateType.StakeRegistration,
+            stakeCredential
           }
         ],
         CONTEXT_WITHOUT_KNOWN_ADDRESSES
@@ -50,8 +50,8 @@ describe('certificates', () => {
       const ledgerCerts = mapCerts(
         [
           {
-            __typename: Cardano.CertificateType.StakeKeyRegistration,
-            stakeKeyHash
+            __typename: Cardano.CertificateType.StakeRegistration,
+            stakeCredential
           }
         ],
         CONTEXT_WITH_KNOWN_ADDRESSES
@@ -80,8 +80,8 @@ describe('certificates', () => {
       const ledgerCerts = mapCerts(
         [
           {
-            __typename: Cardano.CertificateType.StakeKeyDeregistration,
-            stakeKeyHash
+            __typename: Cardano.CertificateType.StakeDeregistration,
+            stakeCredential
           }
         ],
         CONTEXT_WITHOUT_KNOWN_ADDRESSES
@@ -104,8 +104,8 @@ describe('certificates', () => {
       const ledgerCerts = mapCerts(
         [
           {
-            __typename: Cardano.CertificateType.StakeKeyDeregistration,
-            stakeKeyHash
+            __typename: Cardano.CertificateType.StakeDeregistration,
+            stakeCredential
           }
         ],
         CONTEXT_WITH_KNOWN_ADDRESSES
@@ -344,7 +344,7 @@ describe('certificates', () => {
           {
             __typename: Cardano.CertificateType.StakeDelegation,
             poolId: poolId2,
-            stakeKeyHash
+            stakeCredential
           }
         ],
         CONTEXT_WITHOUT_KNOWN_ADDRESSES
@@ -370,7 +370,7 @@ describe('certificates', () => {
           {
             __typename: Cardano.CertificateType.StakeDelegation,
             poolId: poolId2,
-            stakeKeyHash
+            stakeCredential
           }
         ],
         CONTEXT_WITH_KNOWN_ADDRESSES

--- a/packages/hardware-trezor/src/transformers/certificates.ts
+++ b/packages/hardware-trezor/src/transformers/certificates.ts
@@ -66,7 +66,10 @@ const getStakeAddressCertificate = (
   context: TrezorTxTransformerContext,
   type: StakeKeyCertificateType
 ): TrezorStakeKeyCertificate => {
-  const credentials = getCertCredentials(certificate.stakeKeyHash, context.knownAddresses);
+  const credentials = getCertCredentials(
+    certificate.stakeCredential.hash as unknown as Crypto.Ed25519KeyHashHex,
+    context.knownAddresses
+  );
   return {
     ...credentials,
     type
@@ -78,7 +81,10 @@ const getStakeDelegationCertificate = (
   context: TrezorTxTransformerContext
 ): TrezorDelegationCertificate => {
   const poolIdKeyHash = Cardano.PoolId.toKeyHash(certificate.poolId);
-  const credentials = getCertCredentials(certificate.stakeKeyHash, context.knownAddresses);
+  const credentials = getCertCredentials(
+    certificate.stakeCredential.hash as unknown as Crypto.Ed25519KeyHashHex,
+    context.knownAddresses
+  );
   return {
     ...credentials,
     pool: poolIdKeyHash,
@@ -153,9 +159,9 @@ export const getPoolRegistrationCertificate = (
 
 const toCert = (cert: Cardano.Certificate, context: TrezorTxTransformerContext) => {
   switch (cert.__typename) {
-    case Cardano.CertificateType.StakeKeyRegistration:
+    case Cardano.CertificateType.StakeRegistration:
       return getStakeAddressCertificate(cert, context, Trezor.PROTO.CardanoCertificateType.STAKE_REGISTRATION);
-    case Cardano.CertificateType.StakeKeyDeregistration:
+    case Cardano.CertificateType.StakeDeregistration:
       return getStakeAddressCertificate(cert, context, Trezor.PROTO.CardanoCertificateType.STAKE_DEREGISTRATION);
     case Cardano.CertificateType.StakeDelegation:
       return getStakeDelegationCertificate(cert, context);

--- a/packages/hardware-trezor/test/testData.ts
+++ b/packages/hardware-trezor/test/testData.ts
@@ -92,6 +92,10 @@ export const rewardAccount = Cardano.RewardAccount(rewardKey);
 export const rewardAddress = Cardano.Address.fromBech32(rewardAccount)?.asReward();
 export const rewardAccountWithPaymentScriptCredential = Cardano.RewardAccount(rewardScript);
 export const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
+export const stakeCredential = {
+  hash: stakeKeyHash as unknown as Crypto.Hash28ByteBase16,
+  type: Cardano.CredentialType.KeyHash
+};
 export const stakeScriptHash = Cardano.RewardAccount.toHash(rewardAccountWithPaymentScriptCredential);
 export const knownAddressKeyPath = [2_147_485_500, 2_147_485_463, 2_147_483_648, 1, 0];
 export const knownAddressStakeKeyPath = [2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0];
@@ -168,19 +172,19 @@ export const coreWithdrawalWithScriptHashCredential = {
 };
 
 export const stakeRegistrationCertificate = {
-  __typename: Cardano.CertificateType.StakeKeyRegistration,
-  stakeKeyHash
+  __typename: Cardano.CertificateType.StakeRegistration,
+  stakeCredential
 } as Cardano.StakeAddressCertificate;
 
 export const stakeDeregistrationCertificate = {
-  __typename: Cardano.CertificateType.StakeKeyDeregistration,
-  stakeKeyHash
+  __typename: Cardano.CertificateType.StakeDeregistration,
+  stakeCredential
 } as Cardano.StakeAddressCertificate;
 
 export const stakeDelegationCertificate = {
   __typename: Cardano.CertificateType.StakeDelegation,
   poolId: poolId2,
-  stakeKeyHash
+  stakeCredential
 } as Cardano.StakeDelegationCertificate;
 
 export const poolRegistrationCertificate = {

--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -55,9 +55,13 @@ const checkStakeKeyHashCertificate = (
     case Cardano.CertificateType.VoteRegistrationDelegation:
     case Cardano.CertificateType.StakeVoteRegistrationDelegation:
     case Cardano.CertificateType.Unregistration:
-    case Cardano.CertificateType.StakeKeyDeregistration:
+    case Cardano.CertificateType.StakeDeregistration:
     case Cardano.CertificateType.StakeDelegation: {
-      const account = accounts.find((acct) => acct.stakeKeyHash === certificate.stakeKeyHash);
+      const account = accounts.find(
+        (acct) =>
+          certificate.stakeCredential.type === Cardano.CredentialType.KeyHash &&
+          acct.stakeKeyHash === (certificate.stakeCredential.hash as unknown as Crypto.Ed25519KeyHashHex)
+      );
       if (account) {
         signatureCheck.derivationPaths = [account.derivationPath];
       } else {
@@ -152,7 +156,7 @@ export const checkStakeCredentialCertificates = (
     signatureCheck.requiresForeignSignatures ||= mirCheck.requiresForeignSignatures;
     signatureCheck.derivationPaths.push(...mirCheck.derivationPaths);
 
-    // StakeKeyRegistration and GenesisKeyDelegation do not require signing
+    // StakeRegistration and GenesisKeyDelegation do not require signing
   }
 
   signatureCheck.derivationPaths = uniqWith(signatureCheck.derivationPaths, isEqual);

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -9,6 +9,11 @@ export const stakeKeyPath = {
   role: KeyRole.Stake
 };
 
+const toStakeCredential = (stakeKeyHash: Crypto.Ed25519KeyHashHex): Cardano.Credential => ({
+  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyHash),
+  type: Cardano.CredentialType.KeyHash
+});
+
 const createGroupedAddress = (
   address: Cardano.PaymentAddress,
   rewardAccount: Cardano.RewardAccount,
@@ -36,7 +41,16 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   );
 
   const ownStakeKeyHash = Cardano.RewardAccount.toHash(ownRewardAccount);
+  const ownStakeCredential = {
+    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(ownStakeKeyHash),
+    type: Cardano.CredentialType.KeyHash
+  };
+
   const otherStakeKeyHash = Cardano.RewardAccount.toHash(otherRewardAccount);
+  const otherStakeCredential = {
+    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(otherStakeKeyHash),
+    type: Cardano.CredentialType.KeyHash
+  };
 
   let dRepPublicKey: Crypto.Ed25519PublicKeyHex;
   let dRepKeyHash: Crypto.Ed25519KeyHashHex;
@@ -74,11 +88,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   });
 
   it(
-    'does not return stake key derivation path when a StakeKeyRegistration' +
+    'does not return stake key derivation path when a StakeRegistration' +
       ' certificate with the wallet stake key hash is present',
     async () => {
       const txBody = {
-        certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash: ownStakeKeyHash }],
+        certificates: [{ __typename: Cardano.CertificateType.StakeRegistration, stakeCredential: ownStakeCredential }],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
       const resolveInput = jest
@@ -95,11 +109,13 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   );
 
   it(
-    'returns stake key derivation path when a StakeKeyDeregistration' +
+    'returns stake key derivation path when a StakeDeregistration' +
       ' certificate with the wallet stake key hash is present',
     async () => {
       const txBody = {
-        certificates: [{ __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash: ownStakeKeyHash }],
+        certificates: [
+          { __typename: Cardano.CertificateType.StakeDeregistration, stakeCredential: ownStakeCredential }
+        ],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
       const resolveInput = jest
@@ -124,7 +140,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       ' certificate with the wallet stake key hash is present',
     async () => {
       const txBody = {
-        certificates: [{ __typename: Cardano.CertificateType.StakeDelegation, stakeKeyHash: ownStakeKeyHash }],
+        certificates: [{ __typename: Cardano.CertificateType.StakeDelegation, stakeCredential: ownStakeCredential }],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
       const resolveInput = jest
@@ -148,8 +164,8 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   it('returns stake key derivation path when at least one certificate with the wallet stake key hash is present', async () => {
     const txBody = {
       certificates: [
-        { __typename: Cardano.CertificateType.StakeDelegation, stakeKeyHash: ownStakeKeyHash },
-        { __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash: otherStakeKeyHash }
+        { __typename: Cardano.CertificateType.StakeDelegation, stakeCredential: ownStakeCredential },
+        { __typename: Cardano.CertificateType.StakeDeregistration, stakeCredential: otherStakeCredential }
       ],
       inputs: [{}, {}, {}]
     } as Cardano.TxBody;
@@ -277,22 +293,22 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   it('does not return derivation paths when all certificates and voting procedures are foreign', async () => {
     const txBody = {
       certificates: [
-        { __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash: otherStakeKeyHash },
-        { __typename: Cardano.CertificateType.VoteDelegation, stakeKeyHash: otherStakeKeyHash },
-        { __typename: Cardano.CertificateType.StakeVoteDelegation, stakeKeyHash: otherStakeKeyHash },
+        { __typename: Cardano.CertificateType.StakeRegistration, stakeCredential: otherStakeCredential },
+        { __typename: Cardano.CertificateType.VoteDelegation, stakeCredential: otherStakeCredential },
+        { __typename: Cardano.CertificateType.StakeVoteDelegation, stakeCredential: otherStakeCredential },
         {
           __typename: Cardano.CertificateType.StakeRegistrationDelegation,
-          stakeKeyHash: otherStakeKeyHash
+          stakeCredential: otherStakeCredential
         },
         {
           __typename: Cardano.CertificateType.VoteRegistrationDelegation,
-          stakeKeyHash: otherStakeKeyHash
+          stakeCredential: otherStakeCredential
         },
         {
           __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
-          stakeKeyHash: otherStakeKeyHash
+          stakeCredential: otherStakeCredential
         },
-        { __typename: Cardano.CertificateType.Unregistration, otherStakeKeyHash },
+        { __typename: Cardano.CertificateType.Unregistration, stakeCredential: otherStakeCredential },
         {
           __typename: Cardano.CertificateType.UnregisterDelegateRepresentative,
           dRepCredential: {
@@ -440,21 +456,30 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     it('is returned for certificates with the wallet stake key hash', async () => {
       const txBody = {
         certificates: [
-          { __typename: Cardano.CertificateType.VoteDelegation, stakeKeyHash: rewardAccounts[0].stakeKeyHash },
-          { __typename: Cardano.CertificateType.StakeVoteDelegation, stakeKeyHash: rewardAccounts[1].stakeKeyHash },
+          {
+            __typename: Cardano.CertificateType.VoteDelegation,
+            stakeCredential: toStakeCredential(rewardAccounts[0].stakeKeyHash)
+          },
+          {
+            __typename: Cardano.CertificateType.StakeVoteDelegation,
+            stakeCredential: toStakeCredential(rewardAccounts[1].stakeKeyHash)
+          },
           {
             __typename: Cardano.CertificateType.StakeRegistrationDelegation,
-            stakeKeyHash: rewardAccounts[2].stakeKeyHash
+            stakeCredential: toStakeCredential(rewardAccounts[2].stakeKeyHash)
           },
           {
             __typename: Cardano.CertificateType.VoteRegistrationDelegation,
-            stakeKeyHash: rewardAccounts[3].stakeKeyHash
+            stakeCredential: toStakeCredential(rewardAccounts[3].stakeKeyHash)
           },
           {
             __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
-            stakeKeyHash: rewardAccounts[4].stakeKeyHash
+            stakeCredential: toStakeCredential(rewardAccounts[4].stakeKeyHash)
           },
-          { __typename: Cardano.CertificateType.Unregistration, stakeKeyHash: rewardAccounts[5].stakeKeyHash }
+          {
+            __typename: Cardano.CertificateType.Unregistration,
+            stakeCredential: toStakeCredential(rewardAccounts[5].stakeKeyHash)
+          }
         ],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
@@ -476,8 +501,14 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     it('duplicates are removed when multiple certificates use the wallet stake key hash', async () => {
       const txBody = {
         certificates: [
-          { __typename: Cardano.CertificateType.VoteDelegation, stakeKeyHash: rewardAccounts[0].stakeKeyHash },
-          { __typename: Cardano.CertificateType.StakeVoteDelegation, stakeKeyHash: rewardAccounts[0].stakeKeyHash }
+          {
+            __typename: Cardano.CertificateType.VoteDelegation,
+            stakeCredential: toStakeCredential(rewardAccounts[0].stakeKeyHash)
+          },
+          {
+            __typename: Cardano.CertificateType.StakeVoteDelegation,
+            stakeCredential: toStakeCredential(rewardAccounts[0].stakeKeyHash)
+          }
         ],
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;

--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -76,19 +76,28 @@ const mapCertificate = (certificate: Schema.Certificate): Cardano.Certificate =>
     return {
       __typename: Cardano.CertificateType.StakeDelegation,
       poolId: Cardano.PoolId(certificate.stakeDelegation.delegatee),
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(certificate.stakeDelegation.delegator)
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16(certificate.stakeDelegation.delegator),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
   }
   if ('stakeKeyRegistration' in certificate) {
     return {
-      __typename: Cardano.CertificateType.StakeKeyRegistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(certificate.stakeKeyRegistration)
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16(certificate.stakeKeyRegistration),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
   }
   if ('stakeKeyDeregistration' in certificate) {
     return {
-      __typename: Cardano.CertificateType.StakeKeyDeregistration,
-      stakeKeyHash: Crypto.Ed25519KeyHashHex(certificate.stakeKeyDeregistration)
+      __typename: Cardano.CertificateType.StakeDeregistration,
+      stakeCredential: {
+        hash: Crypto.Hash28ByteBase16(certificate.stakeKeyDeregistration),
+        type: Cardano.CredentialType.KeyHash
+      }
     };
   }
   if ('poolRegistration' in certificate) {

--- a/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
+++ b/packages/ogmios/test/ogmiosToCore/__snapshots__/block.test.ts.snap
@@ -483,11 +483,17 @@ Object {
           Object {
             "__typename": "StakeDelegationCertificate",
             "poolId": "pool15erywju02scjv9gxkmp885c8catf5n4ke9459h2299fq57u9c3e",
-            "stakeKeyHash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+            "stakeCredential": Object {
+              "hash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+              "type": 0,
+            },
           },
           Object {
-            "__typename": "StakeKeyDeregistrationCertificate",
-            "stakeKeyHash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+            "__typename": "StakeDeregistrationCertificate",
+            "stakeCredential": Object {
+              "hash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+              "type": 0,
+            },
           },
           Object {
             "__typename": "PoolRetirementCertificate",
@@ -599,8 +605,11 @@ Object {
         "auxiliaryDataHash": undefined,
         "certificates": Array [
           Object {
-            "__typename": "StakeKeyRegistrationCertificate",
-            "stakeKeyHash": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
+            "__typename": "StakeRegistrationCertificate",
+            "stakeCredential": Object {
+              "hash": "b5ae663aaea8e500157bdf4baafd6f5ba0ce5759f7cd4101fc132f54",
+              "type": 0,
+            },
           },
           Object {
             "__typename": "GenesisKeyDelegationCertificate",

--- a/packages/projection-typeorm/test/operators/storeStakeKeys.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakeKeys.test.ts
@@ -30,13 +30,13 @@ describe('storeStakeKeys', () => {
 
   it('inserts and deletes rows based on event', async () => {
     await processEvent({
-      del: [] as Crypto.Ed25519KeyHashHex[],
-      insert: [Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')]
+      del: [] as Crypto.Hash28ByteBase16[],
+      insert: [Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')]
     });
     expect(await queryRunner.manager.count(StakeKeyEntity)).toBe(1);
     await processEvent({
-      del: [Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')],
-      insert: [] as Crypto.Ed25519KeyHashHex[]
+      del: [Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')],
+      insert: [] as Crypto.Hash28ByteBase16[]
     });
     expect(await queryRunner.manager.count(StakeKeyEntity)).toBe(0);
   });

--- a/packages/projection/src/InMemory/operators/storeStakeKeys.ts
+++ b/packages/projection/src/InMemory/operators/storeStakeKeys.ts
@@ -1,11 +1,12 @@
+import { Ed25519KeyHashHex } from '@cardano-sdk/crypto';
 import { Mappers } from '../../operators';
 import { inMemoryStoreOperator } from './utils';
 
 export const storeStakeKeys = inMemoryStoreOperator<Mappers.WithStakeKeys>(({ stakeKeys: { insert, del }, store }) => {
   for (const stakeKey of insert) {
-    store.stakeKeys.add(stakeKey);
+    store.stakeKeys.add(stakeKey as unknown as Ed25519KeyHashHex);
   }
   for (const stakeKey of del) {
-    store.stakeKeys.delete(stakeKey);
+    store.stakeKeys.delete(stakeKey as unknown as Ed25519KeyHashHex);
   }
 });

--- a/packages/projection/src/operators/Mappers/certificates/withStakeKeyRegistrations.ts
+++ b/packages/projection/src/operators/Mappers/certificates/withStakeKeyRegistrations.ts
@@ -19,10 +19,10 @@ export const withStakeKeyRegistrations = unifiedProjectorOperator<WithCertificat
     ...evt,
     stakeKeyRegistrations: evt.certificates
       .map(({ pointer, certificate }): StakeKeyRegistration | null => {
-        if (certificate.__typename === Cardano.CertificateType.StakeKeyRegistration) {
+        if (certificate.__typename === Cardano.CertificateType.StakeRegistration) {
           return {
             pointer,
-            stakeKeyHash: certificate.stakeKeyHash
+            stakeKeyHash: certificate.stakeCredential.hash as unknown as Ed25519KeyHashHex
           };
         }
         return null;

--- a/packages/projection/src/operators/Mappers/certificates/withStakeKeys.ts
+++ b/packages/projection/src/operators/Mappers/certificates/withStakeKeys.ts
@@ -5,8 +5,8 @@ import { unifiedProjectorOperator } from '../../utils';
 
 export interface WithStakeKeys {
   stakeKeys: {
-    insert: Crypto.Ed25519KeyHashHex[];
-    del: Crypto.Ed25519KeyHashHex[];
+    insert: Crypto.Hash28ByteBase16[];
+    del: Crypto.Hash28ByteBase16[];
   };
 }
 
@@ -21,22 +21,22 @@ export interface WithStakeKeys {
  * ignoring **when** they were registered or unregistered.
  */
 export const withStakeKeys = unifiedProjectorOperator<WithCertificates, WithStakeKeys>((evt) => {
-  const register = new Set<Crypto.Ed25519KeyHashHex>();
-  const deregister = new Set<Crypto.Ed25519KeyHashHex>();
+  const register = new Set<Crypto.Hash28ByteBase16>();
+  const deregister = new Set<Crypto.Hash28ByteBase16>();
   for (const { certificate } of evt.certificates) {
     switch (certificate.__typename) {
-      case Cardano.CertificateType.StakeKeyRegistration:
-        if (deregister.has(certificate.stakeKeyHash)) {
-          deregister.delete(certificate.stakeKeyHash);
+      case Cardano.CertificateType.StakeRegistration:
+        if (deregister.has(certificate.stakeCredential.hash)) {
+          deregister.delete(certificate.stakeCredential.hash);
         } else {
-          register.add(certificate.stakeKeyHash);
+          register.add(certificate.stakeCredential.hash);
         }
         break;
-      case Cardano.CertificateType.StakeKeyDeregistration:
-        if (register.has(certificate.stakeKeyHash)) {
-          register.delete(certificate.stakeKeyHash);
+      case Cardano.CertificateType.StakeDeregistration:
+        if (register.has(certificate.stakeCredential.hash)) {
+          register.delete(certificate.stakeCredential.hash);
         } else {
-          deregister.add(certificate.stakeKeyHash);
+          deregister.add(certificate.stakeCredential.hash);
         }
         break;
     }

--- a/packages/projection/test/InMemory/stakeKeys.test.ts
+++ b/packages/projection/test/InMemory/stakeKeys.test.ts
@@ -8,8 +8,8 @@ describe('InMemory.storeStakeKeys', () => {
     const store = InMemory.createStore();
     const project = async (
       eventType: ChainSyncEventType,
-      register: Crypto.Ed25519KeyHashHex[],
-      deregister: Crypto.Ed25519KeyHashHex[]
+      register: Crypto.Hash28ByteBase16[],
+      deregister: Crypto.Hash28ByteBase16[]
     ) => {
       await firstValueFrom(
         InMemory.storeStakeKeys()(
@@ -26,31 +26,31 @@ describe('InMemory.storeStakeKeys', () => {
     };
     await project(
       ChainSyncEventType.RollForward,
-      [Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')],
+      [Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')],
       []
     );
     await project(
       ChainSyncEventType.RollForward,
-      [Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')],
+      [Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')],
       []
     );
     expect(store.stakeKeys.size).toBe(2);
     await project(
       ChainSyncEventType.RollForward,
       [],
-      [Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')]
+      [Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')]
     );
     expect(store.stakeKeys.size).toBe(1);
     await project(
       ChainSyncEventType.RollBackward,
-      [Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')],
+      [Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')],
       []
     );
     expect(store.stakeKeys.size).toBe(0);
     await project(
       ChainSyncEventType.RollBackward,
       [],
-      [Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')]
+      [Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')]
     );
     expect(store.stakeKeys.size).toBe(1);
   });

--- a/packages/projection/test/integration/InMemory.test.ts
+++ b/packages/projection/test/integration/InMemory.test.ts
@@ -124,7 +124,13 @@ describe('integration/InMemory', () => {
                 {
                   body: {
                     certificates: [
-                      { __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash: rolledBackKey }
+                      {
+                        __typename: Cardano.CertificateType.StakeRegistration,
+                        stakeCredential: {
+                          hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(rolledBackKey),
+                          type: Cardano.CredentialType.KeyHash
+                        }
+                      }
                     ]
                   }
                 } as Cardano.Tx

--- a/packages/projection/test/operators/Mappers/certificates/withCertificates.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withCertificates.test.ts
@@ -23,9 +23,9 @@ const createEvent = (
   } as RollForwardEvent);
 
 const certificates = [
-  [{ __typename: Cardano.CertificateType.StakeKeyRegistration }] as Cardano.Certificate[],
+  [{ __typename: Cardano.CertificateType.StakeRegistration }] as Cardano.Certificate[],
   [
-    { __typename: Cardano.CertificateType.StakeKeyDeregistration },
+    { __typename: Cardano.CertificateType.StakeDeregistration },
     { __typename: Cardano.CertificateType.GenesisKeyDelegation }
   ] as Cardano.Certificate[]
 ];

--- a/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
@@ -16,15 +16,21 @@ describe('withStakeKeyRegistrations', () => {
       certificates: [
         {
           certificate: {
-            __typename: Cardano.CertificateType.StakeKeyRegistration,
-            stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+            __typename: Cardano.CertificateType.StakeRegistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+              type: Cardano.CredentialType.KeyHash
+            }
           },
           pointer
         },
         {
           certificate: {
-            __typename: Cardano.CertificateType.StakeKeyDeregistration,
-            stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')
+            __typename: Cardano.CertificateType.StakeDeregistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+              type: Cardano.CredentialType.KeyHash
+            }
           },
           pointer: {} as Cardano.Pointer
         }

--- a/packages/projection/test/operators/Mappers/certificates/withStakeKeys.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withStakeKeys.test.ts
@@ -12,15 +12,21 @@ describe('withStakeKeys', () => {
         certificates: [
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyRegistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+              __typename: Cardano.CertificateType.StakeRegistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           },
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyDeregistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')
+              __typename: Cardano.CertificateType.StakeDeregistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           }
@@ -40,15 +46,21 @@ describe('withStakeKeys', () => {
         certificates: [
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyRegistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+              __typename: Cardano.CertificateType.StakeRegistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           },
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyDeregistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c')
+              __typename: Cardano.CertificateType.StakeDeregistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857c'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           }
@@ -68,15 +80,21 @@ describe('withStakeKeys', () => {
         certificates: [
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyRegistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+              __typename: Cardano.CertificateType.StakeRegistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           },
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyDeregistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+              __typename: Cardano.CertificateType.StakeDeregistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           }
@@ -95,15 +113,21 @@ describe('withStakeKeys', () => {
         certificates: [
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyDeregistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+              __typename: Cardano.CertificateType.StakeDeregistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           },
           {
             certificate: {
-              __typename: Cardano.CertificateType.StakeKeyRegistration,
-              stakeKeyHash: Crypto.Ed25519KeyHashHex('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b')
+              __typename: Cardano.CertificateType.StakeRegistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16('3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b'),
+                type: Cardano.CredentialType.KeyHash
+              }
             },
             pointer: {} as Cardano.Pointer
           }

--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -381,7 +381,7 @@ export class GenericTxBuilder implements TxBuilder {
       const rewardAccount = availableRewardAccounts.pop()!;
       this.#logger.debug(`Building delegation certificate for ${newPoolId} ${rewardAccount}`);
       if (rewardAccount.keyStatus !== Cardano.StakeKeyStatus.Registered) {
-        certificates.push(Cardano.createStakeKeyRegistrationCert(rewardAccount.address));
+        certificates.push(Cardano.createStakeRegistrationCert(rewardAccount.address));
       }
       certificates.push(Cardano.createDelegationCert(rewardAccount.address, newPoolId));
       rewardAccountsWithWeights.set(rewardAccount.address, weight);
@@ -391,7 +391,7 @@ export class GenericTxBuilder implements TxBuilder {
     this.#logger.debug(`De-registering ${availableRewardAccounts.length} stake keys`);
     for (const rewardAccount of availableRewardAccounts) {
       if (rewardAccount.keyStatus === Cardano.StakeKeyStatus.Registered) {
-        certificates.push(Cardano.createStakeKeyDeregistrationCert(rewardAccount.address));
+        certificates.push(Cardano.createStakeDeregistrationCert(rewardAccount.address));
       }
     }
     this.partialTxBody = { ...this.partialTxBody, certificates };

--- a/packages/util-dev/src/chainSync/data/with-mint.json
+++ b/packages/util-dev/src/chainSync/data/with-mint.json
@@ -371,7 +371,10 @@
                 {
                   "__typename": "StakeDelegationCertificate",
                   "poolId": "pool1xpr3e4gt8knxq82hpc30a3xa5j0pgwz3c9v5xjdrtuf66ez3m8u",
-                  "stakeKeyHash": "489afd7951769c2f0c6a306c4ed07f1166e3944f563aae38a658241f"
+                  "stakeCredential": {
+                    "hash": "489afd7951769c2f0c6a306c4ed07f1166e3944f563aae38a658241f",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],

--- a/packages/util-dev/src/chainSync/data/with-pool-retirement.json
+++ b/packages/util-dev/src/chainSync/data/with-pool-retirement.json
@@ -46,7 +46,10 @@
                 {
                   "__typename": "StakeDelegationCertificate",
                   "poolId": "pool1n3s8unkvmre59uzt4ned0903f9q2p8dhscw5v9eeyc0sw0m439t",
-                  "stakeKeyHash": "dcb10cd4e761c827dbf0dfb92e91358c2f5f811203bb5080819e2103"
+                  "stakeCredential": {
+                    "hash": "dcb10cd4e761c827dbf0dfb92e91358c2f5f811203bb5080819e2103",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -339,7 +342,10 @@
                 {
                   "__typename": "StakeDelegationCertificate",
                   "poolId": "pool1n3s8unkvmre59uzt4ned0903f9q2p8dhscw5v9eeyc0sw0m439t",
-                  "stakeKeyHash": "0529bf3474dba38d888d7301f4a6e456812cc6175d57fb0b514aa911"
+                  "stakeCredential": {
+                    "hash": "0529bf3474dba38d888d7301f4a6e456812cc6175d57fb0b514aa911",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -1737,7 +1743,10 @@
                 {
                   "__typename": "StakeDelegationCertificate",
                   "poolId": "pool1n3s8unkvmre59uzt4ned0903f9q2p8dhscw5v9eeyc0sw0m439t",
-                  "stakeKeyHash": "dcb10cd4e761c827dbf0dfb92e91358c2f5f811203bb5080819e2103"
+                  "stakeCredential": {
+                    "hash": "dcb10cd4e761c827dbf0dfb92e91358c2f5f811203bb5080819e2103",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -2018,7 +2027,10 @@
                 {
                   "__typename": "StakeDelegationCertificate",
                   "poolId": "pool1n3s8unkvmre59uzt4ned0903f9q2p8dhscw5v9eeyc0sw0m439t",
-                  "stakeKeyHash": "dcb10cd4e761c827dbf0dfb92e91358c2f5f811203bb5080819e2103"
+                  "stakeCredential": {
+                    "hash": "dcb10cd4e761c827dbf0dfb92e91358c2f5f811203bb5080819e2103",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -2135,8 +2147,11 @@
             "body": {
               "certificates": [
                 {
-                  "__typename": "StakeKeyRegistrationCertificate",
-                  "stakeKeyHash": "4e25df68ddb210e2233fb0102aa6384571046fa3b163ae5a04cfadac"
+                  "__typename": "StakeRegistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "4e25df68ddb210e2233fb0102aa6384571046fa3b163ae5a04cfadac",
+                    "type": 0
+                  }
                 },
                 {
                   "__typename": "PoolRegistrationCertificate",
@@ -2176,7 +2191,10 @@
                 {
                   "__typename": "StakeDelegationCertificate",
                   "poolId": "pool12pq2rzx8d7ern46udp6xrn0e0jaqt9hes9gs85hstp0egvfnf9q",
-                  "stakeKeyHash": "4e25df68ddb210e2233fb0102aa6384571046fa3b163ae5a04cfadac"
+                  "stakeCredential": {
+                    "hash": "4e25df68ddb210e2233fb0102aa6384571046fa3b163ae5a04cfadac",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -3780,8 +3798,11 @@
             "body": {
               "certificates": [
                 {
-                  "__typename": "StakeKeyRegistrationCertificate",
-                  "stakeKeyHash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049"
+                  "__typename": "StakeRegistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+                    "type": 0
+                  }
                 },
                 {
                   "__typename": "PoolRegistrationCertificate",
@@ -3821,7 +3842,10 @@
                 {
                   "__typename": "StakeDelegationCertificate",
                   "poolId": "pool1ml3j87d8n3u8czhej8pxfmnpmdt7jgqyv7kraqdvnx9lztt6xrt",
-                  "stakeKeyHash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049"
+                  "stakeCredential": {
+                    "hash": "f2f6381fa7a3dcc144939b47dffb7dad677856dfbbee4c4b7e426049",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],

--- a/packages/util-dev/src/chainSync/data/with-stake-key-deregistration.json
+++ b/packages/util-dev/src/chainSync/data/with-stake-key-deregistration.json
@@ -10,8 +10,11 @@
             "body": {
               "certificates": [
                 {
-                  "__typename": "StakeKeyRegistrationCertificate",
-                  "stakeKeyHash": "e0a76f244a3713cca96055cc819939676f81bd022bbc8da593e979ab"
+                  "__typename": "StakeRegistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "e0a76f244a3713cca96055cc819939676f81bd022bbc8da593e979ab",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -443,8 +446,11 @@
             "body": {
               "certificates": [
                 {
-                  "__typename": "StakeKeyDeregistrationCertificate",
-                  "stakeKeyHash": "e0a76f244a3713cca96055cc819939676f81bd022bbc8da593e979ab"
+                  "__typename": "StakeDeregistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "e0a76f244a3713cca96055cc819939676f81bd022bbc8da593e979ab",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -598,8 +604,11 @@
             "body": {
               "certificates": [
                 {
-                  "__typename": "StakeKeyDeregistrationCertificate",
-                  "stakeKeyHash": "e0a76f244a3713cca96055cc819939676f81bd022bbc8da593e979ab"
+                  "__typename": "StakeDeregistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "e0a76f244a3713cca96055cc819939676f81bd022bbc8da593e979ab",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -4096,8 +4105,11 @@
             "body": {
               "certificates": [
                 {
-                  "__typename": "StakeKeyRegistrationCertificate",
-                  "stakeKeyHash": "3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b"
+                  "__typename": "StakeRegistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],
@@ -4226,8 +4238,11 @@
             "body": {
               "certificates": [
                 {
-                  "__typename": "StakeKeyRegistrationCertificate",
-                  "stakeKeyHash": "3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b"
+                  "__typename": "StakeRegistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "3b62970858d61cf667701c1f34abef41659516b191d7d374e8b0857b",
+                    "type": 0
+                  }
                 }
               ],
               "collaterals": [],

--- a/packages/util-dev/src/mockProviders/mockChainHistoryProvider.ts
+++ b/packages/util-dev/src/mockProviders/mockChainHistoryProvider.ts
@@ -1,6 +1,7 @@
 import * as AssetId from '../assetId';
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano, Paginated } from '@cardano-sdk/core';
-import { currentEpoch, handleAssetId, ledgerTip, stakeKeyHash } from './mockData';
+import { currentEpoch, handleAssetId, ledgerTip, stakeCredential } from './mockData';
 import { somePartialStakePools } from '../createStubStakePoolProvider';
 import delay from 'delay';
 
@@ -57,13 +58,13 @@ export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
       body: {
         certificates: [
           {
-            __typename: Cardano.CertificateType.StakeKeyRegistration,
-            stakeKeyHash
+            __typename: Cardano.CertificateType.StakeRegistration,
+            stakeCredential
           },
           {
             __typename: Cardano.CertificateType.StakeDelegation,
             poolId: somePartialStakePools[0].id,
-            stakeKeyHash
+            stakeCredential
           }
         ],
         fee: 200_000n,
@@ -180,10 +181,13 @@ const queryTransactions = ({ rewardAccount }: { rewardAccount?: Cardano.RewardAc
             body: {
               ...tx.body,
               certificates: tx.body.certificates?.map((certificate) =>
-                'stakeKeyHash' in certificate
+                'stakeCredential' in certificate
                   ? {
                       ...certificate,
-                      stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                      stakeCredential: {
+                        hash: Cardano.RewardAccount.toHash(rewardAccount) as unknown as Crypto.Hash28ByteBase16,
+                        type: Cardano.CredentialType.KeyHash
+                      }
                     }
                   : certificate
               )

--- a/packages/util-dev/src/mockProviders/mockData.ts
+++ b/packages/util-dev/src/mockProviders/mockData.ts
@@ -1,10 +1,14 @@
 import * as AssetId from '../assetId';
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano, Reward, Seconds } from '@cardano-sdk/core';
 import { resolvedHandle } from './mockHandleProvider';
 
 export const rewardAccount = Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d');
 export const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
-
+export const stakeCredential = {
+  hash: stakeKeyHash as unknown as Crypto.Hash28ByteBase16,
+  type: Cardano.CredentialType.KeyHash
+};
 export const rewardAccountBalance = 33_333n;
 
 export const handlePolicyId = resolvedHandle.policyId;

--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -79,8 +79,8 @@ const hasDelegationCert = (certificates: Array<Cardano.Certificate> | undefined)
 
     switch (cert.__typename) {
       case Cardano.CertificateType.StakeDelegation:
-      case Cardano.CertificateType.StakeKeyRegistration:
-      case Cardano.CertificateType.StakeKeyDeregistration:
+      case Cardano.CertificateType.StakeRegistration:
+      case Cardano.CertificateType.StakeDeregistration:
         hasCert = true;
         break;
       default:
@@ -155,8 +155,8 @@ export const createDelegationTracker = ({
     slotEpochCalc$,
     [
       Cardano.CertificateType.StakeDelegation,
-      Cardano.CertificateType.StakeKeyRegistration,
-      Cardano.CertificateType.StakeKeyDeregistration
+      Cardano.CertificateType.StakeRegistration,
+      Cardano.CertificateType.StakeDeregistration
     ]
   ).pipe(tap((transactionsWithEpochs) => logger.debug(`Found ${transactionsWithEpochs.length} staking transactions`)));
 

--- a/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
@@ -1,4 +1,5 @@
 /* eslint-disable unicorn/no-nested-ternary */
+import * as Crypto from '@cardano-sdk/crypto';
 import { BigIntMath, deepEquals, isNotNil } from '@cardano-sdk/util';
 import { Cardano, RewardsProvider, StakePoolProvider } from '@cardano-sdk/core';
 import {
@@ -143,17 +144,17 @@ const getAccountsKeyStatus =
             }
           }) => certificates || []
         ),
-        Cardano.CertificateType.StakeKeyRegistration,
+        Cardano.CertificateType.StakeRegistration,
         address
       );
       const isRegistering = isLastStakeKeyCertOfType(
         certificatesInFlight,
-        Cardano.CertificateType.StakeKeyRegistration,
+        Cardano.CertificateType.StakeRegistration,
         address
       );
       const isUnregistering = isLastStakeKeyCertOfType(
         certificatesInFlight,
-        Cardano.CertificateType.StakeKeyDeregistration,
+        Cardano.CertificateType.StakeDeregistration,
         address
       );
       return isRegistering
@@ -179,7 +180,7 @@ const accountCertificateTransactions = (
             .filter((cert): cert is Cardano.StakeDelegationCertificate | Cardano.StakeAddressCertificate =>
               [...RegAndDeregCertificateTypes, Cardano.CertificateType.StakeDelegation].includes(cert.__typename)
             )
-            .filter((cert) => cert.stakeKeyHash === stakeKeyHash),
+            .filter((cert) => (cert.stakeCredential.hash as unknown as Crypto.Ed25519KeyHashHex) === stakeKeyHash),
           epoch
         }))
         .filter(({ certificates }) => certificates.length > 0)
@@ -195,7 +196,7 @@ export const getStakePoolIdAtEpoch = (transactions: TransactionsCertificates) =>
   const certificatesUpToEpoch = transactions
     .filter(({ epoch }) => epoch < atEpoch - 2)
     .map(({ certificates }) => certificates);
-  if (!isLastStakeKeyCertOfType(certificatesUpToEpoch, Cardano.CertificateType.StakeKeyRegistration)) return;
+  if (!isLastStakeKeyCertOfType(certificatesUpToEpoch, Cardano.CertificateType.StakeRegistration)) return;
   const delegationTxCertificates = findLast(certificatesUpToEpoch, (certs) =>
     includesAnyCertificate(certs, [Cardano.CertificateType.StakeDelegation])
   );

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
@@ -181,15 +181,19 @@ describe('TrezorKeyAgent', () => {
 
     it('successfully signs stake registration and delegation transaction', async () => {
       const rewardAccount = keyAgent.knownAddresses[0].rewardAccount;
-      const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
+      const stakeCredential = {
+        hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+        type: Cardano.CredentialType.KeyHash
+      };
+
       const stakeRegistrationCert = {
-        __typename: Cardano.CertificateType.StakeKeyRegistration,
-        stakeKeyHash
+        __typename: Cardano.CertificateType.StakeRegistration,
+        stakeCredential
       } as Cardano.StakeAddressCertificate;
       const stakeDelegationCert = {
         __typename: Cardano.CertificateType.StakeDelegation,
         poolId,
-        stakeKeyHash
+        stakeCredential
       } as Cardano.StakeDelegationCertificate;
 
       props = {
@@ -207,10 +211,14 @@ describe('TrezorKeyAgent', () => {
 
     it('successfully signs stake deregistration transaction', async () => {
       const rewardAccount = keyAgent.knownAddresses[0].rewardAccount;
-      const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
+      const stakeCredential = {
+        hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+        type: Cardano.CredentialType.KeyHash
+      };
+
       const stakeDeregistrationCert = {
-        __typename: Cardano.CertificateType.StakeKeyDeregistration,
-        stakeKeyHash
+        __typename: Cardano.CertificateType.StakeDeregistration,
+        stakeCredential
       } as Cardano.StakeAddressCertificate;
 
       props = {

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -711,8 +711,11 @@ describe('cip30', () => {
         const props = {
           certificates: [
             {
-              __typename: Cardano.CertificateType.StakeKeyDeregistration,
-              stakeKeyHash: mocks.stakeKeyHash
+              __typename: Cardano.CertificateType.StakeDeregistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+                type: Cardano.CredentialType.KeyHash
+              }
             } as Cardano.StakeAddressCertificate
           ],
           collaterals: new Set([mockUtxo[2][0]]),
@@ -835,7 +838,10 @@ describe('cip30', () => {
             {
               __typename: Cardano.CertificateType.StakeDelegation,
               poolId: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash),
-              stakeKeyHash: foreignRewardAccountHash
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+                type: Cardano.CredentialType.KeyHash
+              }
             } as Cardano.StakeDelegationCertificate,
             ...tx.body.certificates!
           ];
@@ -909,7 +915,10 @@ describe('cip30', () => {
             {
               __typename: Cardano.CertificateType.StakeDelegation,
               poolId: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash),
-              stakeKeyHash: foreignRewardAccountHash
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+                type: Cardano.CredentialType.KeyHash
+              }
             } as Cardano.StakeDelegationCertificate,
             ...tx.body.certificates!
           ];

--- a/packages/wallet/test/integration/withdrawal.test.ts
+++ b/packages/wallet/test/integration/withdrawal.test.ts
@@ -1,3 +1,4 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { PersonalWallet, TransactionFailure } from '../../src';
 import { createWallet } from './util';
@@ -82,8 +83,11 @@ describe('integration/withdrawal', () => {
     const txInternals = await wallet.initializeTx({
       certificates: [
         {
-          __typename: Cardano.CertificateType.StakeKeyDeregistration,
-          stakeKeyHash: Cardano.RewardAccount.toHash(accounts[0])
+          __typename: Cardano.CertificateType.StakeDeregistration,
+          stakeCredential: {
+            hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(accounts[0])),
+            type: Cardano.CredentialType.KeyHash
+          }
         }
       ],
       outputs: new Set() // In a real transaction you would probably want to have some outputs

--- a/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
@@ -1,3 +1,4 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano, ChainHistoryProvider, metadatum } from '@cardano-sdk/core';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { TransactionsTracker, createDelegationPortfolioTracker } from '../../../src/services';
@@ -44,8 +45,11 @@ describe('DelegationTracker', () => {
         const transactions = [
           createStubTxWithCertificates([
             {
-              __typename: Cardano.CertificateType.StakeKeyRegistration,
-              stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+              __typename: Cardano.CertificateType.StakeRegistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                type: Cardano.CredentialType.KeyHash
+              }
             }
           ]),
           createStubTxWithCertificates([
@@ -54,14 +58,20 @@ describe('DelegationTracker', () => {
             } as Cardano.Certificate,
             {
               __typename: Cardano.CertificateType.StakeDelegation,
-              stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                type: Cardano.CredentialType.KeyHash
+              }
             } as Cardano.Certificate
           ]),
           createStubTxWithCertificates(),
           createStubTxWithCertificates([
             {
-              __typename: Cardano.CertificateType.StakeKeyDeregistration,
-              stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+              __typename: Cardano.CertificateType.StakeDeregistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                type: Cardano.CredentialType.KeyHash
+              }
             }
           ])
         ];
@@ -80,7 +90,7 @@ describe('DelegationTracker', () => {
           } as unknown as TransactionsTracker,
           rewardAccounts$,
           slotEpochCalc$,
-          [Cardano.CertificateType.StakeDelegation, Cardano.CertificateType.StakeKeyDeregistration]
+          [Cardano.CertificateType.StakeDelegation, Cardano.CertificateType.StakeDeregistration]
         );
         expectObservable(target$).toBe('-a', {
           a: [
@@ -95,7 +105,7 @@ describe('DelegationTracker', () => {
         const rewardAccount = Cardano.RewardAccount('stake_test1upqykkjq3zhf4085s6n70w8cyp57dl87r0ezduv9rnnj2uqk5zmdv');
         const transactions = [
           createStubTxWithCertificates([
-            { __typename: Cardano.CertificateType.StakeKeyRegistration } as Cardano.Certificate
+            { __typename: Cardano.CertificateType.StakeRegistration } as Cardano.Certificate
           ]),
           createStubTxWithCertificates([
             { __typename: Cardano.CertificateType.PoolRetirement } as Cardano.Certificate,
@@ -103,7 +113,7 @@ describe('DelegationTracker', () => {
           ]),
           createStubTxWithCertificates(),
           createStubTxWithCertificates([
-            { __typename: Cardano.CertificateType.StakeKeyDeregistration } as Cardano.Certificate
+            { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.Certificate
           ])
         ];
         const slotEpochCalc = jest.fn().mockReturnValueOnce(284).mockReturnValueOnce(285);
@@ -120,7 +130,7 @@ describe('DelegationTracker', () => {
           } as unknown as TransactionsTracker,
           rewardAccounts$,
           slotEpochCalc$,
-          [Cardano.CertificateType.StakeDelegation, Cardano.CertificateType.StakeKeyDeregistration]
+          [Cardano.CertificateType.StakeDelegation, Cardano.CertificateType.StakeDeregistration]
         );
         expectObservable(target$).toBe('-a', {
           a: []
@@ -179,24 +189,33 @@ describe('DelegationTracker', () => {
           a: [
             createStubTxWithSlot(284, [
               {
-                __typename: Cardano.CertificateType.StakeKeyRegistration,
-                stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                  type: Cardano.CredentialType.KeyHash
+                }
               }
             ])
           ],
           b: [
             createStubTxWithSlot(284, [
               {
-                __typename: Cardano.CertificateType.StakeKeyRegistration,
-                stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                  type: Cardano.CredentialType.KeyHash
+                }
               }
             ]),
             createStubTxWithSlot(
               285,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeKeyRegistration,
-                  stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }
               ],
               {
@@ -207,16 +226,22 @@ describe('DelegationTracker', () => {
           c: [
             createStubTxWithSlot(284, [
               {
-                __typename: Cardano.CertificateType.StakeKeyRegistration,
-                stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                  type: Cardano.CredentialType.KeyHash
+                }
               }
             ]),
             createStubTxWithSlot(
               285,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeKeyRegistration,
-                  stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }
               ],
               {
@@ -225,24 +250,33 @@ describe('DelegationTracker', () => {
             ),
             createStubTxWithSlot(286, [
               {
-                __typename: Cardano.CertificateType.StakeKeyRegistration,
-                stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                  type: Cardano.CredentialType.KeyHash
+                }
               }
             ])
           ],
           d: [
             createStubTxWithSlot(284, [
               {
-                __typename: Cardano.CertificateType.StakeKeyRegistration,
-                stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                  type: Cardano.CredentialType.KeyHash
+                }
               }
             ]),
             createStubTxWithSlot(
               285,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeKeyRegistration,
-                  stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }
               ],
               {
@@ -251,16 +285,22 @@ describe('DelegationTracker', () => {
             ),
             createStubTxWithSlot(286, [
               {
-                __typename: Cardano.CertificateType.StakeKeyRegistration,
-                stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                  type: Cardano.CredentialType.KeyHash
+                }
               }
             ]),
             createStubTxWithSlot(
               287,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeKeyRegistration,
-                  stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }
               ],
               {
@@ -291,8 +331,11 @@ describe('DelegationTracker', () => {
               284,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeKeyRegistration,
-                  stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }
               ],
               {
@@ -303,8 +346,11 @@ describe('DelegationTracker', () => {
           b: [
             createStubTxWithSlot(286, [
               {
-                __typename: Cardano.CertificateType.StakeKeyRegistration,
-                stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                  type: Cardano.CredentialType.KeyHash
+                }
               }
             ])
           ]
@@ -329,8 +375,11 @@ describe('DelegationTracker', () => {
               284,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeKeyRegistration,
-                  stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount)
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }
               ],
               {

--- a/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-multi-spaces */
 /* eslint-disable prettier/prettier */
 /* eslint-disable sonarjs/no-duplicate-string */
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano, RewardsProvider, StakePoolProvider } from '@cardano-sdk/core';
 import { EMPTY, Observable, firstValueFrom, of } from 'rxjs';
 import { InMemoryStakePoolsStore, KeyValueStore } from '../../../src/persistence';
@@ -91,7 +92,7 @@ describe('RewardAccounts', () => {
   test('getStakePoolIdAtEpoch ', () => {
     const transactions = [
       {
-        certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration } as Cardano.StakeAddressCertificate],
+        certificates: [{ __typename: Cardano.CertificateType.StakeRegistration } as Cardano.StakeAddressCertificate],
         epoch: Cardano.EpochNo(100)
       },
       {
@@ -102,7 +103,7 @@ describe('RewardAccounts', () => {
       },
       {
         certificates: [
-          { __typename: Cardano.CertificateType.StakeKeyDeregistration } as Cardano.StakeAddressCertificate
+          { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.StakeAddressCertificate
         ],
         epoch: Cardano.EpochNo(102)
       },
@@ -131,7 +132,11 @@ describe('RewardAccounts', () => {
             tx: {
               body: {
                 certificates: [{
-                  __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyHash),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }]
               }
             }
@@ -142,7 +147,11 @@ describe('RewardAccounts', () => {
             tx: {
               body: {
                 certificates: [{
-                  __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyHash),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }]
               }
             }
@@ -151,7 +160,11 @@ describe('RewardAccounts', () => {
             tx: {
               body: {
                 certificates: [{
-                  __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash
+                  __typename: Cardano.CertificateType.StakeDeregistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyHash),
+                    type: Cardano.CredentialType.KeyHash
+                  }
                 }]
               }
             }
@@ -163,7 +176,11 @@ describe('RewardAccounts', () => {
         b: [
           {
             body: {
-              certificates: [{ __typename: Cardano.CertificateType.StakeKeyRegistration, stakeKeyHash }]
+              certificates: [{ __typename: Cardano.CertificateType.StakeRegistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyHash),
+                  type: Cardano.CredentialType.KeyHash
+                } }]
             } as Cardano.TxBody,
             cbor: dummyCbor,
             id: txId1
@@ -172,7 +189,11 @@ describe('RewardAccounts', () => {
         c: [
           {
             body: {
-              certificates: [{ __typename: Cardano.CertificateType.StakeKeyDeregistration, stakeKeyHash }]
+              certificates: [{ __typename: Cardano.CertificateType.StakeDeregistration,
+                stakeCredential: {
+                  hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyHash),
+                  type: Cardano.CredentialType.KeyHash
+                } }]
             } as Cardano.TxBody,
             cbor: dummyCbor,
             id: txId2
@@ -368,7 +389,7 @@ describe('RewardAccounts', () => {
             a: [
               {
                 certificates: [
-                  { __typename: Cardano.CertificateType.StakeKeyRegistration } as Cardano.StakeAddressCertificate,
+                  { __typename: Cardano.CertificateType.StakeRegistration } as Cardano.StakeAddressCertificate,
                   {
                     __typename: Cardano.CertificateType.StakeDelegation,
                     poolId: poolId1

--- a/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable unicorn/no-useless-undefined */
+import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { InMemoryRewardsHistoryStore } from '../../../src/persistence';
 import {
@@ -53,14 +54,19 @@ describe('RewardsHistory', () => {
               {
                 epoch: Cardano.EpochNo(0),
                 tx: createStubTxWithCertificates([
-                  { __typename: Cardano.CertificateType.StakeKeyDeregistration } as Cardano.Certificate
+                  { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.Certificate
                 ])
               },
               {
                 epoch,
                 tx: createStubTxWithCertificates(
                   [{ __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate],
-                  { stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount) }
+                  {
+                    stakeCredential: {
+                      hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                      type: Cardano.CredentialType.KeyHash
+                    }
+                  }
                 )
               }
             ]
@@ -100,14 +106,24 @@ describe('RewardsHistory', () => {
                 epoch: Cardano.EpochNo(0),
                 tx: createStubTxWithCertificates(
                   [{ __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate],
-                  { stakeKeyHash: '' }
+                  {
+                    stakeCredential: {
+                      hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+                      type: Cardano.CredentialType.KeyHash
+                    }
+                  }
                 )
               },
               {
                 epoch,
                 tx: createStubTxWithCertificates(
                   [{ __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate],
-                  { stakeKeyHash: Cardano.RewardAccount.toHash(rewardAccount) }
+                  {
+                    stakeCredential: {
+                      hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                      type: Cardano.CredentialType.KeyHash
+                    }
+                  }
                 )
               }
             ]

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -132,8 +132,11 @@ describe('WalletUtil', () => {
       const props = {
         certificates: [
           {
-            __typename: Cardano.CertificateType.StakeKeyDeregistration,
-            stakeKeyHash: mocks.stakeKeyHash
+            __typename: Cardano.CertificateType.StakeDeregistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeAddressCertificate
         ],
         collaterals: new Set([mocks.utxo[2][0]]),
@@ -181,11 +184,14 @@ describe('WalletUtil', () => {
     });
 
     describe('StakeCredential based check', () => {
-      it('detects foreign stakeKeyHash in StakeKeyDeregistration certificate', async () => {
+      it('detects foreign stakeKeyHash in StakeDeregistration certificate', async () => {
         tx.body.certificates = [
           {
-            __typename: Cardano.CertificateType.StakeKeyDeregistration,
-            stakeKeyHash: foreignRewardAccountHash
+            __typename: Cardano.CertificateType.StakeDeregistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeAddressCertificate,
           ...tx.body.certificates!
         ];
@@ -197,7 +203,10 @@ describe('WalletUtil', () => {
           {
             __typename: Cardano.CertificateType.StakeDelegation,
             poolId: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash),
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeDelegationCertificate,
           ...tx.body.certificates!
         ];
@@ -248,11 +257,14 @@ describe('WalletUtil', () => {
         expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
       });
 
-      it('returns false when a StakeKeyRegistration certificate can not be accounted for', async () => {
+      it('returns false when a StakeRegistration certificate can not be accounted for', async () => {
         tx.body.certificates = [
           {
-            __typename: Cardano.CertificateType.StakeKeyRegistration,
-            stakeKeyHash: foreignRewardAccountHash
+            __typename: Cardano.CertificateType.StakeRegistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeAddressCertificate,
           ...tx.body.certificates!
         ];
@@ -264,31 +276,52 @@ describe('WalletUtil', () => {
           {
             __typename: Cardano.CertificateType.Registration,
             // using foreign intentionally because registration is not signed so it should be accepted
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.NewStakeAddressCertificate,
           {
             __typename: Cardano.CertificateType.Unregistration,
-            stakeKeyHash: mocks.stakeKeyHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.NewStakeAddressCertificate,
           {
             __typename: Cardano.CertificateType.VoteDelegation,
-            stakeKeyHash: mocks.stakeKeyHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.VoteDelegationCertificate,
           {
             __typename: Cardano.CertificateType.StakeVoteDelegation,
-            stakeKeyHash: mocks.stakeKeyHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeVoteDelegationCertificate,
           {
             __typename: Cardano.CertificateType.StakeRegistrationDelegation,
-            stakeKeyHash: mocks.stakeKeyHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeRegistrationDelegationCertificate,
           {
             __typename: Cardano.CertificateType.VoteRegistrationDelegation,
-            stakeKeyHash: mocks.stakeKeyHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.VoteRegistrationDelegationCertificate,
           {
             __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
-            stakeKeyHash: mocks.stakeKeyHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeVoteRegistrationDelegationCertificate,
           ...tx.body.certificates!
         ];
@@ -300,7 +333,10 @@ describe('WalletUtil', () => {
         tx.body.certificates = [
           {
             __typename: Cardano.CertificateType.VoteDelegation,
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.VoteDelegationCertificate,
           ...tx.body.certificates!
         ];
@@ -312,7 +348,10 @@ describe('WalletUtil', () => {
         tx.body.certificates = [
           {
             __typename: Cardano.CertificateType.StakeVoteDelegation,
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeVoteDelegationCertificate,
           ...tx.body.certificates!
         ];
@@ -324,7 +363,10 @@ describe('WalletUtil', () => {
         tx.body.certificates = [
           {
             __typename: Cardano.CertificateType.StakeRegistrationDelegation,
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeRegistrationDelegationCertificate,
           ...tx.body.certificates!
         ];
@@ -336,7 +378,10 @@ describe('WalletUtil', () => {
         tx.body.certificates = [
           {
             __typename: Cardano.CertificateType.VoteRegistrationDelegation,
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.VoteRegistrationDelegationCertificate,
           ...tx.body.certificates!
         ];
@@ -348,7 +393,10 @@ describe('WalletUtil', () => {
         tx.body.certificates = [
           {
             __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.StakeVoteRegistrationDelegationCertificate,
           ...tx.body.certificates!
         ];
@@ -360,7 +408,10 @@ describe('WalletUtil', () => {
         tx.body.certificates = [
           {
             __typename: Cardano.CertificateType.Unregistration,
-            stakeKeyHash: foreignRewardAccountHash
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
           } as Cardano.NewStakeAddressCertificate,
           ...tx.body.certificates!
         ];


### PR DESCRIPTION
# Context

We need to validate our understanding of how Native Scripts work & whether/how we can apply them to Shared Wallet work.

# Proposed Solution

Create a POC using the cardano-js-sdk of a multi signature wallet and show its usage in a e2e test.

This POC introduces two classes for demonstration:

**MultiSigWallet:** This kind of wallet can be created with a set of public keys, the wallet internally creates a script using said keys. The keys are sorted so the script can be recreated the same way every time, so every participant only needs to known which keys are involved in the multsignature wallet and they can recreate the wallet individually. The wallet then uses the script to create a credential, this credential is used for both the payment part and the staking part of the wallet address. This means users can control the funds and the stake rewards with the same script.

The wallet only supports two type of transactions. transferFunds and delegate, as these actions were enough to demonstrate the concept, but transaction of any nature can be included. The wallet also allows a particular user to sign a trnasaction and submit it to the network.

**MultiSigTx:** This class keeps track of the transaction and the participants involved in the multigisnature wallet. It also ahs some utility methods to determine which participates have signed and which signatures are missing. The transaction can also be encoded/decoded to CBOR for easy trasmition between participants.

This PR also includes 2 e2e tests.

**Simple fund transfer:** In this test 3 participants share a wallet Alice, Bob and Charlotte. Alice inanities the transaction and sings it. She then serializes the MultiSigTx and sends it to Bob (transmission method out of the scope of the POC), Bob receives the transaction, verify its contents, signs it, and finally checks whether any participant signature is missing (and which participant), he sees Charlotte signature is missing, so he serializes the transaction (now with his signature) and relays it to Charlotte. Charlotte receives the transaction, deserializes it and check the contents, she then signs it and sees that all required participants have already signed so she submits the transaction to the network. The last step of the test is to verify that the transaction made it on chain and the funds arrived back to the faucet wallet.

This test demonstrates the basic use case of a multi signature wallet.

**Delegate and claim rewards:** In this test, the three participants build and sign a transaction to delegate to one of the pools on our local network, after the delegation has been confirmed and some epochs have elapse, we use the faucet wallet to spam transaction on the network in order to generate some transaction fees that can be distribute as rewards to the delegators. We then check our reward account and wait until rewards are available, after we confirm the rewards are present, we send a transaction which consumes the rewards, the final step is to confirm that the transaction made it on chain, and that all rewards were successfully withdrawn from the account.

All transaction related to the multisig wallet used as a sole witness the script.

# Bug fixes

When developing the POC I encounter two problems, one was a bug that was preventing the correct creation of credentials using script hashes (fixed here https://github.com/input-output-hk/cardano-js-sdk/commit/e249448bfd31f1d1d24a0f215761b0b785e254ac).

The second problem is that our Certificate core types, for StakeRegistration, StakeDeregistration and Stake always assume we are using a stakeKeyHash, so they had to be refactored to be inclusive of all types of credentials. This ended being a big refactor.
