### PR TITLE
test(cardano-services): fix flaky test

### DIFF
--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -94,6 +94,8 @@ describe('HttpServer', () => {
     provider = new DbSyncUtxoProvider({ cache, cardanoNode, dbPools, logger });
   });
 
+  afterAll(() => Promise.all([dbPools.healthCheck.end(), dbPools.main.end()]));
+
   describe('initialize', () => {
     afterEach(() => httpServer.shutdown());
     it('initializes the express application', async () => {

--- a/packages/cardano-services/test/PgBoss/stakePoolBatchDelistHandler.test.ts
+++ b/packages/cardano-services/test/PgBoss/stakePoolBatchDelistHandler.test.ts
@@ -1,4 +1,5 @@
 import { DataSource } from 'typeorm';
+import { Pool } from 'pg';
 import { PoolDelistedEntity } from '@cardano-sdk/projection-typeorm';
 import { WorkerHandlerFactoryOptions } from '../../src/PgBoss';
 import { createSmashStakePoolDelistedService } from '../../src/StakePool/HttpStakePoolMetadata/SmashStakePoolDelistedService';
@@ -10,11 +11,16 @@ jest.mock('../../src/StakePool/HttpStakePoolMetadata/SmashStakePoolDelistedServi
 
 describe('stakePoolBatchDelistHandler', () => {
   let dataSource: DataSource;
+  let db: Pool;
 
   beforeAll(async () => {
     const testData = await initHandlerTest();
-    dataSource = testData.dataSource;
+
+    ({ dataSource, db } = testData);
   });
+
+  afterAll(() => Promise.all([db.end(), dataSource.destroy()]));
+
   it('contain latest delisted pools only', async () => {
     // Padded by spaces because pool id length is fixed to 56 chars
     const expected = ['pool1', 'pool2', 'pool3'].map((p) => p.padEnd(56, ' '));

--- a/packages/cardano-services/test/PgBoss/stakePoolMetricsHandler.test.ts
+++ b/packages/cardano-services/test/PgBoss/stakePoolMetricsHandler.test.ts
@@ -2,6 +2,7 @@ import { Cardano, StakePoolProvider } from '@cardano-sdk/core';
 import { CurrentPoolMetricsEntity, StakePoolEntity } from '@cardano-sdk/projection-typeorm';
 import { DataSource } from 'typeorm';
 import { Percent } from '@cardano-sdk/util';
+import { Pool } from 'pg';
 import { Repository } from 'typeorm/repository/Repository';
 import { getPoolIdsToUpdate, savePoolMetrics } from '../../src/PgBoss/stakePoolMetricsHandler';
 import { initHandlerTest, poolId } from './util';
@@ -9,6 +10,7 @@ import { logger } from '@cardano-sdk/util-dev';
 
 describe('stakePoolMetricsHandler', () => {
   let dataSource: DataSource;
+  let db: Pool;
   let metricsRepos: Repository<CurrentPoolMetricsEntity>;
   const metrics: Cardano.StakePoolMetrics = {
     blocksCreated: 23,
@@ -23,10 +25,12 @@ describe('stakePoolMetricsHandler', () => {
 
   beforeAll(async () => {
     const testData = await initHandlerTest();
-    ({ dataSource } = testData);
+    ({ dataSource, db } = testData);
 
     metricsRepos = dataSource.getRepository(CurrentPoolMetricsEntity);
   });
+
+  afterAll(() => Promise.all([db.end(), dataSource.destroy()]));
 
   describe('getPoolIdsToUpdate', () => {
     const partialOptions = {

--- a/packages/cardano-services/test/PgBoss/util.ts
+++ b/packages/cardano-services/test/PgBoss/util.ts
@@ -55,5 +55,5 @@ export const initHandlerTest = async () => {
   await blockRepos.insert(block);
   await poolRepos.insert(stakePool);
 
-  return { block, dataSource, stakePool };
+  return { block, dataSource, db, stakePool };
 };


### PR DESCRIPTION
# Context

`yarn workspace @cardano-sdk/cardano-services test` sometimes fails with following error

```
Error: Unhandled error. (error: terminating connection due to administrator command
    at Parser.parseErrorMessage (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/parser.ts:369:69)
    at Parser.handlePacket (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/parser.ts:188:21)
    at Parser.parse (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/parser.ts:103:30)
    at Socket.<anonymous> (/home/cicci/iohk/cardano-js-sdk/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:513:28)
    at addChunk (node:internal/streams/readable:324:12)
    at readableAddChunk (node:internal/streams/readable:297:9)
    at Socket.Readable.push (node:internal/streams/readable:234:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
  length: 116,
  severity: 'FATAL',
  code: '57P01',
  detail: undefined,
  hint: undefined,
  position: undefined,
```

I noticed that
- `yarn workspace @cardano-sdk/cardano-services test test/Http/HttpServer.test.ts`
- `yarn workspace @cardano-sdk/cardano-services test test/PgBoss/stakePoolBatchDelistHandler.test.ts`
- `yarn workspace @cardano-sdk/cardano-services test test/PgBoss/stakePoolMetadataHandler.test.ts`
- `yarn workspace @cardano-sdk/cardano-services test test/PgBoss/stakePoolMetricsHandler.test.ts`

deterministically fail with the same error.

**yarn** chooses by itself the order of test files: when all the given files are executed early, no problems; when at least one is executed close to the end of the tests, the test suite fails.

# Proposed Solution

Explicitly closed some DB connections.