### PR TITLE
feat(tx-construction): add customizeCb to GenericTxBuilder

### DIFF
--- a/packages/core/src/Serialization/TransactionBody/ProposalProcedure/ProposalProcedure.ts
+++ b/packages/core/src/Serialization/TransactionBody/ProposalProcedure/ProposalProcedure.ts
@@ -1,6 +1,6 @@
 import * as Cardano from '../../../Cardano';
 import { Anchor } from '../../Common/Anchor';
-import { CborReader, CborWriter } from '../../CBOR';
+import { CborReader, CborReaderState, CborWriter } from '../../CBOR';
 import { GovernanceActionKind } from './GovernanceActionKind';
 import { HardForkInitiationAction } from './HardForkInitiationAction';
 import { HexBlob, InvalidStateError } from '@cardano-sdk/util';
@@ -115,9 +115,16 @@ export class ProposalProcedure {
     reader.readEndArray();
 
     const actionReader = new CborReader(actionCbor);
-    actionReader.readStartArray();
-    const kind = Number(actionReader.readInt());
+
+    let kind;
     let action;
+
+    if (actionReader.peekState() === CborReaderState.UnsignedInteger) {
+      kind = Number(actionReader.readInt());
+    } else {
+      actionReader.readStartArray();
+      kind = Number(actionReader.readInt());
+    }
 
     switch (kind) {
       case GovernanceActionKind.ParameterChange:

--- a/packages/core/test/Serialization/TransactionBody/ProposalProcedure/ProposalProcedure.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/ProposalProcedure/ProposalProcedure.test.ts
@@ -3,6 +3,22 @@ import * as Cardano from '../../../../src/Cardano';
 import { HexBlob } from '@cardano-sdk/util';
 import { ProposalProcedure } from '../../../../src/Serialization';
 
+const infoActionCbor = HexBlob(
+  '841a000f4240581de1cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f06827668747470733a2f2f7777772e736f6d6575726c2e696f58200000000000000000000000000000000000000000000000000000000000000000'
+);
+
+const infoActionCore = {
+  anchor: {
+    dataHash: '0000000000000000000000000000000000000000000000000000000000000000',
+    url: 'https://www.someurl.io'
+  },
+  deposit: 1_000_000n,
+  governanceAction: {
+    __typename: Cardano.GovernanceActionType.info_action
+  },
+  rewardAccount: 'stake1u89sasnfyjtmgk8ydqfv3fdl52f36x3djedfnzfc9rkgzrcss5vgr'
+} as Cardano.ProposalProcedure;
+
 const cbor = HexBlob(
   '841a000f4240581de1cb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f830582582000000000000000000000000000000000000000000000000000000000000000000382827668747470733a2f2f7777772e736f6d6575726c2e696f58200000000000000000000000000000000000000000000000000000000000000000f6827668747470733a2f2f7777772e736f6d6575726c2e696f58200000000000000000000000000000000000000000000000000000000000000000'
 );
@@ -40,5 +56,17 @@ describe('ProposalProcedure', () => {
     const action = ProposalProcedure.fromCbor(cbor);
 
     expect(action.toCore()).toEqual(core);
+  });
+
+  it('can encode InfoAction ProposalProcedure to CBOR', () => {
+    const action = ProposalProcedure.fromCore(infoActionCore);
+
+    expect(action.toCbor()).toEqual(infoActionCbor);
+  });
+
+  it('can encode InfoAction ProposalProcedure to Core', () => {
+    const action = ProposalProcedure.fromCbor(infoActionCbor);
+
+    expect(action.toCore()).toEqual(infoActionCore);
   });
 });

--- a/packages/tx-construction/src/index.ts
+++ b/packages/tx-construction/src/index.ts
@@ -1,4 +1,4 @@
-export * from './createTransactionInternals';
+export { CreateTxInternalsProps, createTransactionInternals } from './createTransactionInternals';
 export * from './fees';
 export * from './input-selection';
 export * from './output-validation';

--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -8,8 +8,8 @@ import {
   util
 } from '@cardano-sdk/key-management';
 import { Cardano, HandleProvider, HandleResolution, metadatum } from '@cardano-sdk/core';
