### PR TITLE
Feat/lw 9412 delegation tracker should use new conway certificates

### DIFF
--- a/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
@@ -23,6 +23,10 @@ import { OutgoingOnChainTx, TxInFlight } from '../types';
 import { PAGE_SIZE } from '../TransactionsTracker';
 import {
   RegAndDeregCertificateTypes,
+  RegAndDeregCertificateUnion,
+  StakeDelegationCertificateTypes,
+  StakeDelegationCertificateUnion,
+  StakeRegistrationCertificateTypes,
   includesAnyCertificate,
   isLastStakeKeyCertOfType
 } from './transactionCertificates';
@@ -128,8 +132,8 @@ export const createRewardsProvider =
     );
 export type ObservableRewardsProvider = ReturnType<typeof createRewardsProvider>;
 
-const isDelegationCertificate = (cert: Cardano.Certificate): cert is Cardano.StakeDelegationCertificate =>
-  cert.__typename === Cardano.CertificateType.StakeDelegation;
+const isDelegationCertificate = (cert: Cardano.Certificate): cert is StakeDelegationCertificateUnion =>
+  StakeDelegationCertificateTypes.includes(cert.__typename as StakeDelegationCertificateTypes);
 
 const getAccountsKeyStatus =
   (addresses: Cardano.RewardAccount[]) =>
@@ -144,14 +148,10 @@ const getAccountsKeyStatus =
             }
           }) => certificates || []
         ),
-        [Cardano.CertificateType.StakeRegistration, Cardano.CertificateType.Registration],
+        StakeRegistrationCertificateTypes,
         address
       );
