### PR TITLE
test(cardano-services): test ogmios utils

### DIFF
--- a/packages/cardano-services/test/Program/services/ogmios.test.ts
+++ b/packages/cardano-services/test/Program/services/ogmios.test.ts
@@ -1,45 +1,39 @@
-/* eslint-disable sonarjs/no-identical-functions */
-/* eslint-disable sonarjs/no-duplicate-string */
-import { Connection } from '@cardano-ogmios/client';
-import { DbPools, LedgerTipModel, findLedgerTip } from '../../../src/util/DbSyncProvider';
-import { DbSyncEpochPollService, listenPromise, loadGenesisData, serverClosePromise } from '../../../src/util';
-import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../../src/NetworkInfo';
 import {
-  HttpServer,
-  HttpServerConfig,
-  TxSubmitHttpService,
+  MissingCardanoNodeOption,
   createDnsResolver,
   getOgmiosCardanoNode,
-  getPool
+  getOgmiosObservableCardanoNode
 } from '../../../src';
-import { InMemoryCache, UNLIMITED_CACHE_TTL } from '../../../src/InMemoryCache';
-import { Ogmios, OgmiosCardanoNode } from '@cardano-sdk/ogmios';
-import { Pool } from 'pg';
-import { SrvRecord } from 'dns';
-import { TxSubmissionError, TxSubmitProvider } from '@cardano-sdk/core';
-import { bufferToHexString } from '@cardano-sdk/util';
-import { clearDbPools, servicesWithVersionPath as services } from '../../util';
-import { getPort, getRandomPort } from 'get-port-please';
-import { handleProviderMocks, logger } from '@cardano-sdk/util-dev';
-import { healthCheckResponseMock } from '../../../../core/test/CardanoNode/mocks';
 import { mockDnsResolverFactory } from './util';
-import { types } from 'util';
-import axios from 'axios';
-import http from 'http';
 
