### PR TITLE
Feat/lw 9089 add address manager and witnesser to personal wallet

### DIFF
--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -355,7 +355,16 @@ export const getWallet = async (props: GetWalletProps) => {
       ? () => Promise.resolve(keyAgent)
       : await keyManagementFactory.create(env.KEY_MANAGEMENT_PROVIDER, keyManagementParams, logger),
     createWallet: async (asyncKeyAgent: AsyncKeyAgent) =>
-      new PersonalWallet({ name, polling }, { ...providers, keyAgent: asyncKeyAgent, logger, stores }),
+      new PersonalWallet(
+        { name, polling },
+        {
+          ...providers,
+          addressManager: util.createBip32Ed25519AddressManager(asyncKeyAgent),
+          logger,
+          stores,
+          witnesser: util.createBip32Ed25519Witnesser(asyncKeyAgent)
+        }
+      ),
     logger
   });
 

--- a/packages/e2e/test/load-test-custom/wallet-init/wallet-init.test.ts
+++ b/packages/e2e/test/load-test-custom/wallet-init/wallet-init.test.ts
@@ -26,6 +26,7 @@ import {
   waitForWalletStateSettle,
   walletVariables
 } from '../../../src';
+import { util } from '@cardano-sdk/key-management';
 
 // Example call that creates 5000 wallets in 10 minutes:
 // VIRTUAL_USERS_GENERATE_DURATION=600 VIRTUAL_USERS_COUNT=5000 yarn load-test-custom:wallet-init
@@ -84,7 +85,15 @@ const createWallet = async (accountIndex: number): Promise<PersonalWallet> => {
   measurementUtil.addMeasureMarker(MeasureTarget.keyAgent, accountIndex);
 
   measurementUtil.addStartMarker(MeasureTarget.wallet, accountIndex);
-  const wallet = new PersonalWallet({ name: `Wallet ${accountIndex}` }, { ...providers, keyAgent, logger });
+  const wallet = new PersonalWallet(
+    { name: `Wallet ${accountIndex}` },
+    {
+      ...providers,
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
+      logger,
+      witnesser: util.createBip32Ed25519Witnesser(keyAgent)
+    }
+  );
   walletUtil.initialize(wallet);
   return wallet;
 };

