### PR TITLE
LW-9237 typeorm stake pool provider backward compatibility

### DIFF
--- a/packages/cardano-services-client/package.json
+++ b/packages/cardano-services-client/package.json
@@ -29,7 +29,7 @@
     "cleanup:dist": "rm -rf dist",
     "circular-deps:check": "madge --circular dist/cjs",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "yarn build:version && jest -c ./jest.config.js",

--- a/packages/cardano-services-client/src/version.ts
+++ b/packages/cardano-services-client/src/version.ts
@@ -6,7 +6,7 @@ export const apiVersion = {
   networkInfo: '1.0.0',
   rewards: '1.0.0',
   root: '1.0.0',
-  stakePool: '1.0.0',
+  stakePool: '1.1.0',
   txSubmit: '2.0.0',
   utxo: '2.0.0'
 };

--- a/packages/cardano-services-client/version.json
+++ b/packages/cardano-services-client/version.json
@@ -5,7 +5,7 @@
   "networkInfo": "1.0.0",
   "rewards": "1.0.0",
   "root": "1.0.0",
-  "stakePool": "1.0.0",
+  "stakePool": "1.1.0",
   "txSubmit": "2.0.0",
   "utxo": "2.0.0"
 }

--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -27,7 +27,7 @@
     "build:test-db": "./test/jest-setup/rebuild-test-db.sh",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "cli": "ts-node --transpile-only src/cli.ts",
     "compose:up": "docker compose --env-file environments/.env.$NETWORK -p cardano-services-$NETWORK -f docker-compose.yml -f ../../compose/common.yml -f ../../compose/pg-agent.yml ${FILES:-} up",
     "compose:down": "docker compose -p cardano-services-$NETWORK -f docker-compose.yml -f ../../compose/common.yml -f ../../compose/pg-agent.yml down -t 120",

