### PR TITLE
feat: track cip30 method call origin

### DIFF
--- a/packages/dapp-connector/src/AuthenticatorApi/types.ts
+++ b/packages/dapp-connector/src/AuthenticatorApi/types.ts
@@ -1,7 +1,9 @@
+import { Runtime } from 'webextension-polyfill';
+
 export type Origin = string;
 
 /** Resolve true to authorise access to the WalletAPI, or resolve false to deny. Errors: `ApiError` */
-export type RequestAccess = (origin: Origin) => Promise<boolean>;
+export type RequestAccess = (sender: Runtime.MessageSender) => Promise<boolean>;
 export type RevokeAccess = RequestAccess;
 export type HaveAccess = RequestAccess;
 

--- a/packages/dapp-connector/src/WalletApi/types.ts
+++ b/packages/dapp-connector/src/WalletApi/types.ts
@@ -1,6 +1,7 @@
 import { Cardano } from '@cardano-sdk/core';
 import { Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
+import { Runtime } from 'webextension-polyfill';
 
 /** A hex-encoded string of the corresponding bytes. */
 export type Bytes = string;
@@ -212,3 +213,10 @@ export interface CipExtensionApis {
 }
 
 export type Cip30WalletApiWithPossibleExtensions = Cip30WalletApi & Partial<CipExtensionApis>;
+
+export type SenderContext = { sender: Runtime.MessageSender };
+type FnWithSender<T> = T extends (...args: infer Args) => infer R ? (context: SenderContext, ...args: Args) => R : T;
+
+export type WithSenderContext<T> = {
+  [K in keyof T]: FnWithSender<T[K]>;
+};

--- a/packages/dapp-connector/src/index.ts
+++ b/packages/dapp-connector/src/index.ts
@@ -2,3 +2,4 @@ export * from './errors';
 export * from './WalletApi';
 export * from './AuthenticatorApi';
 export * from './injectGlobal';
+export * from './util';

--- a/packages/dapp-connector/src/util.ts
+++ b/packages/dapp-connector/src/util.ts
@@ -1,0 +1,10 @@
+import { Runtime } from 'webextension-polyfill';
+
+export const senderOrigin = (sender?: Runtime.MessageSender): string | null => {
+  try {
+    const { origin } = new URL(sender?.url || 'throw');
+    return origin;
+  } catch {
+    return null;
+  }
+};

--- a/packages/dapp-connector/test/AuthenticatorApi/PersistentAuthenticator.test.ts
+++ b/packages/dapp-connector/test/AuthenticatorApi/PersistentAuthenticator.test.ts
@@ -1,4 +1,5 @@
-import { Origin, PersistentAuthenticator } from '../../src';
+import { Origin, PersistentAuthenticator, senderOrigin } from '../../src';
+import { Runtime } from 'webextension-polyfill';
 import { dummyLogger } from 'ts-log';
 
 const createStubStorage = () => {
@@ -12,8 +13,8 @@ const createStubStorage = () => {
 };
 
 describe('PersistentAuthenticator', () => {
-  const origin1: Origin = 'origin1';
-  const origin2: Origin = 'origin2';
+  const sender1: Runtime.MessageSender = { url: 'https://sender1.com' };
+  const sender2: Runtime.MessageSender = { url: 'https://sender2.com' };
   let requestAccess: jest.Mock;
   let storage: ReturnType<typeof createStubStorage>;
   let authenticator: PersistentAuthenticator;
@@ -28,35 +29,35 @@ describe('PersistentAuthenticator', () => {
   describe('requestAccess', () => {
     it('resolves to true if allowed and persists the decision', async () => {
       requestAccess.mockResolvedValueOnce(true);
-      expect(await authenticator.requestAccess(origin1)).toBe(true);
-      expect(await authenticator.requestAccess(origin1)).toBe(true);
+      expect(await authenticator.requestAccess(sender1)).toBe(true);
+      expect(await authenticator.requestAccess(sender1)).toBe(true);
       expect(requestAccess).toBeCalledTimes(1);
-      expect(await storage.get()).toContain(origin1);
+      expect(await storage.get()).toContain(senderOrigin(sender1));
     });
 
     it('resolves to false if denied an error and does not persist the decision', async () => {
       requestAccess.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
-      expect(await authenticator.requestAccess(origin1)).toBe(false);
-      expect(await storage.get()).not.toContain(origin1);
-      expect(await authenticator.requestAccess(origin1)).toBe(true);
-      expect(await storage.get()).toContain(origin1);
+      expect(await authenticator.requestAccess(sender1)).toBe(false);
+      expect(await storage.get()).not.toContain(senderOrigin(sender1));
+      expect(await authenticator.requestAccess(sender1)).toBe(true);
+      expect(await storage.get()).toContain(senderOrigin(sender1));
       expect(requestAccess).toBeCalledTimes(2);
     });
 
     it('resolves to false if any error is encountered and does not persist the decision', async () => {
       requestAccess.mockResolvedValue(true).mockRejectedValueOnce(new Error('any error'));
-      expect(await authenticator.requestAccess(origin1)).toBe(false);
-      expect(await storage.get()).not.toContain(origin1);
+      expect(await authenticator.requestAccess(sender1)).toBe(false);
+      expect(await storage.get()).not.toContain(senderOrigin(sender1));
 
       storage.set.mockResolvedValue(void 0).mockRejectedValueOnce(new Error('any error'));
-      expect(await authenticator.requestAccess(origin1)).toBe(false);
-      expect(await storage.get()).not.toContain(origin1);
+      expect(await authenticator.requestAccess(sender1)).toBe(false);
+      expect(await storage.get()).not.toContain(senderOrigin(sender1));
     });
 
     it('caches storage by origin', async () => {
       requestAccess.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-      expect(await authenticator.requestAccess(origin1)).toBe(true);
-      expect(await authenticator.requestAccess(origin2)).toBe(false);
+      expect(await authenticator.requestAccess(sender1)).toBe(true);
+      expect(await authenticator.requestAccess(sender2)).toBe(false);
       expect(requestAccess).toBeCalledTimes(2);
     });
   });
@@ -64,24 +65,24 @@ describe('PersistentAuthenticator', () => {
   describe('revokeAccess', () => {
     beforeEach(async () => {
       requestAccess.mockResolvedValueOnce(true);
-      await authenticator.requestAccess(origin1);
+      await authenticator.requestAccess(sender1);
       storage.set.mockReset();
     });
 
     it('unknown origin => returns false', async () => {
-      expect(await authenticator.revokeAccess(origin2)).toBe(false);
+      expect(await authenticator.revokeAccess(sender2)).toBe(false);
     });
 
     describe('allowed origin', () => {
       it('returns true and removes origin from cache', async () => {
-        expect(await authenticator.revokeAccess(origin1)).toBe(true);
-        expect(await authenticator.revokeAccess(origin1)).toBe(false);
+        expect(await authenticator.revokeAccess(sender1)).toBe(true);
+        expect(await authenticator.revokeAccess(sender1)).toBe(false);
         expect(storage.set).toBeCalledTimes(1);
       });
 
       it('returns false if storage throws', async () => {
         storage.set.mockRejectedValueOnce(new Error('any error'));
-        expect(await authenticator.revokeAccess(origin1)).toBe(false);
+        expect(await authenticator.revokeAccess(sender1)).toBe(false);
       });
     });
   });
@@ -89,26 +90,26 @@ describe('PersistentAuthenticator', () => {
   describe('haveAccess', () => {
     beforeEach(async () => {
       requestAccess.mockResolvedValueOnce(true);
-      await authenticator.requestAccess(origin1);
+      await authenticator.requestAccess(sender1);
     });
 
     it('unknown origin => returns false', async () => {
-      expect(await authenticator.haveAccess(origin2)).toBe(false);
+      expect(await authenticator.haveAccess(sender2)).toBe(false);
     });
 
     it('allowed origin => returns true', async () => {
-      expect(await authenticator.haveAccess(origin1)).toBe(true);
+      expect(await authenticator.haveAccess(sender1)).toBe(true);
     });
   });
 
   describe('clear', () => {
     it('removes all origins', async () => {
       requestAccess.mockResolvedValue(true);
-      await authenticator.requestAccess(origin1);
-      await authenticator.requestAccess(origin2);
+      await authenticator.requestAccess(sender1);
+      await authenticator.requestAccess(sender2);
       await authenticator.clear();
-      expect(await authenticator.haveAccess(origin1)).toBe(false);
-      expect(await authenticator.haveAccess(origin2)).toBe(false);
+      expect(await authenticator.haveAccess(sender1)).toBe(false);
+      expect(await authenticator.haveAccess(sender2)).toBe(false);
     });
   });
 });

--- a/packages/dapp-connector/test/util.test.ts
+++ b/packages/dapp-connector/test/util.test.ts
@@ -1,0 +1,13 @@
+import { senderOrigin } from '../src';
+
+describe('util', () => {
+  describe('senderOrigin', () => {
+    it('returns null when origin url is not present', () => {
+      expect(senderOrigin()).toBe(null);
+      expect(senderOrigin({ id: 'id' })).toBe(null);
+    });
+    it('returns origin url it is present', () => {
+      expect(senderOrigin({ url: 'http://origin' })).toBe('http://origin');
+    });
+  });
+});

--- a/packages/e2e/test/web-extension/extension/background/cip30.ts
+++ b/packages/e2e/test/web-extension/extension/background/cip30.ts
@@ -9,8 +9,16 @@ import { walletName } from '../const';
 
 // this should come from remote api
 const confirmationCallback: walletCip30.CallbackConfirmation = {
-  signData: async () => true,
-  signTx: async () => true,
+  signData: async ({ sender }) => {
+    if (!sender) throw new Error('No sender context');
+    logger.info('signData request from', sender);
+    return true;
+  },
+  signTx: async ({ sender }) => {
+    if (!sender) throw new Error('No sender context');
+    logger.info('signTx request', sender);
+    return true;
+  },
   submitTx: async () => true
 };
 

--- a/packages/e2e/test/web-extension/extension/background/requestAccess.ts
+++ b/packages/e2e/test/web-extension/extension/background/requestAccess.ts
@@ -1,5 +1,5 @@
 import { RemoteApiPropertyType, consumeRemoteApi } from '@cardano-sdk/web-extension';
-import { RequestAccess } from '@cardano-sdk/dapp-connector';
+import { RequestAccess, senderOrigin } from '@cardano-sdk/dapp-connector';
 import { UserPromptService, logger } from '../util';
 import { ensureUiIsOpenAndLoaded } from './windowManager';
 import { runtime } from 'webextension-polyfill';
@@ -15,7 +15,9 @@ const userPromptService = consumeRemoteApi<UserPromptService>(
   { logger, runtime }
 );
 
-export const requestAccess: RequestAccess = async (origin) => {
+export const requestAccess: RequestAccess = async (sender) => {
+  const origin = senderOrigin(sender);
+  if (!origin) throw new Error('Invalid requestAccess request: unknown sender origin');
   await ensureUiIsOpenAndLoaded();
   return await userPromptService.allowOrigin(origin);
 };

--- a/packages/key-management/package.json
+++ b/packages/key-management/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.182",
     "@types/pbkdf2": "^3.1.0",
+    "@types/webextension-polyfill": "^0.8.0",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",
     "madge": "^5.0.1",

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -2,6 +2,9 @@ import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { HexBlob, OpaqueString, Shutdown } from '@cardano-sdk/util';
 import { Logger } from 'ts-log';
+import type { Runtime } from 'webextension-polyfill';
+
+export type MessageSender = Runtime.MessageSender;
 
 export interface SignBlobResult {
   publicKey: Crypto.Ed25519PublicKeyHex;
@@ -141,6 +144,7 @@ export interface SignTransactionOptions {
 export interface SignTransactionContext {
   txInKeyPathMap: TxInKeyPathMap;
   knownAddresses: GroupedAddress[];
+  sender?: MessageSender;
 }
 
 export interface KeyAgent {
@@ -231,5 +235,5 @@ export interface Witnesser {
   /**
    * @throws AuthenticationError
    */
-  signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob): Promise<SignBlobResult>;
+  signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob, sender?: MessageSender): Promise<SignBlobResult>;
 }

--- a/packages/key-management/src/util/createWitnesser.ts
+++ b/packages/key-management/src/util/createWitnesser.ts
@@ -1,6 +1,7 @@
 import {
   AccountKeyDerivationPath,
   AsyncKeyAgent,
+  MessageSender,
   SignBlobResult,
   SignTransactionContext,
   WitnessOptions,
@@ -25,7 +26,11 @@ export class Bip32Ed25519Witnesser implements Witnesser {
     return { signatures: await this.#keyAgent.signTransaction(txInternals, context, options) };
   }
 
-  async signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob): Promise<SignBlobResult> {
+  async signBlob(
+    derivationPath: AccountKeyDerivationPath,
+    blob: HexBlob,
+    _sender?: MessageSender
+  ): Promise<SignBlobResult> {
     return this.#keyAgent.signBlob(derivationPath, blob);
   }
 }

--- a/packages/key-management/test/cip8/cip30signData.test.ts
+++ b/packages/key-management/test/cip8/cip30signData.test.ts
@@ -6,8 +6,10 @@ import {
   KeyAgent,
   util as KeyManagementUtil,
   KeyRole,
+  MessageSender,
   cip8
 } from '../../src';
+import { Bip32Ed25519Witnesser } from '../../src/util';
 import { COSEKey, COSESign1, SigStructure } from '@emurgo/cardano-message-signing-nodejs';
 import { Cardano, util } from '@cardano-sdk/core';
 import { CoseLabel } from '../../src/cip8/util';
@@ -17,6 +19,7 @@ import { testAsyncKeyAgent, testKeyAgent } from '../mocks';
 describe('cip30signData', () => {
   const addressDerivationPath = { index: 0, type: AddressType.External };
   let keyAgent: KeyAgent;
+  let witnesser: Bip32Ed25519Witnesser;
   let asyncKeyAgent: AsyncKeyAgent;
   let address: GroupedAddress;
   const cryptoProvider = new Crypto.SodiumBip32Ed25519();
@@ -26,17 +29,20 @@ describe('cip30signData', () => {
     keyAgent = await keyAgentReady;
     asyncKeyAgent = await testAsyncKeyAgent(undefined, keyAgentReady);
     address = await asyncKeyAgent.deriveAddress(addressDerivationPath, 0);
+    witnesser = KeyManagementUtil.createBip32Ed25519Witnesser(asyncKeyAgent);
   });
 
   const signAndDecode = async (
     signWith: Cardano.PaymentAddress | Cardano.RewardAccount,
-    knownAddresses: GroupedAddress[]
+    knownAddresses: GroupedAddress[],
+    sender?: MessageSender
   ) => {
     const dataSignature = await cip8.cip30signData({
       knownAddresses,
       payload: HexBlob('abc123'),
+      sender,
       signWith,
-      witnesser: KeyManagementUtil.createBip32Ed25519Witnesser(asyncKeyAgent)
+      witnesser
     });
 
     const coseKey = COSEKey.from_bytes(Buffer.from(dataSignature.key, 'hex'));
@@ -101,5 +107,12 @@ describe('cip30signData', () => {
         publicKeyHex as unknown as Crypto.Ed25519PublicKeyHex
       )
     ).toBe(true);
+  });
+
+  it('passes through sender to witnesser', async () => {
+    const signBlobSpy = jest.spyOn(witnesser, 'signBlob');
+    const sender = { url: 'https://lace.io' };
+    await signAndDecode(address.address, [address], sender);
+    expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), sender);
   });
 });

--- a/packages/wallet/src/PersonalWallet/PersonalWallet.ts
+++ b/packages/wallet/src/PersonalWallet/PersonalWallet.ts
@@ -533,7 +533,7 @@ export class PersonalWallet implements ObservableWallet {
     return initializeTx(props, this.getTxBuilderDependencies());
   }
 
-  async finalizeTx({ tx, ...rest }: FinalizeTxProps, stubSign = false): Promise<Cardano.Tx> {
+  async finalizeTx({ tx, sender, ...rest }: FinalizeTxProps, stubSign = false): Promise<Cardano.Tx> {
     const knownAddresses = await firstValueFrom(this.addresses$);
     const { tx: signedTx } = await finalizeTx(
       tx,
@@ -541,6 +541,7 @@ export class PersonalWallet implements ObservableWallet {
         ...rest,
         signingContext: {
           knownAddresses,
+          sender,
           txInKeyPathMap: await util.createTxInKeyPathMap(tx.body, knownAddresses, this.util)
         }
       },

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -10,7 +10,7 @@ import {
 import { BalanceTracker, DelegationTracker, TransactionsTracker, UtxoTracker } from './services';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
-import { GroupedAddress, SignTransactionOptions, cip8 } from '@cardano-sdk/key-management';
+import { GroupedAddress, MessageSender, SignTransactionOptions, cip8 } from '@cardano-sdk/key-management';
 import { InitializeTxProps, InitializeTxResult, SignedTx, TxBuilder, TxContext } from '@cardano-sdk/tx-construction';
 import { Observable } from 'rxjs';
 import { PubStakeKeyAndStatus } from './services/PublicStakeKeysTracker';
@@ -46,6 +46,7 @@ export interface SyncStatus extends Shutdown {
 export type FinalizeTxProps = Omit<TxContext, 'signingContext'> & {
   tx: Cardano.TxBodyWithHash;
   signingOptions?: SignTransactionOptions;
+  sender?: MessageSender;
 };
 
 export type HandleInfo = HandleResolution & Asset.AssetInfo;

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -8,9 +8,11 @@ import {
   DataSignError,
   DataSignErrorCode,
   Paginate,
+  SenderContext,
   TxSendError,
   TxSignError,
-  WalletApi
+  WalletApi,
+  WithSenderContext
 } from '@cardano-sdk/dapp-connector';
 import { AddressType, Bip32Account, GroupedAddress, util } from '@cardano-sdk/key-management';
 import { AssetId, createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
@@ -47,7 +49,7 @@ const {
 
 type TestProviders = Required<Pick<Providers, 'txSubmitProvider' | 'networkInfoProvider'>>;
 const mockCollateralCallback = jest.fn().mockResolvedValue([mockUtxo[3]]);
-const mockGenericCallback = jest.fn().mockResolvedValue(true);
+const createMockGenericCallback = () => jest.fn().mockResolvedValue(true);
 
 const createWalletAndApiWithStores = async (
   unspendableUtxos: Cardano.Utxo[],
@@ -68,9 +70,9 @@ const createWalletAndApiWithStores = async (
     wallet.utxo.available$ = of(availableUtxos);
   }
   const confirmationCallback = {
-    signData: mockGenericCallback,
-    signTx: mockGenericCallback,
-    submitTx: mockGenericCallback,
+    signData: createMockGenericCallback(),
+    signTx: createMockGenericCallback(),
+    submitTx: createMockGenericCallback(),
     ...(!!getCollateralCallback && { getCollateral: getCollateralCallback })
   };
   wallet.getPubDRepKey = jest.fn(wallet.getPubDRepKey);
@@ -81,8 +83,9 @@ const createWalletAndApiWithStores = async (
 };
 
 describe('cip30', () => {
+  const context: SenderContext = { sender: { url: 'https://lace.io' } };
   let wallet: PersonalWallet;
-  let api: WalletApi;
+  let api: WithSenderContext<WalletApi>;
   let confirmationCallback: CallbackConfirmation;
 
   const simpleTxProps: InitializeTxProps = {
@@ -138,7 +141,7 @@ describe('cip30', () => {
             // Validity interval of serializedTx is 20263284 <= n <= 20266884
             slot: Cardano.Slot(20_263_285)
           });
-          await expect(api.submitTx(serializedTx)).resolves.not.toThrow();
+          await expect(api.submitTx(context, serializedTx)).resolves.not.toThrow();
           expect(providers.txSubmitProvider.submitTx).toHaveBeenCalledWith({ signedTransaction: serializedTx });
         });
       });
@@ -167,13 +170,13 @@ describe('cip30', () => {
 
     describe('createWalletApi', () => {
       test('api.getNetworkId', async () => {
-        const cip30NetworkId = await api.getNetworkId();
+        const cip30NetworkId = await api.getNetworkId(context);
         expect(cip30NetworkId).toEqual(Cardano.NetworkId.Testnet);
       });
 
       describe('api.getUtxos', () => {
         it('returns all utxo without arguments', async () => {
-          const utxos = await api.getUtxos();
+          const utxos = await api.getUtxos(context);
           expect(utxos?.length).toBe((await firstValueFrom(wallet.utxo.available$)).length);
           expect(() =>
             utxos!.map((utxo) => Serialization.TransactionUnspentOutput.fromCbor(HexBlob(utxo)))
@@ -189,7 +192,7 @@ describe('cip30', () => {
               multiAsset.set(AssetId.TSLA, tslaQuantity);
               filterAmountValue.setMultiasset(multiAsset);
             }
-            const utxoCbor = await api.getUtxos(filterAmountValue.toCbor(), paginate);
+            const utxoCbor = await api.getUtxos(context, filterAmountValue.toCbor(), paginate);
             if (!utxoCbor) return null;
             return utxoCbor.map((utxo) => Serialization.TransactionUnspentOutput.fromCbor(HexBlob(utxo)).toCore());
           };
@@ -264,27 +267,27 @@ describe('cip30', () => {
       describe('api.getCollateral', () => {
         // Wallet 2
         let wallet2: PersonalWallet;
-        let api2: WalletApi;
+        let api2: WithSenderContext<WalletApi>;
 
         // Wallet 3
         let wallet3: PersonalWallet;
-        let api3: WalletApi;
+        let api3: WithSenderContext<WalletApi>;
 
         // Wallet 4
         let wallet4: PersonalWallet;
-        let api4: WalletApi;
+        let api4: WithSenderContext<WalletApi>;
 
         // Wallet 5
         let wallet5: PersonalWallet;
-        let api5: WalletApi;
+        let api5: WithSenderContext<WalletApi>;
 
         // Wallet 6
         let wallet6: PersonalWallet;
-        let api6: WalletApi;
+        let api6: WithSenderContext<WalletApi>;
 
         // Wallet 7
         let wallet7: PersonalWallet;
-        let api7: WalletApi;
+        let api7: WithSenderContext<WalletApi>;
 
         beforeAll(async () => {
           // CREATE A WALLET WITH LOW COINS UTxOs
@@ -336,11 +339,11 @@ describe('cip30', () => {
 
         test('can handle serialization errors', async () => {
           // YYYY is invalid hex that will throw at serialization
-          await expect(api.getCollateral({ amount: 'YYYY' })).rejects.toThrowError(ApiError);
+          await expect(api.getCollateral(context, { amount: 'YYYY' })).rejects.toThrowError(ApiError);
         });
 
         it('executes collateral callback if provided and unspendable UTxOs do not meet amount required', async () => {
-          const collateral = await api5.getCollateral();
+          const collateral = await api5.getCollateral(context);
           expect(mockCollateralCallback).toHaveBeenCalledWith({
             data: {
               amount: 5_000_000n,
@@ -354,7 +357,7 @@ describe('cip30', () => {
         });
 
         it('executes collateral callback if provided and no unspendable UTxOs are available', async () => {
-          const collateral = await api6.getCollateral();
+          const collateral = await api6.getCollateral(context);
           expect(mockCollateralCallback).toHaveBeenCalledWith({
             data: {
               amount: 5_000_000n,
@@ -368,23 +371,23 @@ describe('cip30', () => {
         });
 
         it('does not execute collateral callback if provided with no available UTxOs', async () => {
-          await expect(api7.getCollateral()).rejects.toThrow(ApiError);
+          await expect(api7.getCollateral(context)).rejects.toThrow(ApiError);
           expect(mockCollateralCallback).not.toHaveBeenCalled();
           wallet7.shutdown();
         });
 
         it('does not execute collateral callback if not provided', async () => {
-          await expect(api2.getCollateral()).rejects.toThrow(ApiError);
+          await expect(api2.getCollateral(context)).rejects.toThrow(ApiError);
           expect(mockCollateralCallback).not.toHaveBeenCalled();
         });
 
         test('accepts amount as tagged integer', async () => {
-          await expect(api.getCollateral({ amount: 'c2434c4b40' })).resolves.not.toThrow();
+          await expect(api.getCollateral(context, { amount: 'c2434c4b40' })).resolves.not.toThrow();
         });
 
         test('returns multiple UTxOs when more than 1 utxo needed to satisfy amount', async () => {
           // 1a003d0900 Represents a BigNum object of 4 ADA
-          const utxos = await api2.getCollateral({ amount: '1a003d0900' });
+          const utxos = await api2.getCollateral(context, { amount: '1a003d0900' });
           // eslint-disable-next-line sonarjs/no-identical-functions
 
           expect(() =>
@@ -395,23 +398,23 @@ describe('cip30', () => {
 
         test('throws when there are not enough UTxOs', async () => {
           // 1a004c4b40 Represents a BigNum object of 5 ADA
-          await expect(api2.getCollateral({ amount: '1a004c4b40' })).rejects.toThrow(ApiError);
+          await expect(api2.getCollateral(context, { amount: '1a004c4b40' })).rejects.toThrow(ApiError);
         });
 
         test('returns null when there are no "unspendable" UTxOs in the wallet', async () => {
           // 1a003d0900 Represents a BigNum object of 4 ADA
-          expect(await api3.getCollateral({ amount: '1a003d0900' })).toBe(null);
+          expect(await api3.getCollateral(context, { amount: '1a003d0900' })).toBe(null);
           wallet3.shutdown();
         });
 
         test('throws when the given amount is greater than max amount', async () => {
           // 1a005b8d80 Represents a BigNum object of 6 ADA
-          await expect(api2.getCollateral({ amount: '1a005b8d80' })).rejects.toThrow(ApiError);
+          await expect(api2.getCollateral(context, { amount: '1a005b8d80' })).rejects.toThrow(ApiError);
         });
 
         test('returns first UTxO when amount is 0', async () => {
           // 00 Represents a BigNum object of 0 ADA
-          const utxos = await api2.getCollateral({ amount: '00' });
+          const utxos = await api2.getCollateral(context, { amount: '00' });
           // eslint-disable-next-line sonarjs/no-identical-functions
           expect(() =>
             utxos!.map((utxo) => Serialization.TransactionUnspentOutput.fromCbor(HexBlob(utxo)))
@@ -419,7 +422,7 @@ describe('cip30', () => {
         });
 
         test('returns all UTxOs when there is no given amount', async () => {
-          const utxos = await api.getCollateral();
+          const utxos = await api.getCollateral(context);
           // eslint-disable-next-line sonarjs/no-identical-functions
           expect(() =>
             utxos!.map((utxo) => Serialization.TransactionUnspentOutput.fromCbor(HexBlob(utxo)))
@@ -428,21 +431,21 @@ describe('cip30', () => {
         });
 
         test('returns null when there is no given amount and wallet has no UTxOs', async () => {
-          expect(await api3.getCollateral()).toBe(null);
+          expect(await api3.getCollateral(context)).toBe(null);
         });
 
         test('throws when unspendable UTxOs contain assets', async () => {
-          await expect(api4.getCollateral()).rejects.toThrow(ApiError);
+          await expect(api4.getCollateral(context)).rejects.toThrow(ApiError);
         });
       });
 
       test('api.getBalance', async () => {
-        const balanceCborBytes = await api.getBalance();
+        const balanceCborBytes = await api.getBalance(context);
         expect(() => Serialization.Value.fromCbor(HexBlob(balanceCborBytes))).not.toThrow();
       });
 
       test('api.getUsedAddresses', async () => {
-        const cipUsedAddressess = await api.getUsedAddresses();
+        const cipUsedAddressess = await api.getUsedAddresses(context);
         const usedAddresses = (await firstValueFrom(wallet.addresses$)).map((grouped) => grouped.address);
 
         expect(cipUsedAddressess.length).toBeGreaterThan(1);
@@ -450,18 +453,18 @@ describe('cip30', () => {
       });
 
       test('api.getUnusedAddresses', async () => {
-        const cipUsedAddressess = await api.getUnusedAddresses();
+        const cipUsedAddressess = await api.getUnusedAddresses(context);
         expect(cipUsedAddressess).toEqual([]);
       });
 
       test('api.getChangeAddress', async () => {
-        const cipChangeAddress = await api.getChangeAddress();
+        const cipChangeAddress = await api.getChangeAddress(context);
         const [{ address: walletAddress }] = await firstValueFrom(wallet.addresses$);
         expect(Cardano.PaymentAddress(cipChangeAddress)).toEqual(walletAddress);
       });
 
       test('api.getRewardAddresses', async () => {
-        const cipRewardAddressesCbor = await api.getRewardAddresses();
+        const cipRewardAddressesCbor = await api.getRewardAddresses(context);
         const cipRewardAddresses = cipRewardAddressesCbor.map((cipAddr) =>
           Cardano.Address.fromBytes(HexBlob(cipAddr)).toBech32()
         );
@@ -470,40 +473,74 @@ describe('cip30', () => {
         expect(cipRewardAddresses).toEqual([walletRewardAccount]);
       });
 
-      test('api.signTx', async () => {
-        const txInternals = await wallet.initializeTx(simpleTxProps);
-        const finalizedTx = await wallet.finalizeTx({ tx: txInternals });
-        const hexTx = Serialization.Transaction.fromCore(finalizedTx).toCbor();
+      describe('api.signTx', () => {
+        let finalizedTx: Cardano.Tx;
+        let hexTx: TxCBOR;
 
-        const cip30witnessSet = await api.signTx(hexTx);
-        expect(() => Serialization.TransactionWitnessSet.fromCbor(HexBlob(cip30witnessSet))).not.toThrow();
+        beforeEach(async () => {
+          const txInternals: InitializeTxResult = await wallet.initializeTx(simpleTxProps);
+          finalizedTx = await wallet.finalizeTx({ tx: txInternals });
+          hexTx = Serialization.Transaction.fromCore(finalizedTx).toCbor();
+        });
+
+        it('resolves with TransactionWitnessSet', async () => {
+          const cip30witnessSet = await api.signTx(context, hexTx);
+          expect(() => Serialization.TransactionWitnessSet.fromCbor(HexBlob(cip30witnessSet))).not.toThrow();
+        });
+
+        it('passes through sender from dapp connector context', async () => {
+          const finalizeTxSpy = jest.spyOn(wallet, 'finalizeTx');
+          await api.signTx(context, hexTx);
+          expect(finalizeTxSpy).toBeCalledWith(
+            expect.objectContaining({
+              sender: {
+                url: context.sender.url
+              }
+            })
+          );
+          expect(confirmationCallback.signTx).toBeCalledWith(expect.objectContaining({ sender: context.sender }));
+        });
       });
 
       describe('api.signData', () => {
         test('sign with address', async () => {
           const [{ address }] = await firstValueFrom(wallet.addresses$);
-          const cip30dataSignature = await api.signData(address, HexBlob('abc123'));
+          const cip30dataSignature = await api.signData(context, address, HexBlob('abc123'));
           expect(typeof cip30dataSignature.key).toBe('string');
           expect(typeof cip30dataSignature.signature).toBe('string');
         });
 
         test('sign with bech32 DRepID', async () => {
-          const dRepKey = await api.getPubDRepKey();
+          const dRepKey = await api.getPubDRepKey(context);
           const drepid = buildDRepIDFromDRepKey(dRepKey);
 
-          const cip95dataSignature = await api.signData(drepid, HexBlob('abc123'));
+          const cip95dataSignature = await api.signData(context, drepid, HexBlob('abc123'));
           expect(typeof cip95dataSignature.key).toBe('string');
           expect(typeof cip95dataSignature.signature).toBe('string');
         });
 
         test('rejects if bech32 DRepID is not a type 6 address', async () => {
-          const dRepKey = await api.getPubDRepKey();
+          const dRepKey = await api.getPubDRepKey(context);
           for (const type in Cardano.AddressType) {
             if (!Number.isNaN(Number(type)) && Number(type) !== Cardano.AddressType.EnterpriseKey) {
               const drepid = buildDRepIDFromDRepKey(dRepKey, 0, type as unknown as Cardano.AddressType);
-              await expect(api.signData(drepid, HexBlob('abc123'))).rejects.toThrow();
+              await expect(api.signData(context, drepid, HexBlob('abc123'))).rejects.toThrow();
             }
           }
+        });
+
+        it('passes through sender from dapp connector context', async () => {
+          const [{ address }] = await firstValueFrom(wallet.addresses$);
+          const signDataSpy = jest.spyOn(wallet, 'signData');
+          await api.signData(context, address, HexBlob('abc123'));
+          expect(signDataSpy).toBeCalledWith(
+            expect.objectContaining({
+              sender: {
+                url: context.sender.url
+              }
+            })
+          );
+          expect(confirmationCallback.signData).toBeCalledWith(expect.objectContaining({ sender: context.sender }));
         });
       });
 
@@ -520,7 +557,7 @@ describe('cip30', () => {
         });
 
         it('resolves with transaction id when submitting a valid transaction', async () => {
-          const txId = await api.submitTx(hexTx);
+          const txId = await api.submitTx(context, hexTx);
           expect(txId).toBe(finalizedTx.id);
         });
 
@@ -528,11 +565,11 @@ describe('cip30', () => {
         it.todo('resolves with original transactionId (not the one computed when re-serializing the transaction)');
 
         it('throws ApiError when submitting a transaction that has invalid encoding', async () => {
-          await expect(api.submitTx(Buffer.from(txBytes).toString('base64'))).rejects.toThrowError(ApiError);
+          await expect(api.submitTx(context, Buffer.from(txBytes).toString('base64'))).rejects.toThrowError(ApiError);
         });
 
         it('throws ApiError when submitting a hex string that is not a serialized transaction', async () => {
-          await expect(api.submitTx(Buffer.from([0, 1, 3]).toString('hex'))).rejects.toThrowError(ApiError);
+          await expect(api.submitTx(context, Buffer.from([0, 1, 3]).toString('hex'))).rejects.toThrowError(ApiError);
         });
 
         it('throws TxSendError when submission fails', async () => {
@@ -546,19 +583,19 @@ describe('cip30', () => {
               'Outside of validity interval'
             )
           );
-          await expect(api.submitTx(hexTx)).rejects.toThrowError(TxSendError);
+          await expect(api.submitTx(context, hexTx)).rejects.toThrowError(TxSendError);
         });
       });
 
       describe('api.getPubDRepKey', () => {
         test("returns the DRep key derived from the wallet's public key", async () => {
-          const cip95PubDRepKey = await api.getPubDRepKey();
+          const cip95PubDRepKey = await api.getPubDRepKey(context);
           expect(cip95PubDRepKey).toEqual(await wallet.getPubDRepKey());
         });
         test('throws an ApiError on unexpected error', async () => {
           (wallet.getPubDRepKey as jest.Mock).mockRejectedValueOnce(new Error('unexpected error'));
           try {
-            await api.getPubDRepKey();
+            await api.getPubDRepKey(context);
           } catch (error) {
             expect(error instanceof ApiError).toBe(true);
             expect((error as ApiError).code).toEqual(APIErrorCode.InternalError);
@@ -570,7 +607,7 @@ describe('cip30', () => {
       });
 
       test('api.getExtensions', async () => {
-        const extensions = await api.getExtensions();
+        const extensions = await api.getExtensions(context);
         expect(extensions).toEqual([{ cip: 95 }]);
       });
     });
@@ -587,17 +624,17 @@ describe('cip30', () => {
 
         test('resolves true', async () => {
           confirmationCallback.signData = jest.fn().mockResolvedValueOnce(true);
-          await expect(api.signData(address, payload)).resolves.not.toThrow();
+          await expect(api.signData(context, address, payload)).resolves.not.toThrow();
         });
 
         test('resolves false', async () => {
           confirmationCallback.signData = jest.fn().mockResolvedValueOnce(false);
-          await expect(api.signData(address, payload)).rejects.toThrowError(DataSignError);
+          await expect(api.signData(context, address, payload)).rejects.toThrowError(DataSignError);
         });
 
         test('rejects', async () => {
           confirmationCallback.signData = jest.fn().mockRejectedValue(1);
-          await expect(api.signData(address, payload)).rejects.toThrowError(DataSignError);
+          await expect(api.signData(context, address, payload)).rejects.toThrowError(DataSignError);
         });
 
         test('gets the Cardano.Address equivalent of the hex address', async () => {
@@ -605,7 +642,7 @@ describe('cip30', () => {
 
           const hexAddr = Cardano.Address.fromBech32(address).toBytes();
 
-          await api.signData(hexAddr, payload);
+          await api.signData(context, hexAddr, payload);
           expect(confirmationCallback.signData).toHaveBeenCalledWith(
             expect.objectContaining({ data: expect.objectContaining({ addr: address }) })
           );
@@ -622,17 +659,17 @@ describe('cip30', () => {
 
         test('resolves true', async () => {
           confirmationCallback.signTx = jest.fn().mockResolvedValueOnce(true);
-          await expect(api.signTx(hexTx)).resolves.not.toThrow();
+          await expect(api.signTx(context, hexTx)).resolves.not.toThrow();
         });
 
         test('resolves false', async () => {
           confirmationCallback.signTx = jest.fn().mockResolvedValueOnce(false);
-          await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
+          await expect(api.signTx(context, hexTx)).rejects.toThrowError(TxSignError);
         });
 
         test('rejects', async () => {
           confirmationCallback.signTx = jest.fn().mockRejectedValue(1);
-          await expect(api.signTx(hexTx)).rejects.toThrowError(TxSignError);
+          await expect(api.signTx(context, hexTx)).rejects.toThrowError(TxSignError);
         });
       });
 
@@ -649,17 +686,17 @@ describe('cip30', () => {
 
         test('resolves true', async () => {
           confirmationCallback.submitTx = jest.fn().mockResolvedValueOnce(true);
-          await expect(api.submitTx(serializedTx)).resolves.toBe(finalizedTx.id);
+          await expect(api.submitTx(context, serializedTx)).resolves.toBe(finalizedTx.id);
         });
 
         test('resolves false', async () => {
           confirmationCallback.submitTx = jest.fn().mockResolvedValueOnce(false);
-          await expect(api.submitTx(serializedTx)).rejects.toThrowError(TxSendError);
+          await expect(api.submitTx(context, serializedTx)).rejects.toThrowError(TxSendError);
         });
 
         test('rejects', async () => {
           confirmationCallback.submitTx = jest.fn().mockRejectedValue(1);
-          await expect(api.submitTx(serializedTx)).rejects.toThrowError(TxSendError);
+          await expect(api.submitTx(context, serializedTx)).rejects.toThrowError(TxSendError);
         });
       });
     });
@@ -671,7 +708,7 @@ describe('cip30', () => {
       let mockWallet: PersonalWallet;
       let utxoProvider: mocks.UtxoProviderStub;
       let tx: Cardano.Tx;
-      let mockApi: WalletApi;
+      let mockApi: WithSenderContext<WalletApi>;
 
       beforeEach(async () => {
         txSubmitProvider = mocks.mockTxSubmitProvider();
@@ -758,7 +795,7 @@ describe('cip30', () => {
           // Inputs are selected by input selection algorithm
           expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
           expect(tx.body.certificates!.length).toBe(1);
-          await expect(mockApi.signTx(cbor, false)).resolves.not.toThrow();
+          await expect(mockApi.signTx(context, cbor, false)).resolves.not.toThrow();
         }
       );
 
@@ -785,7 +822,7 @@ describe('cip30', () => {
           // Inputs are selected by input selection algorithm
           expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
           expect(tx.body.certificates!.length).toBe(1);
-          await expect(mockApi.signTx(cbor, true)).resolves.not.toThrow();
+          await expect(mockApi.signTx(context, cbor, true)).resolves.not.toThrow();
         }
       );
 
@@ -820,7 +857,7 @@ describe('cip30', () => {
           // Inputs are selected by input selection algorithm
           expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
           expect(tx.body.certificates!.length).toBe(1);
-          await expect(mockApi.signTx(cbor, true)).resolves.not.toThrow();
+          await expect(mockApi.signTx(context, cbor, true)).resolves.not.toThrow();
         }
       );
 
@@ -862,7 +899,7 @@ describe('cip30', () => {
 
           expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
           expect(tx.body.certificates!.length).toBe(2);
-          await expect(mockApi.signTx(cbor, true)).resolves.not.toThrow();
+          await expect(mockApi.signTx(context, cbor, true)).resolves.not.toThrow();
         }
       );
 
@@ -879,7 +916,7 @@ describe('cip30', () => {
           expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
           expect(tx.body.certificates!.length).toBe(1);
 
-          await expect(mockApi.signTx(cbor, true)).rejects.toMatchObject(
+          await expect(mockApi.signTx(context, cbor, true)).rejects.toMatchObject(
             new DataSignError(
               DataSignErrorCode.ProofGeneration,
               'The wallet does not have the secret key associated with any of the inputs and certificates.'
@@ -906,7 +943,7 @@ describe('cip30', () => {
           expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
           expect(tx.body.certificates!.length).toBe(1);
 
-          await expect(mockApi.signTx(cbor, false)).rejects.toMatchObject(
+          await expect(mockApi.signTx(context, cbor, false)).rejects.toMatchObject(
             new DataSignError(
               DataSignErrorCode.ProofGeneration,
               'The wallet does not have the secret key associated with some of the inputs or certificates.'
@@ -941,7 +978,7 @@ describe('cip30', () => {
           expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
           expect(tx.body.certificates!.length).toBe(2);
 
-          await expect(mockApi.signTx(cbor, false)).rejects.toMatchObject(
+          await expect(mockApi.signTx(context, cbor, false)).rejects.toMatchObject(
             new DataSignError(
               DataSignErrorCode.ProofGeneration,
               'The wallet does not have the secret key associated with some of the inputs or certificates.'

--- a/packages/web-extension/src/cip30/exposeAuthenticatorApi.ts
+++ b/packages/web-extension/src/cip30/exposeAuthenticatorApi.ts
@@ -4,10 +4,10 @@ import {
   RemoteApiMethod,
   RemoteApiProperties,
   RemoteApiPropertyType,
-  exposeApi,
-  senderOrigin
+  exposeApi
 } from '../messaging';
 import { RemoteAuthenticatorMethodNames } from './consumeRemoteAuthenticatorApi';
+import { cloneSender } from './util';
 import { of } from 'rxjs';
 
 export interface ExposeAuthenticatorApiOptions {
@@ -35,10 +35,13 @@ export const exposeAuthenticatorApi = (
           {
             propType: RemoteApiPropertyType.MethodReturningPromise,
             requestOptions: {
-              transform: ({ method }, sender) => ({
-                args: [senderOrigin(sender)],
-                method
-              })
+              transform: ({ method }, sender) => {
+                if (!sender) throw new Error('Unknown sender');
+                return {
+                  args: [cloneSender(sender)],
+                  method
+                };
+              }
             }
           } as RemoteApiMethod
         ])

--- a/packages/web-extension/src/cip30/initializeBackgroundScript.ts
+++ b/packages/web-extension/src/cip30/initializeBackgroundScript.ts
@@ -1,4 +1,4 @@
-import { AuthenticatorApi, WalletApi, WalletName } from '@cardano-sdk/dapp-connector';
+import { AuthenticatorApi, WalletApi, WalletName, WithSenderContext } from '@cardano-sdk/dapp-connector';
 import { Logger } from 'ts-log';
 import { Runtime } from 'webextension-polyfill';
 import { exposeAuthenticatorApi } from './exposeAuthenticatorApi';
@@ -12,7 +12,7 @@ export interface InitializeBackgroundScriptDependencies {
   logger: Logger;
   runtime: Runtime.Static;
   authenticator: AuthenticatorApi;
-  walletApi: WalletApi;
+  walletApi: WithSenderContext<WalletApi>;
 }
 
 // tested in e2e tests

--- a/packages/web-extension/src/cip30/util.ts
+++ b/packages/web-extension/src/cip30/util.ts
@@ -1,3 +1,47 @@
+import { MessageSender } from '@cardano-sdk/key-management';
+
 export const walletApiChannel = (walletName: string) => `wallet-api-${walletName}`;
 
 export const authenticatorChannel = (walletName: string) => `authenticator-${walletName}`;
+
+/**
+ * sender object is intended to be used as a parameter in APIs exposed via extension messaging.
+ * This function clones the sender object provided by the browser in order to ensure it's a pojo.
+ */
+export const cloneSender = ({ frameId, id, tab, url }: MessageSender): MessageSender => ({
+  frameId,
+  id,
+  tab: tab
+    ? {
+        active: tab.active,
+        attention: tab.attention,
+        audible: tab.audible,
+        autoDiscardable: tab.autoDiscardable,
+        cookieStoreId: tab.cookieStoreId,
+        discarded: tab.discarded,
+        favIconUrl: tab.favIconUrl,
+        height: tab.height,
+        hidden: tab.hidden,
+        highlighted: tab.highlighted,
+        id: tab.id,
+        incognito: tab.incognito,
+        index: tab.index,
+        isArticle: tab.isArticle,
+        isInReaderMode: tab.isInReaderMode,
+        lastAccessed: tab.lastAccessed,
+        mutedInfo: tab.mutedInfo ? { ...tab.mutedInfo } : void 0,
+        openerTabId: tab.openerTabId,
+        pendingUrl: tab.pendingUrl,
+        pinned: tab.pinned,
+        sessionId: tab.sessionId,
+        sharingState: tab.sharingState ? { ...tab.sharingState } : void 0,
+        status: tab.status,
+        successorTabId: tab.successorTabId,
+        title: tab.title,
+        url: tab.url,
+        width: tab.width,
+        windowId: tab.windowId
+      }
+    : void 0,
+  url
+});

--- a/packages/web-extension/src/messaging/util.ts
+++ b/packages/web-extension/src/messaging/util.ts
@@ -13,7 +13,6 @@ import {
   ResponseMessage
 } from './types';
 import { Logger } from 'ts-log';
-import { Runtime } from 'webextension-polyfill';
 import { v4 as uuidv4 } from 'uuid';
 
 const isRequestLike = (message: any): message is MethodRequest & Partial<Record<string, unknown>> =>
@@ -42,15 +41,6 @@ export const isCompletionMessage = (message: any): message is CompletionMessage 
 
 export const isEmitMessage = (message: any): message is EmitMessage =>
   looksLikeMessage(message) && message.hasOwnProperty('emit');
-
-export const senderOrigin = (sender?: Runtime.MessageSender): string | null => {
-  try {
-    const { origin } = new URL(sender?.url || 'throw');
-    return origin;
-  } catch {
-    return null;
-  }
-};
 
 export const newMessageId = uuidv4;
 

--- a/packages/web-extension/test/messaging/util.test.ts
+++ b/packages/web-extension/test/messaging/util.test.ts
@@ -9,8 +9,7 @@ import {
   isRequest,
   isRequestMessage,
   isResponseMessage,
-  newMessageId,
-  senderOrigin
+  newMessageId
 } from '../../src';
 
 describe('messaging/util', () => {
@@ -69,15 +68,6 @@ describe('messaging/util', () => {
   describe('messageId', () => {
     it('returns a different random ID on each call', () => {
       expect(newMessageId()).not.toEqual(newMessageId());
-    });
-  });
-  describe('senderOrigin', () => {
-    it('returns null when origin url is not present', () => {
-      expect(senderOrigin()).toBe(null);
-      expect(senderOrigin({ id: 'id' })).toBe(null);
-    });
-    it('returns origin url it is present', () => {
-      expect(senderOrigin({ url: 'http://origin' })).toBe('http://origin');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,6 +3525,7 @@ __metadata:
     "@trezor/connect-web": 9.0.11
     "@types/lodash": ^4.14.182
     "@types/pbkdf2": ^3.1.0
+    "@types/webextension-polyfill": ^0.8.0
     bip39: ^3.0.4
     chacha: ^2.1.0
     eslint: ^7.32.0


### PR DESCRIPTION
# Context

Current setup loses information about the sender/origin of cip30 method calls

LW-7832

# Proposed Solution

- add a context argument to all cip30 implementation methods and map sender via messaging transformer
- (BREAKING) replace authenticator 'origin' argument to 'sender'
- (BREAKING) hoist 'senderOrigin' util to dapp-connector package