-import { GreedyInputSelector, SelectionSkeleton } from '@cardano-sdk/input-selection';
 import {
+  CustomizeCb,
   InsufficientRewardAccounts,
   OutOfSyncRewardAccounts,
   OutputBuilderTxOut,
@@ -23,6 +23,7 @@ import {
   TxOutValidationError,
   UnsignedTx
 } from './types';
+import { GreedyInputSelector, SelectionSkeleton } from '@cardano-sdk/input-selection';
 import { Logger } from 'ts-log';
 import { OutputBuilderValidator, TxOutputBuilder } from './OutputBuilder';
 import { RewardAccountWithPoolId } from '../types';
@@ -102,6 +103,7 @@ export class GenericTxBuilder implements TxBuilder {
   #logger: Logger;
   #handleProvider?: HandleProvider;
   #handleResolutions: HandleResolution[];
+  #customizeCb: CustomizeCb;
 
   constructor(dependencies: TxBuilderDependencies) {
     this.#outputValidator =
@@ -194,6 +196,11 @@ export class GenericTxBuilder implements TxBuilder {
     return this;
   }
 
+  customize(cb: CustomizeCb): TxBuilder {
+    this.#customizeCb = cb;
+    return this;
+  }
+
   build(): UnsignedTx {
     return new LazyTxSigner({
       builder: {
@@ -250,6 +257,7 @@ export class GenericTxBuilder implements TxBuilder {
               {
                 auxiliaryData,
                 certificates: this.partialTxBody.certificates,
+                customizeCb: this.#customizeCb,
                 handleResolutions: this.#handleResolutions,
                 outputs: new Set(this.partialTxBody.outputs || []),
                 signingOptions: partialSigningOptions,

--- a/packages/tx-construction/src/types.ts
+++ b/packages/tx-construction/src/types.ts
@@ -3,6 +3,7 @@ import { Cardano, HandleResolution } from '@cardano-sdk/core';
 import { GroupedAddress, SignTransactionOptions, TransactionSigner } from '@cardano-sdk/key-management';
 import { SelectionSkeleton } from '@cardano-sdk/input-selection';
 
+import { CustomizeCb } from './tx-builder';
 import { MinimumCoinQuantityPerOutput } from './output-validation';
 
 export type InitializeTxResult = Cardano.TxBodyWithHash & { inputSelection: SelectionSkeleton };
@@ -31,6 +32,7 @@ export interface TxBuilderProviders {
 }
 
 export type InitializeTxWitness = Partial<Cardano.Witness> & { extraSigners?: TransactionSigner[] };
+export type TxBodyPreInputSelection = Omit<Cardano.TxBody, 'inputs' | 'fee'>;
 
 export interface InitializeTxProps {
   outputs?: Set<Cardano.TxOut>;
@@ -46,6 +48,8 @@ export interface InitializeTxProps {
   witness?: InitializeTxWitness;
   signingOptions?: Pick<SignTransactionOptions, 'additionalKeyPaths'>;
   handleResolutions?: HandleResolution[];
+  /** callback function that allows updating the transaction before input selection */
+  customizeCb?: CustomizeCb;
 }
 
 export interface InitializeTxPropsValidationResult {

--- a/packages/tx-construction/test/createTransactionInternals.test.ts
+++ b/packages/tx-construction/test/createTransactionInternals.test.ts
@@ -38,7 +38,7 @@ describe('createTransactionInternals', () => {
     });
     const ledgerTip = await provider.ledgerTip();
     const overrides = props(result.selection);
-    return await createTransactionInternals({
+    return createTransactionInternals({
       validityInterval: {
         invalidHereafter: Cardano.Slot(ledgerTip.slot + 3600)
       },

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -38,7 +38,7 @@ export const outputBuilderProperties: RemoteApiProperties<OutputBuilder> = {
   }
 };
 
-export const txBuilderProperties: RemoteApiProperties<TxBuilder> = {
+export const txBuilderProperties: RemoteApiProperties<Omit<TxBuilder, 'customize'>> = {
   addOutput: {
     getApiProperties: () => txBuilderProperties,
     propType: RemoteApiPropertyType.ApiFactory


### PR DESCRIPTION
# Context


Implement a method that would allow users of TxBuilder to update the transaction body.
For example, a user could build and insert a certificate, allowing the user to leverage the input selection, fee calculation, etc, even if TxBuilder does not have a high-level API to support adding that certificate.

Non-goal: guard users against malformed/incorrect transactions.
For example: users could potentially modify the certificates already added by the txbuilder for staking distribution.

# Proposed Solution

Add a `customize` method to TxBuilder. The callback passed into `customize` will be called on transaction `build`, before input selection is performed.

# Important Changes Introduced
