### PR TITLE
Feat/lw 9145 implement utilities to compute asset diff

### DIFF
--- a/packages/core/src/Asset/util/subtractTokenMaps.ts
+++ b/packages/core/src/Asset/util/subtractTokenMaps.ts
@@ -1,20 +1,80 @@
-import { TokenMap } from '../../Cardano';
-import { isNotNil } from '@cardano-sdk/util';
+/* eslint-disable complexity,sonarjs/cognitive-complexity */
+import * as Cardano from '../../Cardano';
+import uniq from 'lodash/uniq';
+
+/**
+ * Given two Cardano.TokenMaps, compute a Cardano.TokenMap with the difference between the left-hand side and the right-hand side.
+ *
+ * @param lhs the left-hand side of the subtraction operation.
+ * @param rhs the right-hand side of the subtraction operation.
+ * @returns The difference between both Cardano.TokenMaps.
+ */
+export const subtractMaps = (
+  lhs: Cardano.TokenMap | undefined,
+  rhs: Cardano.TokenMap | undefined
+): Cardano.TokenMap | undefined => {
+  if (!rhs) {
+    if (!lhs) return undefined;
+
+    const nonEmptyValues = new Map<Cardano.AssetId, bigint>();
+
+    for (const [key, value] of lhs.entries()) {
+      if (value !== 0n) nonEmptyValues.set(key, value);
+    }
+
+    return nonEmptyValues;
+  }
+
+  if (!lhs) {
+    const negativeValues = new Map<Cardano.AssetId, bigint>();
+
+    for (const [key, value] of rhs.entries()) {
+      if (value !== 0n) negativeValues.set(key, -value);
+    }
+
+    return negativeValues;
+  }
+
+  const result = new Map<Cardano.AssetId, bigint>();
+  const intersection = new Array<Cardano.AssetId>();
+
+  // any element that is present in the lhs and not in the rhs will be added as a positive value
+  for (const [key, value] of lhs.entries()) {
+    if (rhs.has(key)) {
+      intersection.push(key);
+      continue;
+    }
+
+    if (value !== 0n) result.set(key, value);
+  }
+
+  // any element that is present in the rhs and not in the lhs will be added as a negative value
+  for (const [key, value] of rhs.entries()) {
+    if (lhs.has(key)) {
+      intersection.push(key);
+      continue;
+    }
+
+    if (value !== 0n) result.set(key, -value);
+  }
+
+  // Elements present in both maps will be subtracted (lhs - rhs)
+  const uniqIntersection = uniq(intersection);
+
+  for (const id of uniqIntersection) {
+    const lshVal = lhs.get(id);
+    const rshVal = rhs.get(id);
+    const remainingCoins = lshVal! - rshVal!;
+
+    if (remainingCoins !== 0n) result.set(id, remainingCoins);
+  }
+
+  return result;
+};
 
 /** Subtract asset quantities in order */
-export const subtractTokenMaps = (assets: (TokenMap | undefined)[]): TokenMap | undefined => {
-  if (assets.length <= 0 || !isNotNil(assets[0])) return undefined;
-  const result: TokenMap = new Map(assets[0]);
-  const rest: TokenMap[] = assets.slice(1).filter(isNotNil);
-  for (const assetTotals of rest) {
-    for (const [assetId, assetQuantity] of assetTotals.entries()) {
-      const total = result.get(assetId) ?? 0n;
-      const diff = total - assetQuantity;
-      diff === 0n ? result.delete(assetId) : result.set(assetId, diff);
-    }
-  }
-  if (result.size === 0) {
-    return undefined;
-  }
-  return result;
+export const subtractTokenMaps = (assets: (Cardano.TokenMap | undefined)[]): Cardano.TokenMap | undefined => {
+  if (!assets || assets.length === 0) return undefined;
+
+  return assets.reduce(subtractMaps);
 };

--- a/packages/core/src/Cardano/Address/RewardAccount.ts
+++ b/packages/core/src/Cardano/Address/RewardAccount.ts
@@ -1,4 +1,4 @@
-import { Address, CredentialType } from './Address';
+import { Address, Credential, CredentialType } from './Address';
 import { Ed25519KeyHashHex, Hash28ByteBase16 } from '@cardano-sdk/crypto';
 import { NetworkId } from '../ChainId';
 import { OpaqueString, typedBech32 } from '@cardano-sdk/util';
@@ -14,6 +14,26 @@ export type RewardAccount = OpaqueString<'RewardAccount'>;
 export const RewardAccount = (value: string): RewardAccount => typedBech32(value, ['stake', 'stake_test'], 47);
 RewardAccount.toHash = (rewardAccount: RewardAccount): Ed25519KeyHashHex =>
   Ed25519KeyHashHex(Address.fromBech32(rewardAccount).asReward()!.getPaymentCredential().hash);
+
+/**
+ * Creates a reward account from a given credential and network id.
+ *
+ * @param credential The credential.
+ * @param networkId The network id.
+ */
+RewardAccount.fromCredential = (credential: Credential, networkId: NetworkId): RewardAccount =>
+  RewardAccount(
+    RewardAddress.fromCredentials(networkId, { hash: credential.hash, type: credential.type }).toAddress().toBech32()
+  );
+
+/**
+ * Returns the network id encoded in the given reward account.
+ *
+ * @param rewardAccount The reward account.
+ * @returns The network id.
+ */
+RewardAccount.toNetworkId = (rewardAccount: RewardAccount): NetworkId =>
+  Address.fromBech32(rewardAccount).asReward()!.toAddress().getNetworkId();
 
 /**
  * Creates a reward account from a given key hash and network id.

--- a/packages/core/src/Cardano/util/computeImplicitCoin.ts
+++ b/packages/core/src/Cardano/util/computeImplicitCoin.ts
@@ -10,35 +10,166 @@ export interface ImplicitCoin {
   input?: Lovelace;
   /** Delegation registration deposit */
   deposit?: Lovelace;
+  /** Deposits returned */
+  reclaimDeposit?: Lovelace;
 }
 