-jest.mock('@cardano-sdk/cardano-services-client', () => ({
-  ...jest.requireActual('@cardano-sdk/cardano-services-client'),
-  KoraLabsHandleProvider: jest.fn().mockImplementation(() => ({
-    healthCheck: jest.fn(),
-    resolveHandles: jest.fn().mockResolvedValue([handleProviderMocks.getAliceHandleProviderResponse])
-  }))
+import { OgmiosCardanoNode, OgmiosObservableCardanoNode, OgmiosObservableCardanoNodeProps } from '@cardano-sdk/ogmios';
+import { SrvRecord } from 'dns';
+import { firstValueFrom } from 'rxjs';
+import { logger } from '@cardano-sdk/util-dev';
+import { types } from 'util';
+
+// Connection retry mechanism will recreate an OgmiosCardanoNode and try to reconnect.
+// ogmiosCardanoNodeCallTracker tracks which call it is, to configure initialize() to resolve after 1 failure
+let ogmiosCardanoNodeCallTracker: number;
+let connectionFailureCount: number; // number of times to fail initialize with connection error before succeeding
+let initializeError: Object;
+
+jest.mock('@cardano-sdk/ogmios', () => ({
+  ...jest.requireActual('@cardano-sdk/ogmios'),
+  OgmiosCardanoNode: jest.fn().mockImplementation(() => {
+    ogmiosCardanoNodeCallTracker++;
+    return {
+      initialize: jest.fn(() =>
+        ogmiosCardanoNodeCallTracker > connectionFailureCount ? Promise.resolve(true) : Promise.reject(initializeError)
+      ),
+      shutdown: jest.fn().mockResolvedValue(true)
+    };
+  }),
+  OgmiosObservableCardanoNode: jest.fn()
 }));
 
-// TODO: use a mock handle provider
-// const handleProvider = new KoraLabsHandleProvider({
-//   policyId: Cardano.PolicyId('50fdcdbfa3154db86a87e4b5697ae30d272e0bbcfa8122efd3e301cb'),
-//   serverUrl: 'https://localhost:3000'
-// });
+const mockOgmiosObservableNode = OgmiosObservableCardanoNode as jest.MockedClass<typeof OgmiosObservableCardanoNode>;
+const mockOgmiosCardanoNode = OgmiosCardanoNode as jest.MockedClass<typeof OgmiosCardanoNode>;
 
 jest.mock('dns', () => ({
   promises: {
@@ -53,477 +47,113 @@ jest.mock('dns', () => ({
   }
 }));
 
-describe.skip('Service dependency abstractions', () => {
-  const APPLICATION_JSON = 'application/json';
-  const cache = { db: new InMemoryCache(UNLIMITED_CACHE_TTL), healthCheck: new InMemoryCache(UNLIMITED_CACHE_TTL) };
-  const cardanoNodeConfigPath = process.env.CARDANO_NODE_CONFIG_PATH!;
+describe('Ogmios Cardano Node factory utils', () => {
   const dnsResolver = createDnsResolver({ factor: 1.1, maxRetryTime: 1000 }, logger);
-  let lastBlockNoInDb: LedgerTipModel;
-  let dbPools: DbPools;
+  const ogmiosUrl = new URL('http://dummy');
 
   const ogmiosPortDefault = 1337;
   const mockDnsResolver = mockDnsResolverFactory(ogmiosPortDefault);
 
-  beforeAll(async () => {
-    dbPools = {
-      healthCheck: (await getPool(dnsResolver, logger, {
-        postgresDbDbSync: process.env.POSTGRES_DB_DB_SYNC!,
-        postgresPasswordDbSync: process.env.POSTGRES_PASSWORD_DB_SYNC!,
-        postgresSrvServiceNameDbSync: process.env.POSTGRES_SRV_SERVICE_NAME_DB_SYNC!,
-        postgresUserDbSync: process.env.POSTGRES_USER_DB_SYNC!
-      })) as Pool,
-      main: (await getPool(dnsResolver, logger, {
-        postgresDbDbSync: process.env.POSTGRES_DB_DB_SYNC!,
-        postgresPasswordDbSync: process.env.POSTGRES_PASSWORD_DB_SYNC!,
-        postgresSrvServiceNameDbSync: process.env.POSTGRES_SRV_SERVICE_NAME_DB_SYNC!,
-        postgresUserDbSync: process.env.POSTGRES_USER_DB_SYNC!
-      })) as Pool
-    };
+  beforeEach(() => {
+    ogmiosCardanoNodeCallTracker = 0;
+    connectionFailureCount = 1;
+    initializeError = { name: 'ServerNotReady' };
 
-    lastBlockNoInDb = (await dbPools.main!.query<LedgerTipModel>(findLedgerTip)).rows[0];
+    mockOgmiosCardanoNode.mockClear();
+    mockOgmiosObservableNode.mockClear();
   });
 
-  afterAll(async () => {
-    await clearDbPools(dbPools);
-  });
-
-  // TODO: rewrite these tests to not require ogmios server.
-  // It is sufficient to unit test the logic of utils exported from ogmios.ts
-  describe.skip('Ogmios-dependant services with service discovery', () => {
-    let apiUrlBase: string;
-    let ogmiosServer: http.Server;
-    let ogmiosConnection: Connection;
-    let txSubmitProvider: TxSubmitProvider;
-    let ogmiosCardanoNode: OgmiosCardanoNode;
-    let httpServer: HttpServer;
-    let port: number;
-    let config: HttpServerConfig;
-
-    beforeAll(async () => {
-      // ogmiosServer = createHealthyMockOgmiosServer();
-      ogmiosConnection = Ogmios.createConnectionObject();
-      await listenPromise(ogmiosServer, { port: ogmiosConnection.port });
-      // await ogmiosServerReady(ogmiosConnection);
+  describe('getOgmiosCardanoNode', () => {
+    it('creates an OgmiosCardanoNode using the provided URL', async () => {
+      await getOgmiosCardanoNode(dnsResolver, logger, { ogmiosUrl });
+      expect(mockOgmiosCardanoNode).toHaveBeenCalledTimes(1);
+      expect(mockOgmiosCardanoNode.mock.calls[0][0]).toEqual(expect.objectContaining({ host: 'dummy' }));
     });
 
-    afterAll(async () => {
-      await serverClosePromise(ogmiosServer);
-    });
-
-    describe('Established connection', () => {
-      describe('TxSubmitHttpService', () => {
-        beforeAll(async () => {
-          port = await getPort();
-          apiUrlBase = `http://localhost:${port}${services.txSubmit.versionPath}/${services.txSubmit.name}`;
-          config = { listen: { port } };
-          // txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
-          //   ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-          // });
-          httpServer = new HttpServer(config, {
-            logger,
-            runnableDependencies: [],
-            services: [new TxSubmitHttpService({ logger, txSubmitProvider })]
-          });
-          await httpServer.initialize();
-          await httpServer.start();
-        });
-
-        afterAll(async () => {
-          await httpServer.shutdown();
-        });
-
-        it.skip('txSubmitProvider state should be running when http server has started', () => {
-          // expect(txSubmitProvider.state).toEqual('running');
-        });
-
-        it('txSubmitProvider should be instance of a Proxy ', () => {
-          expect(types.isProxy(txSubmitProvider)).toEqual(true);
-        });
-
-        it('forwards the TxSubmitHttpService health response', async () => {
-          const res = await axios.post(`${apiUrlBase}/health`, {
-            headers: { 'Content-Type': APPLICATION_JSON }
-          });
-          expect(res.status).toBe(200);
-          expect(res.data).toEqual(healthCheckResponseMock({ withTip: false }));
-        });
-
-        it('TxSubmitHttpService replies with status 200 OK when /submit endpoint is reached', async () => {
-          const res = await axios.post(
-            `${apiUrlBase}/submit`,
-            { signedTransaction: bufferToHexString(Buffer.from(new Uint8Array())) },
-            { headers: { 'Content-Type': APPLICATION_JSON } }
-          );
-          expect(res.status).toBe(200);
-        });
+    it('dnsResolver takes precedence and is used', async () => {
+      const dnsResolverMock = await mockDnsResolver(0);
+      await getOgmiosCardanoNode(dnsResolverMock, logger, {
+        ogmiosSrvServiceName: 'someName',
+        ogmiosUrl
       });
 
-      describe('NetworkInfoHttpService', () => {
-        beforeAll(async () => {
-          port = await getPort();
-          apiUrlBase = `http://localhost:${port}${services.networkInfo.versionPath}/${services.networkInfo.name}`;
-          config = { listen: { port } };
-          ogmiosCardanoNode = await getOgmiosCardanoNode(dnsResolver, logger, {
-            ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-          });
-          const genesisData = await loadGenesisData(cardanoNodeConfigPath);
-          const epochMonitor = new DbSyncEpochPollService(dbPools.main!, 10_000);
-          const networkInfoProvider = new DbSyncNetworkInfoProvider({
-            cache,
-            cardanoNode: ogmiosCardanoNode,
-            dbPools,
-            epochMonitor,
-            genesisData,
-            logger
-          });
+      expect(dnsResolverMock).toHaveBeenCalledTimes(1);
+      // expected host and port are defined in the mocked dns resolver
+      expect(mockOgmiosCardanoNode.mock.calls[0][0]).toEqual({ host: 'localhost', port: ogmiosPortDefault });
+    });
 
-          httpServer = new HttpServer(config, {
-            logger,
-            runnableDependencies: [ogmiosCardanoNode],
-            services: [new NetworkInfoHttpService({ logger, networkInfoProvider })]
-          });
-          await httpServer.initialize();
-          await httpServer.start();
-        });
+    it('throws MissingCardanoNodeOption if no ogmiosUrl or ogmiosSrvServiceName is provided', async () => {
+      await expect(getOgmiosCardanoNode(dnsResolver, logger)).rejects.toThrowError(MissingCardanoNodeOption);
+    });
 
-        afterAll(async () => {
-          await cache.db.shutdown();
-          await httpServer.shutdown();
-        });
+    describe('With discovery', () => {
+      let ogmiosCardanoNode: OgmiosCardanoNode;
+      let dnsResolverMock: jest.Mock;
 
-        it('ogmiosCardanoNode state should be running when http server has started', () => {
-          expect(ogmiosCardanoNode.state).toEqual('running');
-        });
+      beforeEach(async () => {
+        dnsResolverMock = await mockDnsResolver(0);
+      });
 
-        it('ogmiosCardanoNode should be instance of a Proxy ', () => {
-          expect(types.isProxy(ogmiosCardanoNode)).toEqual(true);
+      it('uses a proxy object', async () => {
+        ogmiosCardanoNode = await getOgmiosCardanoNode(dnsResolverMock, logger, {
+          ogmiosSrvServiceName: 'someName'
         });
+        expect(types.isProxy(ogmiosCardanoNode)).toEqual(true);
+      });
 
-        it('forwards the NetworkInfoHttpService health response', async () => {
-          const res = await axios.post(`${apiUrlBase}/health`, {
-            headers: { 'Content-Type': APPLICATION_JSON }
-          });
-          expect(res.status).toBe(200);
-          expect(res.data).toEqual(
-            healthCheckResponseMock({
-              projectedTip: {
-                blockNo: lastBlockNoInDb.block_no,
-                hash: lastBlockNoInDb.hash.toString('hex'),
-                slot: Number(lastBlockNoInDb.slot_no)
-              },
-              withTip: true
-            })
-          );
+      it('retries connection errors', async () => {
+        connectionFailureCount = 2;
+        ogmiosCardanoNode = await getOgmiosCardanoNode(dnsResolverMock, logger, {
+          ogmiosSrvServiceName: 'someName'
         });
+        await ogmiosCardanoNode.initialize();
+        expect(mockOgmiosCardanoNode).toHaveBeenCalledTimes(3);
+      });
 
-        it('NetworkInfoHttpService replies with status 200 OK when /stake endpoint is reached', async () => {
-          const res = await axios.post(`${apiUrlBase}/stake`, undefined, {
-            headers: { 'Content-Type': APPLICATION_JSON }
-          });
-          expect(res.status).toBe(200);
+      it('rethrows errors', async () => {
+        initializeError = 'uhm... error';
+        ogmiosCardanoNode = await getOgmiosCardanoNode(dnsResolverMock, logger, {
+          ogmiosSrvServiceName: 'someName'
         });
+        // Regular `rejects` does not work here. Probably because of the Proxy object.
+        let hasError = false;
+        try {
+          await ogmiosCardanoNode.initialize();
+        } catch {
+          hasError = true;
+        }
+        expect(hasError).toBeTruthy();
       });
     });
   });
 
-  describe('Ogmios-dependant services with static config', () => {
-    let apiUrlBase: string;
-    let ogmiosServer: http.Server;
-    let ogmiosConnection: Connection;
-    let txSubmitProvider: TxSubmitProvider;
-    let ogmiosCardanoNode: OgmiosCardanoNode;
-    let httpServer: HttpServer;
-    let port: number;
-    let config: HttpServerConfig;
-
-    beforeAll(async () => {
-      // ogmiosServer = createHealthyMockOgmiosServer();
-      ogmiosConnection = Ogmios.createConnectionObject();
-      await listenPromise(ogmiosServer, { port: ogmiosConnection.port });
-      // await ogmiosServerReady(ogmiosConnection);
-      lastBlockNoInDb = (await dbPools.main!.query<LedgerTipModel>(findLedgerTip)).rows[0];
+  describe('getOgmiosObservableCardanoNode', () => {
+    it('creates an OgmiosObservableCardanoNode using the provided URL', async () => {
+      getOgmiosObservableCardanoNode(dnsResolver, logger, { ogmiosUrl });
+      expect(mockOgmiosObservableNode).toHaveBeenCalledTimes(1);
+      const { connectionConfig$ }: Pick<OgmiosObservableCardanoNodeProps, 'connectionConfig$'> =
+        mockOgmiosObservableNode.mock.calls[0][0];
+      expect(await firstValueFrom(connectionConfig$)).toEqual(expect.objectContaining({ host: 'dummy' }));
     });
 
-    afterAll(async () => {
-      await serverClosePromise(ogmiosServer);
-    });
-
-    describe('Established connection', () => {
-      describe('TxSubmitHttpService', () => {
-        beforeAll(async () => {
-          port = await getPort();
-          apiUrlBase = `http://localhost:${port}${services.txSubmit.versionPath}/${services.txSubmit.name}`;
-          config = { listen: { port } };
-          // txSubmitProvider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
-          //   ogmiosUrl: new URL(ogmiosConnection.address.webSocket)
-          // });
-          httpServer = new HttpServer(config, {
-            logger,
-            runnableDependencies: [],
-            services: [new TxSubmitHttpService({ logger, txSubmitProvider })]
-          });
-          await httpServer.initialize();
-          await httpServer.start();
-        });
-
-        afterAll(async () => {
-          await httpServer.shutdown();
-        });
-
-        it('txSubmitProvider should not be a instance of Proxy ', () => {
-          expect(types.isProxy(txSubmitProvider)).toEqual(false);
-        });
-
-        it('forwards the txSubmitProvider health response', async () => {
-          const res = await axios.post(`${apiUrlBase}/health`, {
-            headers: { 'Content-Type': APPLICATION_JSON }
-          });
-          expect(res.status).toBe(200);
-          expect(res.data).toEqual(healthCheckResponseMock({ withTip: false }));
-        });
-
-        it.skip('verifies that the submitted transaction addresses can all correctly be resolved', async () => {
-          // const provider = await getOgmiosTxSubmitProvider(
-          //   dnsResolver,
-          //   logger,
-          //   {
-          //     ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-          //   },
-          //   handleProvider
-          // );
-          // await provider.initialize();
-          // await provider.start();
-          // const res = await provider.submitTx({
-          //   context: { handleResolutions: [handleProviderMocks.getAliceHandleProviderResponse] },
-          //   signedTransaction: bufferToHexString(Buffer.from(new Uint8Array([])))
-          // });
-          // expect(res).toBeUndefined();
-          // await provider.shutdown();
-        });
-
-        it.skip('throws a provider error if the submitted transaction does not contain addresses that can be resolved from the included context', async () => {
-          // const provider = await getOgmiosTxSubmitProvider(
-          //  dnsResolver,
-          //  logger,
-          //  {
-          //    ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-          //  },
-          //  {
-          //    getPolicyIds: async () => [],
-          //    healthCheck: async () => ({ ok: true }),
-          //    resolveHandles: async ({ handles }) => handles.map(() => null)
-          //  }
-          // );
-          // await provider.initialize();
-          // await provider.start();
-          // await expect(
-          //  provider.submitTx({
-          //    context: { handleResolutions: [handleProviderMocks.getWrongHandleProviderResponse] },
-          //    signedTransaction: bufferToHexString(Buffer.from(new Uint8Array([])))
-          //  })
-          // ).rejects.toBeInstanceOf(ProviderError);
-          // await provider.shutdown();
-        });
+    it('dnsResolver takes precedence and is used', async () => {
+      const dnsResolverMock = await mockDnsResolver(0);
+      getOgmiosObservableCardanoNode(dnsResolverMock, logger, {
+        ogmiosSrvServiceName: 'someName',
+        ogmiosUrl
       });
 
-      describe('NetworkInfoHttpService', () => {
-        beforeAll(async () => {
-          port = await getPort();
-          apiUrlBase = `http://localhost:${port}${services.networkInfo.versionPath}/${services.networkInfo.name}`;
-          config = { listen: { port } };
+      expect(mockOgmiosObservableNode).toHaveBeenCalledTimes(1);
 
-          ogmiosCardanoNode = await getOgmiosCardanoNode(dnsResolver, logger, {
-            ogmiosUrl: new URL(ogmiosConnection.address.webSocket)
-          });
-          const genesisData = await loadGenesisData(cardanoNodeConfigPath);
-          const epochMonitor = new DbSyncEpochPollService(dbPools.main!, 10_000);
-          const deps = {
-            cache,
-            cardanoNode: ogmiosCardanoNode,
-            dbPools,
-            epochMonitor,
-            genesisData,
-            logger
-          };
-          const networkInfoProvider = new DbSyncNetworkInfoProvider(deps);
+      const { connectionConfig$ }: Pick<OgmiosObservableCardanoNodeProps, 'connectionConfig$'> =
+        mockOgmiosObservableNode.mock.calls[0][0];
 
-          httpServer = new HttpServer(config, {
-            logger,
-            runnableDependencies: [ogmiosCardanoNode],
-            services: [new NetworkInfoHttpService({ logger, networkInfoProvider })]
-          });
-          await httpServer.initialize();
-          await httpServer.start();
-        });
-
-        afterAll(async () => {
-          await httpServer.shutdown();
-        });
-
-        it('ogmiosCardanoNode should not be a instance of Proxy ', () => {
-          expect(types.isProxy(ogmiosCardanoNode)).toEqual(false);
-        });
-
-        it('forwards the NetworkInfoHttpService health response', async () => {
-          const res = await axios.post(`${apiUrlBase}/health`, {
-            headers: { 'Content-Type': APPLICATION_JSON }
-          });
-          expect(res.status).toBe(200);
-          expect(res.data).toEqual(
-            healthCheckResponseMock({
-              projectedTip: {
-                blockNo: lastBlockNoInDb.block_no,
-                hash: lastBlockNoInDb.hash.toString('hex'),
-                slot: Number(lastBlockNoInDb.slot_no)
-              },
-              withTip: true
-            })
-          );
-        });
-      });
-    });
-  });
-
-  describe('TxSubmitProvider with service discovery and Ogmios server failover', () => {
-    let mockServer: http.Server;
-    let connection: Connection;
-    let provider: TxSubmitProvider;
-
-    beforeEach(async () => {
-      connection = Ogmios.createConnectionObject({ port: ogmiosPortDefault });
-      // Setup working a default Ogmios with submitTx operation throwing a non-connection error
-      // mockServer = createMockOgmiosServer({
-      //   healthCheck: { response: { networkSynchronization: 0.999, success: true } },
-      //   submitTx: { response: { failWith: { type: 'eraMismatch' }, success: false } }
-      // });
-      await listenPromise(mockServer, connection);
-      // await ogmiosServerReady(connection);
+      expect(await firstValueFrom(connectionConfig$)).toEqual({ host: 'localhost', port: ogmiosPortDefault });
+      expect(dnsResolverMock).toHaveBeenCalledTimes(1);
     });
 
-    afterEach(async () => {
-      if (mockServer !== undefined) {
-        await serverClosePromise(mockServer);
-      }
-    });
-
-    it.skip('should resolve DNS twice during initialization without reconnection logic with long ws connection type', async () => {
-      // Resolves with a failing ogmios port twice, then swap to the default one
-      const dnsResolverMock = await mockDnsResolver(2);
-
-      // provider = await getOgmiosTxSubmitProvider(dnsResolverMock, logger, {
-      //   ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-      // });
-
-      // await expect(provider.initialize()).resolves.toBeUndefined();
-      expect(dnsResolverMock).toBeCalledTimes(3);
-      // await provider.start();
-      // await provider.shutdown();
-    });
-
-    it.skip('should initially fail with a connection error, then re-resolve the port and propagate the correct non-connection error to the caller', async () => {
-      // Resolves with a failing ogmios port twice, then swap to the default one
-      const dnsResolverMock = await mockDnsResolver(2);
-
-      // provider = await getOgmiosTxSubmitProvider(dnsResolverMock, logger, {
-      //   ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-      // });
-
-      // await provider.initialize();
-      // await provider.start();
-      await expect(
-        provider.submitTx({ signedTransaction: bufferToHexString(Buffer.from(new Uint8Array([]))) })
-      ).rejects.toBeInstanceOf(TxSubmissionError);
-      expect(dnsResolverMock).toBeCalledTimes(3);
-      // await provider.shutdown();
-    });
-
-    it.skip('should execute a provider operation without to intercept it', async () => {
-      // provider = await getOgmiosTxSubmitProvider(dnsResolver, logger, {
-      //   ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-      // });
-
-      await expect(provider.healthCheck()).resolves.toEqual(healthCheckResponseMock({ withTip: false }));
-    });
-  });
-
-  describe('OgmiosCardanoNode with service discovery and Ogmios server failover', () => {
-    let mockServer: http.Server;
-    let connection: Connection;
-    let node: OgmiosCardanoNode;
-
-    beforeEach(async () => {
-      connection = Ogmios.createConnectionObject({ port: ogmiosPortDefault });
-      // Setup working a default Ogmios with stateQuery eraSummaries operation throwing a non-connection error
-      // mockServer = createMockOgmiosServer({
-      //   healthCheck: { response: { networkSynchronization: 0.999, success: true } },
-      //   stateQuery: {
-      //     eraSummaries: { response: { failWith: { type: 'unknownResultError' }, success: false } },
-      //     systemStart: { response: { success: true } }
-      //   }
-      // });
-      await listenPromise(mockServer, connection);
-      // await ogmiosServerReady(connection);
-    });
-
-    afterEach(async () => {
-      if (mockServer !== undefined) {
-        await serverClosePromise(mockServer);
-      }
-    });
-
-    it('should initially fail with a connection error, then re-resolve the port and initialize', async () => {
-      // Resolves with a failing ogmios port twice, then swap to the default one
-      const dnsResolverMock = await mockDnsResolver(2);
-
-      node = await getOgmiosCardanoNode(dnsResolverMock, logger, {
-        ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-      });
-
-      await expect(node.initialize()).resolves.toBeUndefined();
-      expect(dnsResolverMock).toBeCalledTimes(3);
-      await node.start();
-      await node.shutdown();
-    });
-
-    it('should initially fail with a connection error, then re-resolve the port and propagate the correct non-connection error to the caller', async () => {
-      const failingOgmiosMockPort = await getRandomPort();
-      // const failConnection = Ogmios.createConnectionObject({ port: failingOgmiosMockPort });
-      // const failMockServer = createMockOgmiosServer({
-      //   healthCheck: { response: { networkSynchronization: 0.999, success: true } },
-      //   stateQuery: {
-      //     systemStart: { response: { success: true } }
-      //   }
-      // });
-      // await listenPromise(failMockServer, failConnection);
-      // await ogmiosServerReady(failConnection);
-
-      // Resolves with a failing ogmios port twice, then swap to the default one
-      const dnsResolverMock = await mockDnsResolver(2, failingOgmiosMockPort);
-
-      node = await getOgmiosCardanoNode(dnsResolverMock, logger, {
-        ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-      });
-
-      await node.initialize();
-      await node.start();
-      // for (const socket of failMockServer.wss.clients) {
-      //   socket.close();
-      // }
-      // await serverClosePromise(failMockServer);
-      // await expect(node.eraSummaries()).rejects.toBeInstanceOf(
-      //   CardanoNodeErrors.CardanoClientErrors.UnknownResultError
-      // );
-      expect(dnsResolverMock).toBeCalledTimes(3);
-      await node.shutdown();
-    });
-
-    it('should execute a provider operation without to intercept it', async () => {
-      node = await getOgmiosCardanoNode(dnsResolver, logger, {
-        ogmiosSrvServiceName: process.env.OGMIOS_SRV_SERVICE_NAME
-      });
-      await node.initialize();
-      await node.start();
-      await expect(node.shutdown()).resolves.toBeUndefined();
+    it('throws MissingCardanoNodeOption if no ogmiosUrl or ogmiosSrvServiceName is provided', async () => {
+      expect(() => getOgmiosObservableCardanoNode(dnsResolver, logger)).toThrowError(MissingCardanoNodeOption);
     });
   });
 });


### PR DESCRIPTION
# Context

These tests previously relied on a mocked OgmiosServer, making them tightly coupled with the ogmios implementation.
Since our ogmios implementation was abstracted behind the OgmiosCardanoNode/OgmiosObservableCardanoNode, we can mock them and test the factory utils.

# Proposed Solution
Complete rewrite to not require ogmios server.
Test only the ogmios.ts utils.

# Important Changes Introduced
