### PR TITLE
LW-9518 Log moving average speeds even if after a restart

### DIFF
--- a/packages/projection/src/operators/logProjectionProgress.ts
+++ b/packages/projection/src/operators/logProjectionProgress.ts
@@ -55,7 +55,7 @@ const logSyncLine = (params: {
       else return;
   };
 
-  pruneOldTimes(header.blockNo - 100_000);
+  pruneOldTimes(numEvt - 100_000);
 };
 
 export const logProjectionProgress =


### PR DESCRIPTION
# Context

@mirceahasegan found a minor bug which is preventing the projector to log the moving average speeds after a restart.