-/** Implementation is the same as in CSL.get_implicit_input() and CSL.get_deposit(). */
-export const computeImplicitCoin = (
+type DepositProtocolParams = { stakeKeyDeposit: Cardano.Lovelace; poolDeposit: Cardano.Lovelace };
+
+const computeShellyDeposits = (
+  depositParams: DepositProtocolParams,
+  certificates: Cardano.Certificate[],
+  rewardAccounts: Cardano.RewardAccount[],
+  poolIds: Set<Cardano.PoolId>,
+  networkId: Cardano.NetworkId
+): { deposit: Cardano.Lovelace; reclaimDeposit: Cardano.Lovelace } => {
+  let deposit = 0n;
+  let reclaimDeposit = 0n;
+
+  // TODO: For the case of deregistration (StakeDeregistration and PoolRetirement) the code here is not entirely correct
+  // as we are assuming the current protocol parameters for the deposits where the same as the ones used when the certificates where issued.
+  // This is going to work for now, but to properly implement this we need a way to know when the certificate we are undoing was originally issued
+  // and get the protocol parameters for that epoch. However, these parameters in particular have never change in mainnet, so this is probably
+  // is good for now.
+  for (const cert of certificates) {
+    switch (cert.__typename) {
+      case Cardano.CertificateType.StakeRegistration:
+        if (rewardAccounts.includes(Cardano.RewardAccount.fromCredential(cert.stakeCredential, networkId)))
+          deposit += depositParams.stakeKeyDeposit;
+        break;
+      case Cardano.CertificateType.StakeDeregistration:
+        if (rewardAccounts.includes(Cardano.RewardAccount.fromCredential(cert.stakeCredential, networkId)))
+          reclaimDeposit += depositParams.stakeKeyDeposit;
+        break;
+      case Cardano.CertificateType.PoolRegistration:
+        if (rewardAccounts.some((acct) => cert.poolParameters.owners.includes(acct)))
+          deposit += depositParams.poolDeposit;
+        break;
+      case Cardano.CertificateType.PoolRetirement: {
+        if (poolIds.has(cert.poolId)) reclaimDeposit += depositParams.poolDeposit;
+        break;
+      }
+    }
+  }
+
+  return {
+    deposit,
+    reclaimDeposit
+  };
+};
+
+const computeConwayDeposits = (
+  certificates: Cardano.Certificate[],
+  rewardAccounts: Cardano.RewardAccount[],
+  networkId: Cardano.NetworkId
+): { deposit: Cardano.Lovelace; reclaimDeposit: Cardano.Lovelace } => {
+  let deposit = 0n;
+  let reclaimDeposit = 0n;
+
+  for (const cert of certificates) {
+    switch (cert.__typename) {
+      case Cardano.CertificateType.Registration:
+      case Cardano.CertificateType.StakeRegistrationDelegation:
+      case Cardano.CertificateType.VoteRegistrationDelegation:
+      case Cardano.CertificateType.StakeVoteRegistrationDelegation:
+        if (rewardAccounts.includes(Cardano.RewardAccount.fromCredential(cert.stakeCredential, networkId)))
+          deposit += cert.deposit;
+        break;
+      case Cardano.CertificateType.Unregistration:
+        if (rewardAccounts.includes(Cardano.RewardAccount.fromCredential(cert.stakeCredential, networkId)))
+          reclaimDeposit += cert.deposit;
+        break;
+    }
+  }
+
+  return {
+    deposit,
+    reclaimDeposit
+  };
+};
+
+/** Inspects a transaction for its deposits and returned deposits. */
+const getTxOwnDeposits = (
   { stakeKeyDeposit, poolDeposit }: Pick<Cardano.ProtocolParameters, 'stakeKeyDeposit' | 'poolDeposit'>,
-  { certificates, withdrawals }: Pick<HydratedTxBody, 'certificates' | 'withdrawals'>
-): ImplicitCoin => {
+  certificates: Cardano.Certificate[],
+  rewardAccounts: Cardano.RewardAccount[]
+): { deposit: Cardano.Lovelace; reclaimDeposit: Cardano.Lovelace } => {
+  if (rewardAccounts.length === 0 || certificates.length === 0) return { deposit: 0n, reclaimDeposit: 0n };
+
+  const poolIds = new Set(
+    rewardAccounts
+      .map((account) => Cardano.RewardAccount.toHash(account))
+      .map((hash) => Cardano.PoolId.fromKeyHash(hash))
+  );
+
+  const networkId = Cardano.RewardAccount.toNetworkId(rewardAccounts[0]);
+
+  const depositParams = {
+    poolDeposit: poolDeposit ? BigInt(poolDeposit) : 0n,
+    stakeKeyDeposit: BigInt(stakeKeyDeposit)
+  };
+
+  const shelleyDeposits = computeShellyDeposits(depositParams, certificates, rewardAccounts, poolIds, networkId);
+  const conwayDeposits = computeConwayDeposits(certificates, rewardAccounts, networkId);
+
+  return {
+    deposit: shelleyDeposits.deposit + conwayDeposits.deposit,
+    reclaimDeposit: shelleyDeposits.reclaimDeposit + conwayDeposits.reclaimDeposit
+  };
+};
+
+const getTxDeposits = (
+  { stakeKeyDeposit, poolDeposit }: Pick<Cardano.ProtocolParameters, 'stakeKeyDeposit' | 'poolDeposit'>,
+  certificates: Cardano.Certificate[]
+): { deposit: Lovelace; reclaimDeposit: Lovelace } => {
   const stakeKeyDepositBigint = stakeKeyDeposit && BigInt(stakeKeyDeposit);
   const poolDepositBigint = poolDeposit && BigInt(poolDeposit);
   const deposit = BigIntMath.sum(
-    certificates?.map(
+    certificates.map(
       (cert) =>
         (cert.__typename === CertificateType.StakeRegistration && stakeKeyDepositBigint) ||
         (cert.__typename === CertificateType.PoolRegistration && poolDepositBigint) ||
+        (cert.__typename === CertificateType.Unregistration && cert.deposit) ||
         0n
     ) || []
   );
-  const withdrawalsTotal = (withdrawals && BigIntMath.sum(withdrawals.map(({ quantity }) => quantity))) || 0n;
   const reclaimTotal = BigIntMath.sum(
-    certificates?.map(
+    certificates.map(
+      // eslint-disable-next-line complexity
       (cert) =>
         (cert.__typename === CertificateType.StakeDeregistration && stakeKeyDepositBigint) ||
         (cert.__typename === CertificateType.PoolRetirement && poolDepositBigint) ||
+        (cert.__typename === CertificateType.Registration && cert.deposit) ||
+        (cert.__typename === CertificateType.StakeRegistrationDelegation && cert.deposit) ||
+        (cert.__typename === CertificateType.VoteRegistrationDelegation && cert.deposit) ||
+        (cert.__typename === CertificateType.StakeVoteRegistrationDelegation && cert.deposit) ||
         0n
     ) || []
   );
+
+  return { deposit, reclaimDeposit: reclaimTotal };
+};
+
+/**
+ * Computes the implicit coin from the given transaction.
+ * If rewardAccounts is provided, it will only count the deposits from
+ * Certificates that belong to any of the reward accounts provided.
+ */
+export const computeImplicitCoin = (
+  { stakeKeyDeposit, poolDeposit }: Pick<Cardano.ProtocolParameters, 'stakeKeyDeposit' | 'poolDeposit'>,
+  { certificates, withdrawals }: Pick<HydratedTxBody, 'certificates' | 'withdrawals'>,
+  rewardAccounts?: Cardano.RewardAccount[]
+): ImplicitCoin => {
+  const { deposit, reclaimDeposit } = rewardAccounts
+    ? getTxOwnDeposits({ poolDeposit, stakeKeyDeposit }, certificates ?? [], rewardAccounts)
+    : getTxDeposits({ poolDeposit, stakeKeyDeposit }, certificates ?? []);
+
+  const withdrawalsTotal = (withdrawals && BigIntMath.sum(withdrawals.map(({ quantity }) => quantity))) || 0n;
+
   return {
     deposit,
-    input: withdrawalsTotal + reclaimTotal,
+    input: withdrawalsTotal + reclaimDeposit,
+    reclaimDeposit,
     withdrawals: withdrawalsTotal
   };
 };

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -1,6 +1,8 @@
 export * as util from './misc';
 export * from './slotCalc';
 export * from './txInspector';
+export * from './tokenTransferInspector';
+export * from './transactionSummaryInspector';
 export * from './utxo';
 export * from './calcStabilityWindow';
 export * from './coalesceValueQuantities';

--- a/packages/core/src/util/tokenTransferInspector.ts
+++ b/packages/core/src/util/tokenTransferInspector.ts
@@ -1,0 +1,122 @@
+import * as Cardano from '../Cardano';
+import { Inspector, resolveInputs } from './txInspector';
+import { coalesceValueQuantities } from './coalesceValueQuantities';
+import { subtractValueQuantities } from './subtractValueQuantities';
+import uniq from 'lodash/uniq';
+
+export type TokenTransferInspection = {
+  fromAddress: Map<Cardano.PaymentAddress, Cardano.Value>;
+  toAddress: Map<Cardano.PaymentAddress, Cardano.Value>;
+};
+
+export interface TokenTransferInspectorArgs {
+  inputResolver: Cardano.InputResolver;
+}
+
+export type TokenTransferInspector = (args: TokenTransferInspectorArgs) => Inspector<TokenTransferInspection>;
+
+const coalesceByAddress = <T extends { address: Cardano.PaymentAddress; value: Cardano.Value }>(
+  elements: T[]
+): Map<Cardano.PaymentAddress, Cardano.Value> => {
+  const grouped = elements.reduce((acc, elem) => {
+    if (!acc.has(elem.address)) acc.set(elem.address, []);
+    acc.get(elem.address)?.push(elem);
+    return acc;
+  }, new Map<Cardano.PaymentAddress, T[]>());
+
+  const coalescedByAddress = new Map<Cardano.PaymentAddress, Cardano.Value>();
+
+  for (const [address, elem] of grouped) {
+    coalescedByAddress.set(address, coalesceValueQuantities(elem.map((x) => x.value)));
+  }
+
+  return coalescedByAddress;
+};
+
+const initializeAddressMap = (addresses: Cardano.PaymentAddress[]): Map<Cardano.PaymentAddress, Cardano.Value> =>
+  new Map<Cardano.PaymentAddress, Cardano.Value>(
+    addresses.map((address) => [address, { assets: new Map(), coins: 0n }])
+  );
+
+const updateFromAddressMap = (
+  addressMap: Map<Cardano.PaymentAddress, Cardano.Value>,
+  key: Cardano.PaymentAddress,
+  value: Cardano.Value
+) => {
+  if (value.coins < 0n) {
+    addressMap.get(key)!.coins = value.coins;
+  }
+
+  for (const [assetId, quantity] of value.assets?.entries() ?? [])
+    if (quantity < 0n) {
+      addressMap.get(key)!.assets?.set(assetId, quantity);
+    }
+};
+
+const updateToAddressMap = (
+  addressMap: Map<Cardano.PaymentAddress, Cardano.Value>,
+  key: Cardano.PaymentAddress,
+  value: Cardano.Value
+) => {
+  if (value.coins > 0n) {
+    addressMap.get(key)!.coins = value.coins;
+  }
+
+  for (const [assetId, quantity] of value.assets?.entries() ?? []) {
+    if (quantity > 0n) {
+      addressMap.get(key)!.assets?.set(assetId, quantity);
+    }
+  }
+};
+
+const computeNetDifferences = (
+  inputs: Map<Cardano.PaymentAddress, Cardano.Value>,
+  outputs: Map<Cardano.PaymentAddress, Cardano.Value>,
+  fromAddress: Map<Cardano.PaymentAddress, Cardano.Value>,
+  toAddress: Map<Cardano.PaymentAddress, Cardano.Value>
+) => {
+  for (const [key, inputValue] of inputs.entries()) {
+    const outputValue = outputs.get(key) ?? { assets: new Map(), coins: 0n };
+    const difference = subtractValueQuantities([outputValue, inputValue]);
+
+    updateFromAddressMap(fromAddress, key, difference);
+    updateToAddressMap(toAddress, key, difference);
+  }
+
+  // Process keys that are only in the output map
+  for (const [key, outputValue] of outputs.entries()) {
+    if (!inputs.has(key)) {
+      updateToAddressMap(toAddress, key, outputValue);
+    }
+  }
+};
+
+const removeZeroBalanceEntries = (addressMap: Map<Cardano.PaymentAddress, Cardano.Value>) => {
+  for (const [key, value] of addressMap.entries()) {
+    if (value.coins === 0n && value.assets?.size === 0) {
+      addressMap.delete(key);
+    }
+  }
+};
+
+/** Inspect a transaction and return a map of addresses and their balances. */
+export const tokenTransferInspector: TokenTransferInspector =
+  ({ inputResolver }) =>
+  async (tx) => {
+    const { resolvedInputs } = await resolveInputs(tx.body.inputs, inputResolver);
+
+    const coalescedInputsByAddress = coalesceByAddress(resolvedInputs);
+    const coalescedOutputsByAddress = coalesceByAddress(tx.body.outputs);
+
+    const addresses = uniq([...coalescedInputsByAddress.keys(), ...coalescedOutputsByAddress.keys()]);
+
+    const fromAddress = initializeAddressMap(addresses);
+    const toAddress = initializeAddressMap(addresses);
+
+    computeNetDifferences(coalescedInputsByAddress, coalescedOutputsByAddress, fromAddress, toAddress);
+
+    removeZeroBalanceEntries(fromAddress);
+    removeZeroBalanceEntries(toAddress);
+
+    return { fromAddress, toAddress };
+  };

--- a/packages/core/src/util/transactionSummaryInspector.ts
+++ b/packages/core/src/util/transactionSummaryInspector.ts
@@ -1,0 +1,153 @@
+import * as Cardano from '../Cardano';
+import { AssetId } from '../Cardano';
+import {
+  AssetsMintedInspection,
+  Inspector,
+  ResolutionResult,
+  assetsBurnedInspector,
+  assetsMintedInspector,
+  resolveInputs,
+  totalAddressInputsValueInspector,
+  totalAddressOutputsValueInspector
+} from './txInspector';
+import { BigIntMath } from '@cardano-sdk/util';
+import { coalesceTokenMaps, subtractTokenMaps } from '../Asset/util';
+import { coalesceValueQuantities } from './coalesceValueQuantities';
+import { computeImplicitCoin } from '../Cardano/util';
+import { subtractValueQuantities } from './subtractValueQuantities';
+
+interface TransactionSummaryInspectorArgs {
+  addresses: Cardano.PaymentAddress[];
+  rewardAccounts: Cardano.RewardAccount[];
+  inputResolver: Cardano.InputResolver;
+  protocolParameters: Cardano.ProtocolParameters;
+}
+
+export type TransactionSummaryInspection = {
+  assets: Cardano.TokenMap;
+  coins: Cardano.Lovelace;
+  collateral: Cardano.Lovelace;
+  deposit: Cardano.Lovelace;
+  returnedDeposit: Cardano.Lovelace;
+  fee: Cardano.Lovelace;
+  unresolved: {
+    inputs: Cardano.TxIn[];
+    value: Cardano.Value;
+  };
+};
+
+export type TransactionSummaryInspector = (
+  args: TransactionSummaryInspectorArgs
+) => Inspector<TransactionSummaryInspection>;
+
+/**
+ * Gets the collateral specified for this transaction.
+ *
+ * @param tx transaction to inspect.
+ * @param inputResolver input resolver.
+ * @param addresses addresses to inspect.
+ */
+export const getCollateral = async (
+  tx: Cardano.Tx,
+  inputResolver: Cardano.InputResolver,
+  addresses: Cardano.PaymentAddress[]
+): Promise<Cardano.Lovelace> => {
+  if (!tx.body.collaterals || tx.body.collaterals.length === 0) return 0n;
+
+  const resolvedCollateralInputs = (await resolveInputs(tx.body.collaterals, inputResolver)).resolvedInputs.filter(
+    (input) => addresses.includes(input.address)
+  );
+
+  const totalOwnedValueAtRisk = BigIntMath.sum(resolvedCollateralInputs.map(({ value }) => value.coins));
+
+  // If collateral return is specified, it means that not all the balance in the collateral inputs would be spent given a validation failure
+  if (tx.body.collateralReturn) {
+    // In the case of CIP-40 we need to sum all the collateral inputs we own, and check if the collateral return is coming to one of our addresses
+    // If it is, we can simply subtract the sum of all our collateral inputs with the amount returned in the collateral returned, if the collateral return
+    // is going somewhere else, it means we will lose whatever is on those outputs given a failure.
+    if (!addresses.includes(tx.body.collateralReturn.address)) return totalOwnedValueAtRisk;
+
+    // Should never be negative in a correctly balanced transaction, but let's do a sanity check anyway.
+    return BigIntMath.max([totalOwnedValueAtRisk - tx.body.collateralReturn.value.coins, 0n]) ?? 0n;
+  }
+
+  // Legacy collaterals, we simply return the addition of the collateral inputs we own.
+  return totalOwnedValueAtRisk;
+};
+
+const totalInputsValue = (resolvedInputs: ResolutionResult) => {
+  const receivedInputsValues = resolvedInputs.resolvedInputs.map((input) => input.value);
+  return coalesceValueQuantities(receivedInputsValues);
+};
+
+const totalOutputsValue = (outputs: Cardano.TxOut[]) => coalesceValueQuantities(outputs.map((output) => output.value));
+
+const mintInspectionToTokenMap = (mintedAssets: AssetsMintedInspection) =>
+  new Map<Cardano.AssetId, bigint>(
+    mintedAssets.map((asset) => [AssetId.fromParts(asset.policyId, asset.assetName), asset.quantity])
+  );
+
+const getImplicitAssets = async (tx: Cardano.Tx) => {
+  const mintedAssets = mintInspectionToTokenMap(await assetsMintedInspector(tx));
+  const burnedAssets = mintInspectionToTokenMap(await assetsBurnedInspector(tx));
+
+  return coalesceTokenMaps([mintedAssets, burnedAssets]);
+};
+
+const getUnaccountedFunds = async (
+  tx: Cardano.Tx,
+  resolvedInputs: ResolutionResult,
+  implicitCoin: Cardano.Lovelace,
+  implicitAssets: Cardano.TokenMap = new Map()
+): Promise<Cardano.Value> => {
+  const totalInputs = totalInputsValue(resolvedInputs);
+  const totalOutputs = totalOutputsValue(tx.body.outputs);
+
+  totalInputs.assets = coalesceTokenMaps([totalInputs.assets, implicitAssets]);
+  totalInputs.coins += implicitCoin;
+
+  return subtractValueQuantities([totalOutputs, totalInputs]);
+};
+
+/**
+ * Inspects a transaction and produces a summary.
+ *
+ * @param {TransactionSummaryInspectorArgs} args The arguments for the inspector.
+ */
+export const transactionSummaryInspector: TransactionSummaryInspector =
+  (args: TransactionSummaryInspectorArgs) => async (tx) => {
+    const { inputResolver, addresses, rewardAccounts, protocolParameters } = args;
+    const resolvedInputs = await resolveInputs(tx.body.inputs, inputResolver);
+    const fee = tx.body.fee;
+
+    const implicit = computeImplicitCoin(
+      protocolParameters,
+      { certificates: tx.body.certificates, withdrawals: tx.body.withdrawals },
+      rewardAccounts || []
+    );
+
+    const collateral = await getCollateral(tx, inputResolver, addresses);
+
+    const totalOutputValue = await totalAddressOutputsValueInspector(addresses)(tx);
+    const totalInputValue = await totalAddressInputsValueInspector(addresses, inputResolver)(tx);
+    const implicitCoin = (implicit.withdrawals || 0n) + (implicit.reclaimDeposit || 0n) - (implicit.deposit || 0n);
+    const implicitAssets = await getImplicitAssets(tx);
+
+    const diff = {
+      assets: subtractTokenMaps([totalOutputValue.assets, totalInputValue.assets]),
+      coins: totalOutputValue.coins - totalInputValue.coins
+    };
+
+    return {
+      assets: diff.assets ?? new Map(),
+      coins: diff.coins,
+      collateral,
+      deposit: implicit.deposit || 0n,
+      fee,
+      returnedDeposit: implicit.reclaimDeposit || 0n,
+      unresolved: {
+        inputs: resolvedInputs.unresolvedInputs,
+        value: await getUnaccountedFunds(tx, resolvedInputs, implicitCoin, implicitAssets)
+      }
+    };
+  };

--- a/packages/core/test/Asset/util/coalesceTokenMaps.test.ts
+++ b/packages/core/test/Asset/util/coalesceTokenMaps.test.ts
@@ -1,0 +1,68 @@
+import * as AssetIds from '../../AssetId';
+import { Asset } from '../../../src';
+
+describe('Asset', () => {
+  describe('util', () => {
+    describe('coalesceTokenMaps', () => {
+      it('should add quantities correctly when all assets have the same tokens', () => {
+        const initialAsset = new Map([
+          [AssetIds.PXL, 100n],
+          [AssetIds.Unit, 50n]
+        ]);
+        const asset2 = new Map([
+          [AssetIds.PXL, 23n],
+          [AssetIds.Unit, 20n]
+        ]);
+        expect(Asset.util.coalesceTokenMaps([initialAsset, asset2])).toEqual(
+          new Map([
+            [AssetIds.PXL, 123n],
+            [AssetIds.Unit, 70n]
+          ])
+        );
+      });
+      it('should be able to return negative quantities', () => {
+        const initialAsset = new Map([
+          [AssetIds.PXL, 100n],
+          [AssetIds.Unit, -150n]
+        ]);
+        const asset2 = new Map([
+          [AssetIds.PXL, 173n],
+          [AssetIds.Unit, 50n]
+        ]);
+        const asset3 = new Map([[AssetIds.TSLA, 44n]]);
+        expect(Asset.util.coalesceTokenMaps([initialAsset, asset2, asset3])).toEqual(
+          new Map([
+            [AssetIds.PXL, 273n],
+            [AssetIds.TSLA, 44n],
+            [AssetIds.Unit, -100n]
+          ])
+        );
+      });
+
+      it('should add even if the asset is missing in one of the maps', () => {
+        const asset1 = new Map([
+          [AssetIds.PXL, 1000n],
+          [AssetIds.Unit, 12n]
+        ]);
+
+        const asset2 = new Map([
+          [AssetIds.TSLA, 2n],
+          [AssetIds.PXL, 9n],
+          [AssetIds.Unit, 1000n]
+        ]);
+
+        const result = Asset.util.coalesceTokenMaps([asset1, asset2]);
+
+        expect(result!.get(AssetIds.PXL)).toBe(1009n);
+        expect(result!.get(AssetIds.Unit)).toBe(1012n);
+        expect(result!.get(AssetIds.TSLA)).toBe(2n);
+
+        const result2 = Asset.util.coalesceTokenMaps([asset2, asset1]);
+
+        expect(result2!.get(AssetIds.PXL)).toBe(1009n);
+        expect(result2!.get(AssetIds.Unit)).toBe(1012n);
+        expect(result2!.get(AssetIds.TSLA)).toBe(2n);
+      });
+    });
+  });
+});

--- a/packages/core/test/Asset/util/subtractTokenMaps.test.ts
+++ b/packages/core/test/Asset/util/subtractTokenMaps.test.ts
@@ -1,4 +1,4 @@
-import * as AssetId from '../../AssetId';
+import * as AssetIds from '../../AssetId';
 import { Asset } from '../../../src';
 
 describe('Asset', () => {
@@ -6,56 +6,81 @@ describe('Asset', () => {
     describe('subtractTokenMaps', () => {
       it('should subtract quantities correctly when all assets have the same tokens', () => {
         const initialAsset = new Map([
-          [AssetId.PXL, 100n],
-          [AssetId.Unit, 50n]
+          [AssetIds.PXL, 100n],
+          [AssetIds.Unit, 50n]
         ]);
         const asset2 = new Map([
-          [AssetId.PXL, 23n],
-          [AssetId.Unit, 20n]
+          [AssetIds.PXL, 23n],
+          [AssetIds.Unit, 20n]
         ]);
         expect(Asset.util.subtractTokenMaps([initialAsset, asset2])).toEqual(
           new Map([
-            [AssetId.PXL, 77n],
-            [AssetId.Unit, 30n]
+            [AssetIds.PXL, 77n],
+            [AssetIds.Unit, 30n]
           ])
         );
       });
       it('should delete tokens from result when quantity is 0', () => {
         const initialAsset = new Map([
-          [AssetId.PXL, 100n],
-          [AssetId.Unit, 50n]
+          [AssetIds.PXL, 100n],
+          [AssetIds.Unit, 50n]
         ]);
         const asset2 = new Map([
-          [AssetId.PXL, 23n],
-          [AssetId.Unit, 50n]
+          [AssetIds.PXL, 23n],
+          [AssetIds.Unit, 50n]
         ]);
-        expect(Asset.util.subtractTokenMaps([initialAsset, asset2])).toEqual(new Map([[AssetId.PXL, 77n]]));
+        expect(Asset.util.subtractTokenMaps([initialAsset, asset2])).toEqual(new Map([[AssetIds.PXL, 77n]]));
       });
       it('should be able to return negative quantities', () => {
         const initialAsset = new Map([
-          [AssetId.PXL, 100n],
-          [AssetId.Unit, 50n]
+          [AssetIds.PXL, 100n],
+          [AssetIds.Unit, 50n]
         ]);
         const asset2 = new Map([
-          [AssetId.PXL, 173n],
-          [AssetId.Unit, 50n]
+          [AssetIds.PXL, 173n],
+          [AssetIds.Unit, 50n]
         ]);
-        const asset3 = new Map([[AssetId.TSLA, 44n]]);
+        const asset3 = new Map([[AssetIds.TSLA, 44n]]);
         expect(Asset.util.subtractTokenMaps([initialAsset, asset2, asset3])).toEqual(
           new Map([
-            [AssetId.PXL, -73n],
-            [AssetId.TSLA, -44n]
+            [AssetIds.PXL, -73n],
+            [AssetIds.TSLA, -44n]
           ])
         );
       });
       it('should not change the first element of the array', () => {
-        const asset1 = new Map([[AssetId.PXL, 10n]]);
+        const asset1 = new Map([[AssetIds.PXL, 10n]]);
 
-        const asset2 = new Map([[AssetId.PXL, 5n]]);
+        const asset2 = new Map([[AssetIds.PXL, 5n]]);
 
         Asset.util.subtractTokenMaps([asset1, asset2]);
 
-        expect(asset1.get(AssetId.PXL)).toBe(10n);
+        expect(asset1.get(AssetIds.PXL)).toBe(10n);
+      });
+
+      it('should subtract even if the asset is missing in one of the maps', () => {
+        const asset1 = new Map([
+          [AssetIds.PXL, 1000n],
+          [AssetIds.Unit, 12n]
+        ]);
+
+        const asset2 = new Map([
+          [AssetIds.TSLA, 2n],
+          [AssetIds.PXL, 9n],
+          [AssetIds.Unit, 1120n]
+        ]);
+
+        const result = Asset.util.subtractTokenMaps([asset1, asset2]);
+
+        expect(result!.get(AssetIds.PXL)).toBe(991n);
+        expect(result!.get(AssetIds.Unit)).toBe(-1108n);
+        expect(result!.get(AssetIds.TSLA)).toBe(-2n);
+
+        const result2 = Asset.util.subtractTokenMaps([asset2, asset1]);
+
+        expect(result2!.get(AssetIds.PXL)).toBe(-991n);
+        expect(result2!.get(AssetIds.Unit)).toBe(1108n);
+        expect(result2!.get(AssetIds.TSLA)).toBe(2n);
       });
     });
   });

--- a/packages/core/test/Cardano/Address/RewardAccount.test.ts
+++ b/packages/core/test/Cardano/Address/RewardAccount.test.ts
@@ -1,4 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
+import * as cip19TestVectors from '../../../../util-dev/src/Cip19TestVectors';
 import { Cardano } from '../../../src';
 import { typedBech32 } from '@cardano-sdk/util';
 
@@ -38,6 +39,24 @@ describe('Cardano/Address/RewardAccount', () => {
     it('creates a testnet address', () => {
       const rewardAccount = Cardano.createRewardAccount(keyHash, Cardano.NetworkId.Testnet);
       expect(rewardAccount.startsWith('stake_test')).toBe(true);
+    });
+  });
+
+  describe('fromCredential', () => {
+    it('creates can create a reward account given a credential and a network id', () => {
+      const rewardAccount = Cardano.RewardAccount.fromCredential(
+        cip19TestVectors.KEY_STAKE_CREDENTIAL,
+        Cardano.NetworkId.Mainnet
+      );
+      expect(rewardAccount).toBe(cip19TestVectors.rewardKey);
+    });
+  });
+
+  describe('toNetworkId', () => {
+    it('get the correct network id from a reward account', () => {
+      expect(Cardano.RewardAccount.toNetworkId(Cardano.RewardAccount(cip19TestVectors.rewardKey))).toBe(
+        Cardano.NetworkId.Mainnet
+      );
     });
   });
 });

--- a/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
+++ b/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
@@ -29,5 +29,48 @@ describe('Cardano.util.computeImplicitCoin', () => {
     expect(coin.deposit).toBe(2n + 2n);
     expect(coin.input).toBe(2n + 3n + 5n);
     expect(coin.withdrawals).toBe(5n);
+    expect(coin.reclaimDeposit).toBe(5n);
+  });
+
+  it('sums registrations for deposit, withdrawals and deregistrations for input for own reward accounts when given reward accounts array', async () => {
+    const protocolParameters = { poolDeposit: 3, stakeKeyDeposit: 2 } as Cardano.ProtocolParameters;
+    const rewardAccount = Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27');
+    const foreignRewardAccount = Cardano.RewardAccount(
+      'stake_test17rphkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gtcljw6kf'
+    );
+
+    const stakeCredential = {
+      hash: Cardano.RewardAccount.toHash(rewardAccount) as unknown as Crypto.Hash28ByteBase16,
+      type: Cardano.CredentialType.KeyHash
+    };
+    const foreignStakeCredential = {
+      hash: Cardano.RewardAccount.toHash(foreignRewardAccount) as unknown as Crypto.Hash28ByteBase16,
+      type: Cardano.CredentialType.KeyHash
+    };
+
+    const certificates: Cardano.Certificate[] = [
+      { __typename: Cardano.CertificateType.StakeRegistration, stakeCredential },
+      { __typename: Cardano.CertificateType.Registration, deposit: 10n, stakeCredential },
+      { __typename: Cardano.CertificateType.Unregistration, deposit: 20n, stakeCredential },
+      { __typename: Cardano.CertificateType.Unregistration, deposit: 100n, stakeCredential: foreignStakeCredential },
+      { __typename: Cardano.CertificateType.StakeDeregistration, stakeCredential: foreignStakeCredential },
+      { __typename: Cardano.CertificateType.StakeRegistration, stakeCredential: foreignStakeCredential },
+      {
+        __typename: Cardano.CertificateType.PoolRetirement,
+        epoch: Cardano.EpochNo(500),
+        poolId: Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh')
+      },
+      {
+        __typename: Cardano.CertificateType.StakeDelegation,
+        poolId: Cardano.PoolId('pool1zuevzm3xlrhmwjw87ec38mzs02tlkwec9wxpgafcaykmwg7efhh'),
+        stakeCredential
+      }
+    ];
+    const withdrawals: Cardano.Withdrawal[] = [{ quantity: 10n, stakeAddress: rewardAccount }];
+    const coin = Cardano.util.computeImplicitCoin(protocolParameters, { certificates, withdrawals }, [rewardAccount]);
+    expect(coin.deposit).toBe(2n + 10n);
+    expect(coin.reclaimDeposit).toBe(20n);
+    expect(coin.input).toBe(10n + 20n);
+    expect(coin.withdrawals).toBe(10n);
   });
 });

--- a/packages/core/test/Cardano/util/subtractValueQuantities.test.ts
+++ b/packages/core/test/Cardano/util/subtractValueQuantities.test.ts
@@ -36,7 +36,7 @@ describe('Cardano.util.subtractValueQuantities', () => {
       ]),
       coins: 200n
     };