--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/mappers.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/mappers.ts
@@ -87,7 +87,7 @@ const mapMetadata = ({
 
 // eslint-disable-next-line complexity
 const mapMetrics = (pool: PoolModel): Cardano.StakePoolMetrics => ({
-  apy: pool.metrics_last_ros ? Percent(Number.parseFloat(pool.metrics_last_ros)) : undefined,
+  apy: Percent(Number.parseFloat(pool.metrics_last_ros || '0')),
   blocksCreated: pool.metrics_minted_blocks || 0,
   delegators: pool.metrics_live_delegators || 0,
   lastRos: Percent(Number.parseFloat(pool.metrics_last_ros || '0')),

--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/util.ts
@@ -3,8 +3,6 @@
 import {
   Cardano,
   FilterCondition,
-  ProviderError,
-  ProviderFailure,
   QueryStakePoolsArgs,
   SortField,
   SortOrder,
@@ -51,7 +49,7 @@ export const stakePoolSearchSelection = [
 ];
 
 export const sortSelectionMap: { [key in SortField]: string } = {
-  apy: 'metrics_apy',
+  apy: 'metrics_ros',
   cost: 'params.cost',
   lastRos: 'metrics_last_ros',
   name: 'metadata.name',
@@ -63,32 +61,14 @@ export const nullsInSort = 'NULLS LAST';
 
 export const stakePoolSearchTotalCount = 'count(*) over () as total_count';
 
-export const getSortOptions = (
-  sort?: StakePoolSortOptions,
-  defaultField: SortField = 'name',
-  defaultOrder: SortOrder = 'asc'
-) => {
-  if (!sort) {
-    sort = { field: defaultField, order: defaultOrder };
-  }
-  if (sort.field === 'name') {
-    return {
-      field: `lower(${sortSelectionMap[sort.field as SortField]})`,
-      order: sort.order.toUpperCase() as Uppercase<SortOrder>
-    };
-  }
+const defaultSortOption = { field: 'name', order: 'asc' } as const;
 
-  if (sort.field === 'apy')
-    throw new ProviderError(
-      ProviderFailure.NotImplemented,
-      null,
-      'TypeormStakePoolProvider do not support sort by APY'
-    );
+export const getSortOptions = (sort: StakePoolSortOptions = defaultSortOption) => {
+  const order = sort.order.toUpperCase() as Uppercase<SortOrder>;
 
-  return {
-    field: sortSelectionMap[sort.field as SortField],
-    order: sort.order.toUpperCase() as Uppercase<SortOrder>
-  };
+  if (sort.field === 'name') return { field: `lower(${sortSelectionMap[sort.field]})`, order };
+
+  return { field: sortSelectionMap[sort.field], order };
 };
 
 export const getFilterCondition = (condition?: FilterCondition, defaultCondition: Uppercase<FilterCondition> = 'OR') =>

--- a/packages/cardano-services/src/StakePool/openApi.json
+++ b/packages/cardano-services/src/StakePool/openApi.json
@@ -6,13 +6,13 @@
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "paths": {
-    "/v1.0.0/stake-pool/health": {
+    "/v1.1.0/stake-pool/health": {
       "$ref": "../Http/schema.json#/paths/Health"
     },
-    "/v1.0.0/stake-pool/search": {
+    "/v1.1.0/stake-pool/search": {
       "post": {
         "summary": "stake pool search",
         "operationId": "stakePoolSearch",
@@ -61,7 +61,7 @@
         }
       }
     },
-    "/v1.0.0/stake-pool/stats": {
+    "/v1.1.0/stake-pool/stats": {
       "post": {
         "summary": "stake pool stats",
         "operationId": "stakePoolStats",

--- a/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
+++ b/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
@@ -733,11 +733,6 @@ describe('TypeormStakePoolProvider', () => {
             });
           });
 
-          it('sort by apy', () =>
-            expect(provider.queryStakePools(setSortCondition({ pagination }, 'desc', 'apy'))).rejects.toThrow(
-              'TypeormStakePoolProvider do not support sort by APY'
-            ));
-
           describe('sort by lastRos', () => {
             let expectedLastRos: { max: number; min: number };
 
@@ -762,7 +757,7 @@ describe('TypeormStakePoolProvider', () => {
             });
           });
 
-          describe('sort by ros', () => {
+          describe.each(['apy', 'ros'] as const)('sort by %s', (field) => {
             let expectedRos: { max: number; min: number };
 
             beforeAll(() => {
@@ -776,12 +771,12 @@ describe('TypeormStakePoolProvider', () => {
             });
 
             it('desc order', async () => {
-              const response = await provider.queryStakePools(setSortCondition({ pagination }, 'desc', 'ros'));
+              const response = await provider.queryStakePools(setSortCondition({ pagination }, 'desc', field));
               expect(response.pageResults[0].metrics?.ros).toEqual(expectedRos.max);
             });
 
             it('asc order', async () => {
-              const response = await provider.queryStakePools(setSortCondition({ pagination }, 'asc', 'ros'));
+              const response = await provider.queryStakePools(setSortCondition({ pagination }, 'asc', field));
               expect(response.pageResults[0].metrics?.ros).toEqual(expectedRos.min);
             });
           });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/core/test/CardanoNode/util/bufferChainSyncEvent.test.ts
+++ b/packages/core/test/CardanoNode/util/bufferChainSyncEvent.test.ts
@@ -144,23 +144,23 @@ describe('bufferChainSyncEvent', () => {
   });
 
   const produceAndConsume = async () => {
-    await sleep(10);
+    await sleep(50);
     producer.produceTill(2);
-    await sleep(10);
+    await sleep(50);
     consumer.consumeTill(1);
-    await sleep(10);
+    await sleep(50);
     producer.produceTill(4);
-    await sleep(10);
+    await sleep(50);
     consumer.consumeTill(2);
-    await sleep(10);
+    await sleep(50);
     producer.produceTill(8);
-    await sleep(10);
+    await sleep(50);
     consumer.consumeTill(3);
-    await sleep(10);
+    await sleep(50);
     producer.produceTill(16);
-    await sleep(40);
+    await sleep(50);
     consumer.consumeTill(4);
-    await sleep(10);
+    await sleep(50);
   };
 
   describe('without buffer', () => {
@@ -221,13 +221,13 @@ describe('bufferChainSyncEvent', () => {
     });
 
     it('producer complete is correctly propagated with buffer empty', async () => {
-      await sleep(10);
+      await sleep(50);
       producer.produceTill(2);
-      await sleep(10);
+      await sleep(50);
       consumer.consumeTill(2);
-      await sleep(10);
+      await sleep(50);
       producer.requestComplete();
-      await sleep(10);
+      await sleep(50);
       expect(events).toEqual([
         'Produced 1',
         'Got 1',
@@ -241,12 +241,12 @@ describe('bufferChainSyncEvent', () => {
     });
 
     it('producer complete is correctly propagated with buffer not empty', async () => {
-      await sleep(10);
+      await sleep(50);
       producer.produceTill(2);
       producer.requestComplete();
-      await sleep(10);
+      await sleep(50);
       consumer.consumeTill(2);
-      await sleep(10);
+      await sleep(50);
       expect(events).toEqual([
         'Produced 1',
         'Got 1',
@@ -260,13 +260,13 @@ describe('bufferChainSyncEvent', () => {
     });
 
     it('producer error is correctly propagated with buffer empty', async () => {
-      await sleep(10);
+      await sleep(50);
       producer.produceTill(2);
-      await sleep(10);
+      await sleep(50);
       consumer.consumeTill(2);
-      await sleep(10);
+      await sleep(50);
       producer.requestError('test error');
-      await sleep(10);
+      await sleep(50);
       expect(events).toEqual([
         'Produced 1',
         'Got 1',
@@ -280,12 +280,12 @@ describe('bufferChainSyncEvent', () => {
     });
 
     it('producer error is correctly propagated with buffer not empty', async () => {
-      await sleep(10);
+      await sleep(50);
       producer.produceTill(2);
       producer.requestError('test error');
-      await sleep(10);
+      await sleep(50);
       consumer.consumeTill(2);
-      await sleep(10);
+      await sleep(50);
       expect(events).toEqual([
         'Produced 1',
         'Got 1',

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/dapp-connector/package.json
+++ b/packages/dapp-connector/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -60,7 +60,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "coverage": "yarn test --coverage || true",
     "lint": "eslint --ignore-path ../../.eslintignore \"**/*.ts\"",
     "lint:fix": "eslint --fix --ignore-path ../../.eslintignore \"**/*.ts\"",

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -29,7 +29,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "cli": "ts-node --transpile-only ./src/index.ts",
     "dev": "API_PORT=3000 OGMIOS_HOST=localhost OGMIOS_PORT=1337 ts-node-dev ./src/index.ts",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/hardware-ledger/package.json
+++ b/packages/hardware-ledger/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/hardware-trezor/package.json
+++ b/packages/hardware-trezor/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c test/jest.config.js",

--- a/packages/input-selection/package.json
+++ b/packages/input-selection/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/projection-typeorm/package.json
+++ b/packages/projection-typeorm/package.json
@@ -27,7 +27,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js --runInBand",

--- a/packages/projection/package.json
+++ b/packages/projection/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/tx-construction/package.json
+++ b/packages/tx-construction/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -33,7 +33,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/util-rxjs/package.json
+++ b/packages/util-rxjs/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "coverage": "yarn test --coverage || true",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -28,7 +28,7 @@
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",
     "cleanup:dist": "rm -rf dist",
     "cleanup:nm": "rm -rf node_modules",
-    "cleanup": "run-s cleanup:dist cleanup:nm",
+    "cleanup": "rm -rf dist node_modules",
     "lint": "eslint -c ../../complete.eslintrc.js \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint:fix": "yarn lint --fix",
     "test": "jest -c ./jest.config.js",


### PR DESCRIPTION
# Context

When I introduced `ros` I broken back compatibility; we need to restore it. 

# Proposed Solution

- copy the property `ros` into `apy` one; 
- when sort by `apy` is requested, act as sort by `ros` was requested;

# Important Changes Introduced

- minor change to `yarn cleanup` to make it faster
- increased a delay in test to make the test more strong