### PR TITLE
Feat/lw 9128 conway era compatible sdk clients

### DIFF
--- a/packages/cardano-services-client/src/TxSubmitProvider/TxSubmitApiProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/TxSubmitApiProvider.ts
@@ -1,6 +1,7 @@
 import { Cardano, ProviderError, ProviderFailure, SubmitTxArgs, TxBodyCBOR, TxSubmitProvider } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
 import { hexStringToBuffer } from '@cardano-sdk/util';
+import { mapCardanoTxSubmitError } from './cardanoTxSubmitErrorMapper';
 import axios, { AxiosInstance } from 'axios';
 
 export class TxSubmitApiProvider implements TxSubmitProvider {
@@ -42,7 +43,7 @@ export class TxSubmitApiProvider implements TxSubmitProvider {
 
         if (typeof status === 'number' && status >= 400 && status < 500) this.#healthStatus = true;
 
-        throw new ProviderError(ProviderFailure.BadRequest, null, data as string);
+        throw new ProviderError(ProviderFailure.BadRequest, mapCardanoTxSubmitError(data), data as string);
       }
 
       throw new ProviderError(ProviderFailure.Unknown, error, 'submitting tx');

--- a/packages/cardano-services-client/src/TxSubmitProvider/cardanoTxSubmitErrorMapper.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/cardanoTxSubmitErrorMapper.ts
@@ -1,0 +1,20 @@
+/* eslint-disable wrap-regex */
+import { TxSubmissionError, TxSubmissionErrorCode } from '@cardano-sdk/core';
+
+export const mapCardanoTxSubmitError = (errorData: unknown): TxSubmissionError | null => {
+  if (typeof errorData === 'string') {
+    if (/outsideofvalidity/i.test(errorData)) {
+      return new TxSubmissionError(TxSubmissionErrorCode.OutsideOfValidityInterval, null, errorData);
+    }
+    if (/valuenotconserved/i.test(errorData)) {
+      return new TxSubmissionError(TxSubmissionErrorCode.ValueNotConserved, null, errorData);
+    }
+    if (/nonadacollateral/i.test(errorData)) {
+      return new TxSubmissionError(TxSubmissionErrorCode.NonAdaCollateral, null, errorData);
+    }
+    if (/incompletewithdrawals/i.test(errorData)) {
+      return new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, errorData);
+    }
+  }
+  return null;
+};

--- a/packages/cardano-services-client/test/TxSubmitProvider/cardanoTxSubmitErrorMapper.test.ts
+++ b/packages/cardano-services-client/test/TxSubmitProvider/cardanoTxSubmitErrorMapper.test.ts
@@ -1,0 +1,31 @@
+import { CardanoNodeUtil, TxSubmissionErrorCode } from '@cardano-sdk/core';
+import { mapCardanoTxSubmitError } from '../../src/TxSubmitProvider/cardanoTxSubmitErrorMapper';
+
+describe('mapCardanoTxSubmitError', () => {
+  describe('stringish errors', () => {
+    it('can map OutsideOfValidityIntervalError to TxSubmissionErrorCode.OutsideOfValidityInterval', () => {
+      const errorData = 'blah blah OutsideOfValidity blah blah';
+      expect(CardanoNodeUtil.isOutsideOfValidityIntervalError(mapCardanoTxSubmitError(errorData))).toBeTruthy();
+    });
+
+    it('can map ValueNotConservedError to TxSubmissionErrorCode.ValueNotConserved', () => {
+      const errorData = 'blah blah ValueNotConserved blah blah';
+      expect(CardanoNodeUtil.isValueNotConservedError(mapCardanoTxSubmitError(errorData))).toBeTruthy();
+    });
+
+    it('can map NonAdaCollateralError to TxSubmissionErrorCode.NonAdaCollateral', () => {
+      const errorData = 'blah blah NonAdaCollateral blah blah';
+      expect(mapCardanoTxSubmitError(errorData)?.code).toEqual(TxSubmissionErrorCode.NonAdaCollateral);
+    });
+
+    it('can map IncompleteWithdrawalsError to TxSubmissionErrorCode.IncompleteWithdrawals', () => {
+      const errorData = 'blah blah IncompleteWithdrawals blah blah';
+      expect(CardanoNodeUtil.isIncompleteWithdrawalsError(mapCardanoTxSubmitError(errorData))).toBeTruthy();
+    });
+
+    it('returns null for unknown errors', () => {
+      const errorData = 'blah blah unknown blah blah';
+      expect(mapCardanoTxSubmitError(errorData)).toBeNull();
+    });
+  });
+});

