### PR TITLE
Fix/lw 9414 deposit at unregister stake key on master

### DIFF
--- a/packages/core/src/Cardano/types/Certificate.ts
+++ b/packages/core/src/Cardano/types/Certificate.ts
@@ -176,21 +176,19 @@ export type Certificate =
   | UnRegisterDelegateRepresentativeCertificate
   | UpdateDelegateRepresentativeCertificate;
 
-export const StakeRegistrationCertificateTypes = [
-  CertificateType.StakeRegistration,
+export const PostConwayStakeRegistrationCertificateTypes = [
   CertificateType.Registration,
   CertificateType.VoteRegistrationDelegation,
   CertificateType.StakeRegistrationDelegation,
   CertificateType.StakeVoteRegistrationDelegation
 ] as const;
 
-export type StakeRegistrationCertificateTypes = typeof StakeRegistrationCertificateTypes[number];
+export const StakeRegistrationCertificateTypes = [
+  CertificateType.StakeRegistration,
+  ...PostConwayStakeRegistrationCertificateTypes
+] as const;
 
-export type StakeDelegationCertificateUnion =
-  | StakeDelegationCertificate
-  | StakeVoteDelegationCertificate
-  | StakeRegistrationDelegationCertificate
-  | StakeVoteRegistrationDelegationCertificate;
+export type StakeRegistrationCertificateTypes = typeof StakeRegistrationCertificateTypes[number];
 
 export const StakeDelegationCertificateTypes = [
   CertificateType.StakeDelegation,
@@ -200,13 +198,6 @@ export const StakeDelegationCertificateTypes = [
 ] as const;
 
 export type StakeDelegationCertificateTypes = typeof StakeDelegationCertificateTypes[number];
-
-export type RegAndDeregCertificateUnion =
-  | StakeAddressCertificate
-  | NewStakeAddressCertificate
-  | VoteRegistrationDelegationCertificate
-  | StakeRegistrationDelegationCertificate
-  | StakeVoteRegistrationDelegationCertificate;
 
 export const RegAndDeregCertificateTypes = [
   ...StakeRegistrationCertificateTypes,

--- a/packages/core/src/Cardano/types/Certificate.ts
+++ b/packages/core/src/Cardano/types/Certificate.ts
@@ -259,13 +259,23 @@ export const createStakeRegistrationCert = (rewardAccount: RewardAccount): Certi
  *
  * @param rewardAccount The reward account to be de-registered.
  */
-export const createStakeDeregistrationCert = (rewardAccount: RewardAccount): Certificate => ({
-  __typename: CertificateType.StakeDeregistration,
-  stakeCredential: {
-    hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
-    type: CredentialType.KeyHash
-  }
-});
+export const createStakeDeregistrationCert = (rewardAccount: RewardAccount, deposit?: Lovelace): Certificate =>
+  deposit === undefined
+    ? {
+        __typename: CertificateType.StakeDeregistration,
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+          type: CredentialType.KeyHash
+        }
+      }
+    : {
+        __typename: CertificateType.Unregistration,
+        deposit,
+        stakeCredential: {
+          hash: Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+          type: CredentialType.KeyHash
+        }
+      };
 
 /**
  * Creates a delegation certificate from a given reward account and a pool id.

--- a/packages/core/src/Cardano/types/DelegationsAndRewards.ts
+++ b/packages/core/src/Cardano/types/DelegationsAndRewards.ts
@@ -29,6 +29,7 @@ export interface RewardAccountInfo {
   delegatee?: Delegatee;
   rewardBalance: Lovelace;
   // Maybe add rewardsHistory for each reward account too
+  deposit?: Lovelace; // defined only when keyStatus is Registered
 }
 
 export interface Cip17Pool {

--- a/packages/core/test/Cardano/types/Certificates.test.ts
+++ b/packages/core/test/Cardano/types/Certificates.test.ts
@@ -36,6 +36,15 @@ describe('Certificate', () => {
         stakeCredential
       });
     });
+
+    it('can create a conway stake key de-registration certificate when deposit exists', () => {
+      const cert = createStakeDeregistrationCert(rewardAccount, 5n);
+      expect(cert).toEqual({
+        __typename: CertificateType.Unregistration,
+        deposit: 5n,
+        stakeCredential
+      } as Cardano.NewStakeAddressCertificate);
+    });
   });
 
   describe('createDelegationCert', () => {

--- a/packages/core/test/Cardano/types/Certificates.test.ts
+++ b/packages/core/test/Cardano/types/Certificates.test.ts
@@ -65,4 +65,19 @@ describe('Certificate', () => {
     expect(certificates[0].__typename).toBe(Cardano.CertificateType.StakeRegistration);
     expect(certificates[1].__typename).toBe(Cardano.CertificateType.StakeDeregistration);
   });
+
+  it('can narrow down the type of a certificate based on CertificateType', () => {
+    const cert: Cardano.StakeAddressCertificate = {
+      __typename: Cardano.CertificateType.StakeRegistration,
+      stakeCredential
+    };
+
+    expect(Cardano.isCertType(cert, [Cardano.CertificateType.StakeRegistration])).toBeTruthy();
+    expect(Cardano.isCertType(cert, Cardano.StakeRegistrationCertificateTypes)).toBeTruthy();
+    expect(Cardano.isCertType(cert, Cardano.StakeDelegationCertificateTypes)).toBeFalsy();
+    expect(Cardano.isCertType(cert, Cardano.PostConwayStakeRegistrationCertificateTypes)).toBeFalsy();
+
+    // Narrows down the type to certificates with stakeCredential property, based on the array of certificate types
+    expect(Cardano.isCertType(cert, Cardano.StakeCredentialCertificateTypes) && cert.stakeCredential).toBeTruthy();
+  });
 });

--- a/packages/projection/src/operators/Mappers/certificates/withStakeKeyRegistrations.ts
+++ b/packages/projection/src/operators/Mappers/certificates/withStakeKeyRegistrations.ts
@@ -19,15 +19,10 @@ export const withStakeKeyRegistrations = unifiedProjectorOperator<WithCertificat
     ...evt,
     stakeKeyRegistrations: evt.certificates
       .map(({ pointer, certificate }): StakeKeyRegistration | null => {
-        if (
-          Cardano.StakeRegistrationCertificateTypes.includes(
-            certificate.__typename as Cardano.StakeRegistrationCertificateTypes
-          )
-        ) {
+        if (Cardano.isCertType(certificate, Cardano.StakeRegistrationCertificateTypes)) {
           return {
             pointer,
-            stakeKeyHash: (certificate as Cardano.RegAndDeregCertificateUnion).stakeCredential
-              .hash as unknown as Ed25519KeyHashHex
+            stakeKeyHash: certificate.stakeCredential.hash as unknown as Ed25519KeyHashHex
           };
         }
         return null;

--- a/packages/projection/src/operators/Mappers/certificates/withStakeKeys.ts
+++ b/packages/projection/src/operators/Mappers/certificates/withStakeKeys.ts
@@ -20,36 +20,34 @@ export interface WithStakeKeys {
  * The intended use case of this operator is to keep track of the current set of active stake keys,
  * ignoring **when** they were registered or unregistered.
  */
-// eslint-disable-next-line sonarjs/cognitive-complexity
 export const withStakeKeys = unifiedProjectorOperator<WithCertificates, WithStakeKeys>((evt) => {
   const register = new Set<Crypto.Hash28ByteBase16>();
   const deregister = new Set<Crypto.Hash28ByteBase16>();
   for (const { certificate } of evt.certificates) {
-    if (Cardano.RegAndDeregCertificateTypes.includes(certificate.__typename as Cardano.RegAndDeregCertificateTypes)) {
-      const {
-        stakeCredential: { hash: stakeCredentialHash }
-      } = certificate as Cardano.RegAndDeregCertificateUnion;
+    if (!Cardano.isCertType(certificate, Cardano.RegAndDeregCertificateTypes)) continue;
 
-      switch (certificate.__typename) {
-        case Cardano.CertificateType.StakeDeregistration:
-        case Cardano.CertificateType.Unregistration:
-          if (register.has(certificate.stakeCredential.hash)) {
-            register.delete(certificate.stakeCredential.hash);
-          } else {
-            deregister.add(certificate.stakeCredential.hash);
-          }
-          break;
-        default:
-          // Stake registration
-          if (deregister.has(stakeCredentialHash)) {
-            deregister.delete(stakeCredentialHash);
-          } else {
-            register.add(stakeCredentialHash);
-          }
-          break;
+    const {
+      stakeCredential: { hash: stakeCredentialHash }
+    } = certificate;
+
+    if (Cardano.isCertType(certificate, Cardano.StakeRegistrationCertificateTypes)) {
+      // Stake registration
+      if (deregister.has(stakeCredentialHash)) {
+        deregister.delete(stakeCredentialHash);
+      } else {
+        register.add(stakeCredentialHash);
       }
+      continue;
+    }
+
+    // Stake deregistration
+    if (register.has(stakeCredentialHash)) {
+      register.delete(stakeCredentialHash);
+    } else {
+      deregister.add(stakeCredentialHash);
     }
   }
+
   const [insert, del] =
     evt.eventType === ChainSyncEventType.RollForward
       ? [[...register], [...deregister]]

--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -399,7 +399,7 @@ export class GenericTxBuilder implements TxBuilder {
     this.#logger.debug(`De-registering ${availableRewardAccounts.length} stake keys`);
     for (const rewardAccount of availableRewardAccounts) {
       if (rewardAccount.keyStatus === Cardano.StakeKeyStatus.Registered) {
-        certificates.push(Cardano.createStakeDeregistrationCert(rewardAccount.address));
+        certificates.push(Cardano.createStakeDeregistrationCert(rewardAccount.address, rewardAccount.deposit));
       }
     }
     this.partialTxBody = { ...this.partialTxBody, certificates };

--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -74,9 +74,7 @@ export const certificateTransactionsWithEpochs = (
 const hasDelegationCert = (certificates: Array<Cardano.Certificate> | undefined): boolean =>
   !!certificates &&
   certificates.some((cert) =>
-    [...Cardano.RegAndDeregCertificateTypes, ...Cardano.StakeDelegationCertificateTypes].includes(
-      cert.__typename as Cardano.RegAndDeregCertificateTypes | Cardano.StakeDelegationCertificateTypes
-    )
+    Cardano.isCertType(cert, [...Cardano.RegAndDeregCertificateTypes, ...Cardano.StakeDelegationCertificateTypes])
   );
 
 export const createDelegationPortfolioTracker = (transactions: Observable<Cardano.HydratedTx[]>) =>

--- a/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
+++ b/packages/wallet/src/services/DelegationTracker/transactionCertificates.ts
@@ -5,9 +5,9 @@ import { isNotNil } from '@cardano-sdk/util';
 import { transactionsEquals } from '../util/equals';
 import last from 'lodash/last';
 
-export const isLastStakeKeyCertOfType = (
+export const lastStakeKeyCertOfType = <K extends Cardano.RegAndDeregCertificateTypes>(
   transactionsCertificates: Cardano.Certificate[][],
-  certTypes: readonly Cardano.RegAndDeregCertificateTypes[],
+  certTypes: readonly K[],
   rewardAccount?: Cardano.RewardAccount
 ) => {
   const stakeKeyHash = rewardAccount
@@ -24,7 +24,10 @@ export const isLastStakeKeyCertOfType = (
       })
       .filter(isNotNil)
   );
-  return certTypes.includes(lastRegOrDereg?.__typename as Cardano.RegAndDeregCertificateTypes);
+
+  if (lastRegOrDereg && Cardano.isCertType(lastRegOrDereg, certTypes)) {
+    return lastRegOrDereg;
+  }
 };
 
 export const transactionsWithCertificates = (

--- a/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/DelegationTracker.test.ts
@@ -103,17 +103,35 @@ describe('DelegationTracker', () => {
     it('does not emit outgoing transactions with certificates not signed by the reward accounts', () => {
       createTestScheduler().run(({ cold, expectObservable }) => {
         const rewardAccount = Cardano.RewardAccount('stake_test1upqykkjq3zhf4085s6n70w8cyp57dl87r0ezduv9rnnj2uqk5zmdv');
+        const foreignRewardAccount = Cardano.RewardAccount(
+          'stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d'
+        );
         const transactions = [
           createStubTxWithCertificates([
-            { __typename: Cardano.CertificateType.StakeRegistration } as Cardano.Certificate
+            {
+              __typename: Cardano.CertificateType.StakeRegistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(foreignRewardAccount))
+              }
+            } as Cardano.Certificate
           ]),
           createStubTxWithCertificates([
             { __typename: Cardano.CertificateType.PoolRetirement } as Cardano.Certificate,
-            { __typename: Cardano.CertificateType.StakeDelegation } as Cardano.Certificate
+            {
+              __typename: Cardano.CertificateType.StakeDelegation,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(foreignRewardAccount))
+              }
+            } as Cardano.Certificate
           ]),
           createStubTxWithCertificates(),
           createStubTxWithCertificates([
-            { __typename: Cardano.CertificateType.StakeDeregistration } as Cardano.Certificate
+            {
+              __typename: Cardano.CertificateType.StakeDeregistration,
+              stakeCredential: {
+                hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(Cardano.RewardAccount.toHash(foreignRewardAccount))
+              }
+            } as Cardano.Certificate
           ])
         ];
         const slotEpochCalc = jest.fn().mockReturnValueOnce(284).mockReturnValueOnce(285);

--- a/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/RewardAccounts.test.ts
@@ -217,7 +217,6 @@ describe('RewardAccounts', () => {
 
   test.each([
     Cardano.CertificateType.Registration,
-    Cardano.CertificateType.StakeRegistration,
     Cardano.CertificateType.StakeRegistrationDelegation,
     Cardano.CertificateType.StakeVoteRegistrationDelegation,
     Cardano.CertificateType.VoteRegistrationDelegation
@@ -321,10 +320,10 @@ describe('RewardAccounts', () => {
       });
       const tracker$ = addressKeyStatuses([rewardAccount], transactions$, transactionsInFlight$);
       expectObservable(tracker$).toBe('abcda', {
-        a: [Cardano.StakeKeyStatus.Unregistered],
-        b: [Cardano.StakeKeyStatus.Registering],
-        c: [Cardano.StakeKeyStatus.Registered],
-        d: [Cardano.StakeKeyStatus.Unregistering]
+        a: [{ keyStatus: Cardano.StakeKeyStatus.Unregistered }],
+        b: [{ keyStatus: Cardano.StakeKeyStatus.Registering }],
+        c: [{ deposit: 0n, keyStatus: Cardano.StakeKeyStatus.Registered }],
+        d: [{ keyStatus: Cardano.StakeKeyStatus.Unregistering }]
       });
     });
   });

--- a/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
+++ b/packages/wallet/test/services/DelegationTracker/transactionCertificates.test.ts
@@ -1,10 +1,10 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
-import { isLastStakeKeyCertOfType, transactionsWithCertificates } from '../../../src';
+import { lastStakeKeyCertOfType, transactionsWithCertificates } from '../../../src';
 
 describe('transactionCertificates', () => {
-  test('isLastStakeKeyCertOfType', () => {
+  test('lastStakeKeyCertOfType', () => {
     const rewardAccount = Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d');
     const stakeKeyHash = Cardano.RewardAccount.toHash(rewardAccount);
     const stakeCredential = {
@@ -15,7 +15,8 @@ describe('transactionCertificates', () => {
     const certificates = [
       [
         {
-          __typename: Cardano.CertificateType.StakeRegistration,
+          __typename: Cardano.CertificateType.Registration,
+          deposit: 2_000_000n,
           stakeCredential
         } as Cardano.Certificate,
         {
@@ -26,7 +27,8 @@ describe('transactionCertificates', () => {
       [
         ({ __typename: Cardano.CertificateType.PoolRegistration } as Cardano.Certificate,
         {
-          __typename: Cardano.CertificateType.StakeDeregistration,
+          __typename: Cardano.CertificateType.Unregistration,
+          deposit: 2_000_000n,
           stakeCredential: {
             hash: Crypto.Hash28ByteBase16('00000000000000000000000000000000000000000000000000000000'),
             type: Cardano.CredentialType.KeyHash
@@ -34,11 +36,13 @@ describe('transactionCertificates', () => {
         } as Cardano.Certificate)
       ]
     ];
-    expect(isLastStakeKeyCertOfType(certificates, [Cardano.CertificateType.StakeRegistration])).toBe(false);
-    expect(isLastStakeKeyCertOfType(certificates, [Cardano.CertificateType.StakeRegistration], rewardAccount)).toBe(
-      true
+    expect(lastStakeKeyCertOfType(certificates, [Cardano.CertificateType.Registration])).toBeFalsy();
+    expect(lastStakeKeyCertOfType(certificates, [Cardano.CertificateType.Registration], rewardAccount)).toEqual(
+      expect.objectContaining({ __typename: Cardano.CertificateType.Registration, deposit: 2_000_000n })
     );
-    expect(isLastStakeKeyCertOfType(certificates, [Cardano.CertificateType.StakeDeregistration])).toBe(true);
+    expect(lastStakeKeyCertOfType(certificates, [Cardano.CertificateType.Unregistration])).toEqual(
+      expect.objectContaining({ __typename: Cardano.CertificateType.Unregistration, deposit: 2_000_000n })
+    );
   });
 
   test('outgoingTransactionsWithCertificates', () => {


### PR DESCRIPTION
# Context

Certificates that register stake key include the deposit value, as configured in the protocol parameters at the time of submitting the transaction

Currently, the deposit value is taken from the protocol parameters, and used as [implicit coin](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/core/src/Cardano/util/computeImplicitCoin.ts#L16) when deregistering the stake key

In the conway era, the protocol parameters could change often as a  result of a governance action, leading to a discrepancy in the deposit value at stake key registration and the deposit value at stake key deregistration.

# Proposed Solution
For this reason, the stake key deposit value at the time of registering the stake key should be stored in RewardAccountInfo from ObservableWallet.delegation.rewardAccounts$.

It could for example be undefined when the stake key is not registered, and the real value when the stake key is registered.

This way, on deregistering a stake key, SDK can use this value as deposit value.

# Important Changes Introduced