### PR TITLE
test(core): add unit tests VrfVkBech32.fromHex

### DIFF
--- a/packages/core/src/Cardano/types/Block.ts
+++ b/packages/core/src/Cardano/types/Block.ts
@@ -69,10 +69,9 @@ export const SlotLeader = (value: string): SlotLeader => {
 /**
  * Get Bech32 encoded VRF verification key from base16 encoded string
  *
- * @param value is a Base64 string
+ * @param value is a base16 string
  * @returns Bech32 encoded vrf_vk
  */
-// TODO: test this, rm tests of VrfVkBech32FromBase64
 VrfVkBech32.fromHex = (value: string) => {
   const words = BaseEncoding.bech32.toWords(Buffer.from(value, 'hex'));
   return VrfVkBech32(BaseEncoding.bech32.encode('vrf_vk', words, 1023));

--- a/packages/core/test/Cardano/types/Block.test.ts
+++ b/packages/core/test/Cardano/types/Block.test.ts
@@ -1,3 +1,4 @@
+import * as BaseEncoding from '@scure/base';
 import { BlockId, SlotLeader, VrfVkBech32 } from '../../../src/Cardano';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { InvalidStringError, typedBech32 } from '@cardano-sdk/util';
@@ -25,13 +26,31 @@ describe('Cardano/types/Block', () => {
     expect(Hash32ByteBase16).toBeCalledWith('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5ea4172b2ed');
   });
 
-  it('VrfVkBech32() accepts a valid vrf vkey bech32 string and is implemented using typedBech32', () => {
-    expect(() => VrfVkBech32('vrf_vk19j362pkr4t9y0m3qxgmrv0365vd7c4ze03ny4jh84q8agjy4ep4s99zvg8')).not.toThrow();
-    expect(typedBech32).toBeCalledWith(
-      'vrf_vk19j362pkr4t9y0m3qxgmrv0365vd7c4ze03ny4jh84q8agjy4ep4s99zvg8',
-      'vrf_vk',
-      52
-    );
+  describe('VrfVkBech32', () => {
+    it('accepts a valid vrf vkey bech32 string and is implemented using typedBech32', () => {
+      expect(() => VrfVkBech32('vrf_vk19j362pkr4t9y0m3qxgmrv0365vd7c4ze03ny4jh84q8agjy4ep4s99zvg8')).not.toThrow();
+      expect(typedBech32).toBeCalledWith(
+        'vrf_vk19j362pkr4t9y0m3qxgmrv0365vd7c4ze03ny4jh84q8agjy4ep4s99zvg8',
+        'vrf_vk',
+        52
+      );
+    });
+
+    it('fromHex can parse a base16 encoded string', () => {
+      const base16Vrf = '34b342609f9de7093852e96abdde5a5d8821f59d134f522cad7e5262ff518301';
+      const bech32Vrf = VrfVkBech32.fromHex(base16Vrf);
+      expect(bech32Vrf).toMatch(/^vrf_vk*/);
+
+      // transform it back to hex
+      const vrfToHex = Buffer.from(BaseEncoding.bech32.decodeToBytes(bech32Vrf).bytes).toString('hex');
+      expect(vrfToHex).toEqual(base16Vrf);
+    });
+
+    it('fromHex accepts only valid 52 bytes hex strings', () => {
+      expect(() => VrfVkBech32.fromHex('banana')).toThrow();
+      expect(() => VrfVkBech32.fromHex('34b342609f9de7093852e96abdde5a5d8821f59d134f522cad7e5262ff518301ff')).toThrow();
+      expect(() => VrfVkBech32.fromHex('34b342609f9de7093852e96abdde5a5d8821f59d134f522cad7e5262ff5183')).toThrow();
+    });
   });
 
   describe('SlotLeader()', () => {


### PR DESCRIPTION
# Context

ogmios 6 production readiness task.
Since `VrfVkBech32.fromHex` utility is used only by the ogmios block mapper, this change goes directly into conway-era branch.

# Proposed Solution

# Important Changes Introduced
