### PR TITLE
feat(key-management): add payload to SignDataContext when signing cip8 structure

### DIFF
--- a/packages/key-management/src/cip8/cip30signData.ts
+++ b/packages/key-management/src/cip8/cip30signData.ts
@@ -93,7 +93,8 @@ const signSigStructure = (
   sender?: MessageSender
 ) => {
   try {
-    return witnesser.signBlob(derivationPath, util.bytesToHex(sigStructure.to_bytes()), { address, sender });
+    const payload = util.bytesToHex(sigStructure.payload());
+    return witnesser.signBlob(derivationPath, util.bytesToHex(sigStructure.to_bytes()), { address, payload, sender });
   } catch (error) {
     throw new Cip30DataSignError(Cip30DataSignErrorCode.UserDeclined, 'Failed to sign', error);
   }

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -149,6 +149,8 @@ export interface SignTransactionContext {
 
 export interface SignDataContext {
   address?: Cardano.PaymentAddress | Cardano.RewardAccount | Cardano.DRepID;
+  /** Present when signing CIP-0008 structure */
+  payload?: HexBlob;
   sender?: MessageSender;
 }
 

--- a/packages/key-management/test/cip8/cip30signData.test.ts
+++ b/packages/key-management/test/cip8/cip30signData.test.ts
@@ -17,6 +17,7 @@ import { HexBlob } from '@cardano-sdk/util';
 import { testAsyncKeyAgent, testKeyAgent } from '../mocks';
 
 describe('cip30signData', () => {
+  const payload = HexBlob('abc123');
   const addressDerivationPath = { index: 0, type: AddressType.External };
   let keyAgent: KeyAgent;
   let witnesser: Bip32Ed25519Witnesser;
@@ -39,7 +40,7 @@ describe('cip30signData', () => {
   ) => {
     const dataSignature = await cip8.cip30signData({
       knownAddresses,
-      payload: HexBlob('abc123'),
+      payload,
       sender,
       signWith,
       witnesser
@@ -113,6 +114,10 @@ describe('cip30signData', () => {
     const signBlobSpy = jest.spyOn(witnesser, 'signBlob');
     const sender = { url: 'https://lace.io' };
     await signAndDecode(address.address, [address], sender);
-    expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), { address: address.address, sender });
+    expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), {
+      address: address.address,
+      payload,
+      sender
+    });
   });
 });

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -438,8 +438,9 @@ describe('PersonalWallet methods', () => {
     it('passes through context to witnesser', async () => {
       const sender = { url: 'https://lace.io' };
       const signBlobSpy = jest.spyOn(witnesser, 'signBlob');
-      await wallet.signData({ payload: HexBlob('abc123'), sender, signWith: address });
-      expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), { address, sender });
+      const payload = HexBlob('abc123');
+      await wallet.signData({ payload, sender, signWith: address });
+      expect(signBlobSpy).toBeCalledWith(expect.anything(), expect.anything(), { address, payload, sender });
     });
 
     test('rejects if bech32 DRepID is not a type 6 address', async () => {


### PR DESCRIPTION
# Context

The blob that's being signed wraps the payload

# Proposed Solution

Adding the actual payload to context makes it easier to display it to the signer

# Important Changes Introduced
