### PR TITLE
build: add udev package to LD_LIBRARY_PATH

### DIFF
--- a/nix/local/envs.nix
+++ b/nix/local/envs.nix
@@ -32,6 +32,14 @@ in {
   main = mkShell {
     name = "Cardano JS SDK Local Env";
     imports = [formattingModule];
+
+    env = with inputs.nixpkgs; [
+      {
+        name = "LD_LIBRARY_PATH";
+        value = lib.makeLibraryPath [udev];
+      }
+    ];
+
     commands = [
       {package = std;}
       {package = yarn;}


### PR DESCRIPTION
# Context

`yarn workspace @cardano-sdk/hardware-trezor test` was failing to execute due to missing library. 