--- a/packages/cardano-services-client/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/TxSubmitProvider/txSubmitHttpProvider.test.ts
@@ -1,4 +1,11 @@
-import { CardanoNodeErrors, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import {
+  GeneralCardanoNodeError,
+  GeneralCardanoNodeErrorCode,
+  ProviderError,
+  ProviderFailure,
+  TxSubmissionError,
+  TxSubmissionErrorCode
+} from '@cardano-sdk/core';
 import { bufferToHexString } from '@cardano-sdk/util';
 import { config } from '../util';
 import { handleProviderMocks } from '@cardano-sdk/util-dev';
@@ -53,10 +60,16 @@ describe('txSubmitHttpProvider', () => {
 
       describe('errors', () => {
         const testError =
-          (bodyError: Error, providerFailure: ProviderFailure, providerErrorType: unknown) => async () => {
+          (
+            bodyError: Error | null,
+            providerFailure: ProviderFailure,
+            providerErrorType: unknown,
+            reason?: ProviderFailure
+          ) =>
+          async () => {
             try {
               axiosMock.onPost().replyOnce(() => {
-                throw handleProviderMocks.axiosError(bodyError);
+                throw handleProviderMocks.axiosError(bodyError, reason);
               });
               const provider = txSubmitHttpProvider(config);
               await provider.submitTx({ signedTransaction: emptyUintArrayAsHexString });
@@ -64,8 +77,7 @@ describe('txSubmitHttpProvider', () => {
             } catch (error) {
               if (error instanceof ProviderError) {
                 expect(error.reason).toBe(providerFailure);
-                const innerError = error.innerError as CardanoNodeErrors.TxSubmissionError;
-                expect(innerError).toBeInstanceOf(providerErrorType);
+                expect(error.innerError).toBeInstanceOf(providerErrorType);
               } else {
                 throw new TypeError('Expected ProviderError');
               }
@@ -75,21 +87,33 @@ describe('txSubmitHttpProvider', () => {
         it(
           'rehydrates errors',
           testError(
-            new CardanoNodeErrors.TxSubmissionErrors.BadInputsError({ badInputs: [] }),
+            new TxSubmissionError(TxSubmissionErrorCode.EmptyInputSet, null, ''),
             ProviderFailure.BadRequest,
-            CardanoNodeErrors.TxSubmissionErrors.BadInputsError
+            TxSubmissionError
           )
         );
 
         it(
           'maps unrecognized errors to UnknownTxSubmissionError',
-          testError(new Error('Unknown error'), ProviderFailure.Unknown, CardanoNodeErrors.UnknownTxSubmissionError)
+          testError(new Error('Unknown error'), ProviderFailure.Unknown, GeneralCardanoNodeError)
+        );
+
+        it(
+          'uses reason to determine ProviderFailure type when innerError is missing',
+          testError(null, ProviderFailure.BadRequest, ProviderError)
+        );
+
+        it(
+          'non-providerError reason is mapped to ProviderFailure.Unknown when innerError is missing',
+          testError(null, ProviderFailure.Unknown, ProviderError, 'invalidReason' as ProviderFailure)
         );
 
         it('does not re-wrap UnknownTxSubmissionError', async () => {
           expect.assertions(3);
           axiosMock.onPost().replyOnce(() => {
-            throw handleProviderMocks.axiosError(new CardanoNodeErrors.UnknownTxSubmissionError('Unknown error'));
+            throw handleProviderMocks.axiosError(
+              new GeneralCardanoNodeError(GeneralCardanoNodeErrorCode.Unknown, null, '')
+            );
           });
           const provider = txSubmitHttpProvider(config);
           try {
@@ -97,8 +121,8 @@ describe('txSubmitHttpProvider', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } catch (error: any) {
             expect(error).toBeInstanceOf(ProviderError);
-            expect(error.innerError).toBeInstanceOf(CardanoNodeErrors.UnknownTxSubmissionError);
-            expect(error.innerError.innerError.name).not.toBe(CardanoNodeErrors.UnknownTxSubmissionError.name);
+            expect(error.innerError).toBeInstanceOf(GeneralCardanoNodeError);
+            expect(error.innerError.innerError).toBeUndefined();
           }
         });
       });

--- a/packages/cardano-services/src/TxSubmit/TxSubmitHttpService.ts
+++ b/packages/cardano-services/src/TxSubmit/TxSubmitHttpService.ts
@@ -1,5 +1,5 @@
 import {
-  Cardano,
+  CardanoNodeUtil,
   ProviderError,
   ProviderFailure,
   TxSubmitProvider,
@@ -47,7 +47,7 @@ export class TxSubmitHttpService extends HttpService {
           if (!isHealthy) {
             return HttpServer.sendJSON(res, new ProviderError(ProviderFailure.Unhealthy, firstError), 503);
           }
-          if (Cardano.util.asTxSubmissionError(error)) {
+          if (CardanoNodeUtil.asTxSubmissionError(error)) {
             return HttpServer.sendJSON(res, new ProviderError(ProviderFailure.BadRequest, firstError), 400);
           }
           return HttpServer.sendJSON(res, new ProviderError(ProviderFailure.Unknown, firstError), 500);

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { APPLICATION_JSON, CONTENT_TYPE, HttpServer, HttpServerConfig, TxSubmitHttpService } from '../../src';
-import { CardanoNodeErrors, ProviderError, TxSubmitProvider } from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, txSubmitHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { FATAL, createLogger } from 'bunyan';
 import { OgmiosTxSubmitProvider } from '@cardano-sdk/ogmios';
+import { ProviderError, TxSubmissionError, TxSubmissionErrorCode, TxSubmitProvider } from '@cardano-sdk/core';
 import { bufferToHexString, fromSerializableObject } from '@cardano-sdk/util';
 import { getPort } from 'get-port-please';
 import { logger } from '@cardano-sdk/util-dev';
@@ -172,7 +172,13 @@ describe('TxSubmitHttpService', () => {
 
   describe('healthy but failing submission', () => {
     describe('/submit', () => {
-      const stubErrors = [new CardanoNodeErrors.TxSubmissionErrors.BadInputsError({ badInputs: [] })];
+      const stubErrors = [
+        new TxSubmissionError(
+          TxSubmissionErrorCode.NonEmptyRewardAccount,
+          { nonEmptyRewardAccountBalance: { lovelace: 10n } },
+          'Bad inputs'
+        )
+      ];
 
       beforeAll(async () => {
         txSubmitProvider = txSubmitProviderMock(
@@ -193,14 +199,15 @@ describe('TxSubmitHttpService', () => {
       });
 
       it('rehydrates errors when used with TxSubmitHttpProvider', async () => {
-        expect.assertions(2);
+        expect.assertions(3);
         const clientProvider = txSubmitHttpProvider(clientConfig);
         try {
           await clientProvider.submitTx({ signedTransaction: emptyUintArrayAsHexString });
         } catch (error: any) {
           if (error instanceof ProviderError) {
-            const innerError = error.innerError as CardanoNodeErrors.TxSubmissionError;
-            expect(innerError).toBeInstanceOf(CardanoNodeErrors.TxSubmissionErrors.BadInputsError);
+            const innerError = error.innerError as TxSubmissionError;
+            expect(innerError).toBeInstanceOf(TxSubmissionError);
+            expect(innerError.code).toBe(stubErrors[0].code);
             expect(innerError.message).toBe(stubErrors[0].message);
           }
         }

--- a/packages/core/src/Cardano/types/Certificate.ts
+++ b/packages/core/src/Cardano/types/Certificate.ts
@@ -27,7 +27,9 @@ export enum CertificateType {
   ResignCommitteeCold = 'ResignCommitteeColdCertificate',
   RegisterDelegateRepresentative = 'RegisterDelegateRepresentativeCertificate',
   UnregisterDelegateRepresentative = 'UnregisterDelegateRepresentativeCertificate',
-  UpdateDelegateRepresentative = 'UpdateDelegateRepresentativeCertificate'
+  UpdateDelegateRepresentative = 'UpdateDelegateRepresentativeCertificate',
+  RegisterCcHotKey = 'RegisterCcHotKeyCertificate',
+  RetireCc = 'RetireCcCertificate'
 }
 
 // Conway Certificates
@@ -106,6 +108,14 @@ export interface UpdateDelegateRepresentativeCertificate {
   anchor: Anchor | null;
 }
 
+export interface RegisterCcHotKeyCertificate {
+  __typename: CertificateType.RegisterCcHotKey;
+}
+
+export interface RetireCcCertificate {
+  __typename: CertificateType.RetireCc;
+}
+
 /** To be deprecated in the Era after conway replaced by <NewStakeAddressCertificate> */
 export interface StakeAddressCertificate {
   __typename: CertificateType.StakeRegistration | CertificateType.StakeDeregistration;
@@ -173,7 +183,9 @@ export type Certificate =
   | ResignCommitteeColdCertificate
   | RegisterDelegateRepresentativeCertificate
   | UnRegisterDelegateRepresentativeCertificate
-  | UpdateDelegateRepresentativeCertificate;
+  | UpdateDelegateRepresentativeCertificate
+  | RegisterCcHotKeyCertificate
+  | RetireCcCertificate;
 
 /**
  * Creates a stake key registration certificate from a given reward account.

--- a/packages/core/src/CardanoNode/types/CardanoNodeErrors.ts
+++ b/packages/core/src/CardanoNode/types/CardanoNodeErrors.ts
@@ -1,132 +1,115 @@
-import {
-  AcquirePointNotOnChainError,
-  AcquirePointTooOldError,
-  EraMismatchError,
-  IntersectionNotFoundError,
-  QueryUnavailableInCurrentEraError,
-  ServerNotReady,
-  TipIsOriginError,
-  TxSubmission,
-  UnknownResultError,
-  WebSocketClosed
-} from '@cardano-ogmios/client';
-import { ComposableError } from '@cardano-sdk/util';
+import * as Cardano from '../../Cardano';
 import { CustomError } from 'ts-custom-error';
 
-export class NotInitializedError extends CustomError {
-  constructor(methodName: string, moduleName: string) {
-    super(`${methodName} cannot be called until ${moduleName} is initialized`);
+export enum GeneralCardanoNodeErrorCode {
+  ServerNotReady = 503,
+  Unknown = 500,
+  ConnectionFailure = -1
+}
+
+export enum ChainSyncErrorCode {
+  IntersectionNotFound = 1000,
+  IntersectionInterleaved = 1001
+}
+
+export enum StateQueryErrorCode {
+  AcquireLedgerStateFailure = 2000,
+  EraMismatch = 2001,
+  UnavailableInCurrentEra = 2002,
+  AcquiredExpired = 2003
+}
+
+export enum TxSubmissionErrorCode {
+  EraMismatch = 3005,
+  InvalidSignatories = 3100,
+  MissingSignatories = 3101,
+  MissingScripts = 3102,
+  FailingNativeScript = 3103,
+  ExtraneousScripts = 3104,
+  MissingMetadataHash = 3105,
+  MissingMetadata = 3106,
+  MetadataHashMismatch = 3107,
+  InvalidMetadata = 3108,
+  MissingRedeemers = 3109,
+  ExtraneousRedeemers = 3110,
+  MissingDatums = 3111,
+  ExtraneousDatums = 3112,
+  ScriptIntegrityHashMismatch = 3113,
+  OrphanScriptInputs = 3114,
+  MissingCostModels = 3115,
+  MalformedScripts = 3116,
+  UnknownOutputReferences = 3117,
+  OutsideOfValidityInterval = 3118,
+  TransactionTooLarge = 3119,
+  ValueTooLarge = 3120,
+  EmptyInputSet = 3121,
+  TransactionFeeTooSmall = 3122,
+  ValueNotConserved = 3123,
+  NetworkMismatch = 3124,
+  InsufficientlyFundedOutputs = 3125,
+  BootstrapAttributesTooLarge = 3126,
+  MintingOrBurningAda = 3127,
+  InsufficientCollateral = 3128,
+  CollateralLockedByScript = 3129,
+  UnforeseeableSlot = 3130,
+  TooManyCollateralInputs = 3131,
+  MissingCollateralInputs = 3132,
+  NonAdaCollateral = 3133,
+  ExecutionUnitsTooLarge = 3134,
+  TotalCollateralMismatch = 3135,
+  SpendsMismatch = 3136,
+  UnauthorizedVote = 3137,
+  UnknownGovernanceProposal = 3138,
+  InvalidProtocolParametersUpdate = 3139,
+  UnknownStakePool = 3140,
+  IncompleteWithdrawals = 3141,
+  RetirementTooLate = 3142,
+  StakePoolCostTooLow = 3143,
+  MetadataHashTooLarge = 3144,
+  CredentialAlreadyRegistered = 3145,
+  UnknownCredential = 3146,
+  NonEmptyRewardAccount = 3147,
+  InvalidGenesisDelegation = 3148,
+  InvalidMIRTransfer = 3149,
+  ForbiddenWithdrawal = 3150,
+  CredentialDepositMismatch = 3151,
+  DRepAlreadyRegistered = 3152,
+  DRepNotRegistered = 3153,
+  UnknownConstitutionalCommitteeMember = 3154,
+  GovernanceProposalDepositMismatch = 3155,
+  ConflictingCommitteeUpdate = 3156,
+  InvalidCommitteeUpdate = 3157,
+  TreasuryWithdrawalMismatch = 3158,
+  InvalidOrMissingPreviousProposal = 3159,
+  FailureUnrecognizedCertificateType = 3998,
+  InternalLedgerTypeConversionError = 3999,
+  DeserialisationFailure = -32_602
+}
+
+export abstract class CardanoNodeError<Code extends number, Data = unknown> extends CustomError {
+  code: Code;
+  data: Data;
+
+  constructor(code: Code, data: Data, message: string) {
+    super(message);
+    this.code = code;
+    this.data = data;
   }
 }
 
-// CardanoNode related errors
-export class UnknownCardanoNodeError<InnerError = unknown> extends ComposableError<InnerError> {
-  constructor(innerError: InnerError) {
-    super('Unknown CardanoNode error', innerError);
-  }
-}
+export class GeneralCardanoNodeError<Data = unknown> extends CardanoNodeError<GeneralCardanoNodeErrorCode, Data> {}
+export class ChainSyncError<Data = unknown> extends CardanoNodeError<ChainSyncErrorCode, Data> {}
+export class TxSubmissionError<Data = unknown> extends CardanoNodeError<TxSubmissionErrorCode, Data> {}
+export class StateQueryError<Data = unknown> extends CardanoNodeError<StateQueryErrorCode, Data> {}
 
-export const CardanoClientErrors = {
-  AcquirePointNotOnChainError,
-  AcquirePointTooOldError,
-  ConnectionError: WebSocketClosed,
-  EraMismatchError,
-  IntersectionNotFoundError,
-  QueryUnavailableInCurrentEraError,
-  ServerNotReady,
-  TipIsOriginError,
-  UnknownResultError
+export type OutsideOfValidityIntervalData = {
+  validityInterval: Cardano.ValidityInterval;
+  currentSlot: Cardano.Slot;
 };
-
-type CardanoClientErrorName = keyof typeof CardanoClientErrors;
-type CardanoClientErrorClass = typeof CardanoClientErrors[CardanoClientErrorName];
-
-// TxSubmission related errors
-export class UnknownTxSubmissionError<InnerError = unknown> extends ComposableError<InnerError> {
-  constructor(innerError: InnerError) {
-    super('Unknown submission error', innerError);
-  }
-}
-
-const ogmiosSubmissionErrors = TxSubmission.submissionErrors.errors;
-
-export const TxSubmissionErrors = {
-  AddressAttributesTooLargeError: ogmiosSubmissionErrors.AddressAttributesTooLarge.Error,
-  AlreadyDelegatingError: ogmiosSubmissionErrors.AlreadyDelegating.Error,
-  BadInputsError: ogmiosSubmissionErrors.BadInputs.Error,
-  CollateralHasNonAdaAssetsError: ogmiosSubmissionErrors.CollateralHasNonAdaAssets.Error,
-  CollateralIsScriptError: ogmiosSubmissionErrors.CollateralIsScript.Error,
-  CollateralTooSmallError: ogmiosSubmissionErrors.CollateralTooSmall.Error,
-  CollectErrorsError: ogmiosSubmissionErrors.CollectErrors.Error,
-  DelegateNotRegisteredError: ogmiosSubmissionErrors.DelegateNotRegistered.Error,
-  DuplicateGenesisVrfError: ogmiosSubmissionErrors.DuplicateGenesisVrf.Error,
-  EraMismatchError: ogmiosSubmissionErrors.EraMismatch.Error,
-  ExecutionUnitsTooLargeError: ogmiosSubmissionErrors.ExecutionUnitsTooLarge.Error,
-  ExpiredUtxoError: ogmiosSubmissionErrors.ExpiredUtxo.Error,
-  ExtraDataMismatchError: ogmiosSubmissionErrors.ExtraDataMismatch.Error,
-  ExtraRedeemersError: ogmiosSubmissionErrors.ExtraRedeemers.Error,
-  ExtraScriptWitnessesError: ogmiosSubmissionErrors.ExtraScriptWitnesses.Error,
-  FeeTooSmallError: ogmiosSubmissionErrors.FeeTooSmall.Error,
-  InsufficientFundsForMirError: ogmiosSubmissionErrors.InsufficientFundsForMir.Error,
-  InsufficientGenesisSignaturesError: ogmiosSubmissionErrors.InsufficientGenesisSignatures.Error,
-  InvalidMetadataError: ogmiosSubmissionErrors.InvalidMetadata.Error,
-  InvalidWitnessesError: ogmiosSubmissionErrors.InvalidWitnesses.Error,
-  MalformedReferenceScriptsError: ogmiosSubmissionErrors.MalformedReferenceScripts.Error,
-  MalformedScriptWitnessesError: ogmiosSubmissionErrors.MalformedScriptWitnesses.Error,
-  MirNegativeTransferError: ogmiosSubmissionErrors.MirNegativeTransfer.Error,
-  MirNegativeTransferNotCurrentlyAllowedError: ogmiosSubmissionErrors.MirNegativeTransferNotCurrentlyAllowed.Error,
-  MirProducesNegativeUpdateError: ogmiosSubmissionErrors.MirProducesNegativeUpdate.Error,
-  MirTransferNotCurrentlyAllowedError: ogmiosSubmissionErrors.MirTransferNotCurrentlyAllowed.Error,
-  MissingAtLeastOneInputUtxoError: ogmiosSubmissionErrors.MissingAtLeastOneInputUtxo.Error,
-  MissingCollateralInputsError: ogmiosSubmissionErrors.MissingCollateralInputs.Error,
-  MissingDatumHashesForInputsError: ogmiosSubmissionErrors.MissingDatumHashesForInputs.Error,
-  MissingRequiredDatumsError: ogmiosSubmissionErrors.MissingRequiredDatums.Error,
-  MissingRequiredRedeemersError: ogmiosSubmissionErrors.MissingRequiredRedeemers.Error,
-  MissingRequiredSignaturesError: ogmiosSubmissionErrors.MissingRequiredSignatures.Error,
-  MissingScriptWitnessesError: ogmiosSubmissionErrors.MissingScriptWitnesses.Error,
-  MissingTxMetadataError: ogmiosSubmissionErrors.MissingTxMetadata.Error,
-  MissingTxMetadataHashError: ogmiosSubmissionErrors.MissingTxMetadataHash.Error,
-  MissingVkWitnessesError: ogmiosSubmissionErrors.MissingVkWitnesses.Error,
-  NetworkMismatchError: ogmiosSubmissionErrors.NetworkMismatch.Error,
-  NonGenesisVotersError: ogmiosSubmissionErrors.NonGenesisVoters.Error,
-  OutputTooSmallError: ogmiosSubmissionErrors.OutputTooSmall.Error,
-  OutsideForecastError: ogmiosSubmissionErrors.OutsideForecast.Error,
-  OutsideOfValidityIntervalError: ogmiosSubmissionErrors.OutsideOfValidityInterval.Error,
-  PoolCostTooSmallError: ogmiosSubmissionErrors.PoolCostTooSmall.Error,
-  PoolMetadataHashTooBigError: ogmiosSubmissionErrors.PoolMetadataHashTooBig.Error,
-  ProtocolVersionCannotFollowError: ogmiosSubmissionErrors.ProtocolVersionCannotFollow.Error,
-  RewardAccountNotEmptyError: ogmiosSubmissionErrors.RewardAccountNotEmpty.Error,
-  RewardAccountNotExistingError: ogmiosSubmissionErrors.RewardAccountNotExisting.Error,
-  ScriptWitnessNotValidatingError: ogmiosSubmissionErrors.ScriptWitnessNotValidating.Error,
-  StakeKeyAlreadyRegisteredError: ogmiosSubmissionErrors.StakeKeyAlreadyRegistered.Error,
-  StakeKeyNotRegisteredError: ogmiosSubmissionErrors.StakeKeyNotRegistered.Error,
-  StakePoolNotRegisteredError: ogmiosSubmissionErrors.StakePoolNotRegistered.Error,
-  TooLateForMirError: ogmiosSubmissionErrors.TooLateForMir.Error,
-  TooManyAssetsInOutputError: ogmiosSubmissionErrors.TooManyAssetsInOutput.Error,
-  TooManyCollateralInputsError: ogmiosSubmissionErrors.TooManyCollateralInputs.Error,
-  TotalCollateralMismatchError: ogmiosSubmissionErrors.TotalCollateralMismatch.Error,
-  TriesToForgeAdaError: ogmiosSubmissionErrors.TriesToForgeAda.Error,
-  TxMetadataHashMismatchError: ogmiosSubmissionErrors.TxMetadataHashMismatch.Error,
-  TxTooLargeError: ogmiosSubmissionErrors.TxTooLarge.Error,
-  UnknownGenesisKeyError: ogmiosSubmissionErrors.UnknownGenesisKey.Error,
-  UnknownOrIncompleteWithdrawalsError: ogmiosSubmissionErrors.UnknownOrIncompleteWithdrawals.Error,
-  UnspendableDatumsError: ogmiosSubmissionErrors.UnspendableDatums.Error,
-  UnspendableScriptInputsError: ogmiosSubmissionErrors.UnspendableScriptInputs.Error,
-  UpdateWrongEpochError: ogmiosSubmissionErrors.UpdateWrongEpoch.Error,
-  ValidationTagMismatchError: ogmiosSubmissionErrors.ValidationTagMismatch.Error,
-  ValueNotConservedError: ogmiosSubmissionErrors.ValueNotConserved.Error,
-  WrongCertificateTypeError: ogmiosSubmissionErrors.WrongCertificateType.Error,
-  WrongPoolCertificateError: ogmiosSubmissionErrors.WrongPoolCertificate.Error,
-  WrongRetirementEpochError: ogmiosSubmissionErrors.WrongRetirementEpoch.Error
+export type ValueNotConservedData = {
+  consumed: Cardano.Value;
+  produced: Cardano.Value;
 };
-
-type TxSubmissionErrorName = keyof typeof TxSubmissionErrors;
-type TxSubmissionErrorClass = typeof TxSubmissionErrors[TxSubmissionErrorName];
-
-export type TxSubmissionError = InstanceType<TxSubmissionErrorClass> | UnknownTxSubmissionError;
-
-export type CardanoNodeError =
-  | InstanceType<CardanoClientErrorClass>
-  | UnknownCardanoNodeError
-  | NotInitializedError
-  | TxSubmissionError;
+export type IncompleteWithdrawalsData = {
+  withdrawals: Cardano.Withdrawal[];
+};

--- a/packages/core/src/CardanoNode/types/CardanoNodeLegacyErrors.ts
+++ b/packages/core/src/CardanoNode/types/CardanoNodeLegacyErrors.ts
@@ -1,0 +1,132 @@
+import {
+  AcquirePointNotOnChainError,
+  AcquirePointTooOldError,
+  EraMismatchError,
+  IntersectionNotFoundError,
+  QueryUnavailableInCurrentEraError,
+  ServerNotReady,
+  TipIsOriginError,
+  TxSubmission,
+  UnknownResultError,
+  WebSocketClosed
+} from '@cardano-ogmios/client';
+import { ComposableError } from '@cardano-sdk/util';
+import { CustomError } from 'ts-custom-error';
+
+export class NotInitializedError extends CustomError {
+  constructor(methodName: string, moduleName: string) {
+    super(`${methodName} cannot be called until ${moduleName} is initialized`);
+  }
+}
+
+// CardanoNode related errors
+export class UnknownCardanoNodeError<InnerError = unknown> extends ComposableError<InnerError> {
+  constructor(innerError: InnerError) {
+    super('Unknown CardanoNode error', innerError);
+  }
+}
+
+export const CardanoClientErrors = {
+  AcquirePointNotOnChainError,
+  AcquirePointTooOldError,
+  ConnectionError: WebSocketClosed,
+  EraMismatchError,
+  IntersectionNotFoundError,
+  QueryUnavailableInCurrentEraError,
+  ServerNotReady,
+  TipIsOriginError,
+  UnknownResultError
+};
+
+type CardanoClientErrorName = keyof typeof CardanoClientErrors;
+type CardanoClientErrorClass = typeof CardanoClientErrors[CardanoClientErrorName];
+
+// TxSubmission related errors
+export class UnknownTxSubmissionError<InnerError = unknown> extends ComposableError<InnerError> {
+  constructor(innerError: InnerError) {
+    super('Unknown submission error', innerError);
+  }
+}
+
+const ogmiosSubmissionErrors = TxSubmission.submissionErrors.errors;
+
+export const TxSubmissionErrors = {
+  AddressAttributesTooLargeError: ogmiosSubmissionErrors.AddressAttributesTooLarge.Error,
+  AlreadyDelegatingError: ogmiosSubmissionErrors.AlreadyDelegating.Error,
+  BadInputsError: ogmiosSubmissionErrors.BadInputs.Error,
+  CollateralHasNonAdaAssetsError: ogmiosSubmissionErrors.CollateralHasNonAdaAssets.Error,
+  CollateralIsScriptError: ogmiosSubmissionErrors.CollateralIsScript.Error,
+  CollateralTooSmallError: ogmiosSubmissionErrors.CollateralTooSmall.Error,
+  CollectErrorsError: ogmiosSubmissionErrors.CollectErrors.Error,
+  DelegateNotRegisteredError: ogmiosSubmissionErrors.DelegateNotRegistered.Error,
+  DuplicateGenesisVrfError: ogmiosSubmissionErrors.DuplicateGenesisVrf.Error,
+  EraMismatchError: ogmiosSubmissionErrors.EraMismatch.Error,
+  ExecutionUnitsTooLargeError: ogmiosSubmissionErrors.ExecutionUnitsTooLarge.Error,
+  ExpiredUtxoError: ogmiosSubmissionErrors.ExpiredUtxo.Error,
+  ExtraDataMismatchError: ogmiosSubmissionErrors.ExtraDataMismatch.Error,
+  ExtraRedeemersError: ogmiosSubmissionErrors.ExtraRedeemers.Error,
+  ExtraScriptWitnessesError: ogmiosSubmissionErrors.ExtraScriptWitnesses.Error,
+  FeeTooSmallError: ogmiosSubmissionErrors.FeeTooSmall.Error,
+  InsufficientFundsForMirError: ogmiosSubmissionErrors.InsufficientFundsForMir.Error,
+  InsufficientGenesisSignaturesError: ogmiosSubmissionErrors.InsufficientGenesisSignatures.Error,
+  InvalidMetadataError: ogmiosSubmissionErrors.InvalidMetadata.Error,
+  InvalidWitnessesError: ogmiosSubmissionErrors.InvalidWitnesses.Error,
+  MalformedReferenceScriptsError: ogmiosSubmissionErrors.MalformedReferenceScripts.Error,
+  MalformedScriptWitnessesError: ogmiosSubmissionErrors.MalformedScriptWitnesses.Error,
+  MirNegativeTransferError: ogmiosSubmissionErrors.MirNegativeTransfer.Error,
+  MirNegativeTransferNotCurrentlyAllowedError: ogmiosSubmissionErrors.MirNegativeTransferNotCurrentlyAllowed.Error,
+  MirProducesNegativeUpdateError: ogmiosSubmissionErrors.MirProducesNegativeUpdate.Error,
+  MirTransferNotCurrentlyAllowedError: ogmiosSubmissionErrors.MirTransferNotCurrentlyAllowed.Error,
+  MissingAtLeastOneInputUtxoError: ogmiosSubmissionErrors.MissingAtLeastOneInputUtxo.Error,
+  MissingCollateralInputsError: ogmiosSubmissionErrors.MissingCollateralInputs.Error,
+  MissingDatumHashesForInputsError: ogmiosSubmissionErrors.MissingDatumHashesForInputs.Error,
+  MissingRequiredDatumsError: ogmiosSubmissionErrors.MissingRequiredDatums.Error,
+  MissingRequiredRedeemersError: ogmiosSubmissionErrors.MissingRequiredRedeemers.Error,
+  MissingRequiredSignaturesError: ogmiosSubmissionErrors.MissingRequiredSignatures.Error,
+  MissingScriptWitnessesError: ogmiosSubmissionErrors.MissingScriptWitnesses.Error,
+  MissingTxMetadataError: ogmiosSubmissionErrors.MissingTxMetadata.Error,
+  MissingTxMetadataHashError: ogmiosSubmissionErrors.MissingTxMetadataHash.Error,
+  MissingVkWitnessesError: ogmiosSubmissionErrors.MissingVkWitnesses.Error,
+  NetworkMismatchError: ogmiosSubmissionErrors.NetworkMismatch.Error,
+  NonGenesisVotersError: ogmiosSubmissionErrors.NonGenesisVoters.Error,
+  OutputTooSmallError: ogmiosSubmissionErrors.OutputTooSmall.Error,
+  OutsideForecastError: ogmiosSubmissionErrors.OutsideForecast.Error,
+  OutsideOfValidityIntervalError: ogmiosSubmissionErrors.OutsideOfValidityInterval.Error,
+  PoolCostTooSmallError: ogmiosSubmissionErrors.PoolCostTooSmall.Error,
+  PoolMetadataHashTooBigError: ogmiosSubmissionErrors.PoolMetadataHashTooBig.Error,
+  ProtocolVersionCannotFollowError: ogmiosSubmissionErrors.ProtocolVersionCannotFollow.Error,
+  RewardAccountNotEmptyError: ogmiosSubmissionErrors.RewardAccountNotEmpty.Error,
+  RewardAccountNotExistingError: ogmiosSubmissionErrors.RewardAccountNotExisting.Error,
+  ScriptWitnessNotValidatingError: ogmiosSubmissionErrors.ScriptWitnessNotValidating.Error,
+  StakeKeyAlreadyRegisteredError: ogmiosSubmissionErrors.StakeKeyAlreadyRegistered.Error,
+  StakeKeyNotRegisteredError: ogmiosSubmissionErrors.StakeKeyNotRegistered.Error,
+  StakePoolNotRegisteredError: ogmiosSubmissionErrors.StakePoolNotRegistered.Error,
+  TooLateForMirError: ogmiosSubmissionErrors.TooLateForMir.Error,
+  TooManyAssetsInOutputError: ogmiosSubmissionErrors.TooManyAssetsInOutput.Error,
+  TooManyCollateralInputsError: ogmiosSubmissionErrors.TooManyCollateralInputs.Error,
+  TotalCollateralMismatchError: ogmiosSubmissionErrors.TotalCollateralMismatch.Error,
+  TriesToForgeAdaError: ogmiosSubmissionErrors.TriesToForgeAda.Error,
+  TxMetadataHashMismatchError: ogmiosSubmissionErrors.TxMetadataHashMismatch.Error,
+  TxTooLargeError: ogmiosSubmissionErrors.TxTooLarge.Error,
+  UnknownGenesisKeyError: ogmiosSubmissionErrors.UnknownGenesisKey.Error,
+  UnknownOrIncompleteWithdrawalsError: ogmiosSubmissionErrors.UnknownOrIncompleteWithdrawals.Error,
+  UnspendableDatumsError: ogmiosSubmissionErrors.UnspendableDatums.Error,
+  UnspendableScriptInputsError: ogmiosSubmissionErrors.UnspendableScriptInputs.Error,
+  UpdateWrongEpochError: ogmiosSubmissionErrors.UpdateWrongEpoch.Error,
+  ValidationTagMismatchError: ogmiosSubmissionErrors.ValidationTagMismatch.Error,
+  ValueNotConservedError: ogmiosSubmissionErrors.ValueNotConserved.Error,
+  WrongCertificateTypeError: ogmiosSubmissionErrors.WrongCertificateType.Error,
+  WrongPoolCertificateError: ogmiosSubmissionErrors.WrongPoolCertificate.Error,
+  WrongRetirementEpochError: ogmiosSubmissionErrors.WrongRetirementEpoch.Error
+};
+
+type TxSubmissionErrorName = keyof typeof TxSubmissionErrors;
+type TxSubmissionErrorClass = typeof TxSubmissionErrors[TxSubmissionErrorName];
+
+export type TxSubmissionError = InstanceType<TxSubmissionErrorClass> | UnknownTxSubmissionError;
+
+export type CardanoNodeError =
+  | InstanceType<CardanoClientErrorClass>
+  | UnknownCardanoNodeError
+  | NotInitializedError
+  | TxSubmissionError;

--- a/packages/core/src/CardanoNode/types/index.ts
+++ b/packages/core/src/CardanoNode/types/index.ts
@@ -1,3 +1,4 @@
 export * from './CardanoNode';
-export * as CardanoNodeErrors from './CardanoNodeErrors';
+export * as CardanoNodeErrors from './CardanoNodeLegacyErrors';
+export * from './CardanoNodeErrors';
 export * from './ObservableCardanoNode';

--- a/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
+++ b/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
@@ -1,26 +1,117 @@
-import { CardanoClientErrors, CardanoNodeError } from '../types/CardanoNodeErrors';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  ChainSyncError,
+  ChainSyncErrorCode,
+  GeneralCardanoNodeError,
+  GeneralCardanoNodeErrorCode,
+  IncompleteWithdrawalsData,
+  OutsideOfValidityIntervalData,
+  StateQueryError,
+  StateQueryErrorCode,
+  TxSubmissionError,
+  TxSubmissionErrorCode,
+  ValueNotConservedData
+} from '../types';
+import { isProductionEnvironment, stripStackTrace } from '@cardano-sdk/util';
+
+// TODO: test all new utils
+
+type InferObjectType<T> = T extends new (...args: any[]) => infer O ? O : never;
+
+const asSpecificCardanoNodeError =
+  <ErrorClass extends new (...args: any[]) => any>(ErrorType: ErrorClass) =>
+  (error: unknown): InferObjectType<ErrorClass> | null => {
+    if (Array.isArray(error)) {
+      for (const err of error) {
+        if (err instanceof ErrorType) {
+          if (isProductionEnvironment()) stripStackTrace(err);
+
+          return err;
+        }
+      }
+      return null;
+    }
+
+    if (error instanceof ErrorType) {
+      if (isProductionEnvironment()) stripStackTrace(error);
+
+      return error;
+    }
+
+    return null;
+  };
 
 /**
- * Tests the provided error for an instanceof match in the CardanoErrors object
- *
- * @param {any} error the error under test
- */
-export const isCardanoNodeError = (error: unknown): error is CardanoNodeError =>
-  Object.values(CardanoClientErrors).some((NodeError) => error instanceof NodeError);
-
-/**
- * Attempts to convert the provided error or array of errors into CardanoNodeError object
+ * Attempts to cast the provided error or array of errors into TxSubmissionError object
  *
  * @param {any} error the error or array of errors under test
  */
-export const asCardanoNodeError = (error: unknown): CardanoNodeError | null => {
-  if (Array.isArray(error)) {
-    for (const err of error) {
-      if (isCardanoNodeError(err)) {
-        return err;
-      }
-    }
-    return null;
-  }
-  return isCardanoNodeError(error) ? error : null;
-};
+export const asTxSubmissionError = asSpecificCardanoNodeError(TxSubmissionError);
+
+/**
+ * Attempts to cast the provided error or array of errors into ChainSyncError object
+ *
+ * @param {any} error the error or array of errors under test
+ */
+export const asChainSyncError = asSpecificCardanoNodeError(ChainSyncError);
+
+/**
+ * Attempts to cast the provided error or array of errors into StateQueryError object
+ *
+ * @param {any} error the error or array of errors under test
+ */
+export const asStateQueryError = asSpecificCardanoNodeError(StateQueryError);
+
+/**
+ * Attempts to cast the provided error or array of errors into GeneralCardanoNodeError object
+ *
+ * @param {any} error the error or array of errors under test
+ */
+export const asGeneralCardanoNodeError = asSpecificCardanoNodeError(GeneralCardanoNodeError);
+
+/**
+ * Attempts to cast the provided error or array of errors into any known CardanoNodeError subclass object.
+ * If if it's not of any known subclass, creates a new GeneralCardanoError objects and wraps the original error as "data"
+ *
+ * @param {any} error the error or array of errors under test
+ */
+export const asCardanoNodeError = (error: unknown) =>
+  asGeneralCardanoNodeError(error) ||
+  asTxSubmissionError(error) ||
+  asStateQueryError(error) ||
+  asChainSyncError(error) ||
+  new GeneralCardanoNodeError(GeneralCardanoNodeErrorCode.Unknown, error, 'Unknown Cardano node error, see "data"');
+
+const stateQueryErrorCodes = new Set(Object.values(StateQueryErrorCode));
+const generalCardanoNodeErrorCodes = new Set(Object.values(GeneralCardanoNodeErrorCode));
+const txSubmissionErrorCodes = new Set(Object.values(TxSubmissionErrorCode));
+const chainSyncErrorCodes = new Set(Object.values(ChainSyncErrorCode));
+
+export const isChainSyncErrorCode = (code: unknown): code is ChainSyncErrorCode =>
+  typeof code === 'number' && chainSyncErrorCodes.has(code);
+export const isTxSubmissionErrorCode = (code: unknown): code is TxSubmissionErrorCode =>
+  typeof code === 'number' && txSubmissionErrorCodes.has(code);
+export const isStateQueryErrorCode = (code: unknown): code is StateQueryErrorCode =>
+  typeof code === 'number' && stateQueryErrorCodes.has(code);
+export const isGeneralCardanoNodeErrorCode = (code: unknown): code is GeneralCardanoNodeErrorCode =>
+  typeof code === 'number' && generalCardanoNodeErrorCodes.has(code);
+
+export const asChainSyncErrorCode = (code: unknown): ChainSyncErrorCode | null =>
+  isChainSyncErrorCode(code) ? code : null;
+export const asStateQueryErrorCode = (code: unknown): StateQueryErrorCode | null =>
+  isStateQueryErrorCode(code) ? code : null;
+export const asGeneralCardanoNodeErrorCode = (code: unknown): GeneralCardanoNodeErrorCode | null =>
+  isGeneralCardanoNodeErrorCode(code) ? code : null;
+export const asTxSubmissionErrorCode = (code: unknown): TxSubmissionErrorCode | null =>
+  isTxSubmissionErrorCode(code) ? code : null;
+
+export const isOutsideOfValidityIntervalError = (
+  error: unknown
+): error is TxSubmissionError<OutsideOfValidityIntervalData> =>
+  error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.OutsideOfValidityInterval;
+
+export const isValueNotConservedError = (error: unknown): error is TxSubmissionError<ValueNotConservedData> =>
+  error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.ValueNotConserved;
+
+export const isIncompleteWithdrawalsError = (error: unknown): error is TxSubmissionError<IncompleteWithdrawalsData> =>
+  error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.IncompleteWithdrawals;

--- a/packages/core/src/Provider/Provider.ts
+++ b/packages/core/src/Provider/Provider.ts
@@ -3,7 +3,7 @@ import { Cardano } from '..';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Logger } from 'ts-log';
 import { Percent } from '@cardano-sdk/util';
-import { Tip } from '@cardano-ogmios/schema';
+import { Tip } from '../Cardano';
 
 export type HealthCheckResponse = {
   ok: boolean;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -28,6 +28,12 @@ export const providerFailureToStatusCodeMap: { [key in ProviderFailure]: number 
   [ProviderFailure.ServerUnavailable]: 500
 };
 
+const isProviderFailure = (reason: string): reason is ProviderFailure =>
+  Object.values(ProviderFailure).includes(reason as ProviderFailure);
+
+export const reasonToProviderFailure = (reason: string): ProviderFailure =>
+  isProviderFailure(reason) ? reason : ProviderFailure.Unknown;
+
 export class ProviderError<InnerError = unknown> extends ComposableError<InnerError> {
   constructor(public reason: ProviderFailure, innerError?: InnerError, public detail?: string) {
     super(formatErrorMessage(reason, detail), innerError);

--- a/packages/core/test/CardanoNode/mocks.ts
+++ b/packages/core/test/CardanoNode/mocks.ts
@@ -66,9 +66,9 @@ export const healthCheckResponseMock = (opts?: {
 }) => ({
   localNode: {
     ledgerTip: {
-      blockNo: opts?.blockNo ?? 100,
-      hash: opts?.hash ?? '9ef43ab6e234fcf90d103413096c7da752da2f45b15e1259f43d476afd12932c',
-      slot: opts?.slot ?? 52_819_355
+      blockNo: Cardano.BlockNo(opts?.blockNo ?? 100),
+      hash: Cardano.BlockId(opts?.hash ?? '9ef43ab6e234fcf90d103413096c7da752da2f45b15e1259f43d476afd12932c'),
+      slot: Cardano.Slot(opts?.slot ?? 52_819_355)
     },
     networkSync: opts?.networkSync ?? Percent(0.999)
   },

--- a/packages/core/test/CardanoNode/util/cardanoNodeErrors.test.ts
+++ b/packages/core/test/CardanoNode/util/cardanoNodeErrors.test.ts
@@ -1,53 +1,103 @@
-import { CardanoNodeErrors, CardanoNodeUtil } from '../../../src';
-
-const unavailableQueryError = new CardanoNodeErrors.CardanoClientErrors.QueryUnavailableInCurrentEraError(
-  'currentEpoch'
+import {
+  CardanoNodeUtil,
+  ChainSyncError,
+  ChainSyncErrorCode,
+  GeneralCardanoNodeError,
+  GeneralCardanoNodeErrorCode,
+  OutsideOfValidityIntervalData,
+  StateQueryError,
+  StateQueryErrorCode,
+  TxSubmissionError,
+  TxSubmissionErrorCode
+} from '../../../src';
+const unknownCardanoNodeError = (message: string) =>
+  new GeneralCardanoNodeError(GeneralCardanoNodeErrorCode.Unknown, message, 'Unknown Cardano node error, see "data"');
+const stateQueryError = new StateQueryError(StateQueryErrorCode.UnavailableInCurrentEra, null, 'Query unavailable');
+const generalError = new GeneralCardanoNodeError(GeneralCardanoNodeErrorCode.ConnectionFailure, null, 'Refused');
+const chainSyncError = new ChainSyncError(ChainSyncErrorCode.IntersectionNotFound, null, 'Intersection not found');
+const txSubmissionError = new TxSubmissionError(
+  TxSubmissionErrorCode.OutsideOfValidityInterval,
+  { currentSlot: 123, validityInterval: { invalidHereafter: 122 } } as OutsideOfValidityIntervalData,
+  'Outside of validity interval'
 );
-const unknownResultError = new CardanoNodeErrors.CardanoClientErrors.UnknownResultError('result');
 const someOtherError = new Error('some other error');
 const someString = 'some string';
 
-describe('cardanoNodeErros', () => {
-  describe('isCardanoNodeError', () => {
-    it('is true if the value is a cardano node error', () => {
-      expect(CardanoNodeUtil.isCardanoNodeError(unavailableQueryError)).toBe(true);
+describe('util/cardanoNodeErrors', () => {
+  describe('casting utils', () => {
+    it('returns error if value is instanceof expected type', () => {
+      expect(CardanoNodeUtil.asCardanoNodeError(stateQueryError)).toBe(stateQueryError);
+      expect(CardanoNodeUtil.asStateQueryError(stateQueryError)).toBe(stateQueryError);
     });
-    it('is false if a single generic error is not a cardano node error', () => {
-      expect(CardanoNodeUtil.isCardanoNodeError(someOtherError)).toBe(false);
+    it('returns null if value is not instanceof expected type', () => {
+      expect(CardanoNodeUtil.asStateQueryError(someOtherError)).toBeNull();
+      expect(CardanoNodeUtil.asStateQueryError(chainSyncError)).toBeNull();
+      expect(CardanoNodeUtil.asStateQueryError(txSubmissionError)).toBeNull();
+      expect(CardanoNodeUtil.asStateQueryError(generalError)).toBeNull();
     });
     it('is false if a non-error value is passed', () => {
-      expect(CardanoNodeUtil.isCardanoNodeError(someString)).toBe(false);
+      expect(CardanoNodeUtil.asStateQueryError(someString)).toBeNull();
+    });
+    it('wraps original error in GeneralCardanoError if it is not a known CardanoNodeError', () => {
+      expect(CardanoNodeUtil.asCardanoNodeError(someOtherError)).toEqual(
+        unknownCardanoNodeError(someOtherError.message)
+      );
+      expect(CardanoNodeUtil.asCardanoNodeError(someString)).toEqual(unknownCardanoNodeError(someString));
     });
   });
 
-  describe('asCardanoNodeError', () => {
-    it('returns the same error if it is a cardano node error', () => {
-      expect(CardanoNodeUtil.asCardanoNodeError(unavailableQueryError)).toBe<CardanoNodeErrors.CardanoNodeError>(
-        unavailableQueryError
-      );
+  describe('error code utils', () => {
+    it('returns true if code is one of the options for the error type', () => {
+      expect(CardanoNodeUtil.isChainSyncErrorCode(ChainSyncErrorCode.IntersectionInterleaved)).toBe(true);
+      expect(CardanoNodeUtil.isGeneralCardanoNodeErrorCode(GeneralCardanoNodeErrorCode.ConnectionFailure)).toBe(true);
+      expect(CardanoNodeUtil.isStateQueryErrorCode(StateQueryErrorCode.EraMismatch)).toBe(true);
+      expect(CardanoNodeUtil.isTxSubmissionErrorCode(TxSubmissionErrorCode.ExecutionUnitsTooLarge)).toBe(true);
     });
+    it('returns false if code is not one of the options for the error type', () => {
+      expect(CardanoNodeUtil.isChainSyncErrorCode(GeneralCardanoNodeErrorCode.ConnectionFailure)).toBe(false);
+      expect(CardanoNodeUtil.isGeneralCardanoNodeErrorCode(StateQueryErrorCode.EraMismatch)).toBe(false);
+      expect(CardanoNodeUtil.isStateQueryErrorCode(TxSubmissionErrorCode.ExecutionUnitsTooLarge)).toBe(false);
+      expect(CardanoNodeUtil.isTxSubmissionErrorCode(StateQueryErrorCode.EraMismatch)).toBe(false);
+    });
+  });
 
-    it('returns null if error is not a cardano node error', () => {
-      expect(CardanoNodeUtil.asCardanoNodeError(someOtherError)).toBeNull();
-    });
-    it('returns null if a non-error value is passed', () => {
-      expect(CardanoNodeUtil.asCardanoNodeError(someString)).toBeNull();
-    });
-
-    it('returns the first error if all values in an array are cardano node errors', () => {
+  describe('specific error typeguard utils', () => {
+    it('returns true if error type and code matches', () => {
       expect(
-        CardanoNodeUtil.asCardanoNodeError([unavailableQueryError, unknownResultError])
-      ).toBe<CardanoNodeErrors.CardanoNodeError>(unavailableQueryError);
-    });
-
-    it('returns the first cardano node error if at least one value in an array is a cardano node error', () => {
+        CardanoNodeUtil.isValueNotConservedError(
+          new TxSubmissionError(TxSubmissionErrorCode.ValueNotConserved, null, '')
+        )
+      ).toBe(true);
       expect(
-        CardanoNodeUtil.asCardanoNodeError([someOtherError, unknownResultError])
-      ).toBe<CardanoNodeErrors.CardanoNodeError>(unknownResultError);
+        CardanoNodeUtil.isIncompleteWithdrawalsError(
+          new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
+        )
+      ).toBe(true);
+      expect(
+        CardanoNodeUtil.isOutsideOfValidityIntervalError(
+          new TxSubmissionError(TxSubmissionErrorCode.OutsideOfValidityInterval, null, '')
+        )
+      ).toBe(true);
     });
-
-    it('returns null if none of the values in an array are cardano node errors', () => {
-      expect(CardanoNodeUtil.asCardanoNodeError([someOtherError, someString])).toBeNull();
+    it('returns false if error type or code does not match', () => {
+      expect(CardanoNodeUtil.isValueNotConservedError(generalError)).toBe(false);
+      expect(CardanoNodeUtil.isIncompleteWithdrawalsError(someOtherError)).toBe(false);
+      expect(CardanoNodeUtil.isOutsideOfValidityIntervalError(someString)).toBe(false);
+      expect(
+        CardanoNodeUtil.isValueNotConservedError(
+          new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
+        )
+      ).toBe(false);
+      expect(
+        CardanoNodeUtil.isIncompleteWithdrawalsError(
+          new TxSubmissionError(TxSubmissionErrorCode.OutsideOfValidityInterval, null, '')
+        )
+      ).toBe(false);
+      expect(
+        CardanoNodeUtil.isOutsideOfValidityIntervalError(
+          new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
+        )
+      ).toBe(false);
     });
   });
 });

--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -54,6 +54,7 @@ const checkStakeKeyHashCertificate = (
     case Cardano.CertificateType.StakeRegistrationDelegation:
     case Cardano.CertificateType.VoteRegistrationDelegation:
     case Cardano.CertificateType.StakeVoteRegistrationDelegation:
+    case Cardano.CertificateType.Registration:
     case Cardano.CertificateType.Unregistration:
     case Cardano.CertificateType.StakeDeregistration:
     case Cardano.CertificateType.StakeDelegation: {

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -109,6 +109,36 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   );
 
   it(
+    'returns stake key derivation path when a Conway stake Registration' +
+      ' certificate with the wallet stake key hash is present',
+    async () => {
+      const txBody = {
+        certificates: [
+          {
+            __typename: Cardano.CertificateType.Registration,
+            stakeCredential: ownStakeCredential
+          } as Cardano.NewStakeAddressCertificate
+        ],
+        inputs: [{}, {}, {}]
+      } as Cardano.TxBody;
+      const resolveInput = jest
+        .fn()
+        .mockReturnValueOnce({ ...txOut, address: address1 })
+        .mockReturnValueOnce(address1);
+      expect(await util.ownSignatureKeyPaths(txBody, [knownAddress1], { resolveInput })).toEqual([
+        {
+          index: 0,
+          role: KeyRole.External
+        },
+        {
+          index: 0,
+          role: KeyRole.Stake
+        }
+      ]);
+    }
+  );
+
+  it(
     'returns stake key derivation path when a StakeDeregistration' +
       ' certificate with the wallet stake key hash is present',
     async () => {
@@ -294,6 +324,7 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
     const txBody = {
       certificates: [
         { __typename: Cardano.CertificateType.StakeRegistration, stakeCredential: otherStakeCredential },
+        { __typename: Cardano.CertificateType.Registration, stakeCredential: otherStakeCredential },
         { __typename: Cardano.CertificateType.VoteDelegation, stakeCredential: otherStakeCredential },
         { __typename: Cardano.CertificateType.StakeVoteDelegation, stakeCredential: otherStakeCredential },
         {

--- a/packages/ogmios/src/CardanoNode/OgmiosCardanoNode.ts
+++ b/packages/ogmios/src/CardanoNode/OgmiosCardanoNode.ts
@@ -1,8 +1,8 @@
+import * as CardanoNodeUtil from './errorUtils';
 import {
   Cardano,
   CardanoNode,
   CardanoNodeErrors,
-  CardanoNodeUtil,
   EraSummary,
   HealthCheckResponse,
   StakeDistribution

--- a/packages/ogmios/src/CardanoNode/errorUtils.ts
+++ b/packages/ogmios/src/CardanoNode/errorUtils.ts
@@ -1,0 +1,29 @@
+import { CardanoNodeErrors } from '@cardano-sdk/core';
+
+type CardanoNodeError = CardanoNodeErrors.CardanoNodeError;
+const CardanoClientErrors = CardanoNodeErrors.CardanoClientErrors;
+
+/**
+ * Tests the provided error for an instanceof match in the CardanoErrors object
+ *
+ * @param {any} error the error under test
+ */
+export const isCardanoNodeError = (error: unknown): error is CardanoNodeError =>
+  Object.values(CardanoClientErrors).some((NodeError) => error instanceof NodeError);
+
+/**
+ * Attempts to convert the provided error or array of errors into CardanoNodeError object
+ *
+ * @param {any} error the error or array of errors under test
+ */
+export const asCardanoNodeError = (error: unknown): CardanoNodeError | null => {
+  if (Array.isArray(error)) {
+    for (const err of error) {
+      if (isCardanoNodeError(err)) {
+        return err;
+      }
+    }
+    return null;
+  }
+  return isCardanoNodeError(error) ? error : null;
+};

--- a/packages/ogmios/src/CardanoNode/queries.ts
+++ b/packages/ogmios/src/CardanoNode/queries.ts
@@ -1,4 +1,5 @@
-import { CardanoNodeErrors, CardanoNodeUtil } from '@cardano-sdk/core';
+import * as CardanoNodeUtil from './errorUtils';
+import { CardanoNodeErrors } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
 import { StateQueryClient } from '@cardano-ogmios/client/dist/StateQuery';
 import { eraSummary, genesis } from '../ogmiosToCore';

--- a/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
+++ b/packages/ogmios/src/Provider/TxSubmitProvider/OgmiosTxSubmitProvider.ts
@@ -22,6 +22,7 @@ import { OgmiosCardanoNode } from '../../CardanoNode';
 import { RunnableModule, contextLogger, isNotNil } from '@cardano-sdk/util';
 import { TxSubmissionClient, createTxSubmissionClient } from '../../Ogmios/TxSubmissionClient';
 import { createInteractionContextWithLogger } from '../../util';
+import { mapOgmiosTxSubmitError } from './errorMapper';
 
 /**
  * Connect to an [Ogmios](https://ogmios.dev/) instance
@@ -80,7 +81,10 @@ export class OgmiosTxSubmitProvider extends RunnableModule implements TxSubmitPr
       const id = await this.#txSubmissionClient.submitTx(signedTransaction);
       this.#logger.info(`Submitted ${id}`);
     } catch (error) {
-      throw Cardano.util.asTxSubmissionError(error) || new CardanoNodeErrors.UnknownTxSubmissionError(error);
+      const txSubmitErr =
+        Cardano.util.asTxSubmissionError(error) || new CardanoNodeErrors.UnknownTxSubmissionError(error);
+
+      throw mapOgmiosTxSubmitError(txSubmitErr);
     }
   }
 

--- a/packages/ogmios/src/Provider/TxSubmitProvider/errorMapper.ts
+++ b/packages/ogmios/src/Provider/TxSubmitProvider/errorMapper.ts
@@ -1,0 +1,17 @@
+import { CardanoNodeErrors, TxSubmissionError, TxSubmissionErrorCode } from '@cardano-sdk/core';
+
+export const mapOgmiosTxSubmitError = (error: CardanoNodeErrors.TxSubmissionError): TxSubmissionError => {
+  if (error instanceof CardanoNodeErrors.TxSubmissionErrors.CollateralHasNonAdaAssetsError) {
+    return new TxSubmissionError(TxSubmissionErrorCode.NonAdaCollateral, error.stack, error.message);
+  }
+  if (error instanceof CardanoNodeErrors.TxSubmissionErrors.OutsideOfValidityIntervalError) {
+    return new TxSubmissionError(TxSubmissionErrorCode.OutsideOfValidityInterval, error.stack, error.message);
+  }
+  if (error instanceof CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError) {
+    return new TxSubmissionError(TxSubmissionErrorCode.ValueNotConserved, error.stack, error.message);
+  }
+  if (error instanceof CardanoNodeErrors.TxSubmissionErrors.UnknownOrIncompleteWithdrawalsError) {
+    return new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, error.stack, error.message);
+  }
+  return error as TxSubmissionError;
+};

--- a/packages/ogmios/src/util.ts
+++ b/packages/ogmios/src/util.ts
@@ -1,3 +1,4 @@
+import { Cardano, HealthCheckResponse } from '@cardano-sdk/core';
 import {
   ConnectionConfig,
   InteractionContext,
@@ -53,9 +54,16 @@ export const createInteractionContextWithLogger = (
     options
   );
 
-export const ogmiosServerHealthToHealthCheckResponse = ({ lastKnownTip, networkSynchronization }: ServerHealth) => ({
+export const ogmiosServerHealthToHealthCheckResponse = ({
+  lastKnownTip,
+  networkSynchronization
+}: ServerHealth): HealthCheckResponse => ({
   localNode: {
-    ledgerTip: lastKnownTip,
+    ledgerTip: {
+      blockNo: Cardano.BlockNo(lastKnownTip.blockNo),
+      hash: Cardano.BlockId(lastKnownTip.hash),
+      slot: Cardano.Slot(lastKnownTip.slot)
+    },
     networkSync: Percent(networkSynchronization)
   },
   ok: networkSynchronization > 0.99

--- a/packages/ogmios/test/CardanoNode/errorUtils.test.ts
+++ b/packages/ogmios/test/CardanoNode/errorUtils.test.ts
@@ -1,0 +1,54 @@
+import * as CardanoNodeUtil from '../../src/CardanoNode/errorUtils';
+import { CardanoNodeErrors } from '@cardano-sdk/core';
+
+const unavailableQueryError = new CardanoNodeErrors.CardanoClientErrors.QueryUnavailableInCurrentEraError(
+  'currentEpoch'
+);
+const unknownResultError = new CardanoNodeErrors.CardanoClientErrors.UnknownResultError('result');
+const someOtherError = new Error('some other error');
+const someString = 'some string';
+
+describe('cardanoNodeErros', () => {
+  describe('isCardanoNodeError', () => {
+    it('is true if the value is a cardano node error', () => {
+      expect(CardanoNodeUtil.isCardanoNodeError(unavailableQueryError)).toBe(true);
+    });
+    it('is false if a single generic error is not a cardano node error', () => {
+      expect(CardanoNodeUtil.isCardanoNodeError(someOtherError)).toBe(false);
+    });
+    it('is false if a non-error value is passed', () => {
+      expect(CardanoNodeUtil.isCardanoNodeError(someString)).toBe(false);
+    });
+  });
+
+  describe('asCardanoNodeError', () => {
+    it('returns the same error if it is a cardano node error', () => {
+      expect(CardanoNodeUtil.asCardanoNodeError(unavailableQueryError)).toBe<CardanoNodeErrors.CardanoNodeError>(
+        unavailableQueryError
+      );
+    });
+
+    it('returns null if error is not a cardano node error', () => {
+      expect(CardanoNodeUtil.asCardanoNodeError(someOtherError)).toBeNull();
+    });
+    it('returns null if a non-error value is passed', () => {
+      expect(CardanoNodeUtil.asCardanoNodeError(someString)).toBeNull();
+    });
+
+    it('returns the first error if all values in an array are cardano node errors', () => {
+      expect(
+        CardanoNodeUtil.asCardanoNodeError([unavailableQueryError, unknownResultError])
+      ).toBe<CardanoNodeErrors.CardanoNodeError>(unavailableQueryError);
+    });
+
+    it('returns the first cardano node error if at least one value in an array is a cardano node error', () => {
+      expect(
+        CardanoNodeUtil.asCardanoNodeError([someOtherError, unknownResultError])
+      ).toBe<CardanoNodeErrors.CardanoNodeError>(unknownResultError);
+    });
+
+    it('returns null if none of the values in an array are cardano node errors', () => {
+      expect(CardanoNodeUtil.asCardanoNodeError([someOtherError, someString])).toBeNull();
+    });
+  });
+});

--- a/packages/ogmios/test/Provider/TxSubmitProvider/errorMapper.test.ts
+++ b/packages/ogmios/test/Provider/TxSubmitProvider/errorMapper.test.ts
@@ -1,0 +1,40 @@
+import { CardanoNodeErrors, TxSubmissionErrorCode } from '@cardano-sdk/core';
+import { mapOgmiosTxSubmitError } from '../../../src/Provider/TxSubmitProvider/errorMapper';
+
+describe('mapTxSubmitError', () => {
+  it('should map CollateralHasNonAdaAssetsError to TxSubmissionErrorCode.NonAdaCollateral', () => {
+    const nonAdaAssetErr = new CardanoNodeErrors.TxSubmissionErrors.CollateralHasNonAdaAssetsError({
+      collateralHasNonAdaAssets: { coins: 1n }
+    });
+    expect(mapOgmiosTxSubmitError(nonAdaAssetErr).code).toEqual(TxSubmissionErrorCode.NonAdaCollateral);
+  });
+
+  it('should map OutsideOfValidityIntervalError to TxSubmissionErrorCode.OutsideOfValidityInterval', () => {
+    const outsideOfValidityErr = new CardanoNodeErrors.TxSubmissionErrors.OutsideOfValidityIntervalError({
+      outsideOfValidityInterval: { currentSlot: 3, interval: { invalidBefore: 1, invalidHereafter: 2 } }
+    });
+    expect(mapOgmiosTxSubmitError(outsideOfValidityErr).code).toEqual(TxSubmissionErrorCode.OutsideOfValidityInterval);
+  });
+
+  it('should map ValueNotConservedError to TxSubmissionErrorCode.ValueNotConserved', () => {
+    const valueNotConservedErr = new CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError({
+      valueNotConserved: { consumed: 1, produced: 2 }
+    });
+    expect(mapOgmiosTxSubmitError(valueNotConservedErr).code).toEqual(TxSubmissionErrorCode.ValueNotConserved);
+  });
+
+  it('should map UnknownOrIncompleteWithdrawalsError to TxSubmissionErrorCode.IncompleteWithdrawals', () => {
+    const unknownOrIncompleteWithdrawalsErr =
+      new CardanoNodeErrors.TxSubmissionErrors.UnknownOrIncompleteWithdrawalsError({
+        unknownOrIncompleteWithdrawals: { coin: 1n }
+      });
+    expect(mapOgmiosTxSubmitError(unknownOrIncompleteWithdrawalsErr).code).toEqual(
+      TxSubmissionErrorCode.IncompleteWithdrawals
+    );
+  });
+
+  it('does not map other errors', () => {
+    const unknownErr = new CardanoNodeErrors.UnknownTxSubmissionError({ unknown: { unknown: 'unknown' } });
+    expect(mapOgmiosTxSubmitError(unknownErr)).toEqual(unknownErr);
+  });
+});

--- a/packages/util-dev/src/chainSync/index.ts
+++ b/packages/util-dev/src/chainSync/index.ts
@@ -1,6 +1,7 @@
 import {
   Cardano,
-  CardanoNodeErrors,
+  ChainSyncError,
+  ChainSyncErrorCode,
   ChainSyncEvent,
   ChainSyncEventType,
   ChainSyncRollBackward,
@@ -37,8 +38,11 @@ const intersect = (events: ChainSyncData['body'], points: PointOrOrigin[]) => {
   const blockPoints = points.filter((point): point is Point => point !== 'origin');
   if (blockPoints.length === 0) {
     if (points.length === 0) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      throw new CardanoNodeErrors.CardanoClientErrors.IntersectionNotFoundError(points as any[]);
+      throw new ChainSyncError(
+        ChainSyncErrorCode.IntersectionNotFound,
+        { points, tip: events[0].tip },
+        'Intersection not found'
+      );
     }
     return {
       events,
@@ -83,8 +87,12 @@ const intersect = (events: ChainSyncData['body'], points: PointOrOrigin[]) => {
       }
     };
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  throw new CardanoNodeErrors.CardanoClientErrors.IntersectionNotFoundError(points as any[]);
+
+  throw new ChainSyncError(
+    ChainSyncErrorCode.IntersectionNotFound,
+    { points, tip: events[0].tip },
+    'Intersection not found'
+  );
 };
 
 export enum ChainSyncDataSet {

--- a/packages/util-dev/src/handleProvider.ts
+++ b/packages/util-dev/src/handleProvider.ts
@@ -2,9 +2,9 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { toSerializableObject } from '@cardano-sdk/util';
 
-export const axiosError = (bodyError = new Error('error')) => {
+export const axiosError = (bodyError: Error | null = new Error('error'), reason = ProviderFailure.BadRequest) => {
   const response = {
-    data: toSerializableObject(new ProviderError(ProviderFailure.BadRequest, bodyError))
+    data: toSerializableObject(new ProviderError(reason, bodyError))
   } as AxiosResponse;
   const error = new AxiosError(undefined, undefined, undefined, undefined, response);
   Object.defineProperty(error, 'response', { value: response });

--- a/packages/util/test/serializableObject.test.ts
+++ b/packages/util/test/serializableObject.test.ts
@@ -1,6 +1,15 @@
 import { CustomError } from 'ts-custom-error';
 import { FromSerializableObjectOptions, fromSerializableObject, toSerializableObject } from '../src';
 
+export class ErrorWithData extends CustomError {
+  innerError: { data: unknown };
+
+  constructor(data: unknown, message: string) {
+    super(message);
+    this.innerError = { data };
+  }
+}
+
 const serializeAndDeserialize = (obj: unknown, deserializeOptions?: FromSerializableObjectOptions) =>
   fromSerializableObject(JSON.parse(JSON.stringify(toSerializableObject(obj))), deserializeOptions);
 
@@ -44,6 +53,20 @@ describe('serializableObject', () => {
 
   it('supports custom error types', () => {
     const err = new CustomError('msg');
+    const deserialized = serializeAndDeserialize(err, { getErrorPrototype: () => CustomError.prototype });
+    expect(deserialized).toEqual(err);
+    expect(deserialized).toBeInstanceOf(CustomError);
+  });
+
+  it('supports error types with string data', () => {
+    const err = new ErrorWithData('some-data', 'msg');
+    const deserialized = serializeAndDeserialize(err, { getErrorPrototype: () => CustomError.prototype });
+    expect(deserialized).toEqual(err);
+    expect(deserialized).toBeInstanceOf(CustomError);
+  });
+
+  it('supports error types with object data', () => {
+    const err = new ErrorWithData({ bigIntProp: 15n }, 'msg');
     const deserialized = serializeAndDeserialize(err, { getErrorPrototype: () => CustomError.prototype });
     expect(deserialized).toEqual(err);
     expect(deserialized).toBeInstanceOf(CustomError);

--- a/packages/wallet/src/PersonalWallet/PersonalWallet.ts
+++ b/packages/wallet/src/PersonalWallet/PersonalWallet.ts
@@ -579,7 +579,8 @@ export class PersonalWallet implements ObservableWallet {
         mightBeAlreadySubmitted &&
         error instanceof ProviderError &&
         // Review: not sure if those 2 errors cover the original ones: there is no longer a CollectErrorsError or BadInputsError
-        ((CardanoNodeUtil.isValueNotConservedError(error.innerError) && error.innerError.data.produced.coins === 0n) ||
+        // Re-add error.innerError.data.produced.coins === 0n check once Ogmios6 is released. It is not part of the error in pre-ogmios6.
+        (CardanoNodeUtil.isValueNotConservedError(error.innerError) ||
           // TODO: check if IncompleteWithdrawals available withdrawal amount === wallet's reward acc balance?
           // Not sure what the 'Withdrawals' in error data is exactly: value being withdrawed, or reward acc balance
           CardanoNodeUtil.isIncompleteWithdrawalsError(error.innerError))

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -1,4 +1,4 @@
-import { Cardano, CardanoNodeErrors, Reward, TxCBOR } from '@cardano-sdk/core';
+import { Cardano, Reward, TxCBOR } from '@cardano-sdk/core';
 import { GroupedAddress, util } from '@cardano-sdk/key-management';
 import { Observable } from 'rxjs';
 import { Percent } from '@cardano-sdk/util';
@@ -65,7 +65,7 @@ export interface OutgoingTx {
 
 export interface FailedTx extends OutgoingTx {
   reason: TransactionFailure;
-  error?: CardanoNodeErrors.TxSubmissionError;
+  error?: unknown;
 }
 
 export interface OutgoingOnChainTx extends OutgoingTx {

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -3,7 +3,15 @@ import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, AsyncKeyAgent, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { AssetId, StubKeyAgent, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
 import { BehaviorSubject, Subscription, firstValueFrom, skip } from 'rxjs';
-import { Cardano, CardanoNodeErrors, ProviderError, ProviderFailure, TxCBOR } from '@cardano-sdk/core';
+import {
+  Cardano,
+  ProviderError,
+  ProviderFailure,
+  TxCBOR,
+  TxSubmissionError,
+  TxSubmissionErrorCode,
+  ValueNotConservedData
+} from '@cardano-sdk/core';
 import { HexBlob } from '@cardano-sdk/util';
 import { InitializeTxProps, InitializeTxResult } from '@cardano-sdk/tx-construction';
 import { PersonalWallet, TxInFlight, setupWallet } from '../../src';
@@ -323,9 +331,11 @@ describe('PersonalWallet methods', () => {
     describe('submitTx', () => {
       const valueNotConservedError = new ProviderError(
         ProviderFailure.BadRequest,
-        new CardanoNodeErrors.TxSubmissionErrors.ValueNotConservedError({
-          valueNotConserved: { consumed: 2, produced: 1 }
-        })
+        new TxSubmissionError<ValueNotConservedData>(
+          TxSubmissionErrorCode.ValueNotConserved,
+          { consumed: { coins: 2n }, produced: { coins: 0n } },
+          'Value not conserved'
+        )
       );
 
       it('resolves on success', async () => {

--- a/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
+++ b/packages/wallet/test/services/SmartTxSubmitProvider.test.ts
@@ -69,17 +69,22 @@ describe('SmartTxSubmitProvider', () => {
       it('re-submits transactions that failed to submit due to a recoverable provider failure', async () => {
         underlyingProvider.submitTx
           .mockRejectedValueOnce(new ProviderError(ProviderFailure.ConnectionFailure))
-          .mockRejectedValueOnce(new ProviderError(ProviderFailure.Unhealthy))
-          .mockRejectedValueOnce(new ProviderError(ProviderFailure.Unknown));
+          .mockRejectedValueOnce(new ProviderError(ProviderFailure.Unhealthy));
         await provider.submitTx({ signedTransaction: txWithValidityIntervalHex });
-        expect(underlyingProvider.submitTx).toBeCalledTimes(4);
+        expect(underlyingProvider.submitTx).toBeCalledTimes(3);
       });
 
       it('rejects with any non-recoverable provider error', async () => {
-        const error = new ProviderError(ProviderFailure.BadRequest);
-        underlyingProvider.submitTx.mockRejectedValueOnce(error);
-        await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(error);
-        expect(underlyingProvider.submitTx).toBeCalledTimes(1);
+        const errorBadRequest = new ProviderError(ProviderFailure.BadRequest);
+        const errorUnknown = new ProviderError(ProviderFailure.Unknown);
+        underlyingProvider.submitTx.mockRejectedValueOnce(errorBadRequest).mockRejectedValueOnce(errorUnknown);
+        await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(
+          errorBadRequest
+        );
+        await expect(provider.submitTx({ signedTransaction: txWithValidityIntervalHex })).rejects.toThrowError(
+          errorUnknown
+        );
+        expect(underlyingProvider.submitTx).toBeCalledTimes(2);
       });
     });
 

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -278,7 +278,7 @@ describe('WalletUtil', () => {
             __typename: Cardano.CertificateType.Registration,
             // using foreign intentionally because registration is not signed so it should be accepted
             stakeCredential: {
-              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
               type: Cardano.CredentialType.KeyHash
             }
           } as Cardano.NewStakeAddressCertificate,


### PR DESCRIPTION
# Context

Conway era changes live in conway-era branch, because they require Cardano Node, Ogmios and DbSync versions that are not yet released.

However, SDK client libraries on the `master` branch could be updated such that they are compatible with cardano services (back-ends) deployed from both `master` branch and `conway-era` branch.

# Proposed Solution
- Use new errors from `conway-era` branch in wallet & cardano-services-client packages.
- Create mappers for tx-submit errors in cardano-services, that map old errors to the new ones

# Important Changes Introduced
