### PR TITLE
feat: wallet repository

### DIFF
--- a/packages/crypto/src/Bip32/Bip32PublicKey.ts
+++ b/packages/crypto/src/Bip32/Bip32PublicKey.ts
@@ -1,8 +1,8 @@
 import * as Bip32KeyDerivation from './Bip32KeyDerivation';
-import { Bip32PublicKeyHex } from '../hexTypes';
+import { BIP32_PUBLIC_KEY_HASH_LENGTH, Bip32PublicKeyHashHex, Bip32PublicKeyHex } from '../hexTypes';
 import { ED25519_PUBLIC_KEY_LENGTH, Ed25519PublicKey } from '../Ed25519e';
 import { InvalidArgumentError } from '@cardano-sdk/util';
-import { ready } from 'libsodium-wrappers-sumo';
+import { crypto_generichash, ready } from 'libsodium-wrappers-sumo';
 
 export const BIP32_ED25519_PUBLIC_KEY_LENGTH = 64;
 
@@ -75,5 +75,12 @@ export class Bip32PublicKey {
   /** Gets the Bip32PublicKey as a hex string. */
   hex(): Bip32PublicKeyHex {
     return Bip32PublicKeyHex(Buffer.from(this.#key).toString('hex'));
+  }
+
+  /** Gets the blake2 hash of the key. */
+  async hash(): Promise<Bip32PublicKeyHashHex> {
+    await ready;
+    const hash = crypto_generichash(BIP32_PUBLIC_KEY_HASH_LENGTH, this.#key);
+    return Bip32PublicKeyHashHex(Buffer.from(hash).toString('hex'));
   }
 }

--- a/packages/crypto/src/hexTypes.ts
+++ b/packages/crypto/src/hexTypes.ts
@@ -1,5 +1,7 @@
 import { HexBlob, OpaqueString, castHexBlob, typedHex } from '@cardano-sdk/util';
 
+export const BIP32_PUBLIC_KEY_HASH_LENGTH = 28;
+
 /** Ed25519 signature as hex string */
 export type Ed25519SignatureHex = OpaqueString<'Ed25519SignatureHex'>;
 export const Ed25519SignatureHex = (value: string): Ed25519SignatureHex => typedHex(value, 128);
@@ -27,6 +29,11 @@ export const Ed25519PrivateNormalKeyHex = (value: string): Ed25519PrivateNormalK
 /** 28 byte ED25519 key hash as hex string */
 export type Ed25519KeyHashHex = OpaqueString<'Ed25519KeyHashHex'>;
 export const Ed25519KeyHashHex = (value: string): Ed25519KeyHashHex => typedHex(value, 56);
+
+/** 28 byte BIP32 public key hash as hex string */
+export type Bip32PublicKeyHashHex = OpaqueString<'Bip32PublicKeyHashHex'>;
+export const Bip32PublicKeyHashHex = (value: string): Bip32PublicKeyHashHex =>
+  typedHex(value, BIP32_PUBLIC_KEY_HASH_LENGTH * 2);
 
 /** 32 byte hash as hex string */
 export type Hash32ByteBase16 = OpaqueString<'Hash32ByteBase16'>;

--- a/packages/crypto/test/bip32/Bip32PublicKey.test.ts
+++ b/packages/crypto/test/bip32/Bip32PublicKey.test.ts
@@ -47,4 +47,10 @@ describe('Bip32PublicKey', () => {
       expect(rawKey.hex()).toBe(vector.ed25519eVector.publicKey);
     }
   });
+
+  it('can compute Blake2b hash of a bip32 public key', async () => {
+    const publicKey = Crypto.Bip32PublicKey.fromHex(Crypto.Bip32PublicKeyHex(extendedVectors[0].publicKey));
+    const hash = await publicKey.hash();
+    expect(typeof hash).toBe('string');
+  });
 });

--- a/packages/crypto/test/hexType.test.ts
+++ b/packages/crypto/test/hexType.test.ts
@@ -36,6 +36,12 @@ describe('HexTypes', () => {
     ).not.toThrow();
   });
 
