### PR TITLE
ci: make CI run on all release types

### DIFF
--- a/.github/workflows/std-release.yaml
+++ b/.github/workflows/std-release.yaml
@@ -2,7 +2,6 @@ name: STD-on-release
 
 on:
   release:
-    types: [published]
 
 jobs:
   call-std:


### PR DESCRIPTION
# Context

CI does not run on some releases for some reason, this should resolve issue: https://github.com/input-output-hk/lace-ops/issues/29
Context: https://input-output-rnd.slack.com/archives/C032DECBR6G/p1707739178455329?thread_ts=1707396396.997519&cid=C032DECBR6G

Info on the trigger: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

