### PR TITLE
LW-9518 Fix local testnets cfg for cardano-token-registry

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -93,6 +93,7 @@ x-sdk-environment: &sdk-environment
   POSTGRES_USER_FILE_DB_SYNC: /run/secrets/postgres_user
   POSTGRES_USER_FILE_HANDLE: /run/secrets/postgres_user
   POSTGRES_USER_FILE_STAKE_POOL: /run/secrets/postgres_user
+  TOKEN_METADATA_SERVER_URL: https://metadata.world.dev.cardano.org
 
 services:
   cardano-db-sync:

--- a/packages/cardano-services/environments/.env.mainnet
+++ b/packages/cardano-services/environments/.env.mainnet
@@ -2,3 +2,4 @@ HANDLE_POLICY_IDS=${HANDLE_POLICY_IDS:-f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec4
 METADATA_FETCH_MODE="smash"
 SMASH_URL="https://smash.cardano-mainnet.iohk.io/api/v1"
 SCHEDULES="environments/.schedule.mainnet.json"
+TOKEN_METADATA_SERVER_URL="https://tokens.cardano.org"


### PR DESCRIPTION
# Context

Local test networks in our docker compose infrastructure are using `mainnet` `cardano-token-registry` server URL.
I double checked, this problem do not impact deployed environments.

# Proposed Solution

Fixed the configuration in our docker compose to make test networks using the IOG maintained `dev` server.
