### PR TITLE
chore(cardano-services): un-skip previously skipped unit tests

### DIFF
--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
@@ -270,8 +270,7 @@ describe('StakePoolBuilder', () => {
     });
   });
   describe('buildAndQuery', () => {
-    // TODO LW-9184 REMOVE SKIP
-    it.skip('buildAndQuery, queryPoolHashes & queryTotalCount', async () => {
+    it('buildAndQuery, queryPoolHashes & queryTotalCount', async () => {
       const builtQuery = builder.buildAndQuery(filters);
       const { query, params } = builtQuery;
       const poolHashes = await builder.queryPoolHashes(query, params);

--- a/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
+++ b/packages/cardano-services/test/StakePool/StakePoolHttpService.test.ts
@@ -994,8 +994,7 @@ describe('StakePoolHttpService', () => {
               expect(response.pageResults.length).toBeGreaterThan(0);
               expect(response.pageResults).toEqual(responseCached.pageResults);
             });
-            // TODO LW-9184 REMOVE SKIP
-            it.skip('pledgeMet true, status retired, and condition', async () => {
+            it('pledgeMet true, status retired, and condition', async () => {
               const retiring = await fixtureBuilder.getPools(1, { with: [PoolWith.RetiredState, PoolWith.PledgeMet] });
               const filter: QueryStakePoolsArgs = {
                 filters: {


### PR DESCRIPTION
# Context

Fixtures generated with current cardano stack versions no longer causes problems.

# Proposed Solution

Un-skipped a couple of tests skipped in the past as a quick workaround.