### PR TITLE
Fix signed/unsigned bug in Value.fromCBOR

### DIFF
--- a/packages/core/src/Serialization/TransactionBody/Value.ts
+++ b/packages/core/src/Serialization/TransactionBody/Value.ts
@@ -81,7 +81,7 @@ export class Value {
     const reader = new CborReader(cbor);
 
     if (reader.peekState() === CborReaderState.UnsignedInteger) {
-      const coins = reader.readInt();
+      const coins = reader.readUInt();
       return new Value(coins);
     }
 


### PR DESCRIPTION
It looks like the author meant to do:

    if(reader.peek() === UNSIGNED_INT) { reader.readUInt() }

instead of

    if(reader.peek() === UNSIGNED_INT) { reader.readInt() }