### PR TITLE
chore: fix stake-pool-provider routing

### DIFF
--- a/nix/cardano-services/deployments/backend-ingress.yaml
+++ b/nix/cardano-services/deployments/backend-ingress.yaml
@@ -46,6 +46,13 @@ spec:
             pathType: Prefix
           - backend:
               service:
+                name: dev-preview-cardanojs-stake-pool-provider
+                port:
+                  name: http
+            path: /v1.1.0/stake-pool
+            pathType: Prefix
+          - backend:
+              service:
                 name: dev-preview-cardanojs-handle-provider
                 port:
                   name: http


### PR DESCRIPTION
# Context
`stake-pool-provider` version has not been updated in the deployment manifest thus making it not reachable. This PR fixes this issue