### PR TITLE
chore(hardware-trezor): add trezor tx reference inputs and script mappers

### DIFF
--- a/packages/hardware-trezor/src/transformers/tx.ts
+++ b/packages/hardware-trezor/src/transformers/tx.ts
@@ -28,6 +28,7 @@ const trezorTxTransformer = async (
     networkId: context.chainId.networkId,
     outputs: mapTxOuts(body.outputs, context),
     protocolMagic: context.chainId.networkMagic,
+    referenceInputs: body.referenceInputs ? await mapTxIns(body.referenceInputs, context) : undefined,
     ttl: body.validityInterval?.invalidHereafter?.toString(),
     validityIntervalStart: body.validityInterval?.invalidBefore?.toString(),
     withdrawals: mapWithdrawals(body.withdrawals ?? [], context)

--- a/packages/hardware-trezor/test/testData.ts
+++ b/packages/hardware-trezor/test/testData.ts
@@ -1,6 +1,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, GroupedAddress, KeyRole } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
+import { HexBlob } from '@cardano-sdk/util';
 
 export const mintTokenMap = new Map([
   [Cardano.AssetId('2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740'), 20n],
@@ -84,6 +85,30 @@ export const txOutWithInlineDatum: Cardano.TxOut = {
 export const txOutWithInlineDatumAndOwnedAddress: Cardano.TxOut = {
   ...txOutToOwnedAddress,
   datum: 123n
+};
+
+export const txOutWithReferenceScriptAndDatumHash: Cardano.TxOut = {
+  address: paymentAddress,
+  datumHash: Crypto.Hash32ByteBase16('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5'),
+  scriptReference: {
+    __type: Cardano.ScriptType.Plutus,
+    bytes: HexBlob('b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'),
+    version: Cardano.PlutusLanguageVersion.V1
+  },
+  value: { coins: 10n }
+};
+
+export const txOutWithReferenceScriptAndInlineDatum: Cardano.TxOut = {
+  address: paymentAddress,
+  datum: 123n,
+  scriptReference: {
+    __type: Cardano.ScriptType.Plutus,
+    bytes: HexBlob('b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'),
+    version: Cardano.PlutusLanguageVersion.V1
+  },
+  value: {
+    coins: 10n
+  }
 };
 
 export const rewardKey = 'stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr';
@@ -219,6 +244,21 @@ export const txBody: Cardano.TxBody = {
   inputs: [txIn],
   mint: mintTokenMap,
   outputs: [txOutWithAssets, txOutWithAssetsToOwnedAddress, txOutWithDatumHash],
+  referenceInputs: [txIn],
+  validityInterval: {
+    invalidBefore: Cardano.Slot(100),
+    invalidHereafter: Cardano.Slot(1000)
+  },
+  withdrawals: [coreWithdrawalWithKeyHashCredential]
+};
+
+export const babbageTxBodyWithScripts: Cardano.TxBody = {
+  auxiliaryDataHash,
+  certificates: [stakeDelegationCertificate],
+  fee: 10n,
+  inputs: [txIn],
+  mint: mintTokenMap,
+  outputs: [txOutWithReferenceScriptAndDatumHash, txOutWithReferenceScriptAndInlineDatum],
   validityInterval: {
     invalidBefore: Cardano.Slot(100),
     invalidHereafter: Cardano.Slot(1000)

--- a/packages/hardware-trezor/test/transformers/tx.test.ts
+++ b/packages/hardware-trezor/test/transformers/tx.test.ts
@@ -1,6 +1,7 @@
 import * as Trezor from '@trezor/connect';
 import { CardanoKeyConst, util } from '@cardano-sdk/key-management';
 import {
+  babbageTxBodyWithScripts,
   contextWithKnownAddresses,
   contextWithoutKnownAddresses,
   knownAddressKeyPath,
@@ -47,7 +48,7 @@ describe('tx', () => {
       });
     });
 
-    test('can map transaction', async () => {
+    test('can map transaction without scripts', async () => {
       expect(
         await txToTrezor({
           ...contextWithKnownAddresses,
@@ -182,6 +183,96 @@ describe('tx', () => {
             amount: '10',
             datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
             format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+          }
+        ],
+        protocolMagic: 999,
+        referenceInputs: [
+          {
+            path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 1, 0],
+            prev_hash: txIn.txId,
+            prev_index: txIn.index
+          }
+        ],
+        ttl: '1000',
+        validityIntervalStart: '100',
+        withdrawals: [
+          {
+            amount: '5',
+            path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 2, 0]
+          }
+        ]
+      });
+    });
+
+    test('can map babbage transaction with scripts', async () => {
+      expect(
+        await txToTrezor({
+          ...contextWithKnownAddresses,
+          cardanoTxBody: babbageTxBodyWithScripts
+        })
+      ).toEqual({
+        additionalWitnessRequests: [
+          [2_147_485_500, 2_147_485_463, 2_147_483_648, 1, 0], // payment key path
+          [2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0] // reward account key path
+        ],
+        auxiliaryData: {
+          hash: '2ceb364d93225b4a0f004a0975a13eb50c3cc6348474b4fe9121f8dc72ca0cfa'
+        },
+        certificates: [
+          {
+            path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 2, 0],
+            pool: '153806dbcd134ddee69a8c5204e38ac80448f62342f8c23cfe4b7edf',
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DELEGATION
+          }
+        ],
+        fee: '10',
+        inputs: [
+          {
+            path: knownAddressKeyPath,
+            prev_hash: txIn.txId,
+            prev_index: txIn.index
+          }
+        ],
+        mint: [
+          {
+            policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
+            tokenAmounts: [{ assetNameBytes: '', mintAmount: '20' }]
+          },
+          {
+            policyId: '659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba82',
+            tokenAmounts: [{ assetNameBytes: '54534c41', mintAmount: '-50' }]
+          },
+          {
+            policyId: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+            tokenAmounts: [
+              { assetNameBytes: '', mintAmount: '40' },
+              { assetNameBytes: '504154415445', mintAmount: '30' }
+            ]
+          }
+        ],
+        networkId: 0,
+        outputs: [
+          {
+            addressParameters: {
+              addressType: Trezor.PROTO.CardanoAddressType.BASE,
+              path: knownAddressKeyPath,
+              stakingPath: knownAddressStakeKeyPath
+            },
+            amount: '10',
+            datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+            referenceScript: '82015820b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'
+          },
+          {
+            addressParameters: {
+              addressType: Trezor.PROTO.CardanoAddressType.BASE,
+              path: knownAddressKeyPath,
+              stakingPath: knownAddressStakeKeyPath
+            },
+            amount: '10',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+            inlineDatum: '187b',
+            referenceScript: '82015820b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'
           }
         ],
         protocolMagic: 999,

--- a/packages/hardware-trezor/test/transformers/txOut.test.ts
+++ b/packages/hardware-trezor/test/transformers/txOut.test.ts
@@ -10,7 +10,9 @@ import {
   txOutWithDatumHash,
   txOutWithDatumHashAndOwnedAddress,
   txOutWithInlineDatum,
-  txOutWithInlineDatumAndOwnedAddress
+  txOutWithInlineDatumAndOwnedAddress,
+  txOutWithReferenceScriptAndDatumHash,
+  txOutWithReferenceScriptAndInlineDatum
 } from '../testData';
 import { mapTxOuts, toTxOut } from '../../src/transformers/txOut';
 
@@ -151,6 +153,39 @@ describe('txOut', () => {
           ]
         });
       }
+    });
+
+    it('can map a set of transaction outputs with both output formats', async () => {
+      const txOuts = mapTxOuts(
+        [txOutWithDatumHashAndOwnedAddress, txOutWithReferenceScriptAndDatumHash],
+        contextWithKnownAddresses
+      );
+
+      expect(txOuts.length).toEqual(2);
+
+      expect(txOuts).toEqual([
+        {
+          addressParameters: {
+            addressType: Trezor.PROTO.CardanoAddressType.BASE,
+            path: knownAddressKeyPath,
+            stakingPath: knownAddressStakeKeyPath
+          },
+          amount: '10',
+          datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+        },
+        {
+          addressParameters: {
+            addressType: Trezor.PROTO.CardanoAddressType.BASE,
+            path: knownAddressKeyPath,
+            stakingPath: knownAddressStakeKeyPath
+          },
+          amount: '10',
+          datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+          referenceScript: '82015820b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'
+        }
+      ]);
     });
   });
 
@@ -320,6 +355,36 @@ describe('txOut', () => {
         amount: '10',
         format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
         inlineDatum: '187b'
+      });
+    });
+
+    it('can map a simple transaction output with reference script and datum hash', async () => {
+      const out = toTxOut(txOutWithReferenceScriptAndDatumHash, contextWithKnownAddresses);
+      expect(out).toEqual({
+        addressParameters: {
+          addressType: Trezor.PROTO.CardanoAddressType.BASE,
+          path: knownAddressKeyPath,
+          stakingPath: knownAddressStakeKeyPath
+        },
+        amount: '10',
+        datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+        referenceScript: '82015820b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'
+      });
+    });
+
+    it('can map a simple transaction output with reference script and inline datum', async () => {
+      const out = toTxOut(txOutWithReferenceScriptAndInlineDatum, contextWithKnownAddresses);
+      expect(out).toEqual({
+        addressParameters: {
+          addressType: Trezor.PROTO.CardanoAddressType.BASE,
+          path: knownAddressKeyPath,
+          stakingPath: knownAddressStakeKeyPath
+        },
+        amount: '10',
+        format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+        inlineDatum: '187b',
+        referenceScript: '82015820b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'
       });
     });
   });


### PR DESCRIPTION
This PR introduces additional data mappers where we added `referenceInputs` and `referenceScript`.
[JIRA Ticket](https://input-output.atlassian.net/browse/LW-9015)

# Context

SDK testing standards were followed when developing this ticket
It will not be tested by SDETs in isolation! (Described in JIRA Ticket)

# Proposed Solution

Add Trezor TX reference inputs and script mappers

# Important Changes Introduced

New mappers were added. No breaking changes