### PR TITLE
feat(wallet): forward MessageSender to GetCollateralCallback

### DIFF
--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -349,6 +349,9 @@ describe('cip30', () => {
               amount: 5_000_000n,
               utxos: sortedUtxosWithLowCoins
             },
+            sender: {
+              url: 'https://lace.io'
+            },
             type: 'get_collateral'
           });
 
@@ -362,6 +365,9 @@ describe('cip30', () => {
             data: {
               amount: 5_000_000n,
               utxos: sortedUtxosWithLowCoins
+            },
+            sender: {
+              url: 'https://lace.io'
             },
             type: 'get_collateral'
           });


### PR DESCRIPTION
# Context

When `cip30.getCollateral` is called, Lace will present the dapp information. Thus, we need a reliable way to get the dapp tab. See [cip30.ts](https://github.com/input-output-hk/lace/blob/f7c4fd1972184bf5d84b196894a6e0700236ca0b/apps/browser-extension-wallet/src/lib/scripts/background/cip30.ts#L70-L71)


