### PR TITLE
feat(web-extension): handle wallet metadata in repository [LW-9503]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     // needed for inference from type guards
     '@typescript-eslint/no-var-requires': 0,
+    'brace-style': 0, // collides with prettier formatting
     // typescript checks return types
     camelcase: 0,
     'consistent-return': 0,

--- a/packages/e2e/test/web-extension/extension/background/walletManager.ts
+++ b/packages/e2e/test/web-extension/extension/background/walletManager.ts
@@ -38,7 +38,7 @@ export interface WalletFactoryDependencies {
  * @param accountIndex The account index to get the name from.
  * @private
  */
-const getWalletName = (wallet: AnyWallet<Metadata>, accountIndex?: number): string => {
+const getWalletName = (wallet: AnyWallet<Metadata, Metadata>, accountIndex?: number): string => {
   let name = '';
   switch (wallet.type) {
     case WalletType.InMemory:
@@ -68,10 +68,10 @@ const getWalletName = (wallet: AnyWallet<Metadata>, accountIndex?: number): stri
  * to construct providers for different networks.
  * Please check its documentation for examples.
  */
-const walletFactory: WalletFactory<Metadata> = {
+const walletFactory: WalletFactory<Metadata, Metadata> = {
   create: async (
     props: WalletManagerActivateProps,
-    wallet: AnyWallet<Metadata>,
+    wallet: AnyWallet<Metadata, Metadata>,
     { witnesser, stores }: WalletFactoryDependencies
   ) =>
     (
@@ -89,14 +89,14 @@ const storesFactory: StoresFactory = {
   create: ({ name }) => storage.createPouchDbWalletStores(name, { logger })
 };
 
-const walletRepository = new WalletRepository<Metadata>({
+const walletRepository = new WalletRepository<Metadata, Metadata>({
   logger,
   store: new storage.InMemoryCollectionStore()
 });
 
 const signingCoordinatorApi = consumeSigningCoordinatorApi({ logger, runtime });
 
-const walletManager = new WalletManager<Metadata>(
+const walletManager = new WalletManager<Metadata, Metadata>(
   { name: walletName },
   {
     logger,

--- a/packages/e2e/test/web-extension/extension/ui.ts
+++ b/packages/e2e/test/web-extension/extension/ui.ts
@@ -318,6 +318,7 @@ const createWalletIfNotExistsAndActivate = async (accountIndex: number) => {
         rootPrivateKeyBytes: HexBlob.fromBytes(new Uint8Array(encryptedRootPrivateKey))
       },
       extendedAccountPublicKey: keyAgent.serializableData.extendedAccountPublicKey,
+      metadata: {},
       type: WalletType.InMemory
     });
     await repository.addAccount({

--- a/packages/projection-typeorm/src/TypeormStabilityWindowBuffer.ts
+++ b/packages/projection-typeorm/src/TypeormStabilityWindowBuffer.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable brace-style */
 import { BlockDataEntity } from './entity';
 import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
 import { LessThan, QueryRunner } from 'typeorm';

--- a/packages/projection-typeorm/src/entity/PoolRegistration.entity.ts
+++ b/packages/projection-typeorm/src/entity/PoolRegistration.entity.ts
@@ -1,4 +1,3 @@
-/* eslint-disable brace-style */
 import { BigIntColumnOptions, OnDeleteCascadeRelationOptions, UInt64ColumnOptions } from './util';
 import { BlockEntity } from './Block.entity';
 import { Cardano } from '@cardano-sdk/core';

--- a/packages/wallet/src/persistence/inMemoryStores/InMemoryCollectionStore.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/InMemoryCollectionStore.ts
@@ -1,4 +1,3 @@
-/* eslint-disable brace-style */
 import { CollectionStore } from '../types';
 import { EMPTY, Observable, Subject, delay, of, tap } from 'rxjs';
 import { InMemoryStore } from './InMemoryStore';

--- a/packages/wallet/src/persistence/inMemoryStores/InMemoryDocumentStore.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/InMemoryDocumentStore.ts
@@ -1,4 +1,3 @@
-/* eslint-disable brace-style */
 import { DocumentStore } from '../types';
 import { EMPTY, Observable, of } from 'rxjs';
 import { InMemoryStore } from './InMemoryStore';

--- a/packages/wallet/src/persistence/inMemoryStores/InMemoryKeyValueStore.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/InMemoryKeyValueStore.ts
@@ -1,4 +1,3 @@
-/* eslint-disable brace-style */
 import { EMPTY, Observable, of } from 'rxjs';
 import { InMemoryCollectionStore } from './InMemoryCollectionStore';
 import { KeyValueCollection, KeyValueStore } from '../types';

--- a/packages/wallet/src/persistence/pouchDbStores/PouchDbKeyValueStore.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/PouchDbKeyValueStore.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable promise/always-return */
-/* eslint-disable brace-style */
 import { EMPTY, Observable, from } from 'rxjs';
 import { KeyValueCollection, KeyValueStore } from '../types';
 import { Logger } from 'ts-log';

--- a/packages/wallet/src/services/ProviderTracker/TrackedWalletNetworkInfoProvider.ts
+++ b/packages/wallet/src/services/ProviderTracker/TrackedWalletNetworkInfoProvider.ts
@@ -1,4 +1,3 @@
-/* eslint-disable brace-style */
 import { BehaviorSubject } from 'rxjs';
 import { CLEAN_FN_STATS, ProviderFnStats, ProviderTracker } from './ProviderTracker';
 import { WalletNetworkInfoProvider } from '../../types';

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -141,11 +141,12 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const walletRepositoryProperties: RemoteApiProperties<WalletRepository<any>> = {
+export const walletRepositoryProperties: RemoteApiProperties<WalletRepository<any, any>> = {
   addAccount: RemoteApiPropertyType.MethodReturningPromise,
   addWallet: RemoteApiPropertyType.MethodReturningPromise,
   removeAccount: RemoteApiPropertyType.MethodReturningPromise,
   removeWallet: RemoteApiPropertyType.MethodReturningPromise,
-  updateMetadata: RemoteApiPropertyType.MethodReturningPromise,
+  updateAccountMetadata: RemoteApiPropertyType.MethodReturningPromise,
+  updateWalletMetadata: RemoteApiPropertyType.MethodReturningPromise,
   wallets$: RemoteApiPropertyType.HotObservable
 };

--- a/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable brace-style */
 import { Cardano, Serialization } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 import { InMemoryWallet, WalletType } from '../types';

--- a/packages/web-extension/src/walletManager/SigningCoordinator/exposeSigningCoordinatorApi.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/exposeSigningCoordinatorApi.ts
@@ -5,7 +5,7 @@ import { signingCoordinatorApiChannel, signingCoordinatorApiProperties } from '.
 
 export interface ExposeSigningCoordinatorProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  signingCoordinator: SigningCoordinatorSignApi<any>;
+  signingCoordinator: SigningCoordinatorSignApi<any, any>;
 }
 
 export const exposeSigningCoordinatorApi = (

--- a/packages/web-extension/src/walletManager/SigningCoordinator/types.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/types.ts
@@ -10,14 +10,14 @@ import { Cardano, Serialization, TxCBOR } from '@cardano-sdk/core';
 import { HexBlob } from '@cardano-sdk/util';
 import { Observable } from 'rxjs';
 
-export type RequestContext<WalletMetadata extends {}> = {
-  wallet: AnyBip32Wallet<WalletMetadata>;
+export type RequestContext<WalletMetadata extends {}, AccountMetadata extends {}> = {
+  wallet: AnyBip32Wallet<WalletMetadata, AccountMetadata>;
   accountIndex: number;
   chainId: Cardano.ChainId;
 };
 
-export type RequestBase<WalletMetadata extends {}> = {
-  requestContext: RequestContext<WalletMetadata>;
+export type RequestBase<WalletMetadata extends {}, AccountMetadata extends {}> = {
+  requestContext: RequestContext<WalletMetadata, AccountMetadata>;
   reject(reason: string): Promise<void>;
 };
 
@@ -47,7 +47,10 @@ type SignRequestHardware<R> = {
 
 export type SignRequest<R> = SignRequestHardware<R> | SignRequestInMemory<R>;
 
-export type TransactionWitnessRequest<WalletMetadata extends {}> = RequestBase<WalletMetadata> & {
+export type TransactionWitnessRequest<WalletMetadata extends {}, AccountMetadata extends {}> = RequestBase<
+  WalletMetadata,
+  AccountMetadata
+> & {
   transaction: Serialization.Transaction;
   signContext: SignTransactionContext;
 } & SignRequest<Cardano.Signatures>;
@@ -58,7 +61,10 @@ export type SignDataProps = {
   signContext: SignDataContext;
 };
 
-export type SignDataRequest<WalletMetadata extends {}> = RequestBase<WalletMetadata> &
+export type SignDataRequest<WalletMetadata extends {}, AccountMetadata extends {}> = RequestBase<
+  WalletMetadata,
+  AccountMetadata
+> &
   SignDataProps &
   SignRequest<SignBlobResult>;
 
@@ -68,15 +74,18 @@ export type SignTransactionProps = {
   options?: SignTransactionOptions;
 };
 
-export interface SigningCoordinatorConfirmationApi<WalletMetadata extends {}> {
-  transactionWitnessRequest$: Observable<TransactionWitnessRequest<WalletMetadata>>;
-  signDataRequest$: Observable<SignDataRequest<WalletMetadata>>;
+export interface SigningCoordinatorConfirmationApi<WalletMetadata extends {}, AccountMetadata extends {}> {
+  transactionWitnessRequest$: Observable<TransactionWitnessRequest<WalletMetadata, AccountMetadata>>;
+  signDataRequest$: Observable<SignDataRequest<WalletMetadata, AccountMetadata>>;
 }
 
-export interface SigningCoordinatorSignApi<WalletMetadata extends {}> {
+export interface SigningCoordinatorSignApi<WalletMetadata extends {}, AccountMetadata extends {}> {
   signTransaction(
     props: SignTransactionProps,
-    requestContext: RequestContext<WalletMetadata>
+    requestContext: RequestContext<WalletMetadata, AccountMetadata>
   ): Promise<Cardano.Signatures>;
-  signData(props: SignDataProps, requestContext: RequestContext<WalletMetadata>): Promise<SignBlobResult>;
+  signData(
+    props: SignDataProps,
+    requestContext: RequestContext<WalletMetadata, AccountMetadata>
+  ): Promise<SignBlobResult>;
 }

--- a/packages/web-extension/src/walletManager/SigningCoordinator/util.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/util.ts
@@ -4,7 +4,7 @@ import { SigningCoordinatorSignApi } from './types';
 export const signingCoordinatorApiChannel = 'signingCoordinator';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const signingCoordinatorApiProperties: RemoteApiProperties<SigningCoordinatorSignApi<any>> = {
+export const signingCoordinatorApiProperties: RemoteApiProperties<SigningCoordinatorSignApi<any, any>> = {
   signData: RemoteApiPropertyType.MethodReturningPromise,
   signTransaction: RemoteApiPropertyType.MethodReturningPromise
 };

--- a/packages/web-extension/src/walletManager/WalletRepository/types.ts
+++ b/packages/web-extension/src/walletManager/WalletRepository/types.ts
@@ -14,23 +14,28 @@ export type AddAccountProps<Metadata extends {}> = {
   metadata: Metadata;
 };
 
-export type UpdateMetadataProps<Metadata extends {}> = {
+export type UpdateWalletMetadataProps<Metadata extends {}> = {
   walletId: WalletId;
-  /** account' in cip1852; must be specified for bip32 wallets */
-  accountIndex?: number;
   metadata: Metadata;
 };
 
-export type AddWalletProps<Metadata extends {}> =
-  | Omit<HardwareWallet<Metadata>, 'walletId' | 'accounts'>
-  | Omit<InMemoryWallet<Metadata>, 'walletId' | 'accounts'>
-  | Omit<ScriptWallet<Metadata>, 'walletId'>;
+export type UpdateAccountMetadataProps<Metadata extends {}> = {
+  /** account' in cip1852; must be specified for bip32 wallets */
+  walletId: WalletId;
+  accountIndex: number;
+  metadata: Metadata;
+};
 
-export interface WalletRepositoryApi<Metadata extends {}> {
-  wallets$: Observable<AnyWallet<Metadata>[]>;
+export type AddWalletProps<WalletMetadata extends {}, AccountMetadata extends {}> =
+  | Omit<HardwareWallet<WalletMetadata, AccountMetadata>, 'walletId' | 'accounts'>
+  | Omit<InMemoryWallet<WalletMetadata, AccountMetadata>, 'walletId' | 'accounts'>
+  | Omit<ScriptWallet<WalletMetadata>, 'walletId'>;
+
+export interface WalletRepositoryApi<WalletMetadata extends {}, AccountMetadata extends {}> {
+  wallets$: Observable<AnyWallet<WalletMetadata, AccountMetadata>[]>;
 
   /** Rejects with WalletConflictError when wallet already exists */
-  addWallet(props: AddWalletProps<Metadata>): Promise<WalletId>;
+  addWallet(props: AddWalletProps<WalletMetadata, AccountMetadata>): Promise<WalletId>;
 
   /**
    * Can be used to add a new account to an existing BIP32Wallet
@@ -39,10 +44,16 @@ export interface WalletRepositoryApi<Metadata extends {}> {
    * - wallet with provided `walletId` is not found
    * - account already exists for this wallet
    */
-  addAccount(props: AddAccountProps<Metadata>): Promise<AddAccountProps<Metadata>>;
+  addAccount(props: AddAccountProps<AccountMetadata>): Promise<AddAccountProps<AccountMetadata>>;
 
   /** Rejects with WalletConflictError when wallet or account with specified index is not found */
-  updateMetadata(props: UpdateMetadataProps<Metadata>): Promise<UpdateMetadataProps<Metadata>>;
+  updateWalletMetadata(
+    props: UpdateWalletMetadataProps<WalletMetadata>
+  ): Promise<UpdateWalletMetadataProps<WalletMetadata>>;
+
+  updateAccountMetadata(
+    props: UpdateWalletMetadataProps<AccountMetadata>
+  ): Promise<UpdateWalletMetadataProps<AccountMetadata>>;
 
   /** Rejects with WalletConflictError when account is not found. */
   removeAccount(props: RemoveAccountProps): Promise<RemoveAccountProps>;

--- a/packages/web-extension/src/walletManager/types.ts
+++ b/packages/web-extension/src/walletManager/types.ts
@@ -18,17 +18,24 @@ export type Bip32WalletAccount<Metadata extends {}> = {
   metadata: Metadata;
 };
 
-export type Bip32Wallet<Metadata extends {}> = {
+export type Bip32Wallet<WalletMetadata extends {}, AccountMetadata extends {}> = {
   walletId: WalletId;
   extendedAccountPublicKey: Bip32PublicKeyHex;
-  accounts: Bip32WalletAccount<Metadata>[];
+  metadata: WalletMetadata;
+  accounts: Bip32WalletAccount<AccountMetadata>[];
 };
 
-export type HardwareWallet<Metadata extends {}> = Bip32Wallet<Metadata> & {
+export type HardwareWallet<WalletMetadata extends {}, AccountMetadata extends {}> = Bip32Wallet<
+  WalletMetadata,
+  AccountMetadata
+> & {
   type: WalletType.Ledger | WalletType.Trezor;
 };
 
-export type InMemoryWallet<Metadata extends {}> = Bip32Wallet<Metadata> & {
+export type InMemoryWallet<WalletMetadata extends {}, AccountMetadata extends {}> = Bip32Wallet<
+  WalletMetadata,
+  AccountMetadata
+> & {
   type: WalletType.InMemory;
   encryptedSecrets: {
     /**
@@ -41,7 +48,9 @@ export type InMemoryWallet<Metadata extends {}> = Bip32Wallet<Metadata> & {
   };
 };
 
-export type AnyBip32Wallet<WalletMetadata extends {}> = HardwareWallet<WalletMetadata> | InMemoryWallet<WalletMetadata>;
+export type AnyBip32Wallet<WalletMetadata extends {}, AccountMetadata extends {}> =
+  | HardwareWallet<WalletMetadata, AccountMetadata>
+  | InMemoryWallet<WalletMetadata, AccountMetadata>;
 
 export type OwnSignerAccount = {
   walletId: WalletId;
@@ -57,7 +66,7 @@ export type ScriptWallet<Metadata extends {}> = {
   ownSigners: OwnSignerAccount[];
 };
 
-export type AnyWallet<Metadata extends {}> =
-  | HardwareWallet<Metadata>
-  | InMemoryWallet<Metadata>
-  | ScriptWallet<Metadata>;
+export type AnyWallet<WalletMetadata extends {}, AccountMetadata extends {}> =
+  | HardwareWallet<WalletMetadata, AccountMetadata>
+  | InMemoryWallet<WalletMetadata, AccountMetadata>
+  | ScriptWallet<WalletMetadata>;

--- a/packages/web-extension/src/walletManager/walletManager.types.ts
+++ b/packages/web-extension/src/walletManager/walletManager.types.ts
@@ -82,10 +82,10 @@ export interface WalletManagerApi {
   destroyData(walletId: WalletId, chainId: Cardano.ChainId): Promise<void>;
 }
 
-export interface WalletFactory<Metadata extends { name: string }> {
+export interface WalletFactory<WalletMetadata extends { name: string }, AccountMetadata extends { name: string }> {
   create: (
     props: WalletManagerActivateProps,
-    wallet: AnyWallet<Metadata>,
+    wallet: AnyWallet<WalletMetadata, AccountMetadata>,
     dependencies: { witnesser: Witnesser; stores: storage.WalletStores }
   ) => Promise<ObservableWallet>;
 }

--- a/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
+++ b/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
@@ -15,10 +15,10 @@ import { InMemoryWallet, KeyAgentFactory, SigningCoordinator, WalletType } from 
 import { firstValueFrom } from 'rxjs';
 
 describe('SigningCoordinator', () => {
-  let signingCoordinator: SigningCoordinator<{}>;
+  let signingCoordinator: SigningCoordinator<{}, {}>;
   let keyAgentFactory: jest.Mocked<KeyAgentFactory>;
   let keyAgent: jest.Mocked<InMemoryKeyAgent>;
-  const wallet: InMemoryWallet<{}> = {
+  const wallet: InMemoryWallet<{}, {}> = {
     accounts: [
       {
         accountIndex: 0,
@@ -32,6 +32,7 @@ describe('SigningCoordinator', () => {
     extendedAccountPublicKey: Bip32PublicKeyHex(
       'ba4f80dea2632a17c99ae9d8b934abf02643db5426b889fef14709c85e294aa12ac1f1560a893ea7937c5bfbfdeab459b1a396f1174b9c5a673a640d01880c35'
     ),
+    metadata: {},
     type: WalletType.InMemory,
     walletId: Hash28ByteBase16('ad63f855e831d937457afc52a21a7f351137e4a9fff26c217817335a')
   };


### PR DESCRIPTION
# Context

This PR refactors the `WalletRepository` and related code to handle wallet metadata as well as account metadata.

# Proposed Solution

Introduces a separate `AccountMetadata` type that can be different from the wallet metadata and also splits the `WalletRepository::updateMetadata` into two separate methods `updateWalletMetadata` and `updateAccountMetadata` to avoid confusion and complicated checks.

Both types need to be passed explicitly in most cases as something like `<WalletMetadata extends {}, AccountMetadata extends {} = WalletMetadata>` might be convenient in the first place but obscures the fact that the metadata for wallets and accounts can be different eventually.