-      const isRegistering = isLastStakeKeyCertOfType(
-        certificatesInFlight,
-        [Cardano.CertificateType.StakeRegistration, Cardano.CertificateType.Registration],
-        address
-      );
+      const isRegistering = isLastStakeKeyCertOfType(certificatesInFlight, StakeRegistrationCertificateTypes, address);
       const isUnregistering = isLastStakeKeyCertOfType(
         certificatesInFlight,
         [Cardano.CertificateType.StakeDeregistration, Cardano.CertificateType.Unregistration],
@@ -177,14 +177,10 @@ const accountCertificateTransactions = (
       transactions
         .map(({ tx, epoch }) => ({
           certificates: (tx.body.certificates || [])
-            .filter(
-              (
-                cert
-              ): cert is
-                | Cardano.StakeDelegationCertificate
-                | Cardano.StakeAddressCertificate
-                | Cardano.NewStakeAddressCertificate =>
-                [...RegAndDeregCertificateTypes, Cardano.CertificateType.StakeDelegation].includes(cert.__typename)
+            .filter((cert): cert is RegAndDeregCertificateUnion | StakeDelegationCertificateUnion =>
+              [...RegAndDeregCertificateTypes, ...StakeDelegationCertificateTypes].includes(
+                cert.__typename as RegAndDeregCertificateTypes | StakeDelegationCertificateTypes
+              )
             )
             .filter((cert) => (cert.stakeCredential.hash as unknown as Crypto.Ed25519KeyHashHex) === stakeKeyHash),
           epoch
@@ -212,15 +208,12 @@ export const getStakePoolIdAtEpoch = (transactions: TransactionsCertificates) =>
   const certificatesUpToEpoch = transactions
     .filter(({ epoch }) => epoch < atEpoch - 2)
     .map(({ certificates }) => certificates);
-  if (
-    !isLastStakeKeyCertOfType(certificatesUpToEpoch, [
-      Cardano.CertificateType.StakeRegistration,
-      Cardano.CertificateType.Registration
-    ])
-  )
+  if (!isLastStakeKeyCertOfType(certificatesUpToEpoch, StakeRegistrationCertificateTypes)) {
     return;
+  }
+
   const delegationTxCertificates = findLast(certificatesUpToEpoch, (certs) =>
-    includesAnyCertificate(certs, [Cardano.CertificateType.StakeDelegation])
+    includesAnyCertificate(certs, StakeDelegationCertificateTypes)
   );
   if (!delegationTxCertificates) return;
   return findLast(delegationTxCertificates.filter(isDelegationCertificate))?.poolId;

--- a/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardAccounts.ts
@@ -198,6 +198,16 @@ const accountCertificateTransactions = (
 type ObservableType<O> = O extends Observable<infer T> ? T : unknown;
 type TransactionsCertificates = ObservableType<ReturnType<typeof accountCertificateTransactions>>;
 
+/**
+ * Check if the stake key was registered and is delegated, and return the pool ID.
+ * A stake key is considered delegated 3 epochs after the certificate was sent.
+ *
+ * @returns
+ *  - the stake pool ID that is delegated to at the given epoch.
+ *  - undefined if the stake key was not registered.
+ * Returns the stake pool ID that is delegated to at the given epoch.
+ * If the stake key was not registered, it returns undefined.
+ */
 export const getStakePoolIdAtEpoch = (transactions: TransactionsCertificates) => (atEpoch: Cardano.EpochNo) => {
   const certificatesUpToEpoch = transactions
     .filter(({ epoch }) => epoch < atEpoch - 2)

--- a/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
@@ -5,6 +5,7 @@ import { Logger } from 'ts-log';
 import { Observable, concat, distinctUntilChanged, map, of, switchMap, tap } from 'rxjs';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { RewardsHistory } from '../types';
+import { StakeDelegationCertificateTypes } from './transactionCertificates';
 import { TrackedRewardsProvider } from '../ProviderTracker';
 import { TxWithEpoch } from './types';
 import { coldObservableProvider } from '@cardano-sdk/util-rxjs';
@@ -49,7 +50,7 @@ const firstDelegationEpoch$ = (transactions$: Observable<TxWithEpoch[]>, rewardA
       first(
         transactions.filter(({ tx }) => {
           const inspectTx = createTxInspector({
-            signedCertificates: signedCertificatesInspector(rewardAccounts, [Cardano.CertificateType.StakeDelegation])
+            signedCertificates: signedCertificatesInspector(rewardAccounts, [...StakeDelegationCertificateTypes])
           });
           return inspectTx(tx).signedCertificates.length > 0;
         })

--- a/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
@@ -344,6 +344,21 @@ describe('DelegationTracker', () => {
             )
           ],
           b: [
+            createStubTxWithSlot(
+              284,
+              [
+                {
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
+                }
+              ],
+              {
+                blob: new Map([[Cardano.DelegationMetadataLabel, metadatum.jsonToMetadatum(cip17DelegationPortfolio)]])
+              }
+            ),
             createStubTxWithSlot(286, [
               {
                 __typename: Cardano.CertificateType.StakeRegistration,

--- a/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
@@ -211,7 +211,8 @@ describe('DelegationTracker', () => {
               285,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeRegistration,
+                  __typename: Cardano.CertificateType.Registration,
+                  deposit: 2_000_000n,
                   stakeCredential: {
                     hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                     type: Cardano.CredentialType.KeyHash
@@ -237,7 +238,8 @@ describe('DelegationTracker', () => {
               285,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeRegistration,
+                  __typename: Cardano.CertificateType.Registration,
+                  deposit: 2_000_000n,
                   stakeCredential: {
                     hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                     type: Cardano.CredentialType.KeyHash
@@ -272,7 +274,8 @@ describe('DelegationTracker', () => {
               285,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeRegistration,
+                  __typename: Cardano.CertificateType.Registration,
+                  deposit: 2_000_000n,
                   stakeCredential: {
                     hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                     type: Cardano.CredentialType.KeyHash
@@ -296,7 +299,11 @@ describe('DelegationTracker', () => {
               287,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeRegistration,
+                  __typename: Cardano.CertificateType.VoteRegistrationDelegation,
+                  dRep: {
+                    __typename: 'AlwaysAbstain'
+                  },
+                  deposit: 2_000_000n,
                   stakeCredential: {
                     hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                     type: Cardano.CredentialType.KeyHash
@@ -361,7 +368,12 @@ describe('DelegationTracker', () => {
             ),
             createStubTxWithSlot(286, [
               {
-                __typename: Cardano.CertificateType.StakeRegistration,
+                __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
+                dRep: {
+                  __typename: 'AlwaysAbstain'
+                },
+                deposit: 2_000_000n,
+                poolId: 'abc' as Cardano.PoolId,
                 stakeCredential: {
                   hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                   type: Cardano.CredentialType.KeyHash
@@ -390,7 +402,12 @@ describe('DelegationTracker', () => {
               284,
               [
                 {
-                  __typename: Cardano.CertificateType.StakeRegistration,
+                  __typename: Cardano.CertificateType.StakeVoteDelegation,
+                  dRep: {
+                    __typename: 'AlwaysAbstain'
+                  },
+                  poolId: 'abc' as Cardano.PoolId,
+
                   stakeCredential: {
                     hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                     type: Cardano.CredentialType.KeyHash
@@ -403,6 +420,21 @@ describe('DelegationTracker', () => {
             )
           ],
           b: [
+            createStubTxWithSlot(
+              284,
+              [
+                {
+                  __typename: Cardano.CertificateType.StakeRegistration,
+                  stakeCredential: {
+                    hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
+                    type: Cardano.CredentialType.KeyHash
+                  }
+                }
+              ],
+              {
+                blob: new Map([[Cardano.DelegationMetadataLabel, metadatum.jsonToMetadatum(cip17DelegationPortfolio)]])
+              }
+            ),
             createStubTxWithSlot(289, undefined, {
               blob: new Map([
                 [Cardano.DelegationMetadataLabel, metadatum.jsonToMetadatum(cip17DelegationPortfolioChangeWeights)]

--- a/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
@@ -149,8 +149,10 @@ describe('RewardAccounts', () => {
     ];
     expect(getStakePoolIdAtEpoch(transactions)(Cardano.EpochNo(102))).toBeUndefined();
     expect(getStakePoolIdAtEpoch(transactions)(Cardano.EpochNo(103))).toBeUndefined();
+    // PoolId is available 3 epochs after delegation
     expect(getStakePoolIdAtEpoch(transactions)(Cardano.EpochNo(104))).toBe(poolId1);
     expect(getStakePoolIdAtEpoch(transactions)(Cardano.EpochNo(105))).toBeUndefined();
+    // New delegation has no effect due to stake key being unregistered
     expect(getStakePoolIdAtEpoch(transactions)(Cardano.EpochNo(106))).toBeUndefined();
   });
 

--- a/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardsHistory.test.ts
@@ -5,6 +5,7 @@ import { InMemoryRewardsHistoryStore } from '../../../src/persistence';
 import {
   RewardsHistory,
   RewardsHistoryProvider,
+  StakeDelegationCertificateTypes,
   TrackedRewardsProvider,
   calcFirstDelegationEpoch,
   createRewardsHistoryProvider,
@@ -43,113 +44,110 @@ describe('RewardsHistory', () => {
   });
 
   describe('createRewardsHistoryTracker', () => {
-    it('queries and maps reward history starting from first delegation epoch+2', () => {
-      createTestScheduler().run(({ cold, expectObservable, flush }) => {
-        const accountRewardsHistory = rewardsHistory.get(rewardAccount)!;
-        const epoch = accountRewardsHistory[0].epoch;
-        const getRewardsHistory = jest.fn().mockReturnValue(cold('-a', { a: rewardsHistory }));
-        const target$ = createRewardsHistoryTracker(
-          cold('aa', {
-            a: [
-              {
-                epoch: Cardano.EpochNo(0),
-                tx: createStubTxWithCertificates([
-                  { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.Certificate
-                ])
-              },
-              {
-                epoch,
-                tx: createStubTxWithCertificates(
-                  [{ __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate],
-                  {
+    it.each(StakeDelegationCertificateTypes)(
+      'queries and maps reward history starting from first delegation epoch+2 with %s',
+      (delegationCertificateType) => {
+        createTestScheduler().run(({ cold, expectObservable, flush }) => {
+          const accountRewardsHistory = rewardsHistory.get(rewardAccount)!;
+          const epoch = accountRewardsHistory[0].epoch;
+          const getRewardsHistory = jest.fn().mockReturnValue(cold('-a', { a: rewardsHistory }));
+          const target$ = createRewardsHistoryTracker(
+            cold('aa', {
+              a: [
+                {
+                  epoch: Cardano.EpochNo(0),
+                  tx: createStubTxWithCertificates([
+                    { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.Certificate
+                  ])
+                },
+                {
+                  epoch,
+                  tx: createStubTxWithCertificates([{ __typename: delegationCertificateType } as Cardano.Certificate], {
                     stakeCredential: {
                       hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                       type: Cardano.CredentialType.KeyHash
                     }
-                  }
-                )
-              }
-            ]
-          }),
-          of(rewardAccounts),
-          getRewardsHistory,
-          new InMemoryRewardsHistoryStore(),
-          logger
-        );
-        expectObservable(target$).toBe('-a', {
-          a: {
-            all: accountRewardsHistory,
-            avgReward: 10_500n,
-            lastReward: accountRewardsHistory[1],
-            lifetimeRewards: 21_000n
-          } as RewardsHistory
+                  })
+                }
+              ]
+            }),
+            of(rewardAccounts),
+            getRewardsHistory,
+            new InMemoryRewardsHistoryStore(),
+            logger
+          );
+          expectObservable(target$).toBe('-a', {
+            a: {
+              all: accountRewardsHistory,
+              avgReward: 10_500n,
+              lastReward: accountRewardsHistory[1],
+              lifetimeRewards: 21_000n
+            } as RewardsHistory
+          });
+          flush();
+          expect(getRewardsHistory).toBeCalledTimes(1);
+          expect(getRewardsHistory).toBeCalledWith(
+            rewardAccounts,
+            Cardano.EpochNo(calcFirstDelegationEpoch(epoch)),
+            undefined
+          );
         });
-        flush();
-        expect(getRewardsHistory).toBeCalledTimes(1);
-        expect(getRewardsHistory).toBeCalledWith(
-          rewardAccounts,
-          Cardano.EpochNo(calcFirstDelegationEpoch(epoch)),
-          undefined
-        );
-      });
-    });
+      }
+    );
 
-    it('considers only first delegation signed by the reward account', () => {
-      createTestScheduler().run(({ cold, expectObservable, flush }) => {
-        const accountRewardsHistory = rewardsHistory.get(rewardAccount)!;
-        const epoch = accountRewardsHistory[0].epoch;
-        const getRewardsHistory = jest.fn().mockReturnValue(cold('-a', { a: rewardsHistory }));
-        const target$ = createRewardsHistoryTracker(
-          cold('aa', {
-            a: [
-              {
-                epoch: Cardano.EpochNo(0),
-                tx: createStubTxWithCertificates(
-                  [{ __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate],
-                  {
+    it.each(StakeDelegationCertificateTypes)(
+      'considers only first delegation signed by the reward account with %s',
+      (delegationCertificateType) => {
+        createTestScheduler().run(({ cold, expectObservable, flush }) => {
+          const accountRewardsHistory = rewardsHistory.get(rewardAccount)!;
+          const epoch = accountRewardsHistory[0].epoch;
+          const getRewardsHistory = jest.fn().mockReturnValue(cold('-a', { a: rewardsHistory }));
+          const target$ = createRewardsHistoryTracker(
+            cold('aa', {
+              a: [
+                {
+                  epoch: Cardano.EpochNo(0),
+                  tx: createStubTxWithCertificates([{ __typename: delegationCertificateType } as Cardano.Certificate], {
                     stakeCredential: {
                       hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
                       type: Cardano.CredentialType.KeyHash
                     }
-                  }
-                )
-              },
-              {
-                epoch,
-                tx: createStubTxWithCertificates(
-                  [{ __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate],
-                  {
+                  })
+                },
+                {
+                  epoch,
+                  tx: createStubTxWithCertificates([{ __typename: delegationCertificateType } as Cardano.Certificate], {
                     stakeCredential: {
                       hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(rewardAccount)),
                       type: Cardano.CredentialType.KeyHash
                     }
-                  }
-                )
-              }
-            ]
-          }),
-          of(rewardAccounts),
-          getRewardsHistory,
-          new InMemoryRewardsHistoryStore(),
-          logger
-        );
-        expectObservable(target$).toBe('-a', {
-          a: {
-            all: accountRewardsHistory,
-            avgReward: 10_500n,
-            lastReward: accountRewardsHistory[1],
-            lifetimeRewards: 21_000n
-          } as RewardsHistory
+                  })
+                }
+              ]
+            }),
+            of(rewardAccounts),
+            getRewardsHistory,
+            new InMemoryRewardsHistoryStore(),
+            logger
+          );
+          expectObservable(target$).toBe('-a', {
+            a: {
+              all: accountRewardsHistory,
+              avgReward: 10_500n,
+              lastReward: accountRewardsHistory[1],
+              lifetimeRewards: 21_000n
+            } as RewardsHistory
+          });
+          flush();
+          expect(getRewardsHistory).toBeCalledTimes(1);
+          expect(getRewardsHistory).toBeCalledWith(
+            rewardAccounts,
+            Cardano.EpochNo(calcFirstDelegationEpoch(epoch)),
+            undefined
+          );
         });
-        flush();
-        expect(getRewardsHistory).toBeCalledTimes(1);
-        expect(getRewardsHistory).toBeCalledWith(
-          rewardAccounts,
-          Cardano.EpochNo(calcFirstDelegationEpoch(epoch)),
-          undefined
-        );
-      });
-    });
+      }
+    );
 
     it.todo('emits value from store if it exists and updates store after provider response');
   });

--- a/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
@@ -1,16 +1,22 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
-import { isLastStakeKeyCertOfType, stakeKeyCertficates, transactionsWithCertificates } from '../../../src';
+import { isLastStakeKeyCertOfType, stakeKeyCertificates, transactionsWithCertificates } from '../../../src';
 
 describe('transactionCertificates', () => {
   test('transactionStakeKeyCertficates', () => {
-    const certificates = stakeKeyCertficates([
-      { __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate,
+    const certificates = stakeKeyCertificates([
+      { __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate, // does not register stake key
       { __typename: Cardano.CertificateType.StakeRegistration } as Cardano.Certificate,
-      { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.Certificate
+      { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.Certificate,
+      { __typename: Cardano.CertificateType.StakeVoteDelegation } as Cardano.Certificate, // does not register stake key
+      { __typename: Cardano.CertificateType.StakeRegistrationDelegation } as Cardano.Certificate,
+      { __typename: Cardano.CertificateType.StakeVoteDelegation } as Cardano.Certificate, // does not register stake key
+      { __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation } as Cardano.Certificate,
+      { __typename: Cardano.CertificateType.VoteRegistrationDelegation } as Cardano.Certificate,
+      { __typename: Cardano.CertificateType.Registration } as Cardano.Certificate
     ]);
-    expect(certificates).toHaveLength(2);
+    expect(certificates).toHaveLength(6);
     expect(certificates[0].__typename).toBe(Cardano.CertificateType.StakeRegistration);
     expect(certificates[1].__typename).toBe(Cardano.CertificateType.StakeDeregistration);
   });


### PR DESCRIPTION
# Context

Wallet delegation tracker currently looks for stake registration/deregistration certificates and delegation certificates to detect states like “Registered/Deregistered” and the delegatee values.
In addition to these, the logic should also look for the new Conway certificates:

- stake_vote_deleg_cert - Delegates to a stake pool and a DRep from the same certificate
    - Cardano.StakeVoteDelegationCertificate
    - Should have the same outcome as when encountering a StakeDelegation certificate
- stake_reg_deleg_cert - Registers stake credentials and delegates to a stake pool
    - Cardano.StakeRegistrationDelegationCertificate
    - Should have the same outcome as when encountering a StakeRegistration and a StakeDelegation certificate
- stake_vote_reg_deleg_cert - Registers stake credentials, delegates to a pool, and to a DRep
    - Cardano.StakeVoteRegistrationDelegationCertificate
    - Should have the same outcome as when encountering a StakeRegistration and a StakeDelegation certificate
- vote_reg_deleg_cert - Registers stake credentials and delegates to a DRep
    - Cardano.VoteRegistrationDelegationCertificate
    - Should have the same outcome as when encountering a StakeRegistration certificate

