### PR TITLE
feat!: signerManager and Witnesser now propagate signData confirmation address

### DIFF
--- a/packages/key-management/src/cip8/cip30signData.ts
+++ b/packages/key-management/src/cip8/cip30signData.ts
@@ -89,10 +89,11 @@ const signSigStructure = (
   witnesser: Bip32Ed25519Witnesser,
   derivationPath: AccountKeyDerivationPath,
   sigStructure: SigStructure,
+  address?: Cardano.PaymentAddress | Cardano.RewardAccount | Cardano.DRepID,
   sender?: MessageSender
 ) => {
   try {
-    return witnesser.signBlob(derivationPath, util.bytesToHex(sigStructure.to_bytes()), sender);
+    return witnesser.signBlob(derivationPath, util.bytesToHex(sigStructure.to_bytes()), { address, sender });
   } catch (error) {
     throw new Cip30DataSignError(Cip30DataSignErrorCode.UserDeclined, 'Failed to sign', error);
   }
@@ -132,7 +133,7 @@ export const cip30signData = async ({
     false
   );
   const sigStructure = builder.make_data_to_sign();
-  const { signature, publicKey } = await signSigStructure(witnesser, derivationPath, sigStructure, sender);
+  const { signature, publicKey } = await signSigStructure(witnesser, derivationPath, sigStructure, signWith, sender);
   const coseSign1 = builder.build(Buffer.from(signature, 'hex'));
 
   const coseKey = createCoseKey(addressBytes, publicKey);

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -147,6 +147,11 @@ export interface SignTransactionContext {
   sender?: MessageSender;
 }
 
+export interface SignDataContext {
+  address?: Cardano.PaymentAddress | Cardano.RewardAccount | Cardano.DRepID;
+  sender?: MessageSender;
+}
+
 export interface KeyAgent {
   get chainId(): Cardano.ChainId;
   get accountIndex(): number;
@@ -236,5 +241,5 @@ export interface Witnesser {
   /**
    * @throws AuthenticationError
    */
-  signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob, sender?: MessageSender): Promise<SignBlobResult>;
+  signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob, context: SignDataContext): Promise<SignBlobResult>;
 }

--- a/packages/key-management/src/util/createWitnesser.ts
+++ b/packages/key-management/src/util/createWitnesser.ts
@@ -1,8 +1,8 @@
 import {
   AccountKeyDerivationPath,
   AsyncKeyAgent,
-  MessageSender,
   SignBlobResult,
+  SignDataContext,
   SignTransactionContext,
   WitnessOptions,
   Witnesser
@@ -38,7 +38,7 @@ export class Bip32Ed25519Witnesser implements Witnesser {
   async signBlob(
     derivationPath: AccountKeyDerivationPath,
     blob: HexBlob,
-    _sender?: MessageSender
+    _context: SignDataContext
   ): Promise<SignBlobResult> {
     return this.#keyAgent.signBlob(derivationPath, blob);
   }

--- a/packages/key-management/test/cip8/cip30signData.test.ts
+++ b/packages/key-management/test/cip8/cip30signData.test.ts
@@ -113,6 +113,6 @@ describe('cip30signData', () => {
     const signBlobSpy = jest.spyOn(witnesser, 'signBlob');
     const sender = { url: 'https://lace.io' };
     await signAndDecode(address.address, [address], sender);
-    expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), sender);
+    expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), { address: address.address, sender });
   });
 });

--- a/packages/key-management/test/util/createWitnesser.test.ts
+++ b/packages/key-management/test/util/createWitnesser.test.ts
@@ -19,7 +19,12 @@ describe('createBip32Ed25519Witnesser', () => {
     const blob = HexBlob('abc123');
     const result = {} as SignBlobResult;
     asyncKeyAgent.signBlob.mockResolvedValueOnce(result);
-    await expect(witnesser.signBlob(keyDerivationPath, blob)).resolves.toBe(result);
+    await expect(
+      witnesser.signBlob(keyDerivationPath, blob, {
+        address: 'stub' as Cardano.PaymentAddress,
+        sender: { url: 'some test' }
+      })
+    ).resolves.toBe(result);
     expect(asyncKeyAgent.signBlob).toBeCalledWith(keyDerivationPath, blob);
   });
 

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -233,6 +233,7 @@ describe('PersonalWallet methods', () => {
         const witnessSpy = jest.spyOn(witnesser, 'witness');
         const txInternals = await wallet.initializeTx(props);
         await wallet.finalizeTx({ sender, tx: txInternals });
+
         expect(witnessSpy).toBeCalledWith(expect.anything(), expect.objectContaining({ sender }), void 0);
       });
     });
@@ -434,11 +435,11 @@ describe('PersonalWallet methods', () => {
       expect(response).toHaveProperty('signature');
     });
 
-    it('passes through sender to witnesser', async () => {
+    it('passes through context to witnesser', async () => {
       const sender = { url: 'https://lace.io' };
       const signBlobSpy = jest.spyOn(witnesser, 'signBlob');
       await wallet.signData({ payload: HexBlob('abc123'), sender, signWith: address });
-      expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), sender);
+      expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), { address, sender });
     });
 
     test('rejects if bech32 DRepID is not a type 6 address', async () => {

--- a/packages/web-extension/src/walletManager/SignerManager/types.ts
+++ b/packages/web-extension/src/walletManager/SignerManager/types.ts
@@ -1,7 +1,7 @@
 import {
   AccountKeyDerivationPath,
-  MessageSender,
   SignBlobResult,
+  SignDataContext,
   SignTransactionContext,
   SignTransactionOptions
 } from '@cardano-sdk/key-management';
@@ -51,8 +51,6 @@ export type TransactionWitnessRequest<WalletMetadata extends {}> = RequestBase<W
   transaction: Serialization.Transaction;
   signContext: SignTransactionContext;
 } & SignRequest<Cardano.Signatures>;
-
-export type SignDataContext = { sender?: MessageSender };
 
 export type SignDataProps = {
   derivationPath: AccountKeyDerivationPath;

--- a/packages/web-extension/src/walletManager/walletManager.ts
+++ b/packages/web-extension/src/walletManager/walletManager.ts
@@ -1,6 +1,6 @@
 import {
   AccountKeyDerivationPath,
-  MessageSender,
+  SignDataContext,
   SignTransactionContext,
   WitnessOptions,
   Witnesser
@@ -289,12 +289,12 @@ export class WalletManager<Metadata extends { name: string }> implements WalletM
       case WalletType.Ledger:
       case WalletType.Trezor:
         witnesser = {
-          signBlob: async (derivationPath: AccountKeyDerivationPath, blob: HexBlob, sender?: MessageSender) =>
+          signBlob: async (derivationPath: AccountKeyDerivationPath, blob: HexBlob, context: SignDataContext) =>
             await this.#signerManagerApi.signData(
               {
                 blob,
                 derivationPath,
-                signContext: { sender }
+                signContext: context
               },
               {
                 accountIndex: accountIndex!,


### PR DESCRIPTION
# Context

SignerManager signData requests don’t have ‘address’ property. Instead, it only has derivation path to sign with.

In order to get the address, we need to update Witnesser and SignerManager interfaces to preserve address as additional context of the signing operation.

# Proposed Solution

- SignDataContext now has an additional optional address field.
- Witnesser signBlob now takes a context as one of its arguments (of type SignDataContext, same as SignerManager signData).