### PR TITLE
Feat/extend observable wallet addresses to support script addresses

### DIFF
--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-bitwise */
 import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
-import { util as KeyManagementUtil } from '@cardano-sdk/key-management';
+import { GroupedAddress, util as KeyManagementUtil } from '@cardano-sdk/key-management';
 import { Observable, firstValueFrom } from 'rxjs';
-import { ObservableWallet } from '../types';
+import { ObservableWallet, ScriptAddress, isScriptAddress } from '../types';
 import { ProtocolParametersRequiredByOutputValidator, createOutputValidator } from '@cardano-sdk/tx-construction';
 import { txInEquals } from './util';
 import uniqBy from 'lodash/uniqBy';
@@ -54,6 +54,117 @@ const hasCommitteeCertificates = ({ certificates }: Cardano.TxBody) =>
       certificate.__typename === Cardano.CertificateType.AuthorizeCommitteeHot ||
       certificate.__typename === Cardano.CertificateType.ResignCommitteeCold
   );
+
+/**
+ * Gets whether the given transaction has certificates that require a witness that can not be provided by the script wallet.
+ *
+ * @param rewardAccount The reward account of the script wallet.
+ * @param certificates The certificates to inspect.
+ */
+// eslint-disable-next-line complexity
+const scriptWalletHasForeignCertificates = (
+  rewardAccount: Cardano.RewardAccount,
+  certificates?: Cardano.Certificate[]
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+) => {
+  if (!certificates) {
+    return false;
+  }
+
+  const scriptHash = Cardano.RewardAccount.toHash(rewardAccount) as unknown as Crypto.Hash28ByteBase16;
+  for (const certificate of certificates) {
+    switch (certificate.__typename) {
+      case Cardano.CertificateType.Registration:
+      case Cardano.CertificateType.StakeRegistration:
+      case Cardano.CertificateType.GenesisKeyDelegation:
+        continue; // Doesnt require signature.
+      case Cardano.CertificateType.StakeDeregistration:
+      case Cardano.CertificateType.StakeDelegation:
+      case Cardano.CertificateType.Unregistration:
+      case Cardano.CertificateType.VoteDelegation:
+      case Cardano.CertificateType.StakeVoteDelegation:
+      case Cardano.CertificateType.StakeRegistrationDelegation:
+      case Cardano.CertificateType.VoteRegistrationDelegation:
+      case Cardano.CertificateType.MIR:
+      case Cardano.CertificateType.StakeVoteRegistrationDelegation: {
+        if (
+          !certificate.stakeCredential ||
+          certificate.stakeCredential.type !== Cardano.CredentialType.ScriptHash ||
+          certificate.stakeCredential.hash !== scriptHash
+        ) {
+          return true;
+        }
+
+        break;
+      }
+      case Cardano.CertificateType.PoolRegistration: {
+        const account = certificate.poolParameters.owners.find((acct) => acct === rewardAccount);
+
+        if (!account) {
+          return true;
+        }
+
+        break;
+      }
+      case Cardano.CertificateType.PoolRetirement:
+        {
+          const poolId = Cardano.PoolId.fromKeyHash(Cardano.RewardAccount.toHash(rewardAccount));
+          if (certificate.poolId !== poolId) {
+            return true;
+          }
+        }
+        break;
+      case Cardano.CertificateType.RegisterDelegateRepresentative:
+      case Cardano.CertificateType.UnregisterDelegateRepresentative:
+      case Cardano.CertificateType.UpdateDelegateRepresentative:
+        if (
+          !certificate.dRepCredential ||
+          certificate.dRepCredential.type !== Cardano.CredentialType.ScriptHash ||
+          certificate.dRepCredential.hash !== scriptHash
+        ) {
+          return true;
+        }
+        break;
+      case Cardano.CertificateType.AuthorizeCommitteeHot:
+      case Cardano.CertificateType.ResignCommitteeCold:
+        return true;
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Until CIP-095 supports script credential for dReps, we cant witness any voting procedures as the only
+ * voter type for this type of wallet is DrepScriptHashVoter
+ */
+const scriptWalletHasForeignVotingProcedures = (
+  rewardAccount: Cardano.RewardAccount,
+  votingProcedures?: Cardano.VotingProcedures
+) => {
+  if (!votingProcedures) {
+    return false;
+  }
+
+  for (const procedure of votingProcedures) {
+    switch (procedure.voter.__typename) {
+      case Cardano.VoterType.ccHotKeyHash:
+      case Cardano.VoterType.ccHotScriptHash:
+      case Cardano.VoterType.stakePoolKeyHash:
+      case Cardano.VoterType.dRepKeyHash:
+        return true;
+      case Cardano.VoterType.dRepScriptHash: {
+        const scriptHash = Cardano.RewardAccount.toHash(rewardAccount) as unknown as Crypto.Hash28ByteBase16;
+
+        if (procedure.voter.credential.hash !== scriptHash) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+};
+
 /**
  * Gets whether the given TX requires signatures that can not be provided by the given wallet.
  *
@@ -64,7 +175,22 @@ const hasCommitteeCertificates = ({ certificates }: Cardano.TxBody) =>
 export const requiresForeignSignatures = async (tx: Cardano.Tx, wallet: ObservableWallet): Promise<boolean> => {
   const utxoSet = await firstValueFrom(wallet.utxo.total$);
   const knownAddresses = await firstValueFrom(wallet.addresses$);
-  const uniqueAccounts: KeyManagementUtil.StakeKeySignerData[] = uniqBy(knownAddresses, 'rewardAccount')
+  const isScriptWallet = knownAddresses.some((address) => isScriptAddress(address));
+
+  if (isScriptWallet) {
+    const scriptAddresses = knownAddresses.map((address) => address as ScriptAddress);
+
+    // Script addresses have a single payment credential and stake credential.
+    return (
+      hasForeignInputs(tx, utxoSet) ||
+      scriptWalletHasForeignCertificates(scriptAddresses[0].rewardAccount, tx.body.certificates) ||
+      scriptWalletHasForeignVotingProcedures(scriptAddresses[0].rewardAccount, tx.body.votingProcedures)
+    );
+  }
+
+  const keyHashAddresses = knownAddresses.map((address) => address as GroupedAddress);
+
+  const uniqueAccounts: KeyManagementUtil.StakeKeySignerData[] = uniqBy(keyHashAddresses, 'rewardAccount')
     .map((groupedAddress) => {
       const stakeKeyHash = Cardano.RewardAccount.toHash(groupedAddress.rewardAccount);
       return {
@@ -82,7 +208,7 @@ export const requiresForeignSignatures = async (tx: Cardano.Tx, wallet: Observab
     hasForeignInputs(tx, utxoSet) ||
     KeyManagementUtil.checkStakeCredentialCertificates(uniqueAccounts, tx.body).requiresForeignSignatures ||
     KeyManagementUtil.getDRepCredentialKeyPaths({ dRepKeyHash, txBody: tx.body }).requiresForeignSignatures ||
-    KeyManagementUtil.getVotingProcedureKeyPaths({ dRepKeyHash, groupedAddresses: knownAddresses, txBody: tx.body })
+    KeyManagementUtil.getVotingProcedureKeyPaths({ dRepKeyHash, groupedAddresses: keyHashAddresses, txBody: tx.body })
       .requiresForeignSignatures ||
     hasCommitteeCertificates(tx.body)
   );

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -51,6 +51,22 @@ export type FinalizeTxProps = Omit<TxContext, 'signingContext'> & {
 
 export type HandleInfo = HandleResolution & Asset.AssetInfo;
 
+export interface ScriptAddress {
+  networkId: Cardano.NetworkId;
+  address: Cardano.PaymentAddress;
+  rewardAccount: Cardano.RewardAccount;
+  scripts: {
+    payment: Cardano.NativeScript;
+    stake: Cardano.NativeScript;
+  };
+}
+
+export type WalletAddress = GroupedAddress | ScriptAddress;
+
+export const isScriptAddress = (address: WalletAddress): address is ScriptAddress => 'scripts' in address;
+
+export const isKeyHashAddress = (address: WalletAddress): address is GroupedAddress => !isScriptAddress(address);
+
 export interface ObservableWallet {
   readonly balance: BalanceTracker;
   readonly delegation: DelegationTracker;
@@ -61,7 +77,7 @@ export interface ObservableWallet {
   readonly eraSummaries$: Observable<EraSummary[]>;
   readonly currentEpoch$: Observable<EpochInfo>;
   readonly protocolParameters$: Observable<Cardano.ProtocolParameters>;
-  readonly addresses$: Observable<GroupedAddress[]>;
+  readonly addresses$: Observable<WalletAddress[]>;
   readonly publicStakeKeys$: Observable<PubStakeKeyAndStatus[]>;
   readonly handles$: Observable<HandleInfo[]>;
   /** All owned and historical assets */
@@ -103,7 +119,7 @@ export interface ObservableWallet {
    *
    * @returns Promise that resolves when discovery is complete, with an updated array of wallet addresses
    */
-  discoverAddresses(): Promise<GroupedAddress[]>;
+  discoverAddresses(): Promise<WalletAddress[]>;
 
   shutdown(): void;
 }

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -7,7 +7,14 @@ import {
   KeyRole
 } from '@cardano-sdk/key-management';
 import { Cardano } from '@cardano-sdk/core';
-import { PersonalWallet, createInputResolver, requiresForeignSignatures } from '../../src';
+import { DrepScriptHashVoter } from '@cardano-sdk/core/dist/cjs/Cardano';
+import {
+  ObservableWallet,
+  PersonalWallet,
+  ScriptAddress,
+  createInputResolver,
+  requiresForeignSignatures
+} from '../../src';
 import { createAsyncKeyAgent, waitForWalletStateSettle } from '../util';
 import { createStubStakePoolProvider, mockProviders as mocks } from '@cardano-sdk/util-dev';
 import { dummyLogger as logger } from 'ts-log';
@@ -605,6 +612,370 @@ describe('WalletUtil', () => {
         ];
 
         expect(await requiresForeignSignatures(tx, wallet)).toBeTruthy();
+      });
+    });
+
+    describe('Script Wallet', () => {
+      const scriptCredential = {
+        hash: Crypto.Hash28ByteBase16('0aaa5f1de4257ee30717527c19eea5aa25cbd87f33530699dec851e9'),
+        type: Cardano.CredentialType.ScriptHash
+      };
+
+      const scriptAddress: ScriptAddress = {
+        address: Cardano.PaymentAddress(
+          'addr_test1xq925hcausjhacc8zaf8cx0w5k4ztj7c0ue4xp5emmy9r6g24f03mep90m3sw96j0sv7afd2yh9aslen2vrfnhkg285szhu5xq'
+        ),
+        networkId: Cardano.NetworkId.Testnet,
+        rewardAccount: Cardano.RewardAccount('stake_test17q925hcausjhacc8zaf8cx0w5k4ztj7c0ue4xp5emmy9r6gk8ctn0'),
+        scripts: {
+          payment: {
+            __type: Cardano.ScriptType.Native,
+            kind: Cardano.NativeScriptKind.RequireAllOf,
+            scripts: [
+              {
+                __type: Cardano.ScriptType.Native,
+                keyHash: mocks.stakeKeyHash,
+                kind: Cardano.NativeScriptKind.RequireSignature
+              }
+            ]
+          },
+          stake: {
+            __type: Cardano.ScriptType.Native,
+            kind: Cardano.NativeScriptKind.RequireAllOf,
+            scripts: [
+              {
+                __type: Cardano.ScriptType.Native,
+                keyHash: mocks.stakeKeyHash,
+                kind: Cardano.NativeScriptKind.RequireSignature
+              }
+            ]
+          }
+        }
+      };
+
+      const scriptWallet = {
+        addresses$: of([scriptAddress]),
+        utxo: {
+          total$: of(mocks.utxo)
+        }
+      } as ObservableWallet;
+
+      it('returns false when all inputs and certificates are accounted for ', async () => {
+        // Inputs are selected by input selection algorithm
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.StakeRegistration,
+            stakeCredential: scriptCredential
+          } as Cardano.StakeAddressCertificate
+        ];
+
+        expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+        expect(tx.body.certificates!.length).toBe(1);
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeFalsy();
+      });
+
+      it('returns false when a GenesisKeyDelegation certificate can not be accounted for ', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.GenesisKeyDelegation,
+            genesisDelegateHash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+            genesisHash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
+            vrfKeyHash: Crypto.Hash32ByteBase16('0000000000000000000000000000000000000000000000000000000000000000')
+          } as Cardano.GenesisKeyDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeFalsy();
+      });
+
+      it('detects foreign credential in StakeDeregistration certificate', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.StakeDeregistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.StakeAddressCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign stakeKeyHash in StakeDelegation certificate', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.StakeDelegation,
+            poolId: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash),
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.StakeDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign pool owner in PoolRegistration certificate', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.PoolRegistration,
+            poolParameters: {
+              cost: 340n,
+              id: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash),
+              margin: {
+                denominator: 50,
+                numerator: 10
+              },
+              owners: [foreignRewardAccount],
+              pledge: 10_000n,
+              relays: [
+                {
+                  __typename: 'RelayByName',
+                  hostname: 'localhost'
+                }
+              ],
+              rewardAccount: Cardano.RewardAccount('stake_test17q925hcausjhacc8zaf8cx0w5k4ztj7c0ue4xp5emmy9r6gk8ctn0'),
+              vrf: Cardano.VrfVkHex('641d042ed39c2c258d381060c1424f40ef8abfe25ef566f4cb22477c42b2a014')
+            }
+          } as Cardano.PoolRegistrationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign poolId in PoolRetirement certificate', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.PoolRetirement,
+            epoch: Cardano.EpochNo(100),
+            poolId: Cardano.PoolId.fromKeyHash(foreignRewardAccountHash)
+          } as Cardano.PoolRetirementCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('returns false when a StakeRegistration certificate can not be accounted for', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.StakeRegistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.StakeAddressCertificate
+        ];
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeFalsy();
+      });
+
+      it('accepts valid certificates', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.Registration,
+            // using foreign intentionally because registration is not signed so it should be accepted
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(mocks.stakeKeyHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.NewStakeAddressCertificate,
+          {
+            __typename: Cardano.CertificateType.Unregistration,
+            stakeCredential: scriptCredential
+          } as Cardano.NewStakeAddressCertificate,
+          {
+            __typename: Cardano.CertificateType.VoteDelegation,
+            stakeCredential: scriptCredential
+          } as Cardano.VoteDelegationCertificate,
+          {
+            __typename: Cardano.CertificateType.StakeVoteDelegation,
+            stakeCredential: scriptCredential
+          } as Cardano.StakeVoteDelegationCertificate,
+          {
+            __typename: Cardano.CertificateType.StakeRegistrationDelegation,
+            stakeCredential: scriptCredential
+          } as Cardano.StakeRegistrationDelegationCertificate,
+          {
+            __typename: Cardano.CertificateType.VoteRegistrationDelegation,
+            stakeCredential: scriptCredential
+          } as Cardano.VoteRegistrationDelegationCertificate,
+          {
+            __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
+            stakeCredential: scriptCredential
+          } as Cardano.StakeVoteRegistrationDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeFalsy();
+      });
+
+      it('detects foreign VoteDelegation', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.VoteDelegation,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.VoteDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign StakeVoteDelegation', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.StakeVoteDelegation,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.StakeVoteDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign StakeRegistrationDelegation', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.StakeRegistrationDelegation,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.StakeRegistrationDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign VoteRegistrationDelegation', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.VoteRegistrationDelegation,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.VoteRegistrationDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign stake_vote_reg_deleg_cert', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.StakeVoteRegistrationDelegationCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('detects foreign Unregistration', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.Unregistration,
+            stakeCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            }
+          } as Cardano.NewStakeAddressCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('returns true when at least one input from collateral is not accounted for ', async () => {
+        tx.body.collaterals = [
+          {
+            index: 0,
+            txId: Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
+          },
+          ...tx.body.collaterals!
+        ];
+
+        expect(tx.body.inputs.length).toBeGreaterThanOrEqual(1);
+        expect(tx.body.certificates!.length).toBe(1);
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('returns true when at least one input is not accounted for ', async () => {
+        tx.body.inputs = [
+          {
+            index: 0,
+            txId: Cardano.TransactionId('0000000000000000000000000000000000000000000000000000000000000000')
+          },
+          ...tx.body.inputs
+        ];
+
+        expect(tx.body.inputs.length).toBeGreaterThanOrEqual(2);
+        expect(tx.body.certificates!.length).toBe(1);
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('returns true when at least one voter is not accounted for', async () => {
+        tx.body.certificates = [];
+        tx.body.votingProcedures = [
+          {
+            voter: {
+              __typename: Cardano.VoterType.dRepScriptHash,
+              credential: {
+                hash: Crypto.Hash28ByteBase16(dRepKeyHash),
+                type: Cardano.CredentialType.ScriptHash
+              }
+            },
+            votes: []
+          }
+        ];
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('returns false when all voters are accounted for', async () => {
+        tx.body.certificates = [];
+        tx.body.votingProcedures = [
+          {
+            voter: {
+              __typename: Cardano.VoterType.dRepScriptHash,
+              credential: scriptCredential
+            } as DrepScriptHashVoter,
+            votes: []
+          }
+        ];
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeFalsy();
+      });
+
+      it('returns true when at least one dRep certificate is not accounted for', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.UnregisterDelegateRepresentative,
+            dRepCredential: {
+              hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(foreignRewardAccountHash),
+              type: Cardano.CredentialType.KeyHash
+            },
+            deposit: 0n
+          } as Cardano.UnRegisterDelegateRepresentativeCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeTruthy();
+      });
+
+      it('returns false when all dReps certificates are accounted for', async () => {
+        tx.body.certificates = [
+          {
+            __typename: Cardano.CertificateType.UnregisterDelegateRepresentative,
+            dRepCredential: scriptCredential,
+            deposit: 0n
+          } as Cardano.UnRegisterDelegateRepresentativeCertificate
+        ];
+
+        expect(await requiresForeignSignatures(tx, scriptWallet)).toBeFalsy();
       });
     });
   });


### PR DESCRIPTION
# Context

It should be an Observable<WalletAddress>, where type WalletAddress = GroupedAddress | ScriptAddress

LW-9424

# Proposed Solution

Introduce a new type WalletAddress

# Important Changes Introduced

Observable wallet now emits addresses$ as an array of WalletAddress[] rather than GroupedAddress[]