### PR TITLE
Chore/lw 8952 update comments regarding compact genesis

### DIFF
--- a/packages/ogmios/src/CardanoNode/queries.ts
+++ b/packages/ogmios/src/CardanoNode/queries.ts
@@ -94,8 +94,6 @@ export const queryEraSummaries = (client: LedgerStateQuery.LedgerStateQueryClien
 export const queryGenesisParameters = (client: LedgerStateQuery.LedgerStateQueryClient, logger: Logger) =>
   withCoreCardanoNodeError(async () => {
     logger.info('Querying genesis parameters');
-    // REVIEW: The queryNetwork/genesis local-state-query now expects one era as argument (either 'byron', 'shelley' or 'alonzo')
-    // to retrieve the corresponding genesis configuration.
-    // 'shelley' genesis maps best to the compact genesis we're using
+    // Update this to query multiple eras if the CompactGenesis type will have to include params from other eras
     return genesis(await client.genesisConfiguration('shelley'));
   });

--- a/packages/ogmios/src/ogmiosToCore/genesis.ts
+++ b/packages/ogmios/src/ogmiosToCore/genesis.ts
@@ -2,7 +2,6 @@ import { Cardano, Milliseconds } from '@cardano-sdk/core';
 import { Schema } from '@cardano-ogmios/client';
 import omit from 'lodash/omit';
 
-// REVIEW: Schema.GenesisShelley has all the properties we are looking for here
 export const genesis = (ogmiosGenesis: Schema.GenesisShelley): Cardano.CompactGenesis => ({
   ...omit(ogmiosGenesis, 'initialParameters'),
   activeSlotsCoefficient: (() => {


### PR DESCRIPTION
# Context

Pre ogmios6: ogmios would return a Compact genesis.
Currently: ogmios can return genesis parameters per era.

SDK uses genesis parameters that are currently available in the Shelley era.

If in the future we require Conway-era parameters, we can do 2 queries and merge the result in our unified CompactGenesis type.