### PR TITLE
LW-9535 configurable metadata job retry delay

### DIFF
--- a/packages/cardano-services/src/Program/programs/projector.ts
+++ b/packages/cardano-services/src/Program/programs/projector.ts
@@ -12,7 +12,7 @@ import { MissingProgramOption, UnknownServiceName } from '../errors';
 import { ProjectionHttpService, ProjectionName, createTypeormProjection, storeOperators } from '../../Projection';
 import { SrvRecord } from 'dns';
 import { createLogger } from 'bunyan';
-import { createStorePoolMetricsUpdateJob } from '@cardano-sdk/projection-typeorm';
+import { createStorePoolMetricsUpdateJob, createStoreStakePoolMetadataJob } from '@cardano-sdk/projection-typeorm';
 import { getConnectionConfig, getOgmiosObservableCardanoNode } from '../services';
 
 export const BLOCKS_BUFFER_LENGTH_DEFAULT = 10;
@@ -26,6 +26,7 @@ export type ProjectorArgs = CommonProgramOptions &
     dropSchema: boolean;
     dryRun: boolean;
     exitAtBlockNo: Cardano.BlockNo;
+    metadataJobRetryDelay: number;
     poolsMetricsInterval: number;
     projectionNames: ProjectionName[];
     synchronize: boolean;
@@ -44,6 +45,7 @@ interface ProjectionMapFactoryOptions {
 const createProjectionHttpService = async (options: ProjectionMapFactoryOptions) => {
   const { args, dnsResolver, logger } = options;
   storeOperators.storePoolMetricsUpdateJob = createStorePoolMetricsUpdateJob(args.poolsMetricsInterval)();
+  storeOperators.storeStakePoolMetadataJob = createStoreStakePoolMetadataJob(args.metadataJobRetryDelay)();
   const cardanoNode = getOgmiosObservableCardanoNode(dnsResolver, logger, {
     ogmiosSrvServiceName: args.ogmiosSrvServiceName,
     ogmiosUrl: args.ogmiosUrl

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -6,6 +6,7 @@ import {
 } from '../options';
 import { HandlePolicyIdsProgramOptions } from '../options/policyIds';
 import { Milliseconds, Seconds } from '@cardano-sdk/core';
+import { defaultJobOptions } from '@cardano-sdk/projection-typeorm';
 
 /** cardano-services programs */
 export enum Programs {
@@ -26,6 +27,7 @@ export enum ServiceNames {
   Utxo = 'utxo'
 }
 
+export const METADATA_JOB_RETRY_DELAY_DEFAULT = defaultJobOptions.retryDelay;
 export const POOLS_METRICS_INTERVAL_DEFAULT = 1000;
 export const POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT = 100;
 
@@ -34,6 +36,7 @@ export enum ProjectorOptionDescriptions {
   DropSchema = 'Drop and recreate database schema to project from origin',
   DryRun = 'Initialize the projection, but do not start it',
   ExitAtBlockNo = 'Exit after processing this block. Intended for benchmark testing',
+  MetadataJobRetryDelay = 'Retry delay for metadata fetch job in seconds',
   PoolsMetricsInterval = 'Interval in number of blocks between two stake pools metrics jobs to update all metrics',
   PoolsMetricsOutdatedInterval = 'Interval in number of blocks between two stake pools metrics jobs to update only outdated metrics',
   Synchronize = 'Synchronize the schema from the models'

--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -18,6 +18,7 @@ import {
   StakePoolEntity,
   TokensEntity,
   createStorePoolMetricsUpdateJob,
+  createStoreStakePoolMetadataJob,
   storeAddresses,
   storeAssets,
   storeBlock,
@@ -25,7 +26,6 @@ import {
   storeHandles,
   storeNftMetadata,
   storeStakeKeyRegistrations,
-  storeStakePoolMetadataJob,
   storeStakePoolRewardsJob,
   storeStakePools,
   storeUtxo
@@ -109,7 +109,7 @@ export const storeOperators = {
     POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT
   )(),
   storeStakeKeyRegistrations: storeStakeKeyRegistrations(),
-  storeStakePoolMetadataJob: storeStakePoolMetadataJob(),
+  storeStakePoolMetadataJob: createStoreStakePoolMetadataJob()(),
   storeStakePoolRewardsJob: storeStakePoolRewardsJob(),
   storeStakePools: storeStakePools(),
   storeUtxo: storeUtxo()

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -14,6 +14,7 @@ import {
   DROP_SCHEMA_DEFAULT,
   DRY_RUN_DEFAULT,
   HANDLE_PROVIDER_SERVER_URL_DEFAULT,
+  METADATA_JOB_RETRY_DELAY_DEFAULT,
   PAGINATION_PAGE_SIZE_LIMIT_DEFAULT,
   PARALLEL_JOBS_DEFAULT,
   PG_BOSS_WORKER_API_URL_DEFAULT,
@@ -141,6 +142,13 @@ addOptions(withCommonOptions(projectorWithArgs, PROJECTOR_API_URL_DEFAULT), [
     'EXIT_AT_BLOCK_NO',
     (exitAtBlockNo) => (exitAtBlockNo ? Number.parseInt(exitAtBlockNo, 10) : 0),
     ''
+  ),
+  newOption(
+    '--metadata-job-retry-delay <metadataJobRetryDelay>',
+    ProjectorOptionDescriptions.MetadataJobRetryDelay,
+    'METADATA_JOB_RETRY_DELAY',
+    (metadataJobRetryDelay) => Number.parseInt(metadataJobRetryDelay, 10),
+    METADATA_JOB_RETRY_DELAY_DEFAULT
   ),
   newOption(
     '--pools-metrics-interval <poolsMetricsInterval>',

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -97,6 +97,10 @@ services:
       - ./local-network/config/network:/config
       - sdk-ipc:/sdk-ipc
 
+  stake-pool-projector:
+    environment:
+      METADATA_JOB_RETRY_DELAY: 60
+
 volumes:
   sdk-ipc:
     driver: local

--- a/packages/projection-typeorm/test/operators/storeStakePoolMetadataJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePoolMetadataJob.test.ts
@@ -5,8 +5,8 @@ import {
   TypeormStabilityWindowBuffer,
   TypeormTipTracker,
   createObservableConnection,
+  createStoreStakePoolMetadataJob,
   storeBlock,
-  storeStakePoolMetadataJob,
   typeormTransactionCommit,
   withTypeormTransaction
 } from '../../src';
@@ -44,7 +44,7 @@ describe('storeStakePoolMetadataJob', () => {
         pgBoss: true
       }),
       storeBlock(),
-      storeStakePoolMetadataJob(),
+      createStoreStakePoolMetadataJob()(),
       buffer.storeBlockData(),
       typeormTransactionCommit()
     );


### PR DESCRIPTION
# Context

Latest applied changes in the SDK introduced some delays in fetching stake pool metadata. Since the default retry delay for the job which fetches the metadata is tailored for `live-mainnet` no retries are performed during the rebuild fixtures procedure.

The sum of this two facts makes the newly generated fixtures missing the metadata.

# Proposed Solution

- made the retry delay for the job configurable
- configured said delay to 60" in `local-network`