### PR TITLE
feat: hoist extendedAccountPublicKey into Bip32WalletAccount type

### DIFF
--- a/packages/e2e/test/web-extension/extension/ui.ts
+++ b/packages/e2e/test/web-extension/extension/ui.ts
@@ -313,18 +313,19 @@ const createWalletIfNotExistsAndActivate = async (accountIndex: number) => {
     logger.log('adding to repository wallet');
     // Add wallet to the repository.
     walletId = await repository.addWallet({
+      accounts: [
+        {
+          accountIndex,
+          extendedAccountPublicKey: keyAgent.serializableData.extendedAccountPublicKey,
+          metadata: { name: `wallet-${accountIndex}` }
+        }
+      ],
       encryptedSecrets: {
         keyMaterial: HexBlob.fromBytes(encryptedMnemonic),
         rootPrivateKeyBytes: HexBlob.fromBytes(new Uint8Array(encryptedRootPrivateKey))
       },
-      extendedAccountPublicKey: keyAgent.serializableData.extendedAccountPublicKey,
       metadata: {},
       type: WalletType.InMemory
-    });
-    await repository.addAccount({
-      accountIndex,
-      metadata: { name: `wallet-${accountIndex}` },
-      walletId
     });
 
     logger.log(`Wallet added: ${walletId}`);

--- a/packages/util-rxjs/src/TrackerSubject.ts
+++ b/packages/util-rxjs/src/TrackerSubject.ts
@@ -1,13 +1,17 @@
 import { Observable, ReplaySubject, Subscription } from 'rxjs';
 
+type NO_VALUE_TYPE = 'TRACKER_SUBJECT_NO_VALUE';
+
 export interface BehaviorObservable<T> extends Observable<T> {
-  get value(): T | null;
+  get value(): T | NO_VALUE_TYPE;
 }
 
 export class TrackerSubject<T> extends ReplaySubject<T> implements BehaviorObservable<T> {
+  static NO_VALUE: NO_VALUE_TYPE = 'TRACKER_SUBJECT_NO_VALUE';
+
   #sourceSubscription$: Subscription;
-  #value: T | null = null;
-  get value(): T | null {
+  #value: T | NO_VALUE_TYPE = 'TRACKER_SUBJECT_NO_VALUE';
+  get value(): T | NO_VALUE_TYPE {
     return this.#value;
   }
   constructor(source$: Observable<T>) {

--- a/packages/util-rxjs/test/TrackerSubject.test.ts
+++ b/packages/util-rxjs/test/TrackerSubject.test.ts
@@ -18,13 +18,13 @@ describe('TrackerSubject', () => {
     expect(subject$.value).toBe(true);
   });
 
-  it('value is null by default', () => {
+  it('value is TrackerSubject.NO_VALUE by default', () => {
     createTestScheduler().run(({ cold, expectObservable, flush }) => {
       const source$ = cold('|');
       const subject$ = new TrackerSubject(source$);
       expectObservable(subject$).toBe('|');
       flush();
-      expect(subject$.value).toBe(null);
+      expect(subject$.value).toBe(TrackerSubject.NO_VALUE);
     });
   });
 

--- a/packages/wallet/test/PersonalWallet/load.test.ts
+++ b/packages/wallet/test/PersonalWallet/load.test.ts
@@ -169,7 +169,7 @@ const assertWalletProperties = async (
   await firstValueFrom(wallet.tip$);
   expect(wallet.tip$.value).toEqual(mocks.ledgerTip);
   // currentEpoch$
-  expect(wallet.currentEpoch$.value?.epochNo).toEqual(currentEpoch.number);
+  expect(wallet.currentEpoch$.value).toEqual(expect.objectContaining({ epochNo: currentEpoch.number }));
   // protocolParameters$
   await firstValueFrom(wallet.protocolParameters$);
   expect(wallet.protocolParameters$.value).toEqual(mocks.protocolParameters);

--- a/packages/wallet/test/PersonalWallet/shutdown.test.ts
+++ b/packages/wallet/test/PersonalWallet/shutdown.test.ts
@@ -103,7 +103,7 @@ const assertWalletProperties = async (
   await firstValueFrom(wallet.tip$);
   expect(wallet.tip$.value).toEqual(mocks.ledgerTip);
   // currentEpoch$
-  expect(wallet.currentEpoch$.value?.epochNo).toEqual(mocks.currentEpoch.number);
+  expect(wallet.currentEpoch$.value).toEqual(expect.objectContaining({ epochNo: mocks.currentEpoch.number }));
   // protocolParameters$
   await firstValueFrom(wallet.protocolParameters$);
   expect(wallet.protocolParameters$.value).toEqual(mocks.protocolParameters);

--- a/packages/web-extension/src/messaging/remoteApi.ts
+++ b/packages/web-extension/src/messaging/remoteApi.ts
@@ -379,7 +379,7 @@ export const bindObservableChannels = <API extends object>(
 
       const observableMessenger = messenger.deriveChannel(observableProperty);
       const connectSubscription = observableMessenger.connect$.subscribe((port) => {
-        if (observable$.value !== null) {
+        if (observable$.value !== TrackerSubject.NO_VALUE) {
           try {
             port.postMessage(
               toSerializableObject({ emit: observable$.value, messageId: newMessageId() } as EmitMessage)

--- a/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
@@ -155,7 +155,7 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
                           encryptedRootPrivateKeyBytes: [
                             ...Buffer.from(wallet.encryptedSecrets.rootPrivateKeyBytes, 'hex')
                           ],
-                          extendedAccountPublicKey: wallet.extendedAccountPublicKey,
+                          extendedAccountPublicKey: account.extendedAccountPublicKey,
                           getPassphrase: async () => passphrase
                         })
                       );
@@ -182,12 +182,12 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
                             accountIndex: request.requestContext.accountIndex,
                             chainId: request.requestContext.chainId,
                             communicationType: this.#hwOptions.communicationType,
-                            extendedAccountPublicKey: request.requestContext.wallet.extendedAccountPublicKey
+                            extendedAccountPublicKey: account.extendedAccountPublicKey
                           })
                         : this.#keyAgentFactory.Trezor({
                             accountIndex: request.requestContext.accountIndex,
                             chainId: request.requestContext.chainId,
-                            extendedAccountPublicKey: request.requestContext.wallet.extendedAccountPublicKey,
+                            extendedAccountPublicKey: account.extendedAccountPublicKey,
                             trezorConfig: this.#hwOptions
                           })
                     ).catch((error) => throwMaybeWrappedWithNoRejectError(error, options)),

--- a/packages/web-extension/src/walletManager/WalletRepository/types.ts
+++ b/packages/web-extension/src/walletManager/WalletRepository/types.ts
@@ -1,4 +1,5 @@
 import { AnyWallet, HardwareWallet, InMemoryWallet, ScriptWallet, WalletId } from '../types';
+import { Bip32PublicKeyHex } from '@cardano-sdk/crypto';
 import { Observable } from 'rxjs';
 
 export type RemoveAccountProps = {
@@ -12,6 +13,7 @@ export type AddAccountProps<Metadata extends {}> = {
   /** account' in cip1852 */
   accountIndex: number;
   metadata: Metadata;
+  extendedAccountPublicKey: Bip32PublicKeyHex;
 };
 
 export type UpdateWalletMetadataProps<Metadata extends {}> = {
@@ -27,14 +29,19 @@ export type UpdateAccountMetadataProps<Metadata extends {}> = {
 };
 
 export type AddWalletProps<WalletMetadata extends {}, AccountMetadata extends {}> =
-  | Omit<HardwareWallet<WalletMetadata, AccountMetadata>, 'walletId' | 'accounts'>
-  | Omit<InMemoryWallet<WalletMetadata, AccountMetadata>, 'walletId' | 'accounts'>
+  | Omit<HardwareWallet<WalletMetadata, AccountMetadata>, 'walletId'>
+  | Omit<InMemoryWallet<WalletMetadata, AccountMetadata>, 'walletId'>
   | Omit<ScriptWallet<WalletMetadata>, 'walletId'>;
 
 export interface WalletRepositoryApi<WalletMetadata extends {}, AccountMetadata extends {}> {
   wallets$: Observable<AnyWallet<WalletMetadata, AccountMetadata>[]>;
 
-  /** Rejects with WalletConflictError when wallet already exists */
+  /**
+   * When adding a BIP32 wallet, it must have at least 1 account.
+   * 1st (accounts[0]) account is used to derive wallet id.
+   *
+   * Rejects with WalletConflictError when wallet already exists.
+   */
   addWallet(props: AddWalletProps<WalletMetadata, AccountMetadata>): Promise<WalletId>;
 
   /**

--- a/packages/web-extension/src/walletManager/WalletRepository/types.ts
+++ b/packages/web-extension/src/walletManager/WalletRepository/types.ts
@@ -52,8 +52,8 @@ export interface WalletRepositoryApi<WalletMetadata extends {}, AccountMetadata 
   ): Promise<UpdateWalletMetadataProps<WalletMetadata>>;
 
   updateAccountMetadata(
-    props: UpdateWalletMetadataProps<AccountMetadata>
-  ): Promise<UpdateWalletMetadataProps<AccountMetadata>>;
+    props: UpdateAccountMetadataProps<AccountMetadata>
+  ): Promise<UpdateAccountMetadataProps<AccountMetadata>>;
 
   /** Rejects with WalletConflictError when account is not found. */
   removeAccount(props: RemoveAccountProps): Promise<RemoveAccountProps>;

--- a/packages/web-extension/src/walletManager/types.ts
+++ b/packages/web-extension/src/walletManager/types.ts
@@ -16,11 +16,11 @@ export type Bip32WalletAccount<Metadata extends {}> = {
   accountIndex: number;
   /** e.g. account name, picture */
   metadata: Metadata;
+  extendedAccountPublicKey: Bip32PublicKeyHex;
 };
 
 export type Bip32Wallet<WalletMetadata extends {}, AccountMetadata extends {}> = {
   walletId: WalletId;
-  extendedAccountPublicKey: Bip32PublicKeyHex;
   metadata: WalletMetadata;
   accounts: Bip32WalletAccount<AccountMetadata>[];
 };

--- a/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
+++ b/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
@@ -8,10 +8,11 @@ import {
   SignTransactionContext,
   errors
 } from '@cardano-sdk/key-management';
-import { Bip32PublicKeyHex, Ed25519PublicKeyHex, Ed25519SignatureHex, Hash28ByteBase16 } from '@cardano-sdk/crypto';
 import { Cardano, TxCBOR } from '@cardano-sdk/core';
+import { Ed25519PublicKeyHex, Ed25519SignatureHex, Hash28ByteBase16 } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 import { InMemoryWallet, KeyAgentFactory, SigningCoordinator, WalletType, WrongTargetError } from '../../src';
+import { createAccount } from './util';
 import { firstValueFrom } from 'rxjs';
 
 describe('SigningCoordinator', () => {
@@ -19,19 +20,11 @@ describe('SigningCoordinator', () => {
   let keyAgentFactory: jest.Mocked<KeyAgentFactory>;
   let keyAgent: jest.Mocked<InMemoryKeyAgent>;
   const wallet: InMemoryWallet<{}, {}> = {
-    accounts: [
-      {
-        accountIndex: 0,
-        metadata: { friendlyName: 'My Wallet' }
-      }
-    ],
+    accounts: [createAccount(0, 0)],
     encryptedSecrets: {
       keyMaterial: HexBlob('abc'),
       rootPrivateKeyBytes: HexBlob('123')
     },
-    extendedAccountPublicKey: Bip32PublicKeyHex(
-      'ba4f80dea2632a17c99ae9d8b934abf02643db5426b889fef14709c85e294aa12ac1f1560a893ea7937c5bfbfdeab459b1a396f1174b9c5a673a640d01880c35'
-    ),
     metadata: {},
     type: WalletType.InMemory,
     walletId: Hash28ByteBase16('ad63f855e831d937457afc52a21a7f351137e4a9fff26c217817335a')

--- a/packages/web-extension/test/walletManager/util.ts
+++ b/packages/web-extension/test/walletManager/util.ts
@@ -1,0 +1,16 @@
+import { Bip32PublicKeyHex } from '@cardano-sdk/crypto';
+import { Bip32WalletAccount } from '../../src';
+
+export type WalletMetadata = { name: string };
+export type AccountMetadata = { name: string };
+
+export const createPubKey = (numWallet: number, accountIndex: number) =>
+  Bip32PublicKeyHex(
+    `${numWallet}a4f80dea2632a17c99ae9d8b934abf02643db5426b889fef14709c85e294aa12ac1f1560a893ea7937c5bfbfdeab459b1a396f1174b9c5a673a640d01880c3${accountIndex}`
+  );
+
+export const createAccount = (numWallet: number, accountIndex: number): Bip32WalletAccount<AccountMetadata> => ({
+  accountIndex,
+  extendedAccountPublicKey: createPubKey(numWallet, accountIndex),
+  metadata: { name: `Wallet ${numWallet} Account #${accountIndex}` }
+});


### PR DESCRIPTION
# Context

This PR contains fixes for 2 issues:

1. `WalletRepository` data model is incorrect, because extended**Account**PublicKey is unique to a wallet account, not to a wallet
2. WalletManager.activeWalletId$ emits null when no wallet is active. However, remoteApi.ts implementation relies on TrackerSubject, which uses null to check for value presence and filters it out.

LW-9709 LW-9094 LW-9170

# Proposed Solution

1. Hoist `extendedAccountPublicKey` to `Bip32WalletAccount` type
2. `TrackerSubject.value$` observable type changed to `T | typeof TrackerSubject.NO_VALUE`

# Important Changes Introduced
