### PR TITLE
LW-8968 add voting procedures to db-sync chain history

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -107,17 +107,19 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
     });
     if (txResults.rows.length === 0) return [];
 
-    const [inputs, outputs, mints, withdrawals, redeemers, metadata, collaterals, certificates] = await Promise.all([
-      this.#builder.queryTransactionInputsByIds(ids),
-      this.#builder.queryTransactionOutputsByIds(ids),
-      this.#builder.queryTxMintByIds(ids),
-      this.#builder.queryWithdrawalsByTxIds(ids),
-      this.#builder.queryRedeemersByIds(ids),
-      // Missing witness datums
-      this.#metadataService.queryTxMetadataByRecordIds(ids),
-      this.#builder.queryTransactionInputsByIds(ids, true),
-      this.#builder.queryCertificatesByIds(ids)
-    ]);
+    const [inputs, outputs, mints, withdrawals, redeemers, metadata, collaterals, certificates, votingProcedures] =
+      await Promise.all([
+        this.#builder.queryTransactionInputsByIds(ids),
+        this.#builder.queryTransactionOutputsByIds(ids),
+        this.#builder.queryTxMintByIds(ids),
+        this.#builder.queryWithdrawalsByTxIds(ids),
+        this.#builder.queryRedeemersByIds(ids),
+        // Missing witness datums
+        this.#metadataService.queryTxMetadataByRecordIds(ids),
+        this.#builder.queryTransactionInputsByIds(ids, true),
+        this.#builder.queryCertificatesByIds(ids),
+        this.#builder.queryVotingProceduresByIds(ids)
+      ]);
 
     return txResults.rows.map((tx) => {
       const txId = tx.id.toString('hex') as unknown as Cardano.TransactionId;
@@ -137,6 +139,7 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
         mint: mints.get(txId),
         outputs: txOutputs,
         redeemers: redeemers.get(txId),
+        votingProcedures: votingProcedures.get(txId),
         withdrawals: withdrawals.get(txId)
       });
     });

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -24,7 +24,6 @@ import { Cardano } from '@cardano-sdk/core';
 import { Hash28ByteBase16, Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import {
   isAuthorizeCommitteeHotCertModel,
-  // isAuthorizeCommitteeHotCertModel,
   isDelegationCertModel,
   isDrepRegistrationCertModel,
   isDrepUnregistrationCertModel,
@@ -32,7 +31,6 @@ import {
   isPoolRegisterCertModel,
   isPoolRetireCertModel,
   isResignCommitteeColdCertModel,
-  // isResignCommitteeColdCertModel,
   isStakeCertModel,
   isStakeRegistrationDelegationCertModel,
   isStakeVoteDelegationCertModel,
@@ -351,11 +349,23 @@ interface TxAlonzoData {
   metadata?: Cardano.TxMetadata;
   collaterals?: Cardano.HydratedTxIn[];
   certificates?: Cardano.Certificate[];
+  votingProcedures?: Cardano.VotingProcedures;
 }
 
 export const mapTxAlonzo = (
   txModel: TxModel,
-  { inputSource, inputs, outputs, mint, withdrawals, redeemers, metadata, collaterals, certificates }: TxAlonzoData
+  {
+    certificates,
+    collaterals,
+    inputSource,
+    inputs,
+    metadata,
+    mint,
+    outputs,
+    redeemers,
+    votingProcedures,
+    withdrawals
+  }: TxAlonzoData
 ): Cardano.HydratedTx => ({
   auxiliaryData:
     metadata && metadata.size > 0
@@ -379,6 +389,7 @@ export const mapTxAlonzo = (
       invalidBefore: Cardano.Slot(Number(txModel.invalid_before)) || undefined,
       invalidHereafter: Cardano.Slot(Number(txModel.invalid_hereafter)) || undefined
     },
+    votingProcedures,
     withdrawals
   },
   id: txModel.id.toString('hex') as unknown as Cardano.TransactionId,

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -102,6 +102,24 @@ export interface RedeemerModel {
   tx_id: Buffer;
 }
 
+type VoterRole = 'ConstitutionalCommittee' | 'DRep' | 'SPO';
+
+export interface VotingProceduresModel {
+  tx_id: Buffer;
+  voter_role: VoterRole;
+  drep_voter: Buffer | null;
+  committee_voter: Buffer | null;
+  pool_voter: Buffer | null;
+  governance_action_tx_id: Buffer;
+  governance_action_index: number;
+  drep_hash_raw: string;
+  drep_has_script: boolean;
+  pool_hash_hash_raw: string;
+  vote: Cardano.Vote;
+  url: string;
+  data_hash: Buffer | null;
+}
+
 export interface CertificateModel {
   cert_index: number;
   tx_id: Buffer;


### PR DESCRIPTION
# Context

We need to support Conway era voting procedures.

# Proposed Solution

Added voting procedure to chain `DbSyncChainHistoryProvider`.

# Implementation details

It's enough to take a quick look at the newly introduced query to be warried about its complexity and relative performances issues, so I did some investigation around.

```
cexplorer=# EXPLAIN SELECT
  tx.hash AS tx_id,
  voter_role,
  committee_voter,
  dh.raw AS drep_voter,
  ph.hash_raW as pool_voter,
  tx2.hash AS governance_action_tx_id,
  ga.index::INTEGER AS governance_action_index,
  CASE
   WHEN vote = 'No' THEN 0
   WHEN vote = 'Yes' THEN 1
   WHEN vote = 'Abstain' THEN 2
  END AS vote,
  va.url,
  va.data_hash
 FROM tx
 JOIN voting_procedure AS vp ON vp.tx_id = tx.id
 JOIN governance_action AS ga ON governance_action_id = ga.id
 JOIN tx AS tx2 ON ga.tx_id = tx2.id
 LEFT JOIN drep_hash AS dh ON drep_voter = dh.id
 LEFT JOIN pool_hash AS ph ON pool_voter = ph.id
 LEFT JOIN voting_anchor AS va ON vp.voting_anchor_id = va.id
 WHERE tx.id = ANY('{1166,1812,1819}')
 ORDER BY vp.index;
                                                               QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=27.04..27.05 rows=1 width=237)
   Sort Key: vp.index
   ->  Nested Loop Left Join  (cost=17.92..27.03 rows=1 width=237)
         ->  Nested Loop Left Join  (cost=17.78..26.75 rows=1 width=184)
               ->  Nested Loop Left Join  (cost=17.63..26.43 rows=1 width=160)
                     ->  Nested Loop  (cost=17.49..26.21 rows=1 width=139)
                           ->  Nested Loop  (cost=17.21..25.40 rows=1 width=114)
                                 ->  Hash Join  (cost=16.93..24.77 rows=1 width=106)
                                       Hash Cond: (vp.tx_id = tx.id)
                                       ->  Seq Scan on voting_procedure vp  (cost=0.00..7.04 rows=304 width=81)
                                       ->  Hash  (cost=16.89..16.89 rows=3 width=41)
                                             ->  Index Scan using tx_pkey on tx  (cost=0.28..16.89 rows=3 width=41)
                                                   Index Cond: (id = ANY ('{1166,1812,1819}'::bigint[]))
                                 ->  Index Scan using governance_action_pkey on governance_action ga  (cost=0.28..0.63 rows=1 width=24)
                                       Index Cond: (id = vp.governance_action_id)
                           ->  Index Scan using tx_pkey on tx tx2  (cost=0.28..0.81 rows=1 width=41)
                                 Index Cond: (id = ga.tx_id)
                     ->  Index Scan using drep_hash_pkey on drep_hash dh  (cost=0.14..0.21 rows=1 width=37)
                           Index Cond: (id = vp.drep_voter)
               ->  Index Scan using pool_hash_pkey on pool_hash ph  (cost=0.15..0.33 rows=1 width=40)
                     Index Cond: (id = vp.pool_voter)
         ->  Index Scan using voting_anchor_pkey on voting_anchor va  (cost=0.14..0.27 rows=1 width=73)
               Index Cond: (id = vp.voting_anchor_id)
(23 rows)

cexplorer=# \d voting_procedure
                                    Table "public.voting_procedure"
        Column        |   Type    | Collation | Nullable |                   Default
----------------------+-----------+-----------+----------+----------------------------------------------
 id                   | bigint    |           | not null | nextval('voting_procedure_id_seq'::regclass)
 tx_id                | bigint    |           | not null |
 index                | integer   |           | not null |
 governance_action_id | bigint    |           | not null |
 voter_role           | voterrole |           | not null |
 committee_voter      | bytea     |           |          |
 drep_voter           | bigint    |           |          |
 pool_voter           | bigint    |           |          |
 vote                 | vote      |           | not null |
 voting_anchor_id     | bigint    |           |          |
Indexes:
    "voting_procedure_pkey" PRIMARY KEY, btree (id)

cexplorer=#
```

As we can see all the tables are accessed through an index, the only exception is a sequential scan on `voting_procedure`.

Maybe we should consider to a add a new dedicated index on `voting_procedure.tx_id`.