-    expect(subtractValueQuantities([q1, q1])).toEqual({ assets: undefined, coins: 0n });
+    expect(subtractValueQuantities([q1, q1])).toEqual({ assets: new Map(), coins: 0n });
   });
   it('returns negative quantities', () => {
     const q1: Cardano.Value = {

--- a/packages/core/test/util/tokenTransferInspector.test.ts
+++ b/packages/core/test/util/tokenTransferInspector.test.ts
@@ -1,0 +1,781 @@
+import * as AssetIds from '../AssetId';
+import * as Cardano from '../../src/Cardano';
+import { Ed25519KeyHashHex, Ed25519PublicKeyHex, Ed25519SignatureHex } from '@cardano-sdk/crypto';
+import { createTxInspector, tokenTransferInspector } from '../../src';
+import { jsonToMetadatum } from '../../src/util/metadatum';
+
+const buildValue = (coins: bigint, assets: Array<[Cardano.AssetId, bigint]>): Cardano.Value => ({
+  assets: new Map(assets),
+  coins
+});
+
+const createMockInputResolver = (historicalTxs: Cardano.HydratedTx[]): Cardano.InputResolver => ({
+  async resolveInput(input: Cardano.TxIn) {
+    const tx = historicalTxs.find((historicalTx) => historicalTx.id === input.txId);
+
+    if (!tx || tx.body.outputs.length <= input.index) return Promise.resolve(null);
+
+    return Promise.resolve(tx.body.outputs[input.index]);
+  }
+});
+
+// eslint-disable-next-line max-statements
+describe('txInspector', () => {
+  const sendingAddress = Cardano.PaymentAddress(
+    'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+  );
+  const receivingAddress = Cardano.PaymentAddress(
+    'addr_test1qpfhhfy2qgls50r9u4yh0l7z67xpg0a5rrhkmvzcuqrd0znuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q9gw0lz'
+  );
+  const addresses = [
+    Cardano.PaymentAddress(
+      'addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x'
+    ),
+    Cardano.PaymentAddress(
+      'addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh'
+    ),
+    Cardano.PaymentAddress(
+      'addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve'
+    ),
+    Cardano.PaymentAddress(
+      'addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g'
+    )
+  ];
+
+  const txMetadatum = new Map([
+    [
+      721n,
+      jsonToMetadatum({
+        b8fdbcbe003cef7e47eb5307d328e10191952bd02901a850699e7e35: {
+          'NFT-001': {
+            image: ['ipfs://some_hash1'],
+            name: 'One',
+            version: '1.0'
+          }
+        }
+      })
+    ]
+  ]);
+
+  const mockScript1 = {
+    __type: Cardano.ScriptType.Native,
+    kind: Cardano.NativeScriptKind.RequireAllOf,
+    scripts: [
+      {
+        __type: Cardano.ScriptType.Native,
+        keyHash: Ed25519KeyHashHex('24accb6ca2690388f067175d773871f5640de57bf11aec0be258d6c7'),
+        kind: Cardano.NativeScriptKind.RequireSignature
+      }
+    ]
+  };
+
+  const mockScript2 = {
+    __type: Cardano.ScriptType.Native,
+    kind: Cardano.NativeScriptKind.RequireAllOf,
+    scripts: [
+      {
+        __type: Cardano.ScriptType.Native,
+        keyHash: Ed25519KeyHashHex('00accb6ca2690388f067175d773871f5640de57bf11aec0be258d6c7'),
+        kind: Cardano.NativeScriptKind.RequireSignature
+      }
+    ]
+  };
+
+  const auxiliaryData = {
+    blob: txMetadatum,
+    scripts: [mockScript2]
+  };
+
+  const buildMockTx = (
+    args: {
+      inputs?: Cardano.HydratedTxIn[];
+      outputs?: Cardano.TxOut[];
+      certificates?: Cardano.Certificate[];
+      withdrawals?: Cardano.Withdrawal[];
+      mint?: Cardano.TokenMap;
+      witness?: Cardano.Witness;
+      includeAuxData?: boolean;
+    } = {}
+  ): Cardano.HydratedTx =>
+    ({
+      auxiliaryData: args.includeAuxData ? auxiliaryData : undefined,
+      blockHeader: {
+        blockNo: Cardano.BlockNo(200),
+        hash: Cardano.BlockId('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5ea4172b2ed'),
+        slot: Cardano.Slot(1000)
+      },
+      body: {
+        certificates: args.certificates,
+        fee: 170_000n,
+        inputs: args.inputs ?? [
+          {
+            address: sendingAddress,
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+        mint:
+          args.mint ??
+          new Map([
+            [Cardano.AssetId('b8fdbcbe003cef7e47eb5307d328e10191952bd02901a850699e7e3500000000000000'), 1n],
+            [Cardano.AssetId('5ba141e401cfebf1929d539e48d14f4b20679c5409526814e0f17121ffffffffffffff'), 100_000n],
+            [Cardano.AssetId('00000000000000000000000000000000000000000000000000000000aaaaaaaaaaaaaa'), -1n]
+          ]),
+
+        outputs: args.outputs ?? [
+          {
+            address: receivingAddress,
+            value: { coins: 5_000_000n }
+          },
+          {
+            address: receivingAddress,
+            value: {
+              assets: new Map([
+                [AssetIds.PXL, 3n],
+                [AssetIds.TSLA, 4n]
+              ]),
+              coins: 2_000_000n
+            }
+          },
+          {
+            address: receivingAddress,
+            value: {
+              assets: new Map([[AssetIds.PXL, 6n]]),
+              coins: 2_000_000n
+            }
+          },
+          {
+            address: sendingAddress,
+            value: {
+              assets: new Map([[AssetIds.PXL, 1n]]),
+              coins: 2_000_000n
+            }
+          }
+        ],
+        validityInterval: {},
+        withdrawals: args.withdrawals
+      },
+      id: Cardano.TransactionId('e3a443363eb6ee3d67c5e75ec10b931603787581a948d68fa3b2cd3ff2e0d2ad'),
+      index: 0,
+      witness: args.witness ?? {
+        scripts: [mockScript1],
+        signatures: new Map<Ed25519PublicKeyHex, Ed25519SignatureHex>()
+      }
+    } as Cardano.HydratedTx);
+
+  describe('Token Transfer Inspector', () => {
+    it('does not include addresses which net difference is 0 (assets and coins)', async () => {
+      // Arrange
+      const tx = buildMockTx({
+        inputs: [
+          {
+            address: addresses[0],
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[1],
+            index: 1,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[2],
+            index: 2,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+        outputs: [
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([[AssetIds.TSLA, 1n]]),
+              coins: 4_500_000n
+            }
+          },
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([[AssetIds.TSLA, 15n]]),
+              coins: 5_000_000n
+            }
+          },
+          {
+            address: addresses[1],
+            value: {
+              assets: new Map([[AssetIds.TSLA, 25n]]),
+              coins: 2_000_000n
+            }
+          }
+        ]
+      });
+
+      const histTx: Cardano.HydratedTx[] = [
+        {
+          body: {
+            outputs: [
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([[AssetIds.TSLA, 16n]]),
+                  coins: 9_500_000n
+                }
+              },
+              {
+                address: addresses[1],
+                value: {
+                  assets: new Map([[AssetIds.PXL, 15n]]),
+                  coins: 5_000_000n
+                }
+              },
+              {
+                address: addresses[2],
+                value: {
+                  assets: new Map([[AssetIds.TSLA, 25n]]),
+                  coins: 2_000_000n
+                }
+              }
+            ]
+          },
+          id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        } as unknown as Cardano.HydratedTx
+      ];
+
+      const inspectTx = createTxInspector({
+        tokenTransfer: tokenTransferInspector({ inputResolver: createMockInputResolver(histTx) })
+      });
+
+      // Act
+      const { tokenTransfer } = await inspectTx(tx);
+
+      // Assert
+      expect(tokenTransfer.fromAddress).toEqual(
+        new Map([
+          [addresses[1], buildValue(-3_000_000n, [[AssetIds.PXL, -15n]])],
+          [addresses[2], buildValue(-2_000_000n, [[AssetIds.TSLA, -25n]])]
+        ])
+      );
+      expect(tokenTransfer.toAddress).toEqual(new Map([[addresses[1], buildValue(0n, [[AssetIds.TSLA, 25n]])]]));
+    });
+
+    it('adds assets with a positive net difference to the address in the toAddress list', async () => {
+      // Arrange
+
+      // This TX is not balanced, but it's not the point of this test
+      const tx = buildMockTx({
+        inputs: [
+          {
+            address: addresses[0],
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+        outputs: [
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([[AssetIds.TSLA, 20n]]),
+              coins: 10_500_000n
+            }
+          }
+        ]
+      });
+
+      const histTx: Cardano.HydratedTx[] = [
+        {
+          body: {
+            outputs: [
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([[AssetIds.TSLA, 16n]]),
+                  coins: 9_500_000n
+                }
+              }
+            ]
+          },
+          id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        } as unknown as Cardano.HydratedTx
+      ];
+
+      const inspectTx = createTxInspector({
+        tokenTransfer: tokenTransferInspector({ inputResolver: createMockInputResolver(histTx) })
+      });
+
+      // Act
+      const { tokenTransfer } = await inspectTx(tx);
+
+      // Assert
+      expect(tokenTransfer.fromAddress).toEqual(new Map([]));
+      expect(tokenTransfer.toAddress).toEqual(new Map([[addresses[0], buildValue(1_000_000n, [[AssetIds.TSLA, 4n]])]]));
+    });
+
+    it('adds assets with a negative net difference to the address in the fromAddress list', async () => {
+      // Arrange
+
+      // This TX is not balanced, but it's not the point of this test
+      const tx = buildMockTx({
+        inputs: [
+          {
+            address: addresses[0],
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+        outputs: [
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([[AssetIds.TSLA, 12n]]),
+              coins: 8_500_000n
+            }
+          }
+        ]
+      });
+
+      const histTx: Cardano.HydratedTx[] = [
+        {
+          body: {
+            outputs: [
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([[AssetIds.TSLA, 16n]]),
+                  coins: 9_500_000n
+                }
+              }
+            ]
+          },
+          id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        } as unknown as Cardano.HydratedTx
+      ];
+
+      const inspectTx = createTxInspector({
+        tokenTransfer: tokenTransferInspector({ inputResolver: createMockInputResolver(histTx) })
+      });
+
+      // Act
+      const { tokenTransfer } = await inspectTx(tx);
+
+      // Assert
+      expect(tokenTransfer.fromAddress).toEqual(
+        new Map([[addresses[0], buildValue(-1_000_000n, [[AssetIds.TSLA, -4n]])]])
+      );
+      expect(tokenTransfer.toAddress).toEqual(new Map([]));
+    });
+
+    it('coalesce all inputs from a each address', async () => {
+      // Arrange
+
+      // This TX is not balanced, but it's not the point of this test
+      const tx = buildMockTx({
+        inputs: [
+          {
+            address: addresses[0],
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[0],
+            index: 1,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[0],
+            index: 2,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+        outputs: []
+      });
+
+      const histTx: Cardano.HydratedTx[] = [
+        {
+          body: {
+            outputs: [
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([[AssetIds.TSLA, 15n]]),
+                  coins: 10_000_000n
+                }
+              },
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([
+                    [AssetIds.PXL, 25n],
+                    [AssetIds.TSLA, 15n]
+                  ]),
+                  coins: 10_500_000n
+                }
+              },
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([[AssetIds.Unit, 5n]]),
+                  coins: 10_500_000n
+                }
+              }
+            ]
+          },
+          id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        } as unknown as Cardano.HydratedTx
+      ];
+
+      const inspectTx = createTxInspector({
+        tokenTransfer: tokenTransferInspector({ inputResolver: createMockInputResolver(histTx) })
+      });
+
+      // Act
+      const { tokenTransfer } = await inspectTx(tx);
+
+      // Assert
+      expect(tokenTransfer.fromAddress).toEqual(
+        new Map([
+          [
+            addresses[0],
+            buildValue(-31_000_000n, [
+              [AssetIds.TSLA, -30n],
+              [AssetIds.PXL, -25n],
+              [AssetIds.Unit, -5n]
+            ])
+          ]
+        ])
+      );
+      expect(tokenTransfer.toAddress).toEqual(new Map([]));
+    });
+
+    it('coalesce all outputs from a each address', async () => {
+      // Arrange
+
+      // This TX is not balanced, but it's not the point of this test
+      const tx = buildMockTx({
+        inputs: [],
+        outputs: [
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([[AssetIds.TSLA, 15n]]),
+              coins: 10_000_000n
+            }
+          },
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([
+                [AssetIds.PXL, 25n],
+                [AssetIds.TSLA, 15n]
+              ]),
+              coins: 10_500_000n
+            }
+          },
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([[AssetIds.Unit, 5n]]),
+              coins: 10_500_000n
+            }
+          }
+        ]
+      });
+
+      const histTx: Cardano.HydratedTx[] = [
+        {
+          body: { outputs: [] },
+          id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        } as unknown as Cardano.HydratedTx
+      ];
+
+      const inspectTx = createTxInspector({
+        tokenTransfer: tokenTransferInspector({ inputResolver: createMockInputResolver(histTx) })
+      });
+
+      // Act
+      const { tokenTransfer } = await inspectTx(tx);
+
+      // Assert
+      expect(tokenTransfer.toAddress).toEqual(
+        new Map([
+          [
+            addresses[0],
+            buildValue(31_000_000n, [
+              [AssetIds.TSLA, 30n],
+              [AssetIds.PXL, 25n],
+              [AssetIds.Unit, 5n]
+            ])
+          ]
+        ])
+      );
+      expect(tokenTransfer.fromAddress).toEqual(new Map([]));
+    });
+
+    it('distributes assets from a single address in toAddress and fromAddress depending on their net values', async () => {
+      // Arrange
+
+      // This TX is not balanced, but it's not the point of this test
+      const tx = buildMockTx({
+        inputs: [
+          {
+            address: addresses[0],
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[1],
+            index: 1,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[2],
+            index: 2,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[3],
+            index: 3,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+
+        outputs: [
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([[AssetIds.TSLA, 210n]]),
+              coins: 4_500_000n
+            }
+          },
+          {
+            address: addresses[1],
+            value: {
+              assets: new Map([
+                [AssetIds.TSLA, 15n],
+                [AssetIds.PXL, 1n],
+                [AssetIds.Unit, 12n]
+              ]),
+              coins: 5_000_000n
+            }
+          },
+          {
+            address: addresses[2],
+            value: {
+              assets: new Map([
+                [AssetIds.TSLA, 5000n],
+                [AssetIds.PXL, 1000n],
+                [AssetIds.Unit, 12n]
+              ]),
+              coins: 10_000_000n
+            }
+          },
+          {
+            address: addresses[3],
+            value: {
+              assets: new Map([
+                [AssetIds.PXL, 1000n],
+                [AssetIds.Unit, 12n]
+              ]),
+              coins: 1_000_000n
+            }
+          }
+        ]
+      });
+
+      const histTx: Cardano.HydratedTx[] = [
+        {
+          body: {
+            outputs: [
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([
+                    [AssetIds.TSLA, 100n],
+                    [AssetIds.PXL, 50n],
+                    [AssetIds.Unit, 25n]
+                  ]),
+                  coins: 9_500_000n
+                }
+              },
+              {
+                address: addresses[1],
+                value: {
+                  assets: new Map([
+                    [AssetIds.TSLA, 1n],
+                    [AssetIds.PXL, 2n],
+                    [AssetIds.Unit, 100n]
+                  ]),
+                  coins: 5_000_000n
+                }
+              },
+              {
+                address: addresses[2],
+                value: {
+                  assets: new Map([
+                    [AssetIds.TSLA, 10_000n],
+                    [AssetIds.PXL, 789n],
+                    [AssetIds.Unit, 10n]
+                  ]),
+                  coins: 2_000_000n
+                }
+              },
+              {
+                address: addresses[3],
+                value: {
+                  assets: new Map([
+                    [AssetIds.TSLA, 2n],
+                    [AssetIds.PXL, 9n],
+                    [AssetIds.Unit, 1120n]
+                  ]),
+                  coins: 2_000_000n
+                }
+              }
+            ]
+          },
+          id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        } as unknown as Cardano.HydratedTx
+      ];
+
+      const inspectTx = createTxInspector({
+        tokenTransfer: tokenTransferInspector({ inputResolver: createMockInputResolver(histTx) })
+      });
+
+      // Act
+      const { tokenTransfer } = await inspectTx(tx);
+
+      // Assert
+      expect(tokenTransfer.toAddress).toEqual(
+        new Map([
+          [addresses[0], buildValue(0n, [[AssetIds.TSLA, 110n]])],
+          [addresses[1], buildValue(0n, [[AssetIds.TSLA, 14n]])],
+          [
+            addresses[2],
+            buildValue(8_000_000n, [
+              [AssetIds.PXL, 211n],
+              [AssetIds.Unit, 2n]
+            ])
+          ],
+          [addresses[3], buildValue(0n, [[AssetIds.PXL, 991n]])]
+        ])
+      );
+
+      expect(tokenTransfer.fromAddress).toEqual(
+        new Map([
+          [
+            addresses[0],
+            buildValue(-5_000_000n, [
+              [AssetIds.PXL, -50n],
+              [AssetIds.Unit, -25n]
+            ])
+          ],
+          [
+            addresses[1],
+            buildValue(0n, [
+              [AssetIds.PXL, -1n],
+              [AssetIds.Unit, -88n]
+            ])
+          ],
+          [addresses[2], buildValue(0n, [[AssetIds.TSLA, -5000n]])],
+          [
+            addresses[3],
+            buildValue(-1_000_000n, [
+              [AssetIds.TSLA, -2n],
+              [AssetIds.Unit, -1108n]
+            ])
+          ]
+        ])
+      );
+    });
+
+    it('does not include assets which net values are 0', async () => {
+      // Arrange
+
+      // This TX is not balanced, but it's not the point of this test
+      const tx = buildMockTx({
+        inputs: [
+          {
+            address: addresses[0],
+            index: 0,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[0],
+            index: 1,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: addresses[0],
+            index: 2,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+
+        outputs: [
+          {
+            address: addresses[0],
+            value: {
+              assets: new Map([
+                [AssetIds.TSLA, 100n],
+                [AssetIds.PXL, 50n],
+                [AssetIds.Unit, 30n]
+              ]),
+              coins: 3_000_000n
+            }
+          }
+        ]
+      });
+
+      const histTx: Cardano.HydratedTx[] = [
+        {
+          body: {
+            outputs: [
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([
+                    [AssetIds.TSLA, 25n],
+                    [AssetIds.PXL, 10n],
+                    [AssetIds.Unit, 5n]
+                  ]),
+                  coins: 1_000_000n
+                }
+              },
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([
+                    [AssetIds.TSLA, 25n],
+                    [AssetIds.PXL, 10n],
+                    [AssetIds.Unit, 10n]
+                  ]),
+                  coins: 1_000_000n
+                }
+              },
+              {
+                address: addresses[0],
+                value: {
+                  assets: new Map([
+                    [AssetIds.TSLA, 50n],
+                    [AssetIds.PXL, 30n],
+                    [AssetIds.Unit, 10n]
+                  ]),
+                  coins: 1_000_000n
+                }
+              }
+            ]
+          },
+          id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        } as unknown as Cardano.HydratedTx
+      ];
+
+      const inspectTx = createTxInspector({
+        tokenTransfer: tokenTransferInspector({ inputResolver: createMockInputResolver(histTx) })
+      });
+
+      // Act
+      const { tokenTransfer } = await inspectTx(tx);
+
+      // Assert
+      expect(tokenTransfer.toAddress).toEqual(new Map([[addresses[0], buildValue(0n, [[AssetIds.Unit, 5n]])]]));
+      expect(tokenTransfer.fromAddress).toEqual(new Map([]));
+    });
+  });
+});

