### PR TITLE
feat(wallet): added a new input resolver decorator that also fetches from the backend

### DIFF
--- a/packages/core/src/Cardano/Address/PaymentAddress.ts
+++ b/packages/core/src/Cardano/Address/PaymentAddress.ts
@@ -7,7 +7,7 @@ import {
   assertIsBech32WithPrefix,
   assertIsHexString
 } from '@cardano-sdk/util';
-import { HydratedTx, HydratedTxIn, TxIn, TxOut } from '../types';
+import { HydratedTx, HydratedTxIn, Tx, TxIn, TxOut } from '../types';
 import { NetworkId } from '../ChainId';
 import { RewardAccount } from './RewardAccount';
 
@@ -68,11 +68,15 @@ export const isAddressWithin =
 export const inputsWithAddresses = (tx: HydratedTx, ownAddresses: PaymentAddress[]): HydratedTxIn[] =>
   tx.body.inputs.filter(isAddressWithin(ownAddresses));
 
+export type ResolveOptions = {
+  hints: Tx[];
+};
+
 /**
  * @param txIn transaction input to resolve associated txOut from
  * @returns txOut
  */
-export type ResolveInput = (txIn: TxIn) => Promise<TxOut | null>;
+export type ResolveInput = (txIn: TxIn, options?: ResolveOptions) => Promise<TxOut | null>;
 
 export interface InputResolver {
   resolveInput: ResolveInput;

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-bitwise */
 import * as Crypto from '@cardano-sdk/crypto';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, ChainHistoryProvider } from '@cardano-sdk/core';
 import { GroupedAddress, util as KeyManagementUtil } from '@cardano-sdk/key-management';
 import { Observable, firstValueFrom } from 'rxjs';
 import { ObservableWallet, ScriptAddress, isScriptAddress } from '../types';
@@ -28,6 +28,58 @@ export const createInputResolver = ({ utxo }: InputResolverContext): Cardano.Inp
     const availableUtxo = utxoAvailable?.find(([txIn]) => txInEquals(txIn, input));
     if (!availableUtxo) return null;
     return availableUtxo[1];
+  }
+});
+
+/**
+ * Creates an input resolver that fetch transaction inputs from the backend.
+ *
+ * This function tries to fetch the transaction from the backend using a `ChainHistoryProvider`. It
+ * also caches fetched transactions to optimize subsequent input resolutions.
+ *
+ * @param provider The backend provider used to fetch transactions by their hashes if
+ * they are not found by the inputResolver.
+ * @returns An input resolver that can fetch unresolved inputs from the backend.
+ */
+export const createBackendInputResolver = (provider: ChainHistoryProvider): Cardano.InputResolver => {
+  const txCache = new Map<Cardano.TransactionId, Cardano.Tx>();
+
+  const fetchAndCacheTransaction = async (txId: Cardano.TransactionId): Promise<Cardano.Tx | null> => {
+    if (txCache.has(txId)) {
+      return txCache.get(txId)!;
+    }
+
+    const txs = await provider.transactionsByHashes({ ids: [txId] });
+    if (txs.length > 0) {
+      txCache.set(txId, txs[0]);
+      return txs[0];
+    }
+
+    return null;
+  };
+
+  return {
+    async resolveInput(input: Cardano.TxIn) {
+      const tx = await fetchAndCacheTransaction(input.txId);
+      if (!tx) return null;
+
+      return tx.body.outputs.length > input.index ? tx.body.outputs[input.index] : null;
+    }
+  };
+};
+
+/**
+ * Combines multiple input resolvers into a single resolver.
+ *
+ * @param resolvers The input resolvers to combine.
+ */
+export const combineInputResolvers = (...resolvers: Cardano.InputResolver[]): Cardano.InputResolver => ({
+  async resolveInput(txIn: Cardano.TxIn) {
+    for (const resolver of resolvers) {
+      const resolved = await resolver.resolveInput(txIn);
+      if (resolved) return resolved;
+    }
+    return null;
   }
 });
 

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -70,6 +70,58 @@ describe('WalletUtil', () => {
         })
       ).toBeNull();
     });
