### PR TITLE
feat: add ObservableWallet.discoverAddreses

### DIFF
--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -96,6 +96,14 @@ export interface ObservableWallet {
   /** Create a TxBuilder from this wallet */
   createTxBuilder(): TxBuilder;
 
+  /**
+   * Discover addresses that might have been created by other applications.
+   * This is run automatically when the wallet is first created.
+   *
+   * @returns Promise that resolves when discovery is complete, with an updated array of wallet addresses
+   */
+  discoverAddresses(): Promise<GroupedAddress[]>;
+
   shutdown(): void;
 }
 

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -101,6 +101,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
     rewardAccounts$: RemoteApiPropertyType.HotObservable,
     rewardsHistory$: RemoteApiPropertyType.HotObservable
   },
+  discoverAddresses: RemoteApiPropertyType.MethodReturningPromise,
   eraSummaries$: RemoteApiPropertyType.HotObservable,
   fatalError$: RemoteApiPropertyType.HotObservable,
   finalizeTx: RemoteApiPropertyType.MethodReturningPromise,


### PR DESCRIPTION
# Context

we consolidated address storage in the wallet in #1009 and there was no way to re-discover addresses,
since storage is managed by the wallet internally

# Proposed Solution

add ObservableWallet.discoverAddreses

# Important Changes Introduced
