### PR TITLE
feat(hardware-trezor): add trezor tx collateral mappers

### DIFF
--- a/packages/hardware-trezor/src/TrezorKeyAgent.ts
+++ b/packages/hardware-trezor/src/TrezorKeyAgent.ts
@@ -153,6 +153,13 @@ export class TrezorKeyAgent extends KeyAgentBase {
       }
     }
 
+    // Represents a transaction that includes Plutus script evaluation (e.g. spending from a script address). We will
+    // also flag any transaction with required extra signers as a plutus transaction, since ordinary transactions requires
+    // all inputs to be provided by the wallet
+    if (tx.collateralInputs || tx.requiredSigners) {
+      return Trezor.PROTO.CardanoTxSigningMode.PLUTUS_TRANSACTION;
+    }
+
     // Represents an ordinary user transaction transferring funds.
     return Trezor.PROTO.CardanoTxSigningMode.ORDINARY_TRANSACTION;
   }

--- a/packages/hardware-trezor/src/transformers/tx.ts
+++ b/packages/hardware-trezor/src/transformers/tx.ts
@@ -3,7 +3,7 @@ import { Cardano } from '@cardano-sdk/core';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { TrezorTxTransformerContext } from '../types';
 import { mapAdditionalWitnessRequests } from './additionalWitnessRequests';
