### PR TITLE
Fix smash settings in preview and preprod env files

### DIFF
--- a/packages/cardano-services/environments/.env.preprod
+++ b/packages/cardano-services/environments/.env.preprod
@@ -1,6 +1,4 @@
 HANDLE_POLICY_IDS=${HANDLE_POLICY_IDS:-f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a}
 OGMIOS_PORT=${OGMIOS_PORT:-1339}
-METADATA_FETCH_MODE="smash"
-SMASH_URL="http://cardano-smash:3100/api/v1"
-QUEUES="pool-metadata,pool-metrics,pool-delist-schedule"
+METADATA_FETCH_MODE="direct"
 SCHEDULES="environments/.schedule.preprod.json"

--- a/packages/cardano-services/environments/.env.preview
+++ b/packages/cardano-services/environments/.env.preview
@@ -1,5 +1,4 @@
 HANDLE_POLICY_IDS=${HANDLE_POLICY_IDS:-f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a}
 OGMIOS_PORT=${OGMIOS_PORT:-1340}
-METADATA_FETCH_MODE="smash"
-SMASH_URL="http://cardano-smash:3100/api/v1"
+METADATA_FETCH_MODE="direct"
 SCHEDULES="environments/.schedule.preview.json"


### PR DESCRIPTION
# Context

Our `preview` and `preprod` **docker compose** environments are configured to use **smash**, while they should use the `direct` method.

# Proposed Solution

Fixed the cfg