### PR TITLE
test(cardano-services): fix flaky test

### DIFF
--- a/packages/cardano-services/test/Program/services/postgres.test.ts
+++ b/packages/cardano-services/test/Program/services/postgres.test.ts
@@ -233,6 +233,7 @@ describe('Service dependency abstractions', () => {
       const result = await provider!.query(HEALTH_CHECK_QUERY);
       expect(result.rowCount).toBeTruthy();
       expect(dnsResolverMock).toBeCalledTimes(3);
+      await provider!.end();
     });
 
     it('should execute a provider operation without to intercept it', async () => {


### PR DESCRIPTION
# Context

`yarn workspace @cardano-sdk/cardano-services test` sometimes fails with following error

```
Error: Unhandled error. (error: terminating connection due to administrator command
    at Parser.parseErrorMessage (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/parser.ts:369:69)
    at Parser.handlePacket (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/parser.ts:188:21)
    at Parser.parse (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/parser.ts:103:30)
    at Socket.<anonymous> (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:324:12)
    at readableAddChunk (node:internal/streams/readable:297:9)
    at Socket.Readable.push (node:internal/streams/readable:234:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  length: 116,
  severity: 'FATAL',
  code: '57P01',
  detail: undefined,
  hint: undefined,
  position: undefined,
```

I noticed that `yarn workspace @cardano-sdk/cardano-services test packages/cardano-services/test/Program/services/postgres.test.ts` deterministically fails with the same error.

**yarn** chooses by itself the order of test files: when the given file is executed early, no problems; when it is executed close to the end of the tests, the test suite fails.

# Proposed Solution

Explicitly closed a DB connection.