+  it('Bip32PublicKeyHashHex() accepts a valid public key hash hex string', () => {
+    expect(() =>
+      Crypto.Bip32PublicKeyHashHex('6199186adb51974690d7247d2646097d2c62763b767b528816fb7edc')
+    ).not.toThrow();
+  });
+
   it('Bip32PrivateKeyHex() accepts a valid public key hex string', () => {
     expect(() =>
       Crypto.Bip32PrivateKeyHex(

--- a/packages/wallet/src/persistence/inMemoryStores/InMemoryCollectionStore.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/InMemoryCollectionStore.ts
@@ -1,10 +1,18 @@
 /* eslint-disable brace-style */
 import { CollectionStore } from '../types';
-import { EMPTY, Observable, of } from 'rxjs';
+import { EMPTY, Observable, Subject, of } from 'rxjs';
 import { InMemoryStore } from './InMemoryStore';
+import { observeAll } from '../util';
 
 export class InMemoryCollectionStore<T> extends InMemoryStore implements CollectionStore<T> {
+  readonly #updates$ = new Subject<T[]>();
   protected docs: T[] = [];
+  observeAll: CollectionStore<T>['observeAll'];
+
+  constructor() {
+    super();
+    this.observeAll = observeAll(this, this.#updates$);
+  }
 
   getAll(): Observable<T[]> {
     if (this.docs.length === 0 || this.destroyed) return EMPTY;
@@ -14,8 +22,14 @@ export class InMemoryCollectionStore<T> extends InMemoryStore implements Collect
   setAll(docs: T[]): Observable<void> {
     if (!this.destroyed) {
       this.docs = docs;
+      this.#updates$.next(this.docs);
       return of(void 0);
     }
     return EMPTY;
+  }
+
+  destroy(): Observable<void> {
+    this.#updates$.complete();
+    return super.destroy();
   }
 }

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -16,6 +16,11 @@ export interface Destroyable {
 
 export interface CollectionStore<T> extends Destroyable {
   /**
+   * Similar to getAll, but does not complete. Instead, emits every time the collection is updated (via this store object).
+   * Emits empty array when no documents are stored.
+   */
+  observeAll(): Observable<T[]>;
+  /**
    * Get all stored documents.
    *
    * @returns {Observable}
@@ -54,7 +59,7 @@ export interface DocumentStore<T> extends Destroyable {
 
 export type KeyValueCollection<K, V> = { key: K; value: V };
 // getAll is not currently used anywhere for this type of store
-export interface KeyValueStore<K, V> extends Omit<CollectionStore<KeyValueCollection<K, V>>, 'getAll'> {
+export interface KeyValueStore<K, V> extends Omit<CollectionStore<KeyValueCollection<K, V>>, 'getAll' | 'observeAll'> {
   /**
    * Get the stored documents by keys.
    *

--- a/packages/wallet/src/persistence/util.ts
+++ b/packages/wallet/src/persistence/util.ts
@@ -1,0 +1,9 @@
+import { CollectionStore } from './types';
+import { EMPTY, Subject, concat, defaultIfEmpty, race } from 'rxjs';
+
+export const observeAll =
+  <T>(store: CollectionStore<T>, updates$: Subject<T[]>) =>
+  () => {
+    if (store.destroyed) return EMPTY;
+    return race(concat(store.getAll().pipe(defaultIfEmpty([])), updates$), updates$);
+  };

--- a/packages/web-extension/src/walletManager/WalletRepository/WalletRepository.ts
+++ b/packages/web-extension/src/walletManager/WalletRepository/WalletRepository.ts
@@ -1,0 +1,186 @@
+import {
+  AccountId,
+  AddAccountProps,
+  AddWalletProps,
+  AnyWallet,
+  ScriptWallet,
+  UpdateMetadataProps,
+  WalletId,
+  WalletRepositoryApi,
+  WalletType
+} from './types';
+import { Bip32PublicKey, Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { Logger } from 'ts-log';
+import { Observable, defer, firstValueFrom, map, shareReplay, switchMap } from 'rxjs';
+import { Serialization } from '@cardano-sdk/core';
+import { WalletConflictError } from '../errors';
+import { contextLogger, isNotNil } from '@cardano-sdk/util';
+import { storage } from '@cardano-sdk/wallet';
+
+export interface WalletRepositoryDependencies<AccountMetadata extends {}> {
+  store: storage.CollectionStore<AnyWallet<AccountMetadata>>;
+  logger: Logger;
+}
+
+const cloneSplice = <T>(array: T[], start: number, deleteCount: number, ...items: T[]) => [
+  ...array.slice(0, start),
+  ...items,
+  ...array.slice(start + deleteCount)
+];
+
+const findAccount = <AccountMetadata extends {}>(wallets: AnyWallet<AccountMetadata>[], accountId: AccountId) =>
+  wallets
+    .map((wallet, walletIndex) => {
+      if (wallet.type === WalletType.Script) return;
+      const accountIndex = wallet.accounts.findIndex((a) => a.accountId === accountId);
+      if (accountIndex < 0) return;
+      const account = wallet.accounts[accountIndex];
+      return { account, accountIndex, wallet, walletIndex };
+    })
+    .find(isNotNil);
+
+export class WalletRepository<AccountMetadata extends {}> implements WalletRepositoryApi<AccountMetadata> {
+  readonly #logger: Logger;
+  readonly #store: WalletRepositoryDependencies<AccountMetadata>['store'];
+  readonly wallets$: Observable<AnyWallet<AccountMetadata>[]>;
+
+  constructor({ logger, store }: WalletRepositoryDependencies<AccountMetadata>) {
+    this.#store = store;
+    this.#logger = contextLogger(logger, 'WalletRepository');
+    this.wallets$ = defer(() => store.observeAll()).pipe(shareReplay(1));
+  }
+
+  async addWallet(props: AddWalletProps<AccountMetadata>): Promise<WalletId> {
+    this.#logger.debug('addWallet', props.type);
+    const walletId =
+      props.type === WalletType.Script
+        ? Serialization.Script.fromCore(props.script).hash()
+        : Hash28ByteBase16(await Bip32PublicKey.fromHex(props.extendedAccountPublicKey).hash());
+    return firstValueFrom(
+      this.wallets$.pipe(
+        switchMap((wallets) => {
+          if (wallets.some((wallet) => wallet.walletId === walletId)) {
+            throw new WalletConflictError(`Wallet '${walletId}' already exists`);
+          }
+          return this.#store.setAll([
+            ...wallets,
+            props.type === WalletType.Script ? { ...props, walletId } : { ...props, accounts: [], walletId }
+          ]);
+        }),
+        map(() => walletId)
+      )
+    );
+  }
+
+  addAccount({ walletId, accountIndex, metadata }: AddAccountProps<AccountMetadata>): Promise<AccountId> {
+    this.#logger.debug('addAccount', walletId, accountIndex, metadata);
+    return firstValueFrom(
+      this.wallets$.pipe(
+        switchMap((wallets) => {
+          const walletIndex = wallets.findIndex((w) => w.walletId === walletId);
+          if (walletIndex < 0) {
+            throw new WalletConflictError(`Wallet '${walletId}' does not exist`);
+          }
+          const wallet = wallets[walletIndex];
+          if (wallet.type === WalletType.Script) {
+            throw new WalletConflictError('addAccount for script wallets is not supported');
+          }
+          if (wallet.accounts.some((acc) => acc.accountIndex === accountIndex)) {
+            throw new WalletConflictError(`Account #${accountIndex} for wallet '${walletId}' already exists`);
+          }
+          const accountId = `${walletId}-${accountIndex}`;
+          return this.#store
+            .setAll(
+              cloneSplice(wallets, walletIndex, 1, {
+                ...wallet,
+                accounts: [
+                  ...wallet.accounts,
+                  {
+                    accountId,
+                    accountIndex,
+                    metadata
+                  }
+                ]
+              })
+            )
+            .pipe(map(() => accountId));
+        })
+      )
+    );
+  }
+
+  updateMetadata<ID extends AccountId | WalletId>({
+    target,
+    metadata
+  }: UpdateMetadataProps<AccountMetadata, ID>): Promise<ID> {
+    this.#logger.debug('updateMetadata', target, metadata);
+    return firstValueFrom(
+      this.wallets$.pipe(
+        switchMap((wallets) => {
+          const bip32Account = findAccount(wallets, target);
+          if (bip32Account) {
+            return this.#store.setAll(
+              cloneSplice(wallets, bip32Account.walletIndex, 1, {
+                ...bip32Account.wallet,
+                accounts: cloneSplice(bip32Account.wallet.accounts, bip32Account.accountIndex, 1, {
+                  ...bip32Account.account,
+                  metadata
+                })
+              })
+            );
+          }
+          const scriptWalletIndex = wallets.findIndex(
+            (wallet) => wallet.walletId === target && wallet.type === WalletType.Script
+          );
+          if (scriptWalletIndex >= 0) {
+            return this.#store.setAll(
+              cloneSplice(wallets, scriptWalletIndex, 1, {
+                ...(wallets[scriptWalletIndex] as ScriptWallet<AccountMetadata>),
+                metadata
+              })
+            );
+          }
+          throw new WalletConflictError(`BIP32 AccountId or script WalletId not found: ${target}`);
+        }),
+        map(() => target)
+      )
+    );
+  }
+
+  removeAccount(accountId: AccountId): Promise<AccountId> {
+    this.#logger.debug('removeAccount', accountId);
+    return firstValueFrom(
+      this.wallets$.pipe(
+        switchMap((wallets) => {
+          const bip32Account = findAccount(wallets, accountId);
+          if (!bip32Account) {
+            throw new WalletConflictError(`Account '${accountId}' does not exist`);
+          }
+          return this.#store.setAll(
+            cloneSplice(wallets, bip32Account.walletIndex, 1, {
+              ...bip32Account.wallet,
+              accounts: cloneSplice(bip32Account.wallet.accounts, bip32Account.accountIndex, 1)
+            })
+          );
+        }),
+        map(() => accountId)
+      )
+    );
+  }
+
+  removeWallet(walletId: WalletId): Promise<WalletId> {
+    this.#logger.debug('removeWallet', walletId);
+    return firstValueFrom(
+      this.wallets$.pipe(
+        switchMap((wallets) => {
+          const walletIndex = wallets.findIndex((w) => w.walletId === walletId);
+          if (walletIndex < 0) {
+            throw new WalletConflictError(`Wallet '${walletId}' does not exist`);
+          }
+          return this.#store.setAll(cloneSplice(wallets, walletIndex, 1));
+        }),
+        map(() => walletId)
+      )
+    );
+  }
+}

--- a/packages/web-extension/src/walletManager/WalletRepository/index.ts
+++ b/packages/web-extension/src/walletManager/WalletRepository/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './WalletRepository';

--- a/packages/web-extension/src/walletManager/WalletRepository/types.ts
+++ b/packages/web-extension/src/walletManager/WalletRepository/types.ts
@@ -1,0 +1,82 @@
+import { Bip32PublicKeyHex, Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { Cardano } from '@cardano-sdk/core';
+import { Observable } from 'rxjs';
+
+export enum WalletType {
+  InMemory = 'InMemory',
+  Ledger = 'Ledger',
+  Trezor = 'Trezor',
+  Script = 'Script'
+}
+
+/** For BIP-32 wallets: hash of extended account public key. For script wallets: script hash */
+export type WalletId = Hash28ByteBase16;
+
+/** walletId+accountIndex (only applicable for bip32 wallets) */
+export type AccountId = string;
+
+export type Bip32WalletAccount<Metadata extends {}> = {
+  accountId: AccountId;
+  /** account' in cip1852 */
+  accountIndex: number;
+  /** e.g. account name, picture */
+  metadata: Metadata;
+};
+
+export type Bip32Wallet<Metadata extends {}> = {
+  type: WalletType.InMemory | WalletType.Ledger | WalletType.Trezor;
+  walletId: WalletId;
+  extendedAccountPublicKey: Bip32PublicKeyHex;
+  accounts: Bip32WalletAccount<Metadata>[];
+};
+
+export type ScriptWallet<Metadata extends {}> = {
+  type: WalletType.Script;
+  walletId: WalletId;
+  /** e.g. account name, picture */
+  metadata: Metadata;
+  script: Cardano.Script;
+};
+
+export type AnyWallet<Metadata extends {}> = Bip32Wallet<Metadata> | ScriptWallet<Metadata>;
+
+export type AddAccountProps<Metadata extends {}> = {
+  walletId: WalletId;
+  /** account' in cip1852 */
+  accountIndex: number;
+  metadata: Metadata;
+};
+
+export type UpdateMetadataProps<Metadata extends {}, ID extends AccountId | WalletId> = {
+  target: ID;
+  metadata: Metadata;
+};
+
+export type AddWalletProps<Metadata extends {}> =
+  | Omit<Bip32Wallet<Metadata>, 'walletId' | 'accounts'>
+  | Omit<ScriptWallet<Metadata>, 'walletId'>;
+
+export interface WalletRepositoryApi<Metadata extends {}> {
+  wallets$: Observable<AnyWallet<Metadata>[]>;
+
+  /** Rejects with WalletConflictError when wallet already exists */
+  addWallet(props: AddWalletProps<Metadata>): Promise<WalletId>;
+
+  /**
+   * Can be used to add a new account to an existing BIP32Wallet
+   *
+   * Rejects with WalletConflictError when either
+   * - wallet with provided `walletId` is not found
+   * - account already exists for this wallet
+   */
+  addAccount(props: AddAccountProps<Metadata>): Promise<AccountId>;
+
+  /** Rejects with WalletConflictError when wallet or account with specified id is not found */
+  updateMetadata<ID extends WalletId | AccountId>(props: UpdateMetadataProps<Metadata, ID>): Promise<ID>;
+
+  /** Rejects with WalletConflictError when account is not found. */
+  removeAccount(accountId: AccountId): Promise<AccountId>;
+
+  /** Rejects with WalletConflictError when wallet is not found. */
+  removeWallet(walletId: WalletId): Promise<WalletId>;
+}

--- a/packages/web-extension/src/walletManager/errors.ts
+++ b/packages/web-extension/src/walletManager/errors.ts
@@ -1,0 +1,3 @@
+import { CustomError } from 'ts-custom-error';
+
+export class WalletConflictError extends CustomError {}

--- a/packages/web-extension/src/walletManager/index.ts
+++ b/packages/web-extension/src/walletManager/index.ts
@@ -2,3 +2,5 @@ export * from './walletManager.types';
 export * from './util';
 export * from './walletManagerUi';
 export * from './walletManagerWorker';
+export * from './WalletRepository';
+export * from './errors';

--- a/packages/web-extension/test/walletManager/WalletRepository.test.ts
+++ b/packages/web-extension/test/walletManager/WalletRepository.test.ts
@@ -1,0 +1,246 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import { Bip32PublicKeyHex, Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { Cardano, Serialization } from '@cardano-sdk/core';
+import { WalletConflictError, WalletRepository, WalletRepositoryDependencies, WalletType } from '../../src';
+import { firstValueFrom, of } from 'rxjs';
+import { logger } from '@cardano-sdk/util-dev';
+import pick from 'lodash/pick';
+
+type WalletMetadata = { friendlyName: string };
+
+const storedLedgerWallet = {
+  accounts: [
+    {
+      accountId: 'f15db05f56035465bf8900a09bdaa16c3d8b8244fea686524408dd80-0',
+      accountIndex: 0,
+      metadata: { friendlyName: 'My Ledger Wallet' }
+    }
+  ],
+  extendedAccountPublicKey: Bip32PublicKeyHex(
+    'ba4f80dea2632a17c99ae9d8b934abf02643db5426b889fef14709c85e294aa12ac1f1560a893ea7937c5bfbfdeab459b1a396f1174b9c5a673a640d01880c35'
+  ),
+  type: WalletType.Ledger as const,
+  walletId: Hash28ByteBase16('ad63f855e831d937457afc52a21a7f351137e4a9fff26c217817335a')
+};
+
+const createTrezorWalletProps = {
+  extendedAccountPublicKey: Bip32PublicKeyHex(
+    'ca4f80dea2632a17c99ae9d8b934abf02643db5426b889fef14709c85e294aa12ac1f1560a893ea7937c5bfbfdeab459b1a396f1174b9c5a673a640d01880c35'
+  ),
+  type: WalletType.Trezor as const
+};
+
+const createScriptWalletProps = {
+  metadata: { friendlyName: 'Treasury' },
+  script: {
+    __type: Cardano.ScriptType.Native,
+    kind: Cardano.NativeScriptKind.RequireTimeBefore,
+    slot: 123
+  } as Cardano.Script,
+  type: WalletType.Script as const
+};
+
+const storedScriptWallet = {
+  ...createScriptWalletProps,
+  metadata: { friendlyName: 'Shared' },
+  walletId: Serialization.Script.fromCore(createScriptWalletProps.script).hash()
+};
+
+describe('WalletRepository', () => {
+  let repository: WalletRepository<WalletMetadata>;
+  let store: jest.Mocked<WalletRepositoryDependencies<WalletMetadata>['store']>;
+
+  beforeEach(() => {
+    store = {
+      observeAll: jest.fn() as jest.Mocked<WalletRepositoryDependencies<WalletMetadata>['store']>['observeAll'],
+      setAll: jest.fn() as jest.Mocked<WalletRepositoryDependencies<WalletMetadata>['store']>['setAll']
+    } as jest.Mocked<WalletRepositoryDependencies<WalletMetadata>['store']>;
+    repository = new WalletRepository({ logger, store });
+
+    store.observeAll.mockReturnValue(of([storedLedgerWallet]));
+    store.setAll.mockReturnValue(of(void 0));
+  });
+
+  describe('wallets$', () => {
+    it('is an observable of stored wallets', async () => {
+      store.observeAll.mockReturnValueOnce(of([storedLedgerWallet]));
+      await expect(firstValueFrom(repository.wallets$)).resolves.toEqual([storedLedgerWallet]);
+    });
+
+    it('shares subscription to store', async () => {
+      store.observeAll.mockReturnValueOnce(of([]));
+      await expect(
+        Promise.all([firstValueFrom(repository.wallets$), firstValueFrom(repository.wallets$)])
+      ).resolves.toEqual([[], []]);
+      expect(store.observeAll).toBeCalledTimes(1);
+    });
+  });
+
+  describe('addWallet', () => {
+    it('stores a new wallet', async () => {
+      await repository.addWallet(createTrezorWalletProps);
+      expect(store.setAll).toBeCalledWith([
+        storedLedgerWallet,
+        expect.objectContaining({ ...createTrezorWalletProps, accounts: [], walletId: expect.stringContaining('') })
+      ]);
+    });
+
+    it('rejects with WalletConflictError when wallet already exists', async () => {
+      await expect(
+        repository.addWallet(pick(storedLedgerWallet, ['type', 'extendedAccountPublicKey']))
+      ).rejects.toThrowError(WalletConflictError);
+      expect(store.setAll).not.toBeCalled();
+    });
+
+    it('computes and returns WalletId for bip32 wallets', async () => {
+      await expect(repository.addWallet(createTrezorWalletProps)).resolves.toHaveLength(56);
+    });
+
+    it('computes and returns WalletId for script wallets', async () => {
+      await expect(repository.addWallet(createScriptWalletProps)).resolves.toHaveLength(56);
+    });
+  });
+
+  describe('addAccount', () => {
+    it('adds account to an existing wallet and returns AccountId that also contains walletId', async () => {
+      const accountProps = {
+        accountIndex: storedLedgerWallet.accounts[storedLedgerWallet.accounts.length - 1].accountIndex + 1,
+        metadata: { friendlyName: 'Next account' }
+      };
+      await expect(
+        repository.addAccount({ ...accountProps, walletId: storedLedgerWallet.walletId })
+      ).resolves.toContain(storedLedgerWallet.walletId);
+      expect(store.setAll).toBeCalledWith([
+        {
+          ...storedLedgerWallet,
+          accounts: [
+            ...storedLedgerWallet.accounts,
+            {
+              ...accountProps,
+              accountId: expect.stringContaining(storedLedgerWallet.walletId)
+            }
+          ]
+        }
+      ]);
+    });
+
+    it('rejects with WalletConflictError when wallet is not found', async () => {
+      await expect(
+        repository.addAccount({
+          accountIndex: 1,
+          metadata: { friendlyName: 'Secret Account' },
+          walletId: 'doesnt exist' as Hash28ByteBase16
+        })
+      ).rejects.toThrowError(WalletConflictError);
+      expect(store.setAll).not.toBeCalled();
+    });
+
+    it('rejects with WalletConflictError for script wallets', async () => {
+      store.observeAll.mockReturnValueOnce(of([storedScriptWallet]));
+      await expect(
+        repository.addAccount({
+          accountIndex: 1,
+          metadata: { friendlyName: 'Secret Account' },
+          walletId: storedScriptWallet.walletId
+        })
+      ).rejects.toThrowError(WalletConflictError);
+      expect(store.setAll).not.toBeCalled();
+    });
+
+    it('rejects with WalletConflictError when account already exists', async () => {
+      await expect(
+        repository.addAccount({
+          accountIndex: storedLedgerWallet.accounts[0].accountIndex,
+          metadata: { friendlyName: 'Does not matter' },
+          walletId: storedLedgerWallet.walletId
+        })
+      ).rejects.toThrowError(WalletConflictError);
+      expect(store.setAll).not.toBeCalled();
+    });
+  });
+
+  describe('updateMetadata', () => {
+    const newMetadata = { friendlyName: 'New name' };
+
+    it('updates metadata of an existing bip32 account', async () => {
+      const accountId = storedLedgerWallet.accounts[0].accountId;
+      await expect(
+        repository.updateMetadata({
+          metadata: newMetadata,
+          target: accountId
+        })
+      ).resolves.toBe(accountId);
+      expect(store.setAll).toBeCalledWith([
+        {
+          ...storedLedgerWallet,
+          accounts: [
+            {
+              ...storedLedgerWallet.accounts[0],
+              metadata: newMetadata
+            }
+          ]
+        }
+      ]);
+    });
+
+    it('updates metadata of an existing script wallet', async () => {
+      store.observeAll.mockReturnValueOnce(of([storedScriptWallet]));
+      await expect(
+        repository.updateMetadata({
+          metadata: newMetadata,
+          target: storedScriptWallet.walletId
+        })
+      ).resolves.toBe(storedScriptWallet.walletId);
+      expect(store.setAll).toBeCalledWith([
+        {
+          ...storedScriptWallet,
+          metadata: newMetadata
+        }
+      ]);
+    });
+
+    it('rejects with WalletConflictError when a bip32 account or a script wallet with specified id is not found', async () => {
+      await expect(
+        repository.updateMetadata({
+          metadata: newMetadata,
+          target: 'does not exist'
+        })
+      ).rejects.toThrowError(WalletConflictError);
+      expect(store.setAll).not.toBeCalled();
+    });
+  });
+
+  describe('removeWallet', () => {
+    it('removes wallet with specified id', async () => {
+      await expect(repository.removeWallet(storedLedgerWallet.walletId)).resolves.toBe(storedLedgerWallet.walletId);
+      expect(store.setAll).toBeCalledWith([]);
+    });
+
+    it('rejects with WalletConflictError when wallet is not found', async () => {
+      await expect(repository.removeWallet('doesnt exist' as Hash28ByteBase16)).rejects.toThrowError(
+        WalletConflictError
+      );
+      expect(store.setAll).not.toBeCalled();
+    });
+  });
+
+  describe('removeAccount', () => {
+    it('removes account with specified id', async () => {
+      const accountId = storedLedgerWallet.accounts[0].accountId;
+      await expect(repository.removeAccount(accountId)).resolves.toBe(accountId);
+      expect(store.setAll).toBeCalledWith([
+        {
+          ...storedLedgerWallet,
+          accounts: []
+        }
+      ]);
+    });
+
+    it('rejects with WalletConflictError when wallet is not found', async () => {
+      await expect(repository.removeAccount('doesnt exist' as Hash28ByteBase16)).rejects.toThrowError(
+        WalletConflictError
+      );
+      expect(store.setAll).not.toBeCalled();
+    });
+  });
+});


### PR DESCRIPTION
# Context

In order to implement multi-wallet/multi-account feature, we need to have a persistent repository of multiple wallets/accounts, so that they are restored when application is reloaded.

# Proposed Solution

See commit log