--- a/packages/core/test/util/transactionSummaryInspector.test.ts
+++ b/packages/core/test/util/transactionSummaryInspector.test.ts
@@ -1,0 +1,962 @@
+import * as AssetIds from '../AssetId';
+import * as Cardano from '../../src/Cardano';
+import {
+  CertificateType,
+  CredentialType,
+  RewardAccount,
+  createStakeDeregistrationCert,
+  createStakeRegistrationCert
+} from '../../src/Cardano';
+import { Ed25519KeyHashHex, Ed25519PublicKeyHex, Ed25519SignatureHex, Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { createTxInspector, transactionSummaryInspector } from '../../src';
+import { jsonToMetadatum } from '../../src/util/metadatum';
+
+const buildValue = (coins: bigint, assets: Array<[Cardano.AssetId, bigint]>): Cardano.Value => ({
+  assets: new Map(assets),
+  coins
+});
+
+const createMockInputResolver = (historicalTxs: Cardano.HydratedTx[]): Cardano.InputResolver => ({
+  async resolveInput(input: Cardano.TxIn) {
+    const tx = historicalTxs.find((historicalTx) => historicalTx.id === input.txId);
+
+    if (!tx || tx.body.outputs.length <= input.index) return Promise.resolve(null);
+
+    return Promise.resolve(tx.body.outputs[input.index]);
+  }
+});
+
+// eslint-disable-next-line max-statements
+const externalAddress1 = Cardano.PaymentAddress(
+  'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+);
+const externalAddress2 = Cardano.PaymentAddress(
+  'addr_test1qpfhhfy2qgls50r9u4yh0l7z67xpg0a5rrhkmvzcuqrd0znuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q9gw0lz'
+);
+
+const protocolParameters = {
+  poolDeposit: 2_000_000,
+  stakeKeyDeposit: 2_000_000
+} as unknown as Cardano.ProtocolParameters;
+const rewardAccounts = [
+  Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27'),
+  Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d')
+];
+const addresses = [
+  Cardano.PaymentAddress(
+    'addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x'
+  ),
+  Cardano.PaymentAddress(
+    'addr1z8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gten0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs9yc0hh'
+  ),
+  Cardano.PaymentAddress(
+    'addr1yx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerkr0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shs2z78ve'
+  ),
+  Cardano.PaymentAddress(
+    'addr1x8phkx6acpnf78fuvxn0mkew3l0fd058hzquvz7w36x4gt7r0vd4msrxnuwnccdxlhdjar77j6lg0wypcc9uar5d2shskhj42g'
+  )
+];
+
+const txMetadatum = new Map([
+  [
+    721n,
+    jsonToMetadatum({
+      b8fdbcbe003cef7e47eb5307d328e10191952bd02901a850699e7e35: {
+        'NFT-001': {
+          image: ['ipfs://some_hash1'],
+          name: 'One',
+          version: '1.0'
+        }
+      }
+    })
+  ]
+]);
+
+const mockScript1 = {
+  __type: Cardano.ScriptType.Native,
+  kind: Cardano.NativeScriptKind.RequireAllOf,
+  scripts: [
+    {
+      __type: Cardano.ScriptType.Native,
+      keyHash: Ed25519KeyHashHex('24accb6ca2690388f067175d773871f5640de57bf11aec0be258d6c7'),
+      kind: Cardano.NativeScriptKind.RequireSignature
+    }
+  ]
+};
+
+const mockScript2 = {
+  __type: Cardano.ScriptType.Native,
+  kind: Cardano.NativeScriptKind.RequireAllOf,
+  scripts: [
+    {
+      __type: Cardano.ScriptType.Native,
+      keyHash: Ed25519KeyHashHex('00accb6ca2690388f067175d773871f5640de57bf11aec0be258d6c7'),
+      kind: Cardano.NativeScriptKind.RequireSignature
+    }
+  ]
+};
+
+const auxiliaryData = {
+  blob: txMetadatum,
+  scripts: [mockScript2]
+};
+
+const buildMockTx = (
+  args: {
+    inputs?: Cardano.HydratedTxIn[];
+    outputs?: Cardano.TxOut[];
+    certificates?: Cardano.Certificate[];
+    withdrawals?: Cardano.Withdrawal[];
+    mint?: Cardano.TokenMap;
+    witness?: Cardano.Witness;
+    includeAuxData?: boolean;
+    collaterals?: Cardano.HydratedTxIn[];
+    totalCollateral?: Cardano.Lovelace;
+    collateralReturn?: Cardano.TxOut;
+  } = {}
+): Cardano.HydratedTx =>
+  ({
+    auxiliaryData: args.includeAuxData ? auxiliaryData : undefined,
+    blockHeader: {
+      blockNo: Cardano.BlockNo(200),
+      hash: Cardano.BlockId('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5ea4172b2ed'),
+      slot: Cardano.Slot(1000)
+    },
+    body: {
+      certificates: args.certificates,
+      collateralReturn: args.collateralReturn ?? undefined,
+      collaterals: args.collaterals ?? undefined,
+      fee: 170_000n,
+      inputs: args.inputs ?? [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      mint: args.mint ?? undefined,
+      outputs: args.outputs ?? [
+        {
+          address: addresses[1],
+          value: { coins: 5_000_000n }
+        },
+        {
+          address: addresses[1],
+          value: {
+            assets: new Map([
+              [AssetIds.PXL, 3n],
+              [AssetIds.TSLA, 4n]
+            ]),
+            coins: 2_000_000n
+          }
+        },
+        {
+          address: addresses[1],
+          value: {
+            assets: new Map([[AssetIds.PXL, 6n]]),
+            coins: 2_000_000n
+          }
+        },
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.PXL, 1n]]),
+            coins: 2_000_000n
+          }
+        }
+      ],
+      totalCollateral: args.totalCollateral ?? undefined,
+      validityInterval: {},
+      withdrawals: args.withdrawals
+    },
+    id: Cardano.TransactionId('e3a443363eb6ee3d67c5e75ec10b931603787581a948d68fa3b2cd3ff2e0d2ad'),
+    index: 0,
+    witness: args.witness ?? {
+      scripts: [mockScript1],
+      signatures: new Map<Ed25519PublicKeyHex, Ed25519SignatureHex>()
+    }
+  } as Cardano.HydratedTx);
+
+describe('Transaction Summary Inspector', () => {
+  it('computes the correct asset and coin difference', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        },
+        {
+          address: addresses[1],
+          index: 1,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        },
+        {
+          address: addresses[2],
+          index: 2,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      mint: new Map([
+        [Cardano.AssetId('b8fdbcbe003cef7e47eb5307d328e10191952bd02901a850699e7e3500000000000000'), 1n],
+        [Cardano.AssetId('5ba141e401cfebf1929d539e48d14f4b20679c5409526814e0f17121ffffffffffffff'), 100_000n],
+        [Cardano.AssetId('00000000000000000000000000000000000000000000000000000000aaaaaaaaaaaaaa'), -1n]
+      ]),
+      outputs: [
+        {
+          address: externalAddress1,
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 5_000_000n
+          }
+        },
+        {
+          address: externalAddress2,
+          value: {
+            assets: new Map([
+              [AssetIds.PXL, 6n],
+              [AssetIds.Unit, 7n]
+            ]),
+            coins: 5_000_000n
+          }
+        },
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([
+              [AssetIds.TSLA, 5n],
+              [AssetIds.PXL, 5n],
+              [AssetIds.Unit, 5n],
+              // added by mint
+              [Cardano.AssetId('b8fdbcbe003cef7e47eb5307d328e10191952bd02901a850699e7e3500000000000000'), 1n],
+              [Cardano.AssetId('5ba141e401cfebf1929d539e48d14f4b20679c5409526814e0f17121ffffffffffffff'), 100_000n]
+            ]),
+            coins: 6_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([
+                  [AssetIds.TSLA, 10n],
+                  // to be burned
+                  [Cardano.AssetId('00000000000000000000000000000000000000000000000000000000aaaaaaaaaaaaaa'), 1n]
+                ]),
+                coins: 9_000_000n
+              }
+            },
+            {
+              address: addresses[1],
+              value: {
+                assets: new Map([[AssetIds.PXL, 11n]]),
+                coins: 5_000_000n
+              }
+            },
+            {
+              address: addresses[2],
+              value: {
+                assets: new Map([[AssetIds.Unit, 12n]]),
+                coins: 2_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: buildValue(0n, [
+        [Cardano.AssetId('b8fdbcbe003cef7e47eb5307d328e10191952bd02901a850699e7e3500000000000000'), 1n],
+        [Cardano.AssetId('00000000000000000000000000000000000000000000000000000000aaaaaaaaaaaaaa'), -1n],
+        [Cardano.AssetId('5ba141e401cfebf1929d539e48d14f4b20679c5409526814e0f17121ffffffffffffff'), 100_000n],
+        [AssetIds.TSLA, -5n],
+        [AssetIds.PXL, -6n],
+        [AssetIds.Unit, -7n]
+      ]).assets,
+      coins: -10_000_000n,
+      collateral: 0n,
+      deposit: 0n,
+      fee: 170_000n,
+      returnedDeposit: 0n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('computes legacy collateral', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      collaterals: [
+        {
+          address: addresses[0],
+          index: 1,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        },
+        {
+          address: addresses[0],
+          index: 2,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 5_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 5_000_000n
+              }
+            },
+            {
+              address: addresses[1],
+              value: {
+                coins: 5_000_000n
+              }
+            },
+            {
+              address: addresses[2],
+              value: {
+                coins: 5_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map(),
+      coins: 0n,
+      collateral: 10_000_000n,
+      deposit: 0n,
+      fee: 170_000n,
+      returnedDeposit: 0n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('computes CIP-40 collateral', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      collateralReturn: { address: addresses[0], value: { coins: 7_000_000n } },
+      collaterals: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        },
+        {
+          address: addresses[1],
+          index: 1,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 27_000_000n
+          }
+        }
+      ],
+      totalCollateral: 25_000_000n
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 27_000_000n
+              }
+            },
+            {
+              address: addresses[1],
+              value: {
+                coins: 5_000_000n
+              }
+            },
+            {
+              address: addresses[2],
+              value: {
+                coins: 5_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map(),
+      coins: 0n,
+      collateral: 25_000_000n,
+      deposit: 0n,
+      fee: 170_000n,
+      returnedDeposit: 0n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('only displays collateral coming from own addresses', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      collaterals: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        },
+        {
+          address: externalAddress1,
+          index: 1,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 5_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 5_000_000n
+              }
+            },
+            {
+              address: externalAddress1,
+              value: {
+                coins: 15_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map(),
+      coins: 0n,
+      collateral: 5_000_000n,
+      deposit: 0n,
+      fee: 170_000n,
+      returnedDeposit: 0n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('computes deposits from shelley era certificates', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      certificates: [createStakeRegistrationCert(rewardAccounts[0])],
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 3_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 5_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map(),
+      coins: -2_000_000n,
+      collateral: 0n,
+      deposit: 2_000_000n,
+      fee: 170_000n,
+      returnedDeposit: 0n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('computes return deposits from shelley era certificates', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      certificates: [createStakeDeregistrationCert(rewardAccounts[0])],
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 5_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 3_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map(),
+      coins: 2_000_000n,
+      collateral: 0n,
+      deposit: 0n,
+      fee: 170_000n,
+      returnedDeposit: 2_000_000n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('computes deposits from conway era certificates', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      certificates: [
+        {
+          __typename: CertificateType.Registration,
+          deposit: 15_000_000n,
+          stakeCredential: {
+            hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccounts[0])),
+            type: CredentialType.KeyHash
+          }
+        }
+      ],
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 5_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 20_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map(),
+      coins: -15_000_000n,
+      collateral: 0n,
+      deposit: 15_000_000n,
+      fee: 170_000n,
+      returnedDeposit: 0n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('computes returned deposits from conway era certificates', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      certificates: [
+        {
+          __typename: CertificateType.Unregistration,
+          deposit: 15_000_000n,
+          stakeCredential: {
+            hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccounts[0])),
+            type: CredentialType.KeyHash
+          }
+        }
+      ],
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 20_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 5_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map(),
+      coins: 15_000_000n,
+      collateral: 0n,
+      deposit: 0n,
+      fee: 170_000n,
+      returnedDeposit: 15_000_000n,
+      unresolved: {
+        inputs: [],
+        value: { assets: new Map(), coins: 0n }
+      }
+    });
+  });
+
+  it('computes unresolved inputs and value', async () => {
+    // Arrange
+    const tx = buildMockTx({
+      inputs: [
+        {
+          address: addresses[0],
+          index: 0,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        },
+        {
+          address: externalAddress1,
+          index: 1,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        },
+        {
+          address: externalAddress2,
+          index: 2,
+          txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+        }
+      ],
+      outputs: [
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([[AssetIds.TSLA, 5n]]),
+            coins: 20_000_000n
+          }
+        },
+        {
+          address: addresses[0],
+          value: {
+            assets: new Map([
+              [AssetIds.TSLA, 1n],
+              [AssetIds.PXL, 1n],
+              [AssetIds.Unit, 1n]
+            ]),
+            coins: 100_000_000n
+          }
+        }
+      ]
+    });
+
+    const histTx: Cardano.HydratedTx[] = [
+      {
+        body: {
+          outputs: [
+            {
+              address: addresses[0],
+              value: {
+                assets: new Map([[AssetIds.TSLA, 5n]]),
+                coins: 20_000_000n
+              }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+      } as unknown as Cardano.HydratedTx
+    ];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        inputResolver: createMockInputResolver(histTx),
+        protocolParameters,
+        rewardAccounts
+      })
+    });
+
+    // Act
+    const { summary } = await inspectTx(tx);
+
+    // Assert
+    expect(summary).toEqual({
+      assets: new Map([
+        [AssetIds.TSLA, 1n],
+        [AssetIds.PXL, 1n],
+        [AssetIds.Unit, 1n]
+      ]),
+      coins: 100_000_000n,
+      collateral: 0n,
+      deposit: 0n,
+      fee: 170_000n,
+      returnedDeposit: 0n,
+      unresolved: {
+        inputs: [
+          {
+            address: externalAddress1,
+            index: 1,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          },
+          {
+            address: externalAddress2,
+            index: 2,
+            txId: Cardano.TransactionId('bb217abaca60fc0ca68c1555eca6a96d2478547818ae76ce6836133f3cc546e0')
+          }
+        ],
+        value: {
+          assets: new Map([
+            [AssetIds.TSLA, 1n],
+            [AssetIds.PXL, 1n],
+            [AssetIds.Unit, 1n]
+          ]),
+          coins: 100_000_000n
+        }
+      }
+    });
+  });
+});

