### PR TITLE
chore(cardano-services): use yarn workspace because cwd is ignored

### DIFF
--- a/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
+++ b/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
@@ -12,14 +12,14 @@ PASSWORD=$(cat $SECRETS_DIR/postgres_password)
 
 export DB_SYNC_CONNECTION_STRING="postgresql://${USER}:${PASSWORD}@localhost:5435/${DB_DB_SYNC}"
 
-yarn --cwd "$PACKAGES_DIR"/e2e local-network:down
-yarn --cwd "$PACKAGES_DIR"/e2e local-network:up -d --build
-yarn --cwd "$WORKSPACE_ROOT" build
-yarn --cwd "$PACKAGES_DIR"/e2e wait-for-network
-yarn --cwd "$PACKAGES_DIR"/e2e test:wallet
-yarn --cwd "$PACKAGES_DIR"/e2e test:long-running delegation-rewards.test.ts
+yarn workspace @cardano-sdk/e2e local-network:down
+yarn workspace @cardano-sdk/e2e local-network:up -d --build
+yarn build
+yarn workspace @cardano-sdk/e2e wait-for-network
+yarn workspace @cardano-sdk/e2e test:wallet
+yarn workspace @cardano-sdk/e2e test:long-running delegation-rewards.test.ts
 TL_LEVEL="${TL_LEVEL:=info}" node "$SCRIPT_DIR/mint-handles.js"
-yarn --cwd "$PACKAGES_DIR"/e2e test:local-network register-pool.test.ts
+yarn workspace @cardano-sdk/e2e test:local-network register-pool.test.ts
 
 echo 'Stop providing data to projectors'
 docker compose -p local-network-e2e stop cardano-node ogmios
@@ -34,4 +34,4 @@ for DB_FILE in $(
 done
 echo 'Snapshots created.'
 
-yarn --cwd "$PACKAGES_DIR"/e2e local-network:down
+yarn workspace @cardano-sdk/e2e local-network:down


### PR DESCRIPTION
yarn `--cwd`
[option is ignored](https://github.com/yarnpkg/berry/pull/1812#discussion_r485873759) in some yarn versions.
In my case (yarn 3.2.1), the `cwd` arg from
`yarn --cwd $PACKAGES_DIR/e2e wait-for-network`,
invoked by `rebuild-test-db.sh` is ignored.
This causes yarn to simply search for the `wait-for-network` Since `wait-for-network` does not have a colon (:) in the name, it is not picked up when yarn is run from
the root of the repository, so the step fails due to missing script. [Otherwise, if the specified name contains a colon character, and if one of the workspaces in the project
contains exactly one script with a matching name,
then this script will get executed](https://yarnpkg.com/cli/run). There are 2 possible solutions:
- specify path without --cwd, as suggested in the bug
- use `workspace`. I chose the `workspace` approach because it is the monorepo yarn way. It also changes the `cwd` to the indicated workspace.

