### PR TITLE
fix(web-extension): delete active wallet from storage and emit null

### DIFF
--- a/packages/web-extension/src/walletManager/walletManager.ts
+++ b/packages/web-extension/src/walletManager/walletManager.ts
@@ -160,6 +160,8 @@ export class WalletManager<WalletMetadata extends { name: string }, AccountMetad
   /** Deactivate wallet. Wallet observable properties will emit only after a new wallet is {@link activate}ed. */
   async deactivate(): Promise<void> {
     this.#deactivateWallet();
+    await this.#managerStorage.remove(this.#managerStorageKey);
+    this.activeWalletId$.next(null);
   }
 
   /** Deactivates the active. */


### PR DESCRIPTION
# Context

When wallet is deactivated, it should emit null to indicate there's no active wallet

When wallet manager is reinitialized after deactivation, it shouldn't load any wallet

LW-9094

# Proposed Solution

# Important Changes Introduced
