### PR TITLE
feat(web-extension): add willRetryOnFailure sign option to SignerManager

### DIFF
--- a/packages/web-extension/src/walletManager/SignerManager/types.ts
+++ b/packages/web-extension/src/walletManager/SignerManager/types.ts
@@ -21,15 +21,28 @@ export type RequestBase<WalletMetadata extends {}> = {
   reject(reason: string): Promise<void>;
 };
 
+export type SignOptions = {
+  /**
+   * if `true`,
+   * - underlying KeyAgent errors from this call will not be propagated back to the wallet via SignerManagerSignApi
+   * - SignerManager expects user to either retry the call to `sign` or call `reject` manually
+   */
+  willRetryOnFailure?: boolean;
+};
+
 type SignRequestInMemory<R> = {
   walletType: WalletType.InMemory;
-  sign(passphrase: Uint8Array): Promise<R>;
+  sign(passphrase: Uint8Array, options?: SignOptions): Promise<R>;
 };
 
 type SignRequestHardware<R> = {
   walletType: WalletType.Trezor | WalletType.Ledger;
-  /** Must be called from user gesture when running in web environments */
-  sign(): Promise<R>;
+  /**
+   * Must be called from user gesture when running in web environments
+   *
+   * @param noReject if `true`, underlying KeyAgent errors will not be propagated back to the wallet via SignerManagerSignApi
+   */
+  sign(options?: SignOptions): Promise<R>;
 };
 
 export type SignRequest<R> = SignRequestHardware<R> | SignRequestInMemory<R>;

--- a/packages/web-extension/test/walletManager/SignerManager.test.ts
+++ b/packages/web-extension/test/walletManager/SignerManager.test.ts
@@ -124,6 +124,32 @@ describe('SignerManager', () => {
       await expect(signed).rejects.toThrow(error);
       expect(passphrase).toEqual(new Uint8Array([0, 0, 0]));
     });
+
+    describe('willRetryOnFailure=true', () => {
+      it('does not resolve to original caller until successful signing', async () => {
+        const error = new Error('invalid passphrase, please retry');
+        keyAgent.signTransaction.mockRejectedValueOnce(error).mockResolvedValueOnce(signatures);
+        const reqEmitted = firstValueFrom(signerManager.transactionWitnessRequest$);
+        const signed = signerManager.signTransaction({ signContext, tx }, requestContext);
+        const req = await reqEmitted;
+        await expect(req.sign(passphrase, { willRetryOnFailure: true })).rejects.toThrow(error);
+        await expect(req.sign(passphrase, { willRetryOnFailure: true })).resolves.toEqual(signatures);
+        await expect(signed).resolves.toEqual(signatures);
+        expect(passphrase).toEqual(new Uint8Array([0, 0, 0]));
+      });
+
+      it('does not reject to original caller until explicit rejection', async () => {
+        const error = new Error('invalid passphrase, call reject if dont want to sign again');
+        keyAgent.signTransaction.mockRejectedValueOnce(error).mockResolvedValueOnce(signatures);
+        const reqEmitted = firstValueFrom(signerManager.transactionWitnessRequest$);
+        const signed = signerManager.signTransaction({ signContext, tx }, requestContext);
+        const req = await reqEmitted;
+        await expect(req.sign(passphrase, { willRetryOnFailure: true })).rejects.toThrow(error);
+        await req.reject('forgot password');
+        await expect(signed).rejects.toThrowError(errors.AuthenticationError);
+        expect(passphrase).toEqual(new Uint8Array([0, 0, 0]));
+      });
+    });
   });
 
   describe('signData', () => {
@@ -178,6 +204,32 @@ describe('SignerManager', () => {
       await expect(req.sign(passphrase)).rejects.toThrow(error);
       await expect(signed).rejects.toThrow(error);
       expect(passphrase).toEqual(new Uint8Array([0, 0, 0]));
+    });
+
+    describe('willRetryOnFailure=true', () => {
+      it('does not resolve to original caller until successful signing', async () => {
+        const error = new Error('invalid passphrase, please retry');
+        keyAgent.signBlob.mockRejectedValueOnce(error).mockResolvedValueOnce(signResult);
+        const reqEmitted = firstValueFrom(signerManager.signDataRequest$);
+        const signed = signerManager.signData({ blob, derivationPath, signContext }, requestContext);
+        const req = await reqEmitted;
+        await expect(req.sign(passphrase, { willRetryOnFailure: true })).rejects.toThrow(error);
+        await expect(req.sign(passphrase, { willRetryOnFailure: true })).resolves.toEqual(signResult);
+        await expect(signed).resolves.toEqual(signResult);
+        expect(passphrase).toEqual(new Uint8Array([0, 0, 0]));
+      });
+
+      it('does not reject to original caller until explicit rejection', async () => {
+        const error = new Error('invalid passphrase, call reject if dont want to sign again');
+        keyAgent.signBlob.mockRejectedValueOnce(error);
+        const reqEmitted = firstValueFrom(signerManager.signDataRequest$);
+        const signed = signerManager.signData({ blob, derivationPath, signContext }, requestContext);
+        const req = await reqEmitted;
+        await expect(req.sign(passphrase, { willRetryOnFailure: true })).rejects.toThrow(error);
+        await req.reject('forgot password');
+        await expect(signed).rejects.toThrowError(errors.AuthenticationError);
+        expect(passphrase).toEqual(new Uint8Array([0, 0, 0]));
+      });
     });
   });
 });


### PR DESCRIPTION
# Context

Signing can fail due to user error (e.g. entering wrong passphrase)

LW-9094

# Proposed Solution

This commit adds a mechanism that enables retries for a single sign request