### PR TITLE
feat: sign own dRep registration certificate

### DIFF
--- a/packages/key-management/src/util/ownSignatureKeyPaths.ts
+++ b/packages/key-management/src/util/ownSignatureKeyPaths.ts
@@ -306,8 +306,8 @@ export const getDRepCredentialKeyPaths = ({
   for (const certificate of txBody.certificates || []) {
     if (
       certificate.__typename === Cardano.CertificateType.UnregisterDelegateRepresentative ||
-      certificate.__typename === Cardano.CertificateType.UpdateDelegateRepresentative
-      // Cardano.CertificateType.RegisterDelegateRepresentative does not require signing
+      certificate.__typename === Cardano.CertificateType.UpdateDelegateRepresentative ||
+      certificate.__typename === Cardano.CertificateType.RegisterDelegateRepresentative
     ) {
       if (
         certificate.dRepCredential.type === Cardano.CredentialType.ScriptHash ||

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -495,11 +495,6 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
   });
 
   describe('DRep key derivation path', () => {
-    beforeEach(async () => {
-      dRepPublicKey = Crypto.Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01');
-      dRepKeyHash = (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex();
-    });
-
     it('is returned for UnregisterDelegateRepresentative certificate with the wallet dRep key hash', async () => {
       const txBody = {
         certificates: [
@@ -539,13 +534,13 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
       ]);
     });
 
-    it('is not returned with a DrepRegistration certificate', async () => {
+    it('is returned with a DrepRegistration certificate', async () => {
       const txBody = {
         certificates: [
           {
             __typename: Cardano.CertificateType.RegisterDelegateRepresentative,
             dRepCredential: {
-              hash: foreignDRepKeyHash,
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(dRepKeyHash),
               type: Cardano.CredentialType.KeyHash
             },
             deposit: 0n
@@ -554,7 +549,9 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
         inputs: [{}, {}, {}]
       } as Cardano.TxBody;
 
-      expect(util.ownSignatureKeyPaths(txBody, [knownAddress1], {}, dRepKeyHash)).toEqual([]);
+      expect(util.ownSignatureKeyPaths(txBody, [knownAddress1], {}, dRepKeyHash)).toEqual([
+        { index: 0, role: KeyRole.DRep }
+      ]);
     });
 
     it('is returned for DRep voter in voting procedures', async () => {

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -254,7 +254,6 @@ describe('WalletUtil', () => {
         tx.body.certificates = [
           {
             __typename: Cardano.CertificateType.Registration,
-            // using foreign intentionally because registration is not signed so it should be accepted
             stakeCredential: {
               hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
               type: Cardano.CredentialType.KeyHash
@@ -575,6 +574,11 @@ describe('WalletUtil', () => {
             anchor: null,
             dRepCredential: { hash: dRepKeyHash, type: Cardano.CredentialType.KeyHash }
           } as Cardano.UpdateDelegateRepresentativeCertificate,
+          {
+            __typename: Cardano.CertificateType.RegisterDelegateRepresentative,
+            anchor: null,
+            dRepCredential: { hash: dRepKeyHash, type: Cardano.CredentialType.KeyHash }
+          } as Cardano.RegisterDelegateRepresentativeCertificate,
           ...tx.body.certificates!
         ];
 
@@ -601,6 +605,19 @@ describe('WalletUtil', () => {
             anchor: null,
             dRepCredential: { hash: foreignDRepKeyHash, type: Cardano.CredentialType.KeyHash }
           } as Cardano.UpdateDelegateRepresentativeCertificate,
+          ...tx.body.certificates!
+        ];
+
+        expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+      });
+
+      it('detects foreign register_drep_cert', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.RegisterDelegateRepresentative,
+            anchor: null,
+            dRepCredential: { hash: foreignDRepKeyHash, type: Cardano.CredentialType.KeyHash }
+          } as Cardano.RegisterDelegateRepresentativeCertificate,
           ...tx.body.certificates!
         ];
 


### PR DESCRIPTION
# Context

[Current cardano ledger implementation wrongfully does not require a witness for DRep registration certificate.](https://github.com/input-output-hk/cardano-ledger/issues/3890)

# Proposed Solution

Prepare SDK for when Cardano ledger releases the version which requires witness DRep registration certificates

# Important
- [ ] Merge this PR only once there is a deployed cardano-node deployed release that requires witnessing DRep registration certificates.
