### PR TITLE
LW-9518 Use SIGINT to stop cardano-submit-api

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -177,6 +177,7 @@ services:
     ports:
       - 8090:8090
     restart: on-failure
+    stop_signal: SIGINT
     volumes:
       - node-ipc:/ipc
 


### PR DESCRIPTION
# Context

Shutting down a docker compose infrastructure take a long time due to `cardano-subit-api` hangs.

# Proposed Solution

Changed its stop signal into `SIGINT`.