### PR TITLE
ci: take the exact version from lib/chromedriver.js

### DIFF
--- a/nix/cardano-services/packages.nix
+++ b/nix/cardano-services/packages.nix
@@ -43,8 +43,21 @@ in {
       '';
     });
 
-    chromedriverVersion = "120.0.6099.71";
+    chromedriverVersion = builtins.unsafeDiscardStringContext (builtins.readFile (
+      project.overrideAttrs (oldAttrs: {
+        name = "chromedriver-version";
+        buildInputs = oldAttrs.buildInputs ++ [ nixpkgs.unzip ];
+        buildPhase = "";
+        preConfigure = ''
+          unzip .yarn/cache/chromedriver-*.zip
+          cat node_modules/chromedriver/lib/chromedriver.js \
+            | grep -E '^\s*const version' | grep -Eo '[0-9]+(\.[0-9]+)+' \
+            | tr -d '\n' >$out
+          exit 0
+        '';
+      })));
     chromedriver = nixpkgs.fetchurl {
+      name = "chromedriver-bin-${chromedriverVersion}.zip";  # Note: triggers hash check on version changes.
       url = "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chromedriverVersion}/linux64/chromedriver-linux64.zip";
       hash = "sha256-X8bia1BaLQm5WKn5vdShpQ4A7sPNZ8lgmeXoYj2earc=";
     };


### PR DESCRIPTION
# Context

**LW-9464**

ChromeDriver version was hardcoded. This would break in a non-obvious way on the next ChromeDriver update.

# Proposed Solution

Read the version from `node_modules/chromedriver/lib/chromedriver.js`. The hash will still need to be updated, but at least the error message will be clear, providing both hashes (you can `grep` for the old one and replace it).

It costs us around 5 seconds, I thought it's the least awkward option for the end user (who updates this dependency).

# Important Changes Introduced

—