### PR TITLE
feat(cardano-sevices): allow api compatible version requests

### DIFF
--- a/packages/cardano-services/test/Http/openApi.json
+++ b/packages/cardano-services/test/Http/openApi.json
@@ -6,7 +6,7 @@
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "1.0.0"
+    "version": "15.100.10"
   },
   "paths": {}
 }


### PR DESCRIPTION
# Context

Given /v[major].[minor].[patch],
Server accepts requests to urls that have <= minor version number
Server does not accept requests to urls that have different major version number
Patch version is ignored