-import { mapAuxiliaryData, mapCerts, mapTxIns, mapTxOuts, mapWithdrawals } from './';
+import { mapAuxiliaryData, mapCerts, mapTxIns, mapTxOuts, mapWithdrawals, toTxOut } from './';
 import { mapTokenMap } from './assets';
 
 /**
@@ -22,6 +22,8 @@ const trezorTxTransformer = async (
     additionalWitnessRequests: mapAdditionalWitnessRequests(inputs, context),
     auxiliaryData: body.auxiliaryDataHash ? mapAuxiliaryData(body.auxiliaryDataHash) : undefined,
     certificates: mapCerts(body.certificates ?? [], context),
+    collateralInputs: body.collaterals ? await mapTxIns(body.collaterals, context) : undefined,
+    collateralReturn: body.collateralReturn ? toTxOut(body.collateralReturn, context) : undefined,
     fee: body.fee.toString(),
     inputs,
     mint: mapTokenMap(body.mint, true),
@@ -29,6 +31,7 @@ const trezorTxTransformer = async (
     outputs: mapTxOuts(body.outputs, context),
     protocolMagic: context.chainId.networkMagic,
     referenceInputs: body.referenceInputs ? await mapTxIns(body.referenceInputs, context) : undefined,
+    totalCollateral: body.totalCollateral ? body.totalCollateral.toString() : undefined,
     ttl: body.validityInterval?.invalidHereafter?.toString(),
     validityIntervalStart: body.validityInterval?.invalidBefore?.toString(),
     withdrawals: mapWithdrawals(body.withdrawals ?? [], context)

--- a/packages/hardware-trezor/test/testData.ts
+++ b/packages/hardware-trezor/test/testData.ts
@@ -269,3 +269,16 @@ export const babbageTxBodyWithScripts: Cardano.TxBody = {
   },
   withdrawals: [coreWithdrawalWithKeyHashCredential]
 };
+
+export const txBodyWithCollaterals = {
+  ...minValidTxBody,
+  collateralReturn: txOut,
+  collaterals: [txIn]
+};
+
+export const plutusTxWithBabbage = {
+  ...babbageTxBodyWithScripts,
+  collateralReturn: txOut,
+  collaterals: [txIn],
+  totalCollateral: 1000n
+};

--- a/packages/hardware-trezor/test/transformers/tx.test.ts
+++ b/packages/hardware-trezor/test/transformers/tx.test.ts
@@ -7,7 +7,9 @@ import {
   knownAddressKeyPath,
   knownAddressStakeKeyPath,
   minValidTxBody,
+  plutusTxWithBabbage,
   txBody,
+  txBodyWithCollaterals,
   txIn
 } from '../testData';
 import { txToTrezor } from '../../src/transformers/tx';
@@ -276,6 +278,149 @@ describe('tx', () => {
           }
         ],
         protocolMagic: 999,
+        ttl: '1000',
+        validityIntervalStart: '100',
+        withdrawals: [
+          {
+            amount: '5',
+            path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 2, 0]
+          }
+        ]
+      });
+    });
+
+    test('can map transaction with collaterals', async () => {
+      expect(
+        await txToTrezor({
+          ...contextWithoutKnownAddresses,
+          cardanoTxBody: txBodyWithCollaterals
+        })
+      ).toEqual({
+        additionalWitnessRequests: [],
+        auxiliaryData: undefined,
+        certificates: [],
+        collateralInputs: [
+          {
+            prev_hash: txIn.txId,
+            prev_index: txIn.index
+          }
+        ],
+        collateralReturn: {
+          address:
+            'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+          amount: '10',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+        },
+        fee: '10',
+        inputs: [
+          {
+            prev_hash: txIn.txId,
+            prev_index: txIn.index
+          }
+        ],
+        mint: undefined,
+        networkId: 0,
+        outputs: [
+          {
+            address:
+              'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+            amount: '10',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+          }
+        ],
+        protocolMagic: 999,
+        ttl: undefined,
+        validityIntervalStart: undefined,
+        withdrawals: []
+      });
+    });
+
+    test('can map plutus transaction with babbage elements', async () => {
+      expect(
+        await txToTrezor({
+          ...contextWithKnownAddresses,
+          cardanoTxBody: plutusTxWithBabbage
+        })
+      ).toEqual({
+        additionalWitnessRequests: [
+          [2_147_485_500, 2_147_485_463, 2_147_483_648, 1, 0], // payment key path
+          [2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0] // reward account key path
+        ],
+        auxiliaryData: {
+          hash: '2ceb364d93225b4a0f004a0975a13eb50c3cc6348474b4fe9121f8dc72ca0cfa'
+        },
+        certificates: [
+          {
+            path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 2, 0],
+            pool: '153806dbcd134ddee69a8c5204e38ac80448f62342f8c23cfe4b7edf',
+            type: Trezor.PROTO.CardanoCertificateType.STAKE_DELEGATION
+          }
+        ],
+        collateralInputs: [
+          {
+            path: [util.harden(CardanoKeyConst.PURPOSE), util.harden(CardanoKeyConst.COIN_TYPE), util.harden(0), 1, 0],
+            prev_hash: txIn.txId,
+            prev_index: txIn.index
+          }
+        ],
+        collateralReturn: {
+          address:
+            'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
+          amount: '10',
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+        },
+        fee: '10',
+        inputs: [
+          {
+            path: knownAddressKeyPath,
+            prev_hash: txIn.txId,
+            prev_index: txIn.index
+          }
+        ],
+        mint: [
+          {
+            policyId: '2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740',
+            tokenAmounts: [{ assetNameBytes: '', mintAmount: '20' }]
+          },
+          {
+            policyId: '659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba82',
+            tokenAmounts: [{ assetNameBytes: '54534c41', mintAmount: '-50' }]
+          },
+          {
+            policyId: '7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373',
+            tokenAmounts: [
+              { assetNameBytes: '', mintAmount: '40' },
+              { assetNameBytes: '504154415445', mintAmount: '30' }
+            ]
+          }
+        ],
+        networkId: 0,
+        outputs: [
+          {
+            addressParameters: {
+              addressType: Trezor.PROTO.CardanoAddressType.BASE,
+              path: knownAddressKeyPath,
+              stakingPath: knownAddressStakeKeyPath
+            },
+            amount: '10',
+            datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+            referenceScript: '82015820b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'
+          },
+          {
+            addressParameters: {
+              addressType: Trezor.PROTO.CardanoAddressType.BASE,
+              path: knownAddressKeyPath,
+              stakingPath: knownAddressStakeKeyPath
+            },
+            amount: '10',
+            format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE,
+            inlineDatum: '187b',
+            referenceScript: '82015820b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'
+          }
+        ],
+        protocolMagic: 999,
+        totalCollateral: '1000',
         ttl: '1000',
         validityIntervalStart: '100',
         withdrawals: [

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
@@ -1,7 +1,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, CommunicationType, SerializableTrezorKeyAgentData, util } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Serialization } from '@cardano-sdk/core';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { InitializeTxProps, InitializeTxResult } from '@cardano-sdk/tx-construction';
@@ -70,10 +70,22 @@ describe('TrezorKeyAgent', () => {
 
   describe('sign transaction', () => {
     const poolId = Cardano.PoolId('pool1ev8vy6fyj7693ergzty2t0azjvw35tvkt2vcjwpgajqs7z6u2vn');
-    const scriptReference: Cardano.PlutusScript = {
+    const plutusScriptV1: Cardano.PlutusScript = {
       __type: Cardano.ScriptType.Plutus,
       bytes: HexBlob('b6dbf0b03c93afe5696f10d49e8a8304ebfac01deeb8f82f2af5836ebbc1b450'),
       version: Cardano.PlutusLanguageVersion.V1
+    };
+    const plutusScriptV2: Cardano.PlutusScript = {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob(
+        // eslint-disable-next-line max-len
+        '5907620100003232323232323232323232323232332232323232322232325335320193333573466e1cd55cea80124000466442466002006004646464646464646464646464646666ae68cdc39aab9d500c480008cccccccccccc88888888888848cccccccccccc00403403002c02802402001c01801401000c008cd4050054d5d0a80619a80a00a9aba1500b33501401635742a014666aa030eb9405cd5d0a804999aa80c3ae501735742a01066a02803e6ae85401cccd54060081d69aba150063232323333573466e1cd55cea801240004664424660020060046464646666ae68cdc39aab9d5002480008cc8848cc00400c008cd40a9d69aba15002302b357426ae8940088c98c80b4cd5ce01701681589aab9e5001137540026ae854008c8c8c8cccd5cd19b8735573aa004900011991091980080180119a8153ad35742a00460566ae84d5d1280111931901699ab9c02e02d02b135573ca00226ea8004d5d09aba2500223263202933573805405204e26aae7940044dd50009aba1500533501475c6ae854010ccd540600708004d5d0a801999aa80c3ae200135742a004603c6ae84d5d1280111931901299ab9c026025023135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d55cf280089baa00135742a004601c6ae84d5d1280111931900b99ab9c018017015101613263201633573892010350543500016135573ca00226ea800448c88c008dd6000990009aa80a911999aab9f0012500a233500930043574200460066ae880080508c8c8cccd5cd19b8735573aa004900011991091980080180118061aba150023005357426ae8940088c98c8050cd5ce00a80a00909aab9e5001137540024646464646666ae68cdc39aab9d5004480008cccc888848cccc00401401000c008c8c8c8cccd5cd19b8735573aa0049000119910919800801801180a9aba1500233500f014357426ae8940088c98c8064cd5ce00d00c80b89aab9e5001137540026ae854010ccd54021d728039aba150033232323333573466e1d4005200423212223002004357426aae79400c8cccd5cd19b875002480088c84888c004010dd71aba135573ca00846666ae68cdc3a801a400042444006464c6403666ae7007006c06406005c4d55cea80089baa00135742a00466a016eb8d5d09aba2500223263201533573802c02a02626ae8940044d5d1280089aab9e500113754002266aa002eb9d6889119118011bab00132001355012223233335573e0044a010466a00e66442466002006004600c6aae754008c014d55cf280118021aba200301213574200222440042442446600200800624464646666ae68cdc3a800a40004642446004006600a6ae84d55cf280191999ab9a3370ea0049001109100091931900819ab9c01101000e00d135573aa00226ea80048c8c8cccd5cd19b875001480188c848888c010014c01cd5d09aab9e500323333573466e1d400920042321222230020053009357426aae7940108cccd5cd19b875003480088c848888c004014c01cd5d09aab9e500523333573466e1d40112000232122223003005375c6ae84d55cf280311931900819ab9c01101000e00d00c00b135573aa00226ea80048c8c8cccd5cd19b8735573aa004900011991091980080180118029aba15002375a6ae84d5d1280111931900619ab9c00d00c00a135573ca00226ea80048c8cccd5cd19b8735573aa002900011bae357426aae7940088c98c8028cd5ce00580500409baa001232323232323333573466e1d4005200c21222222200323333573466e1d4009200a21222222200423333573466e1d400d2008233221222222233001009008375c6ae854014dd69aba135744a00a46666ae68cdc3a8022400c4664424444444660040120106eb8d5d0a8039bae357426ae89401c8cccd5cd19b875005480108cc8848888888cc018024020c030d5d0a8049bae357426ae8940248cccd5cd19b875006480088c848888888c01c020c034d5d09aab9e500b23333573466e1d401d2000232122222223005008300e357426aae7940308c98c804ccd5ce00a00980880800780700680600589aab9d5004135573ca00626aae7940084d55cf280089baa0012323232323333573466e1d400520022333222122333001005004003375a6ae854010dd69aba15003375a6ae84d5d1280191999ab9a3370ea0049000119091180100198041aba135573ca00c464c6401866ae700340300280244d55cea80189aba25001135573ca00226ea80048c8c8cccd5cd19b875001480088c8488c00400cdd71aba135573ca00646666ae68cdc3a8012400046424460040066eb8d5d09aab9e500423263200933573801401200e00c26aae7540044dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6401466ae7002c02802001c0184d55cea80089baa0012323333573466e1d40052002212200223333573466e1d40092000200823263200633573800e00c00800626aae74dd5000a4c2400292010350543100122001112323001001223300330020020011'
+      ),
+      version: Cardano.PlutusLanguageVersion.V2
+    };
+    const collateral = {
+      index: 0,
+      txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
     };
     const outputs = {
       outputWithAssets: {
@@ -110,7 +122,7 @@ describe('TrezorKeyAgent', () => {
           'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w'
         ),
         datumHash: Hash32ByteBase16('b6eb57092c330973b23784ac39426921eebd8376343409c03f613fa1a2017126'),
-        scriptReference,
+        scriptReference: plutusScriptV1,
         value: { coins: 11_111_111n }
       }
     };
@@ -323,6 +335,53 @@ describe('TrezorKeyAgent', () => {
         outputs: new Set<Cardano.TxOut>([outputs.simpleOutputWithReferenceScript])
       };
       txInternals = await wallet.initializeTx(props);
+
+      const signatures = await keyAgent.signTransaction({
+        body: txInternals.body,
+        hash: txInternals.hash
+      });
+      expect(signatures.size).toBe(2);
+    });
+
+    it('successfully signs transaction with collaterals', async () => {
+      props = {
+        collaterals: new Set([collateral]),
+        outputs: new Set<Cardano.TxOut>([outputs.simpleOutputWithReferenceScript])
+      };
+      txInternals = await wallet.initializeTx(props);
+
+      const signatures = await keyAgent.signTransaction({
+        body: txInternals.body,
+        hash: txInternals.hash
+      });
+      expect(signatures.size).toBe(2);
+    });
+
+    it('successfully signs transaction that mints a token using a plutus script', async () => {
+      // Script minting policy id.
+      const policyId = Cardano.PolicyId('38299ce86f8cbef9ebeecc2e94370cb49196d60c93797fffb71d3932');
+      const assetId = Cardano.AssetId(`${policyId}707572706C65`);
+
+      const scriptRedeemer: Cardano.Redeemer = {
+        // CBOR for Void redeemer.
+        data: Serialization.PlutusData.fromCbor(HexBlob('d8799fff')).toCore(),
+        executionUnits: {
+          memory: 13_421_562,
+          steps: 9_818_438_928
+        },
+        // Hardcoded to 0 since we only have one script
+        index: 0,
+        purpose: Cardano.RedeemerPurpose.mint
+      };
+
+      const txProps: InitializeTxProps = {
+        collaterals: new Set([collateral]),
+        mint: new Map([[assetId, 1n]]),
+        outputs: new Set([outputs.simpleOutput, outputs.outputWithAssets]),
+        witness: { redeemers: [scriptRedeemer], scripts: [plutusScriptV2] }
+      };
+
+      txInternals = await wallet.initializeTx(txProps);
 
       const signatures = await keyAgent.signTransaction({
         body: txInternals.body,


### PR DESCRIPTION
This PR introduces additional collateral data mappers.
[JIRA Ticket](https://input-output.atlassian.net/browse/LW-8285) and Plutus signing mode https://input-output.atlassian.net/browse/LW-8286 ( described in: https://input-output.atlassian.net/browse/LW-8285?focusedCommentId=235169)

# Context

SDK testing standards were followed when developing this ticket
It will not be tested by SDETs in isolation! (Described in JIRA Ticket)

# Proposed Solution

Add Trezor TX `collateralInputs`, `collateralReturn`, and `totalCollateral` mappers

# Important Changes Introduced

New mappers were added. No breaking changes