### PR TITLE
Fix/lw 9414 deposit at unregister stake key

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
@@ -290,7 +290,7 @@ export class ChainHistoryBuilder {
     return result;
   }
 
-  public async queryCertificatesByIds(ids: string[]): Promise<TransactionDataMap<Cardano.Certificate[]>> {
+  public async queryCertificatesByIds(ids: string[]): Promise<TransactionDataMap<Cardano.CertificatePostConway[]>> {
     this.#logger.debug('About to find certificates for transactions with ids:', ids);
 
     const values = [ids];
@@ -420,7 +420,7 @@ export class ChainHistoryBuilder {
     ];
     if (allCerts.length === 0) return new Map();
 
-    const indexedCertsMap: TransactionDataMap<WithCertIndex<Cardano.Certificate>[]> = new Map();
+    const indexedCertsMap: TransactionDataMap<WithCertIndex<Cardano.CertificatePostConway>[]> = new Map();
     for (const cert of allCerts) {
       const txId = cert.tx_id.toString('hex') as unknown as Cardano.TransactionId;
       const currentCerts = indexedCertsMap.get(txId) ?? [];
@@ -428,11 +428,11 @@ export class ChainHistoryBuilder {
       if (newCert) indexedCertsMap.set(txId, [...currentCerts, newCert]);
     }
 
-    const certsMap: TransactionDataMap<Cardano.Certificate[]> = new Map();
+    const certsMap: TransactionDataMap<Cardano.CertificatePostConway[]> = new Map();
     for (const [txId] of indexedCertsMap) {
       const currentCerts = indexedCertsMap.get(txId) ?? [];
       const certs = orderBy(currentCerts, ['cert_index']).map(
-        (cert) => omit(cert, 'cert_index') as Cardano.Certificate
+        (cert) => omit(cert, 'cert_index') as Cardano.CertificatePostConway
       );
       certsMap.set(txId, certs);
     }

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/DbSyncChainHistoryProvider.ts
@@ -51,7 +51,7 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
     addresses,
     pagination,
     blockRange
-  }: TransactionsByAddressesArgs): Promise<Paginated<Cardano.HydratedTx>> {
+  }: TransactionsByAddressesArgs): Promise<Paginated<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>> {
     if (addresses.length > this.#paginationPageSizeLimit) {
       throw new ProviderError(
         ProviderFailure.BadRequest,
@@ -84,7 +84,9 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
     return { pageResults: totalResultCount ? await this.transactionsByIds(ids) : [], totalResultCount };
   }
 
-  public async transactionsByHashes({ ids }: TransactionsByIdsArgs): Promise<Cardano.HydratedTx[]> {
+  public async transactionsByHashes({
+    ids
+  }: TransactionsByIdsArgs): Promise<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]> {
     if (ids.length > this.#paginationPageSizeLimit) {
       throw new ProviderError(
         ProviderFailure.BadRequest,
@@ -98,7 +100,7 @@ export class DbSyncChainHistoryProvider extends DbSyncProvider() implements Chai
     return this.transactionsByIds(txRecordIds);
   }
 
-  private async transactionsByIds(ids: string[]): Promise<Cardano.HydratedTx[]> {
+  private async transactionsByIds(ids: string[]): Promise<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]> {
     this.logger.debug('About to find transactions with ids:', ids);
     const txResults: QueryResult<TxModel> = await this.dbPools.main.query({
       name: 'transactions_by_ids',

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -155,7 +155,7 @@ export const mapAnchor = (anchorUrl: string, anchorDataHash: string): Cardano.An
 export const mapCertificate = (
   certModel: WithCertType<CertificateModel>
   // eslint-disable-next-line sonarjs/cognitive-complexity
-): WithCertIndex<Cardano.Certificate> | null => {
+): WithCertIndex<Cardano.CertificatePostConway> | null => {
   if (isPoolRetireCertModel(certModel))
     return {
       __typename: Cardano.CertificateType.PoolRetirement,
@@ -364,7 +364,7 @@ interface TxAlonzoData {
   redeemers?: Cardano.Redeemer[];
   metadata?: Cardano.TxMetadata;
   collaterals?: Cardano.HydratedTxIn[];
-  certificates?: Cardano.Certificate[];
+  certificates?: Cardano.CertificatePostConway[];
   proposalProcedures?: Cardano.ProposalProcedure[];
   votingProcedures?: Cardano.VotingProcedures;
 }
@@ -384,7 +384,7 @@ export const mapTxAlonzo = (
     votingProcedures,
     withdrawals
   }: TxAlonzoData
-): Cardano.HydratedTx => ({
+): Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway> => ({
   auxiliaryData:
     metadata && metadata.size > 0
       ? {

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -337,7 +337,7 @@ describe('chain history mappers', () => {
     const metadata: Cardano.TxMetadata = new Map([[1n, 'data']]);
     const inputSource = Cardano.InputSource.inputs;
 
-    const certificates: Cardano.CertificateExclShelleyStake[] = [
+    const certificates: Cardano.CertificatePostConway[] = [
       {
         __typename: Cardano.CertificateType.Registration,
         deposit: 2_000_000n,

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -337,9 +337,10 @@ describe('chain history mappers', () => {
     const metadata: Cardano.TxMetadata = new Map([[1n, 'data']]);
     const inputSource = Cardano.InputSource.inputs;
 
-    const certificates: Cardano.Certificate[] = [
+    const certificates: Cardano.CertificateExclShelleyStake[] = [
       {
-        __typename: Cardano.CertificateType.StakeRegistration,
+        __typename: Cardano.CertificateType.Registration,
+        deposit: 2_000_000n,
         stakeCredential: {
           hash: Hash28ByteBase16.fromEd25519KeyHashHex(
             Cardano.RewardAccount.toHash(Cardano.RewardAccount(stakeAddress))

--- a/packages/core/src/Cardano/types/Certificate.ts
+++ b/packages/core/src/Cardano/types/Certificate.ts
@@ -194,13 +194,23 @@ export const createStakeRegistrationCert = (rewardAccount: RewardAccount): Certi
  *
  * @param rewardAccount The reward account to be de-registered.
  */
-export const createStakeDeregistrationCert = (rewardAccount: RewardAccount): Certificate => ({
-  __typename: CertificateType.StakeDeregistration,
-  stakeCredential: {
-    hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
-    type: CredentialType.KeyHash
-  }
-});
+export const createStakeDeregistrationCert = (rewardAccount: RewardAccount, deposit?: Lovelace): Certificate =>
+  deposit === undefined
+    ? {
+        __typename: CertificateType.StakeDeregistration,
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+          type: CredentialType.KeyHash
+        }
+      }
+    : {
+        __typename: CertificateType.Unregistration,
+        deposit,
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+          type: CredentialType.KeyHash
+        }
+      };
 
 /**
  * Creates a delegation certificate from a given reward account and a pool id.

--- a/packages/core/src/Cardano/types/Certificate.ts
+++ b/packages/core/src/Cardano/types/Certificate.ts
@@ -156,8 +156,7 @@ export interface GenesisKeyDelegationCertificate {
   vrfKeyHash: Crypto.Hash32ByteBase16;
 }
 
-export type Certificate =
-  | StakeAddressCertificate
+export type CertificatePostConway =
   | PoolRegistrationCertificate
   | PoolRetirementCertificate
   | StakeDelegationCertificate
@@ -174,6 +173,8 @@ export type Certificate =
   | RegisterDelegateRepresentativeCertificate
   | UnRegisterDelegateRepresentativeCertificate
   | UpdateDelegateRepresentativeCertificate;
+
+export type Certificate = CertificatePostConway | StakeAddressCertificate;
 
 /**
  * Creates a stake key registration certificate from a given reward account.

--- a/packages/core/src/Cardano/types/DelegationsAndRewards.ts
+++ b/packages/core/src/Cardano/types/DelegationsAndRewards.ts
@@ -29,6 +29,7 @@ export interface RewardAccountInfo {
   delegatee?: Delegatee;
   rewardBalance: Lovelace;
   // Maybe add rewardsHistory for each reward account too
+  deposit?: Lovelace; // defined only when keyStatus is Registered
 }
 
 export interface Cip17Pool {

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -1,7 +1,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AuxiliaryData } from './AuxiliaryData';
 import { Base64Blob, HexBlob, OpaqueString } from '@cardano-sdk/util';
-import { Certificate } from './Certificate';
+import { Certificate, CertificatePostConway } from './Certificate';
 import { ExUnits, Update, ValidityInterval } from './ProtocolParameters';
 import { HydratedTxIn, TxIn, TxOut } from './Utxo';
 import { Lovelace, TokenMap } from './Value';
@@ -80,6 +80,11 @@ export interface HydratedTxBody {
   donation?: Lovelace;
 }
 
+/** Does not contain legacy Stake registration/deregistration certificates */
+export interface HydratedTxBodyPostConway extends Omit<HydratedTxBody, 'certificates'> {
+  certificates?: CertificatePostConway[];
+}
+
 export interface TxBody extends Omit<HydratedTxBody, 'inputs' | 'collaterals' | 'referenceInputs'> {
   inputs: TxIn[];
   collaterals?: TxIn[];
@@ -153,10 +158,10 @@ export interface OnChainTx<TBody extends TxBody = TxBody>
   auxiliaryData?: Omit<AuxiliaryData, 'scripts'>;
 }
 
-export interface HydratedTx extends TxWithInputSource<HydratedTxBody> {
+export interface HydratedTx<TBody extends HydratedTxBody = HydratedTxBody> extends TxWithInputSource<TBody> {
   index: number;
   blockHeader: PartialBlockHeader;
-  body: HydratedTxBody;
+  body: TBody;
   txSize: number;
 }
 

--- a/packages/core/src/Provider/ChainHistoryProvider/types.ts
+++ b/packages/core/src/Provider/ChainHistoryProvider/types.ts
@@ -19,14 +19,18 @@ export interface ChainHistoryProvider extends Provider {
    * @param {Range<Cardano.BlockNo>} [blockRange] transactions in specified block ranges (lower and upper bounds inclusive)
    * @returns {Cardano.HydratedTx[]} an array of transactions involving the addresses
    */
-  transactionsByAddresses: (args: TransactionsByAddressesArgs) => Promise<Paginated<Cardano.HydratedTx>>;
+  transactionsByAddresses: (
+    args: TransactionsByAddressesArgs
+  ) => Promise<Paginated<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>>;
   /**
    * Gets the transactions matching the provided hashes.
    *
    * @param {Cardano.TransactionId[]} ids array of transaction ids
    * @returns {Cardano.HydratedTx[]} an array of transactions
    */
-  transactionsByHashes: (args: TransactionsByIdsArgs) => Promise<Cardano.HydratedTx[]>;
+  transactionsByHashes: (
+    args: TransactionsByIdsArgs
+  ) => Promise<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>;
   /**
    * Gets the blocks matching the provided hashes.
    *

--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -399,7 +399,7 @@ export class GenericTxBuilder implements TxBuilder {
     this.#logger.debug(`De-registering ${availableRewardAccounts.length} stake keys`);
     for (const rewardAccount of availableRewardAccounts) {
       if (rewardAccount.keyStatus === Cardano.StakeKeyStatus.Registered) {
-        certificates.push(Cardano.createStakeDeregistrationCert(rewardAccount.address));
+        certificates.push(Cardano.createStakeDeregistrationCert(rewardAccount.address, rewardAccount.deposit));
       }
     }
     this.partialTxBody = { ...this.partialTxBody, certificates };

--- a/packages/util-dev/src/mockProviders/mockChainHistoryProvider.ts
+++ b/packages/util-dev/src/mockProviders/mockChainHistoryProvider.ts
@@ -48,7 +48,7 @@ export const generateTxAlonzo = (qty: number): Cardano.HydratedTx[] =>
     }
   }));
 
-export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
+export const queryTransactionsResult: Paginated<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>> = {
   pageResults: [
     {
       blockHeader: {
@@ -58,7 +58,8 @@ export const queryTransactionsResult: Paginated<Cardano.HydratedTx> = {
       body: {
         certificates: [
           {
-            __typename: Cardano.CertificateType.StakeRegistration,
+            __typename: Cardano.CertificateType.Registration,
+            deposit: 2_000_000n,
             stakeCredential
           },
           {

--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -19,7 +19,9 @@ export class InMemoryAddressesStore extends InMemoryDocumentStore<GroupedAddress
 export class InMemoryInFlightTransactionsStore extends InMemoryDocumentStore<TxInFlight[]> {}
 export class InMemoryVolatileTransactionsStore extends InMemoryDocumentStore<OutgoingOnChainTx[]> {}
 
-export class InMemoryTransactionsStore extends InMemoryCollectionStore<Cardano.HydratedTx> {}
+export class InMemoryTransactionsStore extends InMemoryCollectionStore<
+  Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>
+> {}
 export class InMemoryUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}
 export class InMemoryUnspendableUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}
 

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -20,7 +20,9 @@ export class PouchDbInFlightTransactionsStore extends PouchDbDocumentStore<TxInF
 export class PouchDbVolatileTransactionsStore extends PouchDbDocumentStore<OutgoingOnChainTx[]> {}
 export class PouchDbPolicyIdsStore extends PouchDbDocumentStore<Cardano.PolicyId[]> {}
 
-export class PouchDbTransactionsStore extends PouchDbCollectionStore<Cardano.HydratedTx> {}
+export class PouchDbTransactionsStore extends PouchDbCollectionStore<
+  Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>
+> {}
 export class PouchDbUtxoStore extends PouchDbCollectionStore<Cardano.Utxo> {}
 
 export class PouchDbRewardsHistoryStore extends PouchDbKeyValueStore<Cardano.RewardAccount, Reward[]> {}

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -76,7 +76,7 @@ export interface WalletStores extends Destroyable {
   tip: DocumentStore<Cardano.Tip>;
   utxo: CollectionStore<Cardano.Utxo>;
   unspendableUtxo: CollectionStore<Cardano.Utxo>;
-  transactions: OrderedCollectionStore<Cardano.HydratedTx>;
+  transactions: OrderedCollectionStore<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>;
   inFlightTransactions: DocumentStore<TxInFlight[]>;
   volatileTransactions: DocumentStore<OutgoingOnChainTx[]>;
   rewardsHistory: KeyValueStore<Cardano.RewardAccount, Reward[]>;

--- a/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
+++ b/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
@@ -54,7 +54,7 @@ export const stakeKeyCertificates = (certificates?: Cardano.Certificate[]) =>
 export const includesAnyCertificate = (haystack: Cardano.Certificate[], needle: readonly Cardano.CertificateType[]) =>
   haystack.some(({ __typename }) => needle.includes(__typename)) || false;
 
-export const isLastStakeKeyCertOfType = (
+export const lastStakeKeyCertOfType = (
   transactionsCertificates: Cardano.Certificate[][],
   certTypes: readonly RegAndDeregCertificateTypes[],
   rewardAccount?: Cardano.RewardAccount
@@ -73,11 +73,13 @@ export const isLastStakeKeyCertOfType = (
       })
       .filter(isNotNil)
   );
-  return certTypes.includes(lastRegOrDereg?.__typename as RegAndDeregCertificateTypes);
+  if (certTypes.includes(lastRegOrDereg?.__typename as RegAndDeregCertificateTypes)) {
+    return lastRegOrDereg;
+  }
 };
 
 export const transactionsWithCertificates = (
-  transactions$: Observable<Cardano.HydratedTx[]>,
+  transactions$: Observable<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>,
   rewardAccounts$: Observable<Cardano.RewardAccount[]>,
   certificateTypes: Cardano.CertificateType[]
 ) =>

--- a/packages/wallet/src/services/DelegationTracker/types.ts
+++ b/packages/wallet/src/services/DelegationTracker/types.ts
@@ -1,6 +1,6 @@
 import { Cardano } from '@cardano-sdk/core';
 
 export interface TxWithEpoch {
-  tx: Cardano.HydratedTx;
+  tx: Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>;
   epoch: Cardano.EpochNo;
 }

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -77,7 +77,7 @@ export interface TxInFlight extends OutgoingTx {
 }
 
 export interface TransactionsTracker {
-  readonly history$: Observable<Cardano.HydratedTx[]>;
+  readonly history$: Observable<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>;
   readonly rollback$: Observable<Cardano.HydratedTx>;
   readonly outgoing: {
     readonly inFlight$: Observable<TxInFlight[]>;

--- a/packages/wallet/src/services/util/equals.ts
+++ b/packages/wallet/src/services/util/equals.ts
@@ -5,9 +5,10 @@ import { sameArrayItems } from '@cardano-sdk/util';
 
 export const tipEquals = (a: Cardano.Tip, b: Cardano.Tip) => a.hash === b.hash;
 
-export const txEquals = (a: Cardano.HydratedTx, b: Cardano.HydratedTx) => a.id === b.id;
+export const txEquals = <T extends Pick<Cardano.HydratedTx, 'id'> = Cardano.HydratedTx>(a: T, b: T) => a.id === b.id;
 
-export const transactionsEquals = (a: Cardano.HydratedTx[], b: Cardano.HydratedTx[]) => sameArrayItems(a, b, txEquals);
+export const transactionsEquals = <T extends Pick<Cardano.HydratedTx, 'id'> = Cardano.HydratedTx>(a: T[], b: T[]) =>
+  sameArrayItems(a, b, txEquals);
 
 export const txInEquals = (a: Cardano.TxIn, b: Cardano.TxIn) => a.txId === b.txId && a.index === b.index;
 

--- a/packages/wallet/test/services/AssetsTracker.test.ts
+++ b/packages/wallet/test/services/AssetsTracker.test.ts
@@ -11,8 +11,11 @@ import {
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import { from, lastValueFrom, of, tap } from 'rxjs';
 
-const createTxWithValues = (values: Partial<Cardano.Value>[]): Cardano.HydratedTx =>
-  ({ body: { outputs: values.map((value) => ({ value })) }, id: generateRandomHexString(64) } as Cardano.HydratedTx);
+const createTxWithValues = (values: Partial<Cardano.Value>[]): Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway> =>
+  ({
+    body: { outputs: values.map((value) => ({ value })) },
+    id: generateRandomHexString(64)
+  } as Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>);
 
 const cip68AssetId = {
   referenceNFT: Cardano.AssetId.fromParts(

--- a/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
@@ -91,7 +91,8 @@ describe('RewardAccounts', () => {
   test('getStakePoolIdAtEpoch', () => {
     const transactions = [
       {
-        certificates: [{ __typename: Cardano.CertificateType.StakeRegistration } as Cardano.StakeAddressCertificate],
+        certificates: [{ __typename: Cardano.CertificateType.Registration } as Cardano.NewStakeAddressCertificate],
+        deposit: 2_000_000n,
         epoch: Cardano.EpochNo(100)
       },
       {
@@ -104,7 +105,8 @@ describe('RewardAccounts', () => {
         epoch: Cardano.EpochNo(101)
       },
       {
-        certificates: [{ __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.StakeAddressCertificate],
+        certificates: [{ __typename: Cardano.CertificateType.Unregistration } as Cardano.NewStakeAddressCertificate],
+        deposit: 2_000_000n,
         epoch: Cardano.EpochNo(102)
       },
       {
@@ -523,7 +525,7 @@ describe('RewardAccounts', () => {
             a: [
               {
                 certificates: [
-                  { __typename: Cardano.CertificateType.StakeRegistration } as Cardano.StakeAddressCertificate,
+                  { __typename: Cardano.CertificateType.Registration } as Cardano.NewStakeAddressCertificate,
                   {
                     __typename: Cardano.CertificateType.StakeDelegation,
                     poolId: poolId1

--- a/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
@@ -219,7 +219,6 @@ describe('RewardAccounts', () => {
 
   test.each([
     Cardano.CertificateType.Registration,
-    Cardano.CertificateType.StakeRegistration,
     Cardano.CertificateType.StakeRegistrationDelegation,
     Cardano.CertificateType.StakeVoteRegistrationDelegation,
     Cardano.CertificateType.VoteRegistrationDelegation
@@ -323,10 +322,10 @@ describe('RewardAccounts', () => {
       });
       const tracker$ = addressKeyStatuses([rewardAccount], transactions$, transactionsInFlight$);
       expectObservable(tracker$).toBe('abcda', {
-        a: [Cardano.StakeKeyStatus.Unregistered],
-        b: [Cardano.StakeKeyStatus.Registering],
-        c: [Cardano.StakeKeyStatus.Registered],
-        d: [Cardano.StakeKeyStatus.Unregistering]
+        a: [{ keyStatus: Cardano.StakeKeyStatus.Unregistered }],
+        b: [{ keyStatus: Cardano.StakeKeyStatus.Registering }],
+        c: [{ deposit: 0n, keyStatus: Cardano.StakeKeyStatus.Registered }],
+        d: [{ keyStatus: Cardano.StakeKeyStatus.Unregistering }]
       });
     });
   });

--- a/packages/wallet/test/services/DelegationTracker/stub-tx.ts
+++ b/packages/wallet/test/services/DelegationTracker/stub-tx.ts
@@ -15,7 +15,7 @@ export const createStubTxWithCertificates = (
     body: {
       certificates: certificates?.map((cert) => ({ ...cert, ...commonCertProps }))
     }
-  } as Cardano.HydratedTx);
+  } as Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>);
 
 export const createStubTxWithEpoch = (
   epoch: number,

--- a/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
@@ -72,11 +72,15 @@ describe('transactionCertificates', () => {
             } as Cardano.Certificate
           ]
         }
-      } as Cardano.HydratedTx;
+      } as Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>;
       const outgoing$ = cold('abc', {
         a: [],
-        b: [{ body: { certificates: [{ __typename: Cardano.CertificateType.MIR }] } } as Cardano.HydratedTx],
-        c: [{ body: {} } as Cardano.HydratedTx, tx]
+        b: [
+          {
+            body: { certificates: [{ __typename: Cardano.CertificateType.MIR }] }
+          } as Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>
+        ],
+        c: [{ body: {} } as Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>, tx]
       });
       const rewardAccounts$ = cold('a', {
         a: [rewardAccount]

--- a/packages/wallet/test/services/TransactionsTracker.test.ts
+++ b/packages/wallet/test/services/TransactionsTracker.test.ts
@@ -204,7 +204,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('----|');
         const submitting$ = hot('-a--|', { a: outgoingTx });
         const pending$ = hot('--a-|', { a: outgoingTx });
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('a-bc|', {
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('a-bc|', {
           a: [],
           b: [incomingTx],
           c: [incomingTx, submittedTx]
@@ -259,7 +259,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('--ab-|', { a: tip1, b: tip2 });
         const submitting$ = hot('-a---|', { a: outgoingTx });
         const pending$ = hot('--a--|', { a: outgoingTx });
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('-----|');
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('-----|');
         const failedSubscription = '--^---'; // regression: subscribing after submitting$ emits
         const transactionsTracker = createTransactionsTracker(
           {
@@ -307,7 +307,7 @@ describe('TransactionsTracker', () => {
         const submitting$ = hot('-a---|', { a: outgoingTx });
         const pending$ = hot('--a-a|', { a: outgoingTx }); // second emission must not re-add it to inFlight$
         const rollback$ = hot('---a-|', { a: { id: tx.body.inputs[0].txId } as Cardano.HydratedTx });
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('-----|');
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('-----|');
         const transactionsTracker = createTransactionsTracker(
           {
             addresses$,
@@ -345,7 +345,7 @@ describe('TransactionsTracker', () => {
 
     it('emits phase 2 validation on-chain transactions as failed$', async () => {
       const outgoingTx = toOutgoingTx(queryTransactionsResult.pageResults[0]);
-      const phase2FailedTx: Cardano.HydratedTx = {
+      const phase2FailedTx: Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway> = {
         ...queryTransactionsResult.pageResults[0],
         inputSource: Cardano.InputSource.collaterals
       };
@@ -354,7 +354,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('-----|');
         const submitting$ = cold('-a---|', { a: outgoingTx });
         const pending$ = cold('--a--|', { a: outgoingTx });
-        const transactionsSource$ = cold<Cardano.HydratedTx[]>('a--b-|', { a: [], b: [phase2FailedTx] });
+        const transactionsSource$ = cold<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('a--b-|', { a: [], b: [phase2FailedTx] });
         const failedToSubmit$ = hot<FailedTx>('-----|');
 
         const transactionsTracker = createTransactionsTracker(
@@ -395,7 +395,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('----|');
         const submitting$ = cold('-a--|', { a: outgoingTx });
         const pending$ = cold('--a-|', { a: outgoingTx });
-        const transactionsSource$ = cold<Cardano.HydratedTx[]>('----|');
+        const transactionsSource$ = cold<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('----|');
         const failedToSubmit$ = hot<FailedTx>('---a|', {
           a: { reason: TransactionFailure.FailedToSubmit, ...outgoingTx }
         });
@@ -443,7 +443,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('----|');
         const submitting$ = cold('-a--|', { a: outgoingTx });
         const pending$ = cold('--a-|', { a: outgoingTx });
-        const transactionsSource$ = cold<Cardano.HydratedTx[]>('----|');
+        const transactionsSource$ = cold<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('----|');
         const failedToSubmit$ = hot<FailedTx>('---a|', {
           a: { reason: TransactionFailure.FailedToSubmit, ...outgoingTx }
         });
@@ -489,7 +489,7 @@ describe('TransactionsTracker', () => {
         });
         const submitting$ = hot('-a-b--|', { a: outgoingTx, b: outgoingTx });
         const pending$ = hot('--a-b-|', { a: outgoingTx, b: outgoingTx });
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('-a---b|', {
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('-a---b|', {
           a: [],
           b: [tx]
         });
@@ -543,7 +543,7 @@ describe('TransactionsTracker', () => {
         });
         const submitting$ = hot('-a-b--|', { a: outgoingTx, b: outgoingTx });
         const pending$ = hot<OutgoingTx>('------|');
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('a-----|', { a: [] });
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('a-----|', { a: [] });
         const failedToSubmit$ = hot<FailedTx>('-----a|', {
           a: { reason: TransactionFailure.FailedToSubmit, ...outgoingTx }
         });
@@ -588,7 +588,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('--a-|', { a: { slot: submittedAt } as Cardano.Tip });
         const submitting$ = hot('-a--|', { a: outgoingTx });
         const pending$ = hot('--a-|', { a: outgoingTx });
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('a--b|', {
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('a--b|', {
           a: [],
           b: [tx]
         });
@@ -648,7 +648,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('|');
         const submitting$ = hot('--a|', { a: outgoingTx });
         const pending$ = hot<OutgoingTx>('|');
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('|');
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('|');
 
         const transactionsTracker = createTransactionsTracker(
           {
@@ -705,7 +705,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('----|');
         const submitting$ = hot<OutgoingTx>('----|');
         const pending$ = hot<OutgoingTx>('----|');
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('a-bc|', {
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('a-bc|', {
           a: [],
           b: [incomingTx],
           c: [incomingTx, storedInFlightTx]
@@ -767,7 +767,7 @@ describe('TransactionsTracker', () => {
         const pending$ = hot<OutgoingTx>('-----|');
         // The key of this test is that the 1st emission of transactions source already
         // contains the transaction that we loaded from inFlightTransactionsStore
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('----a|', {
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('----a|', {
           a: [txToBeConfirmed]
         });
 
@@ -818,7 +818,7 @@ describe('TransactionsTracker', () => {
         body: { validityInterval: {} },
         // should remove storedInFlightTx from inFlight$ once discovered on-chain
         id: storedInFlightTx.id
-      } as Cardano.HydratedTx;
+      } as Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>;
 
       createTestScheduler().run(({ hot, expectObservable }) => {
         const storedInFlight$ = hot<TxInFlight[]>('-a|', {
@@ -831,7 +831,7 @@ describe('TransactionsTracker', () => {
         const tip$ = hot<Cardano.Tip>('-----|');
         const submitting$ = hot<OutgoingTx>('--a--|', { a: outgoingTx });
         const pending$ = hot<OutgoingTx>('-----|');
-        const transactionsSource$ = hot<Cardano.HydratedTx[]>('a---b|', {
+        const transactionsSource$ = hot<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>[]>('a---b|', {
           a: [],
           b: [incomingTx]
         });

--- a/packages/wallet/test/services/addressDiscovery/mockData.ts
+++ b/packages/wallet/test/services/addressDiscovery/mockData.ts
@@ -9,7 +9,9 @@ export const mockChainHistoryProvider: ChainHistoryProvider = {
   healthCheck: () => {
     throw new Error(NOT_IMPLEMENTED);
   },
-  transactionsByAddresses: (args: TransactionsByAddressesArgs): Promise<Paginated<Cardano.HydratedTx>> => {
+  transactionsByAddresses: (
+    args: TransactionsByAddressesArgs
+  ): Promise<Paginated<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>> => {
     const address = args.addresses.length > 0 ? args.addresses[0] : undefined;
 
     // Only even payment indices and indices less than 100 will ''return' results.
@@ -22,13 +24,13 @@ export const mockChainHistoryProvider: ChainHistoryProvider = {
       const isStakeAddress = paymentIndex === 0 && stakeIndex > 0;
 
       return Promise.resolve({
-        pageResults: new Array<Cardano.HydratedTx>(),
+        pageResults: new Array<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>(),
         totalResultCount: !isStakeAddress && isExternalAddress && isPaymentEven && paymentIndex < 100 ? 1 : 0
       });
     }
 
     return Promise.resolve({
-      pageResults: new Array<Cardano.HydratedTx>(),
+      pageResults: new Array<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>(),
       totalResultCount: 0
     });
   },
@@ -44,18 +46,20 @@ export const createMockChainHistoryProvider = (addressesWithTx: Map<Cardano.Paym
   healthCheck: () => {
     throw new Error(NOT_IMPLEMENTED);
   },
-  transactionsByAddresses: (args: TransactionsByAddressesArgs): Promise<Paginated<Cardano.HydratedTx>> => {
+  transactionsByAddresses: (
+    args: TransactionsByAddressesArgs
+  ): Promise<Paginated<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>> => {
     const address = args.addresses.length > 0 ? args.addresses[0] : undefined;
 
     if (address && addressesWithTx.has(address)) {
       return Promise.resolve({
-        pageResults: new Array<Cardano.HydratedTx>(),
+        pageResults: new Array<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>(),
         totalResultCount: addressesWithTx.get(address)!
       });
     }
 
     return Promise.resolve({
-      pageResults: new Array<Cardano.HydratedTx>(),
+      pageResults: new Array<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>(),
       totalResultCount: 0
     });
   },
@@ -71,7 +75,7 @@ export const mockAlwaysFailChainHistoryProvider: ChainHistoryProvider = {
   healthCheck: () => {
     throw new Error(NOT_IMPLEMENTED);
   },
-  transactionsByAddresses: (): Promise<Paginated<Cardano.HydratedTx>> => {
+  transactionsByAddresses: (): Promise<Paginated<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>> => {
     throw new Error(NOT_IMPLEMENTED);
   },
   transactionsByHashes: () => {
@@ -86,7 +90,7 @@ export const mockAlwaysEmptyChainHistoryProvider: ChainHistoryProvider = {
   healthCheck: () => {
     throw new Error(NOT_IMPLEMENTED);
   },
-  transactionsByAddresses: async (): Promise<Paginated<Cardano.HydratedTx>> => ({
+  transactionsByAddresses: async (): Promise<Paginated<Cardano.HydratedTx<Cardano.HydratedTxBodyPostConway>>> => ({
     pageResults: [],
     totalResultCount: 0
   }),


### PR DESCRIPTION
# Context

Certificates that register stake key include the deposit value, as configured in the protocol parameters at the time of submitting the transaction

Currently, the deposit value is taken from the protocol parameters, and used as [implicit coin](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/core/src/Cardano/util/computeImplicitCoin.ts#L16) when deregistering the stake key

In the conway era, the protocol parameters could change often as a  result of a governance action, leading to a discrepancy in the deposit value at stake key registration and the deposit value at stake key deregistration.

# Proposed Solution
For this reason, the stake key deposit value at the time of registering the stake key should be stored in RewardAccountInfo from ObservableWallet.delegation.rewardAccounts$.

It could for example be undefined when the stake key is not registered, and the real value when the stake key is registered.

This way, on deregistering a stake key, SDK can use this value as deposit value.

# Important Changes Introduced
