### PR TITLE
chore: add mode skip build in docker image yarn build phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY .yarn .yarn
 COPY .eslintrc.js .prettierrc .yarnrc.yml complete.eslintrc.js eslint.tsconfig.json package.json tsconfig.json yarn.lock yarn-project.nix ./
 
 FROM nodejs-builder as cardano-services-builder
-RUN yarn --immutable --inline-builds
+RUN yarn --immutable --inline-builds --mode=skip-build
 COPY packages packages
 RUN \
   echo "export const unused = 'unused';" > packages/e2e/src/index.ts &&\


### PR DESCRIPTION
# Context

SDK packages are organized in a way that all the dependencies are handled at root level: i.e. all the dependencies are tracked in `/yarn-project.nix` and `/yarn.lock` and installed in `/node_modules`, included dependencies required only at client side and ones required only for e2e testing.

The drawback of this is that all these dependencies not required at back-end side are installed and built inside our `Docker` image.

Some of these dependencies need to be downloaded and rebuild. With a high throughput line, this is not a big issue, but in case of internet problems or for those who have poor lines, this can result in a huge waste of time.

# Proposed Solution

Actually proposed by @mkazlauskas;

adding `--mode=skip-build` to `yarn build` step in Docker image makes the `docker build` time on my local env to drop from about 1200" to about 200"!

This may have some drawbacks we agreed we can tolerate:
- potential runtime errors, if it's using libraries that require native build. We have pretty good test coverage though, so not too worried about this
- potential performance degradation: some libraries have a fallback to js implementation if native libraries are not available