### PR TITLE
re-run failing tests when regenerating fixtures

### DIFF
--- a/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
+++ b/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
@@ -12,14 +12,24 @@ PASSWORD=$(cat $SECRETS_DIR/postgres_password)
 
 export DB_SYNC_CONNECTION_STRING="postgresql://${USER}:${PASSWORD}@localhost:5435/${DB_DB_SYNC}"
 
+yarn cleanup
+yarn
+yarn build
+yarn test:build:verify
+
 yarn workspace @cardano-sdk/e2e local-network:down
 yarn workspace @cardano-sdk/e2e local-network:up -d --build
-yarn build
 yarn workspace @cardano-sdk/e2e wait-for-network
-yarn workspace @cardano-sdk/e2e test:wallet
-yarn workspace @cardano-sdk/e2e test:long-running delegation-rewards.test.ts
+
+TEST1="yarn workspace @cardano-sdk/e2e test:wallet"
+TEST2="yarn workspace @cardano-sdk/e2e test:long-running delegation-rewards.test.ts"
+TEST3="yarn workspace @cardano-sdk/e2e test:local-network register-pool.test.ts"
+
+for test in "$TEST1" "$TEST2" "$TEST3" ; do
+  while ! $test ; do echo repeating... ; done
+done
+
 TL_LEVEL="${TL_LEVEL:=info}" node "$SCRIPT_DIR/mint-handles.js"
-yarn workspace @cardano-sdk/e2e test:local-network register-pool.test.ts
 
 echo 'Stop providing data to projectors'
 docker compose -p local-network-e2e stop cardano-node ogmios


### PR DESCRIPTION
# Context

Our tests historically suffer some instabilities.
When a flaky test fails during the procedure to regenerate the fixtures, implies a huge amount of time to restart it from beginning: from 30m to 1h depending on how much far from the end of the procedure the failing test is.

# Proposed Solution

Launching the tests in `while` loop to let the script to restart them in case of error.

# Important Changes Introduced

Introduced general rebuild steps at the beginning of the procedure to:

- ensure everything builds before _starting_ the actual rebuild procedure
- perform basic rebuild steps to make the script working even if it is the first action after changing branch