+
+    it('resolveInput resolves inputs from provided hints', async () => {
+      const tx = {
+        body: {
+          outputs: [
+            {
+              address: Cardano.PaymentAddress(
+                'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+              ),
+              value: { coins: 50_000_000n }
+            },
+            {
+              address: Cardano.PaymentAddress(
+                'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+              ),
+              value: { coins: 150_000_000n }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+      } as Cardano.HydratedTx;
+
+      const resolver = createInputResolver({ utxo: { available$: of([]) } });
+
+      expect(
+        await resolver.resolveInput(
+          {
+            index: 0,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+          },
+          { hints: [tx] }
+        )
+      ).toEqual({
+        address:
+          'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
+        value: { coins: 50_000_000n }
+      });
+
+      expect(
+        await resolver.resolveInput(
+          {
+            index: 1,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+          },
+          { hints: [tx] }
+        )
+      ).toEqual({
+        address:
+          'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
+        value: { coins: 150_000_000n }
+      });
+    });
   });
 
   describe('createBackendInputResolver', () => {
@@ -111,6 +163,58 @@ describe('WalletUtil', () => {
           index: 1,
           txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
         })
+      ).toEqual({
+        address:
+          'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
+        value: { coins: 150_000_000n }
+      });
+    });
+
+    it('resolveInput resolves inputs from provided hints', async () => {
+      const tx = {
+        body: {
+          outputs: [
+            {
+              address: Cardano.PaymentAddress(
+                'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+              ),
+              value: { coins: 50_000_000n }
+            },
+            {
+              address: Cardano.PaymentAddress(
+                'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+              ),
+              value: { coins: 150_000_000n }
+            }
+          ]
+        },
+        id: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+      } as Cardano.HydratedTx;
+
+      const resolver = createBackendInputResolver(createMockChainHistoryProvider([]));
+
+      expect(
+        await resolver.resolveInput(
+          {
+            index: 0,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+          },
+          { hints: [tx] }
+        )
+      ).toEqual({
+        address:
+          'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
+        value: { coins: 50_000_000n }
+      });
+
+      expect(
+        await resolver.resolveInput(
+          {
+            index: 1,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+          },
+          { hints: [tx] }
+        )
       ).toEqual({
         address:
           'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
@@ -206,7 +310,23 @@ describe('WalletUtil', () => {
       });
     });
 
-    it('can resolve inputs from own transactions and from chain history provider', async () => {
+    it('can resolve inputs from own transactions, hints and from chain history provider', async () => {
+      const hints = [
+        {
+          body: {
+            outputs: [
+              {
+                address: Cardano.PaymentAddress(
+                  'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+                ),
+                value: { coins: 200_000_000n }
+              }
+            ]
+          },
+          id: Cardano.TransactionId('0000bbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0FFFFFFFFFF')
+        } as Cardano.HydratedTx
+      ];
+
       const tx = {
         body: {
           outputs: [
@@ -248,20 +368,26 @@ describe('WalletUtil', () => {
       );
 
       expect(
-        await resolver.resolveInput({
-          index: 0,
-          txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
-        })
+        await resolver.resolveInput(
+          {
+            index: 0,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
+          },
+          { hints }
+        )
       ).toEqual({
         address: 'addr_test1vr8nl4u0u6fmtfnawx2rxfz95dy7m46t6dhzdftp2uha87syeufdg',
         value: { coins: 50_000_000n }
       });
 
       expect(
-        await resolver.resolveInput({
-          index: 0,
-          txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e7FFFFFFFF')
-        })
+        await resolver.resolveInput(
+          {
+            index: 0,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e7FFFFFFFF')
+          },
+          { hints }
+        )
       ).toEqual({
         address:
           'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
@@ -269,14 +395,30 @@ describe('WalletUtil', () => {
       });
 
       expect(
-        await resolver.resolveInput({
-          index: 1,
-          txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e7FFFFFFFF')
-        })
+        await resolver.resolveInput(
+          {
+            index: 1,
+            txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e7FFFFFFFF')
+          },
+          { hints }
+        )
       ).toEqual({
         address:
           'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
         value: { coins: 150_000_000n }
+      });
+      expect(
+        await resolver.resolveInput(
+          {
+            index: 0,
+            txId: Cardano.TransactionId('0000bbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0FFFFFFFFFF')
+          },
+          { hints }
+        )
+      ).toEqual({
+        address:
+          'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz',
+        value: { coins: 200_000_000n }
       });
     });
 


### PR DESCRIPTION
# Context

In order to inspect the transaction that’s build by the dapp, input resolver that we have in WalletUtil is not going to work because it only resolves own addresses.

Create a new input resolver that utilizes the existing one and queries chain history provider for inputs that are not resolved as own

# Proposed Solution

Add a decorator to the inputResolver that additional resolve inputs from the backend if the inputs are not found in our UTXO set.

