### PR TITLE
LW-9518 Use `pgboss.archive` table to check computed epoch rewards

### DIFF
--- a/packages/cardano-services/src/PgBoss/stakePoolRewardsHandler.ts
+++ b/packages/cardano-services/src/PgBoss/stakePoolRewardsHandler.ts
@@ -115,8 +115,10 @@ const checkPreviousEpochCompleted = async (dataSource: DataSource, epochNo: Card
   const queryRunner = dataSource.createQueryRunner();
 
   try {
+    const subQuery = (table: 'archive' | 'job') =>
+      `(SELECT COUNT(*) FROM pgboss.${table} WHERE name = $1 AND singletonkey = $2 AND state = $3)`;
     const result: { completed: string }[] = await queryRunner.query(
-      'SELECT COUNT(*) AS completed FROM pgboss.job WHERE name = $1 AND singletonkey = $2 AND state = $3',
+      `SELECT ${subQuery('archive')} + ${subQuery('job')} AS completed`,
       [STAKE_POOL_REWARDS, epochNo - 1, 'completed']
     );
 


### PR DESCRIPTION
# Context

The `pool-rewards` job uses `pgboss.job` table as a registry to check which is the last epoch for which it run.

This is not enough as **pg-boss** archives completed jobs in `pgboss.archive` table:

# Proposed Solution

Added `COUNT(*) FROM pgboss.archive` to the query which performs given check.