--- a/packages/input-selection/src/util.ts
+++ b/packages/input-selection/src/util.ts
@@ -55,6 +55,7 @@ export const preProcessArgs = (
   const implicitCoin: Required<Cardano.util.ImplicitCoin> = {
     deposit: partialImplicitValue?.coin?.deposit || 0n,
     input: partialImplicitValue?.coin?.input || 0n,
+    reclaimDeposit: partialImplicitValue?.coin?.reclaimDeposit || 0n,
     withdrawals: partialImplicitValue?.coin?.withdrawals || 0n
   };
   const mintMap: Cardano.TokenMap = partialImplicitValue?.mint || new Map();

--- a/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
+++ b/packages/wallet/src/services/DelegationTracker/RewardsHistory.ts
@@ -1,5 +1,5 @@
 import { BigIntMath, isNotNil } from '@cardano-sdk/util';
-import { Cardano, Reward, createTxInspector, signedCertificatesInspector } from '@cardano-sdk/core';
+import { Cardano, Reward, getCertificatesByType } from '@cardano-sdk/core';
 import { KeyValueStore } from '../../persistence';
 import { Logger } from 'ts-log';
 import { Observable, concat, distinctUntilChanged, map, of, switchMap, tap } from 'rxjs';
@@ -47,12 +47,9 @@ const firstDelegationEpoch$ = (transactions$: Observable<TxWithEpoch[]>, rewardA
   transactions$.pipe(
     map((transactions) =>
       first(
-        transactions.filter(({ tx }) => {
-          const inspectTx = createTxInspector({
-            signedCertificates: signedCertificatesInspector(rewardAccounts, [Cardano.CertificateType.StakeDelegation])
-          });
-          return inspectTx(tx).signedCertificates.length > 0;
-        })
+        transactions.filter(
+          ({ tx }) => getCertificatesByType(tx, rewardAccounts, [Cardano.CertificateType.StakeDelegation]).length > 0
+        )
       )
     ),
     map((tx) => (isNotNil(tx) ? calcFirstDelegationEpoch(tx.epoch) : null)),

--- a/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
+++ b/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
@@ -1,5 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { Cardano, createTxInspector, signedCertificatesInspector } from '@cardano-sdk/core';
+import { Cardano, getCertificatesByType } from '@cardano-sdk/core';
 import { Observable, combineLatest, distinctUntilChanged, map } from 'rxjs';
 import { isNotNil } from '@cardano-sdk/util';
 import { transactionsEquals } from '../util/equals';
@@ -47,12 +47,7 @@ export const transactionsWithCertificates = (
 ) =>
   combineLatest([transactions$, rewardAccounts$]).pipe(
     map(([transactions, rewardAccounts]) =>
-      transactions.filter((tx) => {
-        const inspectTx = createTxInspector({
-          signedCertificates: signedCertificatesInspector(rewardAccounts, certificateTypes)
-        });
-        return inspectTx(tx).signedCertificates.length > 0;
-      })
+      transactions.filter((tx) => getCertificatesByType(tx, rewardAccounts, certificateTypes).length > 0)
     ),
     distinctUntilChanged(transactionsEquals)
   );


### PR DESCRIPTION
# Context

To implement new UI components Summary in Lace, From Address and To Address sections, we’ll need to compute the data from the transaction body and resolved inputs.

# Proposed Solution

Implement two new transaction inspectors to produce a renderable object with the summary result.

# Important Changes Introduced

- TxInspectors are now async
- Added new TxSummaryInspector
- Added new TokenTransferInspector