### PR TITLE
Fix/wallet manager active wallet id null

### DIFF
--- a/packages/e2e/test/web-extension/extension/ui.ts
+++ b/packages/e2e/test/web-extension/extension/ui.ts
@@ -35,9 +35,9 @@ import {
   emip3encrypt,
   util
 } from '@cardano-sdk/key-management';
-import { HexBlob } from '@cardano-sdk/util';
+import { HexBlob, isNotNil } from '@cardano-sdk/util';
 import { SodiumBip32Ed25519 } from '@cardano-sdk/crypto';
-import { combineLatest, firstValueFrom, merge, of } from 'rxjs';
+import { combineLatest, filter, firstValueFrom, merge, of } from 'rxjs';
 import { runtime } from 'webextension-polyfill';
 
 const delegationConfig = {
@@ -168,7 +168,7 @@ const clearWalletValues = (): void => {
 
 const destroyWallet = async (): Promise<void> => {
   await walletManager.deactivate();
-  const activeWalletId = await firstValueFrom(walletManager.activeWalletId$);
+  const activeWalletId = await firstValueFrom(walletManager.activeWalletId$.pipe(filter(isNotNil)));
   await walletManager.destroyData(activeWalletId.walletId, env.KEY_MANAGEMENT_PARAMS.chainId);
   clearWalletValues();
 };

--- a/packages/web-extension/src/walletManager/walletManager.ts
+++ b/packages/web-extension/src/walletManager/walletManager.ts
@@ -8,7 +8,7 @@ import {
 import { AnyBip32Wallet, AnyWallet, WalletId, WalletType } from './types';
 import { BehaviorSubject, ReplaySubject, firstValueFrom, lastValueFrom } from 'rxjs';
 import { Cardano, Serialization } from '@cardano-sdk/core';
-import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { HexBlob, InvalidArgumentError, deepEquals } from '@cardano-sdk/util';
 import { Logger } from 'ts-log';
 import { MessengerDependencies } from '../messaging';
 import { ObservableWallet, storage } from '@cardano-sdk/wallet';
@@ -184,7 +184,7 @@ export class WalletManager<Metadata extends { name: string }> implements WalletM
     return (
       this.#activeWalletProps?.walletId === walletProps.walletId &&
       this.#activeWalletProps?.accountIndex === walletProps.accountIndex &&
-      this.#activeWalletProps?.chainId === walletProps.chainId
+      deepEquals(this.#activeWalletProps?.chainId, walletProps.chainId)
     );
   }
 

--- a/packages/web-extension/src/walletManager/walletManager.ts
+++ b/packages/web-extension/src/walletManager/walletManager.ts
@@ -6,9 +6,9 @@ import {
   Witnesser
 } from '@cardano-sdk/key-management';
 import { AnyBip32Wallet, AnyWallet, WalletId, WalletType } from './types';
-import { BehaviorSubject, Observable, ReplaySubject, distinctUntilChanged, firstValueFrom, lastValueFrom } from 'rxjs';
+import { BehaviorSubject, ReplaySubject, firstValueFrom, lastValueFrom } from 'rxjs';
 import { Cardano, Serialization } from '@cardano-sdk/core';
-import { HexBlob, InvalidArgumentError, deepEquals } from '@cardano-sdk/util';
+import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { Logger } from 'ts-log';
 import { MessengerDependencies } from '../messaging';
 import { ObservableWallet, storage } from '@cardano-sdk/wallet';
@@ -55,7 +55,7 @@ export interface WalletManagerDependencies<Metadata extends { name: string }> {
  * Keeps track of created stores and reuses them when a wallet is reactivated.
  */
 export class WalletManager<Metadata extends { name: string }> implements WalletManagerApi {
-  activeWalletId$: Observable<WalletManagerActivateProps>;
+  activeWalletId$ = new ReplaySubject<WalletManagerActivateProps | null>(1);
   activeWallet$ = new BehaviorSubject<ObservableWallet | null>(null);
 
   #activeWalletProps: WalletManagerActivateProps | null = null;
@@ -67,7 +67,6 @@ export class WalletManager<Metadata extends { name: string }> implements WalletM
   #logger: Logger;
   #managerStorageKey: string;
   #managerStorage: Storage.StorageArea;
-  #activeWalletId$ = new ReplaySubject<WalletManagerActivateProps>(1);
 
   constructor(
     { name }: WalletManagerProps,
@@ -81,8 +80,6 @@ export class WalletManager<Metadata extends { name: string }> implements WalletM
     }: MessengerDependencies & WalletManagerDependencies<Metadata>
   ) {
     this.#walletRepository = walletRepository;
-
-    this.activeWalletId$ = this.#activeWalletId$.pipe(distinctUntilChanged(deepEquals));
 
     this.#walletFactory = walletFactory;
     this.#managerStorageKey = `${name}-active-wallet`;
@@ -108,7 +105,10 @@ export class WalletManager<Metadata extends { name: string }> implements WalletM
   async initialize() {
     const { [this.#managerStorageKey]: lastActivateProps } = await this.#managerStorage.get(this.#managerStorageKey);
 
-    if (!lastActivateProps) return;
+    if (!lastActivateProps) {
+      this.activeWalletId$.next(null);
+      return;
+    }
 
     return this.activate(lastActivateProps);
   }
@@ -149,7 +149,7 @@ export class WalletManager<Metadata extends { name: string }> implements WalletM
 
     this.activeWallet$.next(wallet);
 
-    this.#activeWalletId$.next(props);
+    this.activeWalletId$.next(props);
   }
 
   /** Deactivate wallet. Wallet observable properties will emit only after a new wallet is {@link activate}ed. */
@@ -284,7 +284,6 @@ export class WalletManager<Metadata extends { name: string }> implements WalletM
     accountIndex?: number
   ): Witnesser {
     let witnesser;
-    this.#logger.error(wallet);
     switch (wallet.type) {
       case WalletType.InMemory:
       case WalletType.Ledger:

--- a/packages/web-extension/src/walletManager/walletManager.types.ts
+++ b/packages/web-extension/src/walletManager/walletManager.types.ts
@@ -50,7 +50,7 @@ export interface WalletManagerActivateProps<P extends string | number = string, 
 }
 
 export interface WalletManagerApi {
-  activeWalletId$: Observable<WalletManagerActivateProps>;
+  activeWalletId$: Observable<WalletManagerActivateProps | null>;
 
   /**
    * Create and activate a new ObservableWallet.

--- a/packages/web-extension/test/walletManager/walletManager.test.ts
+++ b/packages/web-extension/test/walletManager/walletManager.test.ts
@@ -239,6 +239,10 @@ describe('WalletManagerWorker', () => {
       await expect(
         firstValueFrom(walletManager.activeWallet$.pipe(filter(isNotNil)).pipe(timeout({ first: 50 })))
       ).rejects.toThrowError(TimeoutError);
+
+      await expect(
+        firstValueFrom(walletManager.activeWalletId$.pipe(filter(isNotNil)).pipe(timeout({ first: 50 })))
+      ).rejects.toThrowError(TimeoutError);
     });
 
     it('activates last activated wallet', async () => {
@@ -265,7 +269,7 @@ describe('WalletManagerWorker', () => {
         chainId: chain,
         accountIndex,
         provider
-      } = await firstValueFrom(walletManager.activeWalletId$);
+      } = await firstValueFrom(walletManager.activeWalletId$.pipe(filter(isNotNil)));
 
       expect(id).toEqual('da7b4795b11a79116eb5232c83d2c862');
       expect(accountIndex).toEqual(0);
@@ -294,7 +298,11 @@ describe('WalletManagerWorker', () => {
   describe('switchNetwork', () => {
     it('switches the network but keeps the same wallet id and account index', async () => {
       await walletManager.activate({ accountIndex: 0, chainId, walletId });
-      const { walletId: id, chainId: chain, accountIndex } = await firstValueFrom(walletManager.activeWalletId$);
+      const {
+        walletId: id,
+        chainId: chain,
+        accountIndex
+      } = await firstValueFrom(walletManager.activeWalletId$.pipe(filter(isNotNil)));
       const newChainId = { networkId: Cardano.NetworkId.Testnet, networkMagic: 999 };
 
       expect(id).toEqual(walletId);
@@ -307,7 +315,7 @@ describe('WalletManagerWorker', () => {
         walletId: idUpdated,
         chainId: chainUpdated,
         accountIndex: accountIndexUpdated
-      } = await firstValueFrom(walletManager.activeWalletId$);
+      } = await firstValueFrom(walletManager.activeWalletId$.pipe(filter(isNotNil)));
 
       expect(idUpdated).toEqual(walletId);
       expect(accountIndexUpdated).toEqual(0);

--- a/packages/web-extension/test/walletManager/walletManager.test.ts
+++ b/packages/web-extension/test/walletManager/walletManager.test.ts
@@ -231,6 +231,11 @@ describe('WalletManagerWorker', () => {
       await walletManager.activate({ accountIndex: 0, chainId, walletId });
       expect(walletFactoryCreate).toHaveBeenCalledTimes(1);
     });
+
+    it('compares the chainId using deepEquals', async () => {
+      await walletManager.activate({ accountIndex: 0, chainId: { ...chainId }, walletId });
+      expect(walletFactoryCreate).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('initialize', () => {


### PR DESCRIPTION
# Context

The wallet manager was not emitting null for the activeWalletId$ observable when there was no active wallet. Also the activate method was not comparing the active wallet properties correctly.

LW-9094

# Proposed Solution

Fix both bugs on the wallet manager