--- a/packages/e2e/test/local-network/register-pool.test.ts
+++ b/packages/e2e/test/local-network/register-pool.test.ts
@@ -3,6 +3,7 @@ import { Cardano } from '@cardano-sdk/core';
 import {
   KeyAgentFactoryProps,
   TestWallet,
+  bip32Ed25519Factory,
   getEnv,
   getWallet,
   submitCertificate,
@@ -41,6 +42,7 @@ const wallet2Params: KeyAgentFactoryProps = {
 describe('local-network/register-pool', () => {
   let wallet1: TestWallet;
   let wallet2: TestWallet;
+  let bip32Ed25519: Crypto.Bip32Ed25519;
 
   beforeAll(async () => {
     jest.setTimeout(180_000);
@@ -64,6 +66,7 @@ describe('local-network/register-pool', () => {
 
     await waitForWalletStateSettle(wallet1.wallet);
     await waitForWalletStateSettle(wallet2.wallet);
+    bip32Ed25519 = await bip32Ed25519Factory.create(env.KEY_MANAGEMENT_PARAMS.bip32Ed25519, null, logger);
   });
 
   afterAll(() => {
@@ -76,18 +79,17 @@ describe('local-network/register-pool', () => {
 
     await walletReady(wallet);
 
-    const poolKeyAgent = wallet.keyAgent;
+    const poolAddressManager = wallet.addressManager;
 
-    const poolPubKey = await poolKeyAgent.derivePublicKey({
+    const poolPubKey = await poolAddressManager.derivePublicKey({
       index: 0,
       role: KeyRole.External
     });
 
-    const bip32Ed25519 = await poolKeyAgent.getBip32Ed25519();
     const poolKeyHash = await bip32Ed25519.getPubKeyHash(poolPubKey);
     const poolId = Cardano.PoolId.fromKeyHash(poolKeyHash);
     const poolRewardAccount = (
-      await poolKeyAgent.deriveAddress(
+      await poolAddressManager.deriveAddress(
         {
           index: 0,
           type: AddressType.External
@@ -165,18 +167,17 @@ describe('local-network/register-pool', () => {
 
     await walletReady(wallet);
 
-    const poolKeyAgent = wallet.keyAgent;
+    const poolAddressManager = wallet.addressManager;
 
-    const poolPubKey = await poolKeyAgent.derivePublicKey({
+    const poolPubKey = await poolAddressManager.derivePublicKey({
       index: 0,
       role: KeyRole.External
     });
 
-    const bip32Ed25519 = await poolKeyAgent.getBip32Ed25519();
     const poolKeyHash = await bip32Ed25519.getPubKeyHash(poolPubKey);
     const poolId = Cardano.PoolId.fromKeyHash(poolKeyHash);
     const poolRewardAccount = (
-      await poolKeyAgent.deriveAddress(
+      await poolAddressManager.deriveAddress(
         {
           index: 0,
           type: AddressType.External

--- a/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
@@ -3,6 +3,7 @@ import { Cardano, metadatum } from '@cardano-sdk/core';
 import { KeyAgent, TransactionSigner } from '@cardano-sdk/key-management';
 import { PersonalWallet } from '@cardano-sdk/wallet';
 import {
+  bip32Ed25519Factory,
   burnTokens,
   coinsRequiredByHandleMint,
   createHandleMetadata,
@@ -49,7 +50,7 @@ describe('Ada handle', () => {
     keyAgent = await createStandaloneKeyAgent(
       env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       await firstValueFrom(wallet.genesisParameters$),
-      await wallet.keyAgent.getBip32Ed25519()
+      await bip32Ed25519Factory.create(env.KEY_MANAGEMENT_PARAMS.bip32Ed25519, null, logger)
     );
     ({ policyScript, policySigner, policyId } = await createHandlePolicy(keyAgent));
     const handleProviderPolicyId = await getHandlePolicyId(

--- a/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
@@ -3,6 +3,7 @@ import { FinalizeTxProps, PersonalWallet } from '@cardano-sdk/wallet';
 import { InitializeTxProps } from '@cardano-sdk/tx-construction';
 import { KeyRole, util } from '@cardano-sdk/key-management';
 import {
+  bip32Ed25519Factory,
   burnTokens,
   createStandaloneKeyAgent,
   getEnv,
@@ -36,7 +37,7 @@ describe('PersonalWallet/mint', () => {
     const aliceKeyAgent = await createStandaloneKeyAgent(
       env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
-      await wallet.keyAgent.getBip32Ed25519()
+      await bip32Ed25519Factory.create(env.KEY_MANAGEMENT_PARAMS.bip32Ed25519, null, logger)
     );
 
     const derivationPath = {

--- a/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
@@ -3,6 +3,7 @@ import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import {
   KeyAgentFactoryProps,
+  bip32Ed25519Factory,
   createStandaloneKeyAgent,
   firstValueFromTimed,
   getWallet,
@@ -42,7 +43,7 @@ describe('PersonalWallet/multiAddress', () => {
     const multiAddressKeyAgent = await createStandaloneKeyAgent(
       mnemonics,
       genesis,
-      await wallet.keyAgent.getBip32Ed25519()
+      await bip32Ed25519Factory.create(env.KEY_MANAGEMENT_PARAMS.bip32Ed25519, null, logger)
     );
 
     let txBuilder = wallet.createTxBuilder();

--- a/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
@@ -4,6 +4,7 @@ import { FinalizeTxProps, PersonalWallet } from '@cardano-sdk/wallet';
 import { InitializeTxProps } from '@cardano-sdk/tx-construction';
 import { KeyRole, util } from '@cardano-sdk/key-management';
 import {
+  bip32Ed25519Factory,
   burnTokens,
   createStandaloneKeyAgent,
   getEnv,
@@ -34,15 +35,16 @@ describe('PersonalWallet/multisignature', () => {
 
     const genesis = await firstValueFrom(wallet.genesisParameters$);
 
+    const bip32Ed25519 = await bip32Ed25519Factory.create(env.KEY_MANAGEMENT_PARAMS.bip32Ed25519, null, logger);
     const aliceKeyAgent = await createStandaloneKeyAgent(
       env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
-      await wallet.keyAgent.getBip32Ed25519()
+      bip32Ed25519
     );
     const bobKeyAgent = await createStandaloneKeyAgent(
       env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
-      await wallet.keyAgent.getBip32Ed25519()
+      bip32Ed25519
     );
 
     const aliceDerivationPath = {

--- a/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
@@ -4,6 +4,7 @@ import { Assets, FinalizeTxProps, PersonalWallet } from '@cardano-sdk/wallet';
 import { InitializeTxProps } from '@cardano-sdk/tx-construction';
 import { KeyRole, TransactionSigner, util } from '@cardano-sdk/key-management';
 import {
+  bip32Ed25519Factory,
   burnTokens,
   createStandaloneKeyAgent,
   firstValueFromTimed,
@@ -60,7 +61,7 @@ describe('PersonalWallet.assets/nft', () => {
     const keyAgent = await createStandaloneKeyAgent(
       env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
-      await wallet.keyAgent.getBip32Ed25519()
+      await bip32Ed25519Factory.create(env.KEY_MANAGEMENT_PARAMS.bip32Ed25519, null, logger)
     );
 
     const derivationPath = {

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -201,3 +201,34 @@ export interface TransactionSigner {
    */
   sign(tx: Cardano.TxBodyWithHash): Promise<TransactionSignerResult>;
 }
+
+export type WitnessOptions = SignTransactionOptions;
+
+/** Interface for an entity capable of generating witness data for a transaction. */
+export interface Witnesser {
+  /**
+   * Generates the witness data for a given transaction.
+   *
+   * @param txInternals The transaction body along with its hash for which the witness data is to be generated.
+   * @param options Optional additional parameters that may influence how the witness data is generated.
+   * @returns A promise that resolves to the generated witness data for the transaction.
+   */
+  witness(txInternals: Cardano.TxBodyWithHash, options?: WitnessOptions): Promise<Cardano.Witness>;
+
+  /**
+   * @throws AuthenticationError
+   */
+  signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob): Promise<SignBlobResult>;
+}
+
+/** Interface for managing blockchain addresses. */
+export interface AddressManager {
+  knownAddresses$: Observable<GroupedAddress[]>;
+
+  /**
+   * Sets or updates the list of known addresses managed by this instance.
+   *
+   * @param addresses An array of grouped addresses to be managed.
+   */
+  setKnownAddresses(addresses: GroupedAddress[]): Promise<void>;
+}

--- a/packages/key-management/src/util/createAddressManager.ts
+++ b/packages/key-management/src/util/createAddressManager.ts
@@ -1,0 +1,53 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import {
+  AccountAddressDerivationPath,
+  AccountKeyDerivationPath,
+  AddressManager,
+  AsyncKeyAgent,
+  GroupedAddress
+} from '../types';
+import { Observable } from 'rxjs';
+
+/** An address manager that uses a {@link AsyncKeyAgent} to derive addresses. */
+export class Bip32Ed25519AddressManager implements AddressManager {
+  knownAddresses$: Observable<GroupedAddress[]>;
+  #keyAgent: AsyncKeyAgent;
+
+  /**
+   * Initializes a new instance of the Bip32Ed25519AddressManager class.
+   *
+   * @param keyAgent The key agent that will be used to derive addresses.
+   */
+  constructor(keyAgent: AsyncKeyAgent) {
+    this.#keyAgent = keyAgent;
+    this.knownAddresses$ = keyAgent.knownAddresses$;
+  }
+
+  async setKnownAddresses(addresses: GroupedAddress[]): Promise<void> {
+    return this.#keyAgent.setKnownAddresses(addresses);
+  }
+
+  async derivePublicKey(derivationPath: AccountKeyDerivationPath): Promise<Crypto.Ed25519PublicKeyHex> {
+    return this.#keyAgent.derivePublicKey(derivationPath);
+  }
+
+  async deriveAddress(
+    paymentKeyDerivationPath: AccountAddressDerivationPath,
+    stakeKeyDerivationIndex: number,
+    pure?: boolean
+  ): Promise<GroupedAddress> {
+    return this.#keyAgent.deriveAddress(paymentKeyDerivationPath, stakeKeyDerivationIndex, pure);
+  }
+
+  shutdown(): void {
+    this.#keyAgent.shutdown();
+  }
+}
+
+/**
+ * Creates a new instance of the Bip32Ed25519AddressManager class.
+ *
+ * @param keyAgent The key agent that will be used to derive addresses.
+ */
+export const createBip32Ed25519AddressManager = (keyAgent: AsyncKeyAgent): Bip32Ed25519AddressManager =>
+  new Bip32Ed25519AddressManager(keyAgent);

--- a/packages/key-management/src/util/createWitnesser.ts
+++ b/packages/key-management/src/util/createWitnesser.ts
@@ -1,0 +1,23 @@
+import { AccountKeyDerivationPath, AsyncKeyAgent, SignBlobResult, WitnessOptions, Witnesser } from '../types';
+import { Cardano } from '@cardano-sdk/core';
+import { HexBlob } from '@cardano-sdk/util';
+
+/** A witnesser that uses a {@link KeyAgent} to generate witness data for a transaction. */
+export class Bip32Ed25519Witnesser implements Witnesser {
+  #keyAgent: AsyncKeyAgent;
+
+  constructor(keyAgent: AsyncKeyAgent) {
+    this.#keyAgent = keyAgent;
+  }
+
+  async witness(txInternals: Cardano.TxBodyWithHash, options?: WitnessOptions): Promise<Cardano.Witness> {
+    return { signatures: await this.#keyAgent.signTransaction(txInternals, options) };
+  }
+
+  async signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob): Promise<SignBlobResult> {
+    return this.#keyAgent.signBlob(derivationPath, blob);
+  }
+}
+
+export const createBip32Ed25519Witnesser = (keyAgent: AsyncKeyAgent): Bip32Ed25519Witnesser =>
+  new Bip32Ed25519Witnesser(keyAgent);

--- a/packages/key-management/src/util/index.ts
+++ b/packages/key-management/src/util/index.ts
@@ -5,3 +5,5 @@ export * from './ownSignatureKeyPaths';
 export * from './stubSignTransaction';
 export * from './KeyAgentTransactionSigner';
 export * from './ensureStakeKeys';
+export * from './createAddressManager';
+export * from './createWitnesser';

--- a/packages/key-management/test/cip8/cip30signData.test.ts
+++ b/packages/key-management/test/cip8/cip30signData.test.ts
@@ -1,5 +1,13 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, AsyncKeyAgent, GroupedAddress, KeyAgent, KeyRole, cip8 } from '../../src';
+import {
+  AddressType,
+  AsyncKeyAgent,
+  GroupedAddress,
+  KeyAgent,
+  util as KeyManagementUtil,
+  KeyRole,
+  cip8
+} from '../../src';
 import { COSEKey, COSESign1, SigStructure } from '@emurgo/cardano-message-signing-nodejs';
 import { Cardano, util } from '@cardano-sdk/core';
 import { CoseLabel } from '../../src/cip8/util';
@@ -22,9 +30,10 @@ describe('cip30signData', () => {
 
   const signAndDecode = async (signWith: Cardano.PaymentAddress | Cardano.RewardAccount) => {
     const dataSignature = await cip8.cip30signData({
-      keyAgent: asyncKeyAgent,
+      addressManager: KeyManagementUtil.createBip32Ed25519AddressManager(asyncKeyAgent),
       payload: HexBlob('abc123'),
-      signWith
+      signWith,
+      witnesser: KeyManagementUtil.createBip32Ed25519Witnesser(asyncKeyAgent)
     });
 
     const coseKey = COSEKey.from_bytes(Buffer.from(dataSignature.key, 'hex'));

--- a/packages/key-management/test/util/createAddressManager.test.ts
+++ b/packages/key-management/test/util/createAddressManager.test.ts
@@ -1,0 +1,50 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { AsyncKeyAgent, InMemoryKeyAgent, KeyRole, util } from '../../src';
+import { Cardano } from '@cardano-sdk/core';
+import { dummyLogger } from 'ts-log';
+
+describe('createBip32Ed25519AddressManager', () => {
+  let asyncKeyAgent: AsyncKeyAgent;
+  let addressManager: util.Bip32Ed25519AddressManager;
+  let inputResolver: jest.Mocked<Cardano.InputResolver>;
+  const addressDerivationPath = { index: 0, type: 0 };
+
+  beforeEach(async () => {
+    const mnemonicWords = util.generateMnemonicWords();
+    const getPassphrase = jest.fn().mockResolvedValue(Buffer.from('password'));
+    inputResolver = { resolveInput: jest.fn() };
+    const keyAgent = await InMemoryKeyAgent.fromBip39MnemonicWords(
+      {
+        chainId: Cardano.ChainIds.Preview,
+        getPassphrase,
+        mnemonicWords
+      },
+      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), inputResolver, logger: dummyLogger }
+    );
+    asyncKeyAgent = util.createAsyncKeyAgent(keyAgent);
+    addressManager = util.createBip32Ed25519AddressManager(asyncKeyAgent);
+  });
+
+  it('deriveAddress is unchanged', async () => {
+    await expect(asyncKeyAgent.deriveAddress(addressDerivationPath, 0)).resolves.toEqual(
+      await addressManager.deriveAddress(addressDerivationPath, 0)
+    );
+  });
+
+  it('derivePublicKey is unchanged', async () => {
+    await expect(asyncKeyAgent.derivePublicKey({ index: 0, role: KeyRole.External })).resolves.toEqual(
+      await addressManager.derivePublicKey({ index: 0, role: KeyRole.External })
+    );
+  });
+
+  it('stops emitting addresses$ after shutdown', (done) => {
+    addressManager.shutdown();
+    addressManager.knownAddresses$.subscribe({
+      complete: done,
+      next: () => {
+        throw new Error('Should not emit');
+      }
+    });
+    void addressManager.deriveAddress(addressDerivationPath, 0);
+  });
+});

--- a/packages/key-management/test/util/createWitnesser.test.ts
+++ b/packages/key-management/test/util/createWitnesser.test.ts
@@ -1,0 +1,51 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { AsyncKeyAgent, InMemoryKeyAgent, Witnesser, util } from '../../src';
+import { Cardano } from '@cardano-sdk/core';
+import { HexBlob } from '@cardano-sdk/util';
+import { dummyLogger } from 'ts-log';
+
+describe('createBip32Ed25519Witnesser', () => {
+  let asyncKeyAgent: AsyncKeyAgent;
+  let witnesser: Witnesser;
+  let inputResolver: jest.Mocked<Cardano.InputResolver>;
+
+  beforeEach(async () => {
+    const mnemonicWords = util.generateMnemonicWords();
+    const getPassphrase = jest.fn().mockResolvedValue(Buffer.from('password'));
+    inputResolver = { resolveInput: jest.fn() };
+    const keyAgent = await InMemoryKeyAgent.fromBip39MnemonicWords(
+      {
+        chainId: Cardano.ChainIds.Preview,
+        getPassphrase,
+        mnemonicWords
+      },
+      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), inputResolver, logger: dummyLogger }
+    );
+    asyncKeyAgent = util.createAsyncKeyAgent(keyAgent);
+    witnesser = util.createBip32Ed25519Witnesser(asyncKeyAgent);
+  });
+
+  it('signBlob is unchanged', async () => {
+    const keyDerivationPath = { index: 0, role: 0 };
+    const blob = HexBlob('abc123');
+
+    await expect(asyncKeyAgent.signBlob(keyDerivationPath, blob)).resolves.toEqual(
+      await witnesser.signBlob(keyDerivationPath, blob)
+    );
+  });
+
+  it('signTransaction is unchanged', async () => {
+    inputResolver.resolveInput.mockResolvedValue(null);
+
+    const txInternals = {
+      body: { fee: 20_000n, inputs: [], outputs: [], validityInterval: {} } as Cardano.HydratedTxBody,
+      hash: Cardano.TransactionId('8561258e210352fba2ac0488afed67b3427a27ccf1d41ec030c98a8199bc22ec')
+    };
+
+    await expect(asyncKeyAgent.signTransaction(txInternals)).resolves.toEqual(
+      (
+        await witnesser.witness(txInternals)
+      ).signatures
+    );
+  });
+});

--- a/packages/key-management/test/util/ensureStakeKeys.test.ts
+++ b/packages/key-management/test/util/ensureStakeKeys.test.ts
@@ -26,7 +26,11 @@ describe('ensureStakeKeys', () => {
   });
 
   it('can derive one stake key', async () => {
-    const newRewardAccounts = await util.ensureStakeKeys({ count: 1, keyAgent, logger });
+    const newRewardAccounts = await util.ensureStakeKeys({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
+      count: 1,
+      logger
+    });
     const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
     expect(knownAddresses.length).toBe(1);
     expect(knownAddresses.map(({ rewardAccount }) => rewardAccount)).toEqual(newRewardAccounts);
@@ -36,7 +40,11 @@ describe('ensureStakeKeys', () => {
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 1);
 
-    await util.ensureStakeKeys({ count: 2, keyAgent, logger });
+    await util.ensureStakeKeys({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
+      count: 2,
+      logger
+    });
 
     const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
     expect(knownAddresses.length).toBe(2);
@@ -46,7 +54,7 @@ describe('ensureStakeKeys', () => {
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 2);
 
-    await util.ensureStakeKeys({ count: 4, keyAgent, logger });
+    await util.ensureStakeKeys({ addressManager: util.createBip32Ed25519AddressManager(keyAgent), count: 4, logger });
 
     const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
     const stakeKeyIndices = knownAddresses.map(({ stakeKeyDerivationPath }) => stakeKeyDerivationPath?.index).sort();
@@ -57,7 +65,12 @@ describe('ensureStakeKeys', () => {
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 2);
 
-    await util.ensureStakeKeys({ count: 4, keyAgent, logger, paymentKeyIndex: 1 });
+    await util.ensureStakeKeys({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
+      count: 4,
+      logger,
+      paymentKeyIndex: 1
+    });
 
     const stakeKeyIndicesPaymentKey1 = (await firstValueFrom(keyAgent.knownAddresses$))
       .filter(({ index }) => index === 1)
@@ -67,7 +80,7 @@ describe('ensureStakeKeys', () => {
 
   it('can handle request of 0 stake keys', async () => {
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
-    await util.ensureStakeKeys({ count: 0, keyAgent, logger });
+    await util.ensureStakeKeys({ addressManager: util.createBip32Ed25519AddressManager(keyAgent), count: 0, logger });
 
     const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
     expect(knownAddresses.length).toBe(1);
@@ -75,7 +88,9 @@ describe('ensureStakeKeys', () => {
 
   it('returns all reward accounts', async () => {
     await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
-    await expect(util.ensureStakeKeys({ count: 2, keyAgent, logger })).resolves.toHaveLength(2);
+    await expect(
+      util.ensureStakeKeys({ addressManager: util.createBip32Ed25519AddressManager(keyAgent), count: 2, logger })
+    ).resolves.toHaveLength(2);
   });
 
   it('takes into account addresses with multiple stake keys and payment keys', async () => {
@@ -86,7 +101,7 @@ describe('ensureStakeKeys', () => {
       keyAgent.deriveAddress({ index: 1, type: AddressType.External }, 2)
     ]);
 
-    await util.ensureStakeKeys({ count: 5, keyAgent, logger });
+    await util.ensureStakeKeys({ addressManager: util.createBip32Ed25519AddressManager(keyAgent), count: 5, logger });
     const knownAddresses = await firstValueFrom(keyAgent.knownAddresses$);
     expect(knownAddresses.length).toBe(6);
 

--- a/packages/tx-construction/src/tx-builder/finalizeTx.ts
+++ b/packages/tx-construction/src/tx-builder/finalizeTx.ts
@@ -1,22 +1,23 @@
-import {
-  AsyncKeyAgent,
-  SignTransactionOptions,
-  TransactionSigner,
-  util as keyManagementUtil
-} from '@cardano-sdk/key-management';
 import { Cardano, TxCBOR } from '@cardano-sdk/core';
 import { FinalizeTxDependencies, SignedTx, TxContext } from './types';
+import {
+  SignTransactionOptions,
+  TransactionSigner,
+  Witnesser,
+  util as keyManagementUtil
+} from '@cardano-sdk/key-management';
 import { filter, firstValueFrom } from 'rxjs';
 
 const getSignatures = async (
-  keyAgent: AsyncKeyAgent,
+  addressManager: keyManagementUtil.Bip32Ed25519AddressManager,
+  witnesser: Witnesser,
   txInternals: Cardano.TxBodyWithHash,
   extraSigners?: TransactionSigner[],
   signingOptions?: SignTransactionOptions
 ) => {
   // Wait until the async key agent has at least one known addresses.
-  await firstValueFrom(keyAgent.knownAddresses$.pipe(filter((addresses) => addresses.length > 0)));
-  const signatures: Cardano.Signatures = await keyAgent.signTransaction(txInternals, signingOptions);
+  await firstValueFrom(addressManager.knownAddresses$.pipe(filter((addresses) => addresses.length > 0)));
+  const { signatures } = await witnesser.witness(txInternals, signingOptions);
 
   if (extraSigners) {
     for (const extraSigner of extraSigners) {
@@ -31,19 +32,19 @@ const getSignatures = async (
 export const finalizeTx = async (
   tx: Cardano.TxBodyWithHash,
   { ownAddresses, witness, signingOptions, auxiliaryData, isValid, handleResolutions }: TxContext,
-  { inputResolver, keyAgent }: FinalizeTxDependencies,
+  { inputResolver, addressManager, witnesser }: FinalizeTxDependencies,
   stubSign = false
 ): Promise<SignedTx> => {
   const signatures = stubSign
     ? await keyManagementUtil.stubSignTransaction({
-        dRepPublicKey: await keyAgent.derivePublicKey(keyManagementUtil.DREP_KEY_DERIVATION_PATH),
+        dRepPublicKey: await addressManager.derivePublicKey(keyManagementUtil.DREP_KEY_DERIVATION_PATH),
         extraSigners: witness?.extraSigners,
         inputResolver,
         knownAddresses: ownAddresses,
         signTransactionOptions: signingOptions,
         txBody: tx.body
       })
-    : await getSignatures(keyAgent, tx, witness?.extraSigners, signingOptions);
+    : await getSignatures(addressManager, witnesser, tx, witness?.extraSigners, signingOptions);
 
   const transaction = {
     auxiliaryData,

--- a/packages/tx-construction/src/tx-builder/initializeTx.ts
+++ b/packages/tx-construction/src/tx-builder/initializeTx.ts
@@ -11,13 +11,13 @@ import { firstValueFrom } from 'rxjs';
 
 export const initializeTx = async (
   props: InitializeTxProps,
-  { txBuilderProviders, inputSelector, inputResolver, keyAgent, logger }: TxBuilderDependencies
+  { txBuilderProviders, inputSelector, inputResolver, addressManager, witnesser, logger }: TxBuilderDependencies
 ): Promise<InitializeTxResult> => {
   const [tip, genesisParameters, protocolParameters, addresses, rewardAccounts, utxo] = await Promise.all([
     txBuilderProviders.tip(),
     txBuilderProviders.genesisParameters(),
     txBuilderProviders.protocolParameters(),
-    firstValueFrom(keyAgent.knownAddresses$),
+    firstValueFrom(addressManager.knownAddresses$),
     txBuilderProviders.rewardAccounts(),
     txBuilderProviders.utxoAvailable()
   ]);
@@ -25,7 +25,7 @@ export const initializeTx = async (
   inputSelector =
     inputSelector ??
     roundRobinRandomImprove({
-      changeAddressResolver: new StaticChangeAddressResolver(() => firstValueFrom(keyAgent.knownAddresses$))
+      changeAddressResolver: new StaticChangeAddressResolver(() => firstValueFrom(addressManager.knownAddresses$))
     });
 
   const validityInterval = ensureValidityInterval(tip.slot, genesisParameters, props.options?.validityInterval);
@@ -63,7 +63,7 @@ export const initializeTx = async (
           signingOptions: props.signingOptions,
           witness: props.witness
         },
-        { inputResolver, keyAgent },
+        { addressManager, inputResolver, witnesser },
         true
       );
       return tx;

--- a/packages/tx-construction/src/tx-builder/types.ts
+++ b/packages/tx-construction/src/tx-builder/types.ts
@@ -3,7 +3,13 @@ import { CustomError } from 'ts-custom-error';
 
 import { InputSelectionError, InputSelector, SelectionSkeleton } from '@cardano-sdk/input-selection';
 
-import { AsyncKeyAgent, GroupedAddress, SignTransactionOptions, TransactionSigner } from '@cardano-sdk/key-management';
+import {
+  GroupedAddress,
+  SignTransactionOptions,
+  TransactionSigner,
+  Witnesser,
+  util
+} from '@cardano-sdk/key-management';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { InitializeTxWitness, TxBuilderProviders } from '../types';
 import { Logger } from 'ts-log';
@@ -264,11 +270,12 @@ export interface TxBuilder {
 export interface TxBuilderDependencies {
   inputSelector?: InputSelector;
   inputResolver: Cardano.InputResolver;
-  keyAgent: AsyncKeyAgent;
+  addressManager: util.Bip32Ed25519AddressManager;
+  witnesser: Witnesser;
   txBuilderProviders: TxBuilderProviders;
   logger: Logger;
   outputValidator?: OutputBuilderValidator;
   handleProvider?: HandleProvider;
 }
 
-export type FinalizeTxDependencies = Pick<TxBuilderDependencies, 'inputResolver' | 'keyAgent'>;
+export type FinalizeTxDependencies = Pick<TxBuilderDependencies, 'inputResolver' | 'addressManager' | 'witnesser'>;

--- a/packages/tx-construction/test/tx-builder/TxBuilder.bootstrap.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.bootstrap.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { AddressType } from '@cardano-sdk/key-management';
+import { AddressType, util } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import { GenericTxBuilder, OutputValidation } from '../../src';
 import { StubKeyAgent, mockProviders as mocks } from '@cardano-sdk/util-dev';
@@ -34,12 +34,14 @@ describe('TxBuilder bootstrap', () => {
     const outputValidator = {
       validateOutput: jest.fn().mockResolvedValue({ coinMissing: 0n } as OutputValidation)
     };
+
     const builderParams = {
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
       inputResolver,
-      keyAgent,
       logger: dummyLogger,
       outputValidator,
-      txBuilderProviders
+      txBuilderProviders,
+      witnesser: util.createBip32Ed25519Witnesser(keyAgent)
     };
     const txBuilder = new GenericTxBuilder(builderParams);
 

--- a/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
@@ -91,12 +91,14 @@ describe('GenericTxBuilder', () => {
       validateOutput: jest.fn().mockResolvedValue({ coinMissing: 0n } as OutputValidation)
     };
 
+    const asyncKeyAgent = util.createAsyncKeyAgent(keyAgent);
     const builderParams = {
+      addressManager: util.createBip32Ed25519AddressManager(asyncKeyAgent),
       inputResolver,
-      keyAgent: util.createAsyncKeyAgent(keyAgent),
       logger: dummyLogger,
       outputValidator,
-      txBuilderProviders
+      txBuilderProviders,
+      witnesser: util.createBip32Ed25519Witnesser(asyncKeyAgent)
     };
 
     txBuilder = new GenericTxBuilder({

--- a/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
@@ -98,14 +98,16 @@ const createTxBuilder = async ({
   const outputValidator = {
     validateOutput: jest.fn().mockResolvedValue({ coinMissing: 0n } as OutputValidation)
   };
+  const asyncKeyAgent = util.createAsyncKeyAgent(keyAgent);
   return {
     groupedAddresses,
     txBuilder: new GenericTxBuilder({
+      addressManager: util.createBip32Ed25519AddressManager(asyncKeyAgent),
       inputResolver,
-      keyAgent: util.createAsyncKeyAgent(keyAgent),
       logger: dummyLogger,
       outputValidator,
-      txBuilderProviders
+      txBuilderProviders,
+      witnesser: util.createBip32Ed25519Witnesser(asyncKeyAgent)
     }),
     txBuilderProviders
   };

--- a/packages/wallet/src/PersonalWallet/PersonalWallet.ts
+++ b/packages/wallet/src/PersonalWallet/PersonalWallet.ts
@@ -65,7 +65,6 @@ import {
   SyncStatus,
   WalletNetworkInfoProvider
 } from '../types';
-import { AsyncKeyAgent, GroupedAddress, cip8, util as keyManagementUtil } from '@cardano-sdk/key-management';
 import { BehaviorObservable, TrackerSubject, coldObservableProvider } from '@cardano-sdk/util-rxjs';
 import {
   BehaviorSubject,
@@ -98,6 +97,7 @@ import {
   finalizeTx,
   initializeTx
 } from '@cardano-sdk/tx-construction';
+import { GroupedAddress, Witnesser, cip8, util as keyManagementUtil } from '@cardano-sdk/key-management';
 import { Logger } from 'ts-log';
 import { PubStakeKeyAndStatus, createPublicStakeKeysTracker } from '../services/PublicStakeKeysTracker';
 import { RetryBackoffConfig } from 'backoff-rxjs';
@@ -114,7 +114,8 @@ export interface PersonalWalletProps {
 }
 
 export interface PersonalWalletDependencies {
-  readonly keyAgent: AsyncKeyAgent;
+  readonly witnesser: Witnesser;
+  readonly addressManager: keyManagementUtil.Bip32Ed25519AddressManager;
   readonly txSubmitProvider: TxSubmitProvider;
   readonly stakePoolProvider: StakePoolProvider;
   readonly assetProvider: AssetProvider;
@@ -199,7 +200,8 @@ export class PersonalWallet implements ObservableWallet {
   #addressDiscovery: AddressDiscovery;
   #submittingPromises: Partial<Record<Cardano.TransactionId, Promise<Cardano.TransactionId>>> = {};
 
-  readonly keyAgent: AsyncKeyAgent;
+  readonly witnesser: Witnesser;
+  readonly addressManager: keyManagementUtil.Bip32Ed25519AddressManager;
   readonly currentEpoch$: TrackerSubject<EpochInfo>;
   readonly txSubmitProvider: TxSubmitProvider;
   readonly utxoProvider: TrackedUtxoProvider;
@@ -245,7 +247,8 @@ export class PersonalWallet implements ObservableWallet {
     {
       txSubmitProvider,
       stakePoolProvider,
-      keyAgent,
+      witnesser,
+      addressManager,
       assetProvider,
       handleProvider,
       networkInfoProvider,
@@ -284,7 +287,8 @@ export class PersonalWallet implements ObservableWallet {
       { consideredOutOfSyncAfter }
     );
 
-    this.keyAgent = keyAgent;
+    this.addressManager = addressManager;
+    this.witnesser = witnesser;
 
     this.fatalError$ = new Subject();
 
@@ -299,7 +303,7 @@ export class PersonalWallet implements ObservableWallet {
     this.addresses$ = new TrackerSubject<GroupedAddress[]>(
       concat(
         stores.addresses.get(),
-        keyAgent.knownAddresses$.pipe(
+        this.addressManager.knownAddresses$.pipe(
           distinctUntilChanged(groupedAddressesEquals),
           tap(
             // derive addresses if none available
@@ -311,7 +315,7 @@ export class PersonalWallet implements ObservableWallet {
                   coldObservableProvider({
                     cancel$,
                     onFatalError,
-                    provider: () => this.#addressDiscovery.discover(keyAgent),
+                    provider: () => this.#addressDiscovery.discover(this.addressManager),
                     retryBackoffConfig
                   })
                 ).catch(() => this.#logger.error('Failed to complete the address discovery process'));
@@ -452,7 +456,7 @@ export class PersonalWallet implements ObservableWallet {
     this.delegation = createDelegationTracker({
       epoch$,
       eraSummaries$,
-      knownAddresses$: this.keyAgent.knownAddresses$,
+      knownAddresses$: this.addressManager.knownAddresses$,
       logger: contextLogger(this.#logger, 'delegation'),
       onFatalError,
       retryBackoffConfig,
@@ -481,8 +485,8 @@ export class PersonalWallet implements ObservableWallet {
         });
 
     this.publicStakeKeys$ = createPublicStakeKeysTracker({
+      addressManager: this.addressManager,
       addresses$: this.addresses$,
-      keyAgent: this.keyAgent,
       rewardAccounts$: this.delegation.rewardAccounts$
     });
 
@@ -535,7 +539,7 @@ export class PersonalWallet implements ObservableWallet {
     const { tx: signedTx } = await finalizeTx(
       tx,
       { ...rest, ownAddresses: await firstValueFrom(this.addresses$) },
-      { inputResolver: this.util, keyAgent: this.keyAgent },
+      { addressManager: this.addressManager, inputResolver: this.util, witnesser: this.witnesser },
       stubSign
     );
     return signedTx;
@@ -622,7 +626,14 @@ export class PersonalWallet implements ObservableWallet {
   }
 
   signData(props: SignDataProps): Promise<Cip30DataSignature> {
-    return cip8.cip30signData({ keyAgent: this.keyAgent, ...props });
+    return cip8.cip30signData({
+      // TODO: signData probably needs to be refactored out of the wallet and supported as a stand alone util
+      // as this operation doesnt require any of the wallet state. Also this operation can only be performed
+      // by Bip32Ed25519 type of wallets.
+      addressManager: this.addressManager,
+      witnesser: this.witnesser as keyManagementUtil.Bip32Ed25519Witnesser,
+      ...props
+    });
   }
   sync() {
     this.#tip$.sync();
@@ -642,7 +653,7 @@ export class PersonalWallet implements ObservableWallet {
     this.utxoProvider.stats.shutdown();
     this.rewardsProvider.stats.shutdown();
     this.chainHistoryProvider.stats.shutdown();
-    this.keyAgent.shutdown();
+    this.addressManager.shutdown();
     this.currentEpoch$.complete();
     this.delegation.shutdown();
     this.assetInfo$.complete();
@@ -677,10 +688,10 @@ export class PersonalWallet implements ObservableWallet {
    */
   getTxBuilderDependencies(): TxBuilderDependencies {
     return {
+      addressManager: this.addressManager,
       handleProvider: this.handleProvider,
       inputResolver: this.util,
       inputSelector: this.#inputSelector,
-      keyAgent: this.keyAgent,
       logger: this.#logger,
       outputValidator: this.util,
       txBuilderProviders: {
@@ -689,7 +700,8 @@ export class PersonalWallet implements ObservableWallet {
         rewardAccounts: () => this.#firstValueFromSettled(this.delegation.rewardAccounts$),
         tip: () => this.#firstValueFromSettled(this.tip$),
         utxoAvailable: () => this.#firstValueFromSettled(this.utxo.available$)
-      }
+      },
+      witnesser: this.witnesser
     };
   }
 
@@ -710,7 +722,7 @@ export class PersonalWallet implements ObservableWallet {
   async getPubDRepKey(): Promise<Ed25519PublicKeyHex> {
     if (!this.drepPubKey) {
       try {
-        this.drepPubKey = await this.keyAgent.derivePublicKey(keyManagementUtil.DREP_KEY_DERIVATION_PATH);
+        this.drepPubKey = await this.addressManager.derivePublicKey(keyManagementUtil.DREP_KEY_DERIVATION_PATH);
       } catch (error) {
         this.#logger.error(error);
         throw error;

--- a/packages/wallet/src/services/AddressDiscovery/SingleAddressDiscovery.ts
+++ b/packages/wallet/src/services/AddressDiscovery/SingleAddressDiscovery.ts
@@ -1,13 +1,13 @@
 import { AddressDiscovery } from '../types';
-import { AddressType, AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
+import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
 
 /**
  * Discovers the first address in the derivation chain (both payment and stake credentials) without looking at the
  * chain history.
  */
 export class SingleAddressDiscovery implements AddressDiscovery {
-  public async discover(keyAgent: AsyncKeyAgent): Promise<GroupedAddress[]> {
-    const address = await keyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
+  public async discover(manager: util.Bip32Ed25519AddressManager): Promise<GroupedAddress[]> {
+    const address = await manager.deriveAddress({ index: 0, type: AddressType.External }, 0);
     return [address];
   }
 }

--- a/packages/wallet/src/services/PublicStakeKeysTracker.ts
+++ b/packages/wallet/src/services/PublicStakeKeysTracker.ts
@@ -1,4 +1,4 @@
-import { AccountKeyDerivationPath, AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
+import { AccountKeyDerivationPath, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import { Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
 import { Observable, defaultIfEmpty, distinctUntilChanged, forkJoin, from, map, mergeMap, switchMap } from 'rxjs';
@@ -8,7 +8,7 @@ import { deepEquals } from '@cardano-sdk/util';
 export interface CreatePubStakeKeysTrackerProps {
   addresses$: Observable<GroupedAddress[]>;
   rewardAccounts$: Observable<Cardano.RewardAccountInfo[]>;
-  keyAgent: AsyncKeyAgent;
+  addressManager: util.Bip32Ed25519AddressManager;
 }
 
 export interface PubStakeKeyAndStatus {
@@ -43,7 +43,7 @@ const withStakeKeyDerivationPaths =
 export const createPublicStakeKeysTracker = ({
   addresses$,
   rewardAccounts$,
-  keyAgent
+  addressManager
 }: CreatePubStakeKeysTrackerProps) =>
   new TrackerSubject(
     rewardAccounts$.pipe(
@@ -51,7 +51,7 @@ export const createPublicStakeKeysTracker = ({
       mergeMap((derivationPathsAndStatus) =>
         forkJoin(
           derivationPathsAndStatus.map(({ stakeKeyDerivationPath, keyStatus }) =>
-            from(keyAgent.derivePublicKey(stakeKeyDerivationPath)).pipe(
+            from(addressManager.derivePublicKey(stakeKeyDerivationPath)).pipe(
               map((publicStakeKey) => ({ keyStatus, publicStakeKey }))
             )
           )

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -1,5 +1,5 @@
-import { AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
 import { Cardano, CardanoNodeErrors, Reward, TxCBOR } from '@cardano-sdk/core';
+import { GroupedAddress, util } from '@cardano-sdk/key-management';
 import { Observable } from 'rxjs';
 import { Percent } from '@cardano-sdk/util';
 import { SignedTx } from '@cardano-sdk/tx-construction';
@@ -41,10 +41,10 @@ export interface AddressDiscovery {
   /**
    * Discover used addresses in the HD wallet.
    *
-   * @param keyAgent The key agent controlling the root key to be used to derive the addresses to be discovered.
+   * @param addressManager The address manager to be used to derive the addresses to be discovered.
    * @returns A promise that will be resolved into a GroupedAddress list containing the discovered addresses.
    */
-  discover(keyAgent: AsyncKeyAgent): Promise<GroupedAddress[]>;
+  discover(addressManager: util.Bip32Ed25519AddressManager): Promise<GroupedAddress[]>;
 }
 
 export type Milliseconds = number;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -18,7 +18,7 @@ import { Shutdown } from '@cardano-sdk/util';
 
 export type Assets = Map<Cardano.AssetId, Asset.AssetInfo>;
 
-export type SignDataProps = Omit<cip8.Cip30SignDataRequest, 'keyAgent'>;
+export type SignDataProps = Omit<cip8.Cip30SignDataRequest, 'addressManager' | 'witnesser'>;
 
 export interface SyncStatus extends Shutdown {
   /**

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/consistent-destructuring, sonarjs/no-duplicate-string, @typescript-eslint/no-floating-promises, promise/no-nesting, promise/always-return */
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, AsyncKeyAgent, GroupedAddress } from '@cardano-sdk/key-management';
+import { AddressType, AsyncKeyAgent, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { AssetId, StubKeyAgent, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
 import { BehaviorSubject, Subscription, firstValueFrom, skip } from 'rxjs';
 import { Cardano, CardanoNodeErrors, ProviderError, ProviderFailure, TxCBOR } from '@cardano-sdk/core';
@@ -83,16 +83,17 @@ describe('PersonalWallet methods', () => {
         new PersonalWallet(
           { name: 'Test Wallet' },
           {
+            addressManager: util.createBip32Ed25519AddressManager(keyAgent),
             assetProvider,
             chainHistoryProvider,
             handleProvider,
-            keyAgent,
             logger,
             networkInfoProvider,
             rewardsProvider,
             stakePoolProvider,
             txSubmitProvider,
-            utxoProvider
+            utxoProvider,
+            witnesser: util.createBip32Ed25519Witnesser(keyAgent)
           }
         ),
       logger
@@ -226,16 +227,17 @@ describe('PersonalWallet methods', () => {
           new PersonalWallet(
             { name: 'Stub Wallet' },
             {
+              addressManager: util.createBip32Ed25519AddressManager(keyAgent),
               assetProvider: mocks.mockAssetProvider(),
               chainHistoryProvider: mockChainHistoryProvider(),
               handleProvider: mocks.mockHandleProvider(),
-              keyAgent,
               logger,
               networkInfoProvider: mocks.mockNetworkInfoProvider(),
               rewardsProvider: mockRewardsProvider(),
               stakePoolProvider: createStubStakePoolProvider(),
               txSubmitProvider: mocks.mockTxSubmitProvider(),
-              utxoProvider: mocks.mockUtxoProvider()
+              utxoProvider: mocks.mockUtxoProvider(),
+              witnesser: util.createBip32Ed25519Witnesser(keyAgent)
             }
           ),
         logger
@@ -542,15 +544,16 @@ describe('PersonalWallet methods', () => {
         new PersonalWallet(
           { name: 'Test Wallet' },
           {
+            addressManager: util.createBip32Ed25519AddressManager(keyAgent),
             assetProvider: mocks.mockAssetProvider(),
             chainHistoryProvider: mockChainHistoryProvider(),
-            keyAgent,
             logger,
             networkInfoProvider: mocks.mockNetworkInfoProvider(),
             rewardsProvider: mockRewardsProvider(),
             stakePoolProvider: mocks.mockStakePoolsProvider(),
             txSubmitProvider: mocks.mockTxSubmitProvider(),
-            utxoProvider: mocks.mockUtxoProvider()
+            utxoProvider: mocks.mockUtxoProvider(),
+            witnesser: util.createBip32Ed25519Witnesser(keyAgent)
           }
         ),
       logger

--- a/packages/wallet/test/PersonalWallet/rollback.test.ts
+++ b/packages/wallet/test/PersonalWallet/rollback.test.ts
@@ -1,5 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';
+import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
 import {
   Cardano,
   ChainHistoryProvider,
@@ -61,17 +61,18 @@ const createWallet = async (stores: WalletStores, providers: Providers, pollingC
       return new PersonalWallet(
         { name, polling: pollingConfig },
         {
+          addressManager: util.createBip32Ed25519AddressManager(keyAgent),
           assetProvider,
           chainHistoryProvider,
           connectionStatusTracker$,
-          keyAgent,
           logger,
           networkInfoProvider,
           rewardsProvider,
           stakePoolProvider,
           stores,
           txSubmitProvider,
-          utxoProvider
+          utxoProvider,
+          witnesser: util.createBip32Ed25519Witnesser(keyAgent)
         }
       );
     },

--- a/packages/wallet/test/PersonalWallet/shutdown.test.ts
+++ b/packages/wallet/test/PersonalWallet/shutdown.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';
+import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
 import {
   AssetId,
   createStubStakePoolProvider,
@@ -79,17 +79,18 @@ const createWallet = async (
       return new PersonalWallet(
         { name, polling: pollingConfig },
         {
+          addressManager: util.createBip32Ed25519AddressManager(keyAgent),
           assetProvider,
           chainHistoryProvider,
           connectionStatusTracker$,
-          keyAgent,
           logger,
           networkInfoProvider,
           rewardsProvider,
           stakePoolProvider,
           stores,
           txSubmitProvider,
-          utxoProvider
+          utxoProvider,
+          witnesser: util.createBip32Ed25519Witnesser(keyAgent)
         }
       );
     },
@@ -103,7 +104,8 @@ const assertWalletProperties = async (
   expectedDelegateeId: Cardano.PoolId | undefined,
   expectedRewardsHistory = flatten([...mocks.rewardsHistory.values()])
 ) => {
-  expect(wallet.keyAgent).toBeTruthy();
+  expect(wallet.addressManager).toBeTruthy();
+  expect(wallet.witnesser).toBeTruthy();
   // name
   expect(wallet.name).toBe(name);
   // utxo

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.integration.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.integration.test.ts
@@ -29,15 +29,16 @@ const createWallet = async (keyAgent: KeyAgent) => {
   return new PersonalWallet(
     { name: 'Wallet1' },
     {
+      addressManager: util.createBip32Ed25519AddressManager(asyncKeyAgent),
       assetProvider,
       chainHistoryProvider,
-      keyAgent: asyncKeyAgent,
       logger,
       networkInfoProvider,
       rewardsProvider,
       stakePoolProvider,
       txSubmitProvider,
-      utxoProvider
+      utxoProvider,
+      witnesser: util.createBip32Ed25519Witnesser(asyncKeyAgent)
     }
   );
 };

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -44,15 +44,16 @@ describe('LedgerKeyAgent', () => {
         return new PersonalWallet(
           { name: 'HW Wallet' },
           {
+            addressManager: util.createBip32Ed25519AddressManager(asyncKeyAgent),
             assetProvider,
             chainHistoryProvider,
-            keyAgent: asyncKeyAgent,
             logger,
             networkInfoProvider,
             rewardsProvider,
             stakePoolProvider,
             txSubmitProvider,
-            utxoProvider
+            utxoProvider,
+            witnesser: util.createBip32Ed25519Witnesser(asyncKeyAgent)
           }
         );
       },

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.integration.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.integration.test.ts
@@ -28,15 +28,16 @@ const createWallet = async (keyAgent: KeyAgent) => {
   return new PersonalWallet(
     { name: 'Wallet1' },
     {
+      addressManager: util.createBip32Ed25519AddressManager(asyncKeyAgent),
       assetProvider,
       chainHistoryProvider,
-      keyAgent: asyncKeyAgent,
       logger,
       networkInfoProvider,
       rewardsProvider,
       stakePoolProvider,
       txSubmitProvider,
-      utxoProvider
+      utxoProvider,
+      witnesser: util.createBip32Ed25519Witnesser(asyncKeyAgent)
     }
   );
 };

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
@@ -49,15 +49,16 @@ describe('TrezorKeyAgent', () => {
         return new PersonalWallet(
           { name: 'HW Wallet' },
           {
+            addressManager: util.createBip32Ed25519AddressManager(asyncKeyAgent),
             assetProvider,
             chainHistoryProvider,
-            keyAgent: asyncKeyAgent,
             logger,
             networkInfoProvider,
             rewardsProvider,
             stakePoolProvider,
             txSubmitProvider,
-            utxoProvider
+            utxoProvider,
+            witnesser: util.createBip32Ed25519Witnesser(asyncKeyAgent)
           }
         );
       },

--- a/packages/wallet/test/integration/CustomObservableWallet.test.ts
+++ b/packages/wallet/test/integration/CustomObservableWallet.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable sonarjs/no-extra-arguments */
 /* eslint-disable unicorn/consistent-function-scoping */
 import { Cardano, Serialization } from '@cardano-sdk/core';
-import { GroupedAddress } from '@cardano-sdk/key-management';
+import { GroupedAddress, util } from '@cardano-sdk/key-management';
 import { ObservableWallet, PersonalWallet } from '../../src';
 import {
   OutputValidator,
@@ -43,15 +43,16 @@ describe('CustomObservableWallet', () => {
       const extensionWallet: LaceObservableWallet = new PersonalWallet(
         { name: 'Extension Wallet' },
         {
+          addressManager: util.createBip32Ed25519AddressManager(await testAsyncKeyAgent()),
           assetProvider: mocks.mockAssetProvider(),
           chainHistoryProvider: mocks.mockChainHistoryProvider(),
-          keyAgent: await testAsyncKeyAgent(),
           logger,
           networkInfoProvider: mocks.mockNetworkInfoProvider(),
           rewardsProvider: mocks.mockRewardsProvider(),
           stakePoolProvider: createStubStakePoolProvider(),
           txSubmitProvider: mocks.mockTxSubmitProvider(),
-          utxoProvider: mocks.mockUtxoProvider()
+          utxoProvider: mocks.mockUtxoProvider(),
+          witnesser: util.createBip32Ed25519Witnesser(await testAsyncKeyAgent())
         }
       );
       extensionWallet;

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -12,7 +12,7 @@ import {
   TxSignError,
   WalletApi
 } from '@cardano-sdk/dapp-connector';
-import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';
+import { AddressType, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
 import { CallbackConfirmation, GetCollateralCallbackParams } from '../../src/cip30';
 import { Cardano, CardanoNodeErrors, Serialization, TxCBOR, coalesceValueQuantities } from '@cardano-sdk/core';
@@ -683,15 +683,16 @@ describe('cip30', () => {
             new PersonalWallet(
               { name: 'Test Wallet' },
               {
+                addressManager: util.createBip32Ed25519AddressManager(keyAgent),
                 assetProvider,
                 chainHistoryProvider,
-                keyAgent,
                 logger,
                 networkInfoProvider,
                 rewardsProvider,
                 stakePoolProvider,
                 txSubmitProvider,
-                utxoProvider
+                utxoProvider,
+                witnesser: util.createBip32Ed25519Witnesser(keyAgent)
               }
             ),
           logger

--- a/packages/wallet/test/integration/util.ts
+++ b/packages/wallet/test/integration/util.ts
@@ -4,6 +4,7 @@ import { WalletStores } from '../../src/persistence';
 import { createStubStakePoolProvider, mockProviders } from '@cardano-sdk/util-dev';
 import { dummyLogger as logger } from 'ts-log';
 import { testAsyncKeyAgent } from '../../../key-management/test/mocks';
+import { util } from '@cardano-sdk/key-management';
 
 const {
   mockAssetProvider,
@@ -39,9 +40,10 @@ export const createWallet = async (stores?: WalletStores, providers: Providers =
         {
           ...createDefaultProviders(),
           ...providers,
-          keyAgent,
+          addressManager: util.createBip32Ed25519AddressManager(keyAgent),
           logger,
-          stores
+          stores,
+          witnesser: util.createBip32Ed25519Witnesser(keyAgent)
         }
       ),
     logger

--- a/packages/wallet/test/services/PublicStakeKeysTracker.test.ts
+++ b/packages/wallet/test/services/PublicStakeKeysTracker.test.ts
@@ -1,4 +1,4 @@
-import { AccountKeyDerivationPath, AsyncKeyAgent, GroupedAddress, KeyRole } from '@cardano-sdk/key-management';
+import { AccountKeyDerivationPath, AsyncKeyAgent, GroupedAddress, KeyRole, util } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import { ObservableWallet } from '../../src';
 import { PubStakeKeyAndStatus, createPublicStakeKeysTracker } from '../../src/services/PublicStakeKeysTracker';
@@ -77,8 +77,8 @@ describe('PublicStakeKeysTracker', () => {
     const rewardAccounts$ = of([]);
 
     const stakePubKeys$ = createPublicStakeKeysTracker({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
       addresses$,
-      keyAgent,
       rewardAccounts$
     });
 
@@ -91,8 +91,8 @@ describe('PublicStakeKeysTracker', () => {
     const rewardAccounts$ = of(rewardAccounts);
 
     const stakePubKeys$ = createPublicStakeKeysTracker({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
       addresses$,
-      keyAgent,
       rewardAccounts$
     });
 
@@ -117,8 +117,8 @@ describe('PublicStakeKeysTracker', () => {
     const rewardAccounts$ = of(rewardAccounts);
 
     const stakePubKeys$ = createPublicStakeKeysTracker({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
       addresses$,
-      keyAgent,
       rewardAccounts$
     });
 
@@ -136,8 +136,8 @@ describe('PublicStakeKeysTracker', () => {
     const rewardAccounts$ = from([[rewardAccounts[0]], rewardAccounts]);
 
     const stakePubKeys$ = createPublicStakeKeysTracker({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
       addresses$,
-      keyAgent,
       rewardAccounts$
     });
 
@@ -157,8 +157,8 @@ describe('PublicStakeKeysTracker', () => {
     const rewardAccounts$ = of(rewardAccounts);
 
     const stakePubKeys$ = createPublicStakeKeysTracker({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
       addresses$,
-      keyAgent,
       rewardAccounts$
     });
 
@@ -180,8 +180,8 @@ describe('PublicStakeKeysTracker', () => {
     );
 
     const stakePubKeys$ = createPublicStakeKeysTracker({
+      addressManager: util.createBip32Ed25519AddressManager(keyAgent),
       addresses$,
-      keyAgent,
       rewardAccounts$
     });
 

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -1,5 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, GroupedAddress } from '@cardano-sdk/key-management';
+import { AddressType, GroupedAddress, util as KeyManagementUtil } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import {
   PersonalWallet,
@@ -113,15 +113,16 @@ describe('WalletUtil', () => {
           new PersonalWallet(
             { name: 'Test Wallet' },
             {
+              addressManager: KeyManagementUtil.createBip32Ed25519AddressManager(keyAgent),
               assetProvider,
               chainHistoryProvider,
-              keyAgent,
               logger,
               networkInfoProvider,
               rewardsProvider,
               stakePoolProvider,
               txSubmitProvider,
-              utxoProvider
+              utxoProvider,
+              witnesser: KeyManagementUtil.createBip32Ed25519Witnesser(keyAgent)
             }
           ),
         logger

--- a/packages/wallet/test/services/addressDiscovery/HDSequentialDiscovery.test.ts
+++ b/packages/wallet/test/services/addressDiscovery/HDSequentialDiscovery.test.ts
@@ -1,4 +1,4 @@
-import { AddressType, AsyncKeyAgent, KeyRole } from '@cardano-sdk/key-management';
+import { AddressType, AsyncKeyAgent, KeyRole, util } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
 import { HDSequentialDiscovery } from '../../../src';
 import {
@@ -33,7 +33,7 @@ describe('HDSequentialDiscovery', () => {
       25
     );
 
-    const addresses = await discovery.discover(mockKeyAgent);
+    const addresses = await discovery.discover(util.createBip32Ed25519AddressManager(mockKeyAgent));
 
     expect(addresses.length).toEqual(5);
     expect(addresses[0]).toEqual({
@@ -108,7 +108,7 @@ describe('HDSequentialDiscovery', () => {
 
   it('derives exactly 1 address when no used addresses are found', async () => {
     const discovery = new HDSequentialDiscovery(mockAlwaysEmptyChainHistoryProvider, 25);
-    const addresses = await discovery.discover(mockKeyAgent);
+    const addresses = await discovery.discover(util.createBip32Ed25519AddressManager(mockKeyAgent));
     expect(addresses).toHaveLength(1);
     expect(await firstValueFrom(mockKeyAgent.knownAddresses$)).toHaveLength(1);
   });
@@ -130,7 +130,7 @@ describe('HDSequentialDiscovery', () => {
       25
     );
 
-    const addresses = await discovery.discover(mockKeyAgent);
+    const addresses = await discovery.discover(util.createBip32Ed25519AddressManager(mockKeyAgent));
 
     // 5 payment key + 4 stake keys combined with payment index 0 (the first address overlaps in both sets).
     expect(addresses.length).toEqual(8);
@@ -158,7 +158,7 @@ describe('HDSequentialDiscovery', () => {
   it('return all discovered addresses', async () => {
     const discovery = new HDSequentialDiscovery(mockChainHistoryProvider, 25);
 
-    const addresses = await discovery.discover(mockKeyAgent);
+    const addresses = await discovery.discover(util.createBip32Ed25519AddressManager(mockKeyAgent));
 
     expect(addresses.length).toEqual(50);
 
@@ -213,7 +213,7 @@ describe('HDSequentialDiscovery', () => {
     await mockKeyAgent.setKnownAddresses([knownAddress]);
 
     const discovery = new HDSequentialDiscovery(mockAlwaysFailChainHistoryProvider, 25);
-    await expect(discovery.discover(mockKeyAgent)).rejects.toThrow();
+    await expect(discovery.discover(util.createBip32Ed25519AddressManager(mockKeyAgent))).rejects.toThrow();
 
     const knownAddresses = await firstValueFrom(mockKeyAgent.knownAddresses$);
     expect(knownAddresses).toEqual([knownAddress]);

--- a/packages/wallet/test/services/addressDiscovery/SingleAddressDiscovery.test.ts
+++ b/packages/wallet/test/services/addressDiscovery/SingleAddressDiscovery.test.ts
@@ -1,4 +1,4 @@
-import { AsyncKeyAgent, KeyRole } from '@cardano-sdk/key-management';
+import { AsyncKeyAgent, KeyRole, util } from '@cardano-sdk/key-management';
 import { SingleAddressDiscovery } from '../../../src';
 import { prepareMockKeyAgentWithData } from './mockData';
 
@@ -12,7 +12,7 @@ describe('SingleAddressDiscovery', () => {
   it('return the first derived address', async () => {
     const discovery = new SingleAddressDiscovery();
 
-    const addresses = await discovery.discover(mockKeyAgent);
+    const addresses = await discovery.discover(util.createBip32Ed25519AddressManager(mockKeyAgent));
 
     expect(addresses.length).toEqual(1);
     expect(addresses[0]).toEqual({


### PR DESCRIPTION
# Context

In order to add multi-wallet/account support, we need to re-design wallet manager. We know that we’ll have to implement Shared Wallets after this epic, and the concept of KeyAgent doesn’t work with this type of wallets. Replacing PersonalWallet dependency on KeyAgent with new abstractions now will result in less work overall. 

# Proposed Solution

Replacing PersonalWallet dependency on KeyAgent with new abstractions (AddressManager and Witnesser). 

# Important Changes Introduced

PersonalWallet now takes an AddressManager and a Witnesser instead of a key agent. 