### PR TITLE
LW-9604 deposit values

### DIFF
--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -155,7 +155,7 @@ export const mapAnchor = (anchorUrl: string, anchorDataHash: string): Cardano.An
 export const mapCertificate = (
   certModel: WithCertType<CertificateModel>
   // eslint-disable-next-line sonarjs/cognitive-complexity
-): WithCertIndex<Cardano.Certificate> | null => {
+): WithCertIndex<Cardano.HydratedCertificate> | null => {
   if (isPoolRetireCertModel(certModel))
     return {
       __typename: Cardano.CertificateType.PoolRetirement,
@@ -168,8 +168,9 @@ export const mapCertificate = (
     return {
       __typename: Cardano.CertificateType.PoolRegistration,
       cert_index: certModel.cert_index,
+      deposit: BigInt(certModel.deposit),
       poolParameters: null as unknown as Cardano.PoolParameters
-    } as WithCertIndex<Cardano.PoolRegistrationCertificate>;
+    } as WithCertIndex<Cardano.HydratedPoolRegistrationCertificate>;
 
   if (isMirCertModel(certModel)) {
     const credential = Cardano.Address.fromString(certModel.address)?.asReward()?.getPaymentCredential();

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -163,8 +163,10 @@ export interface PoolRetireCertModel extends CertificateModel {
   retiring_epoch: number;
   pool_id: string;
 }
+
 export interface PoolRegisterCertModel extends CertificateModel {
   pool_id: string;
+  deposit: string;
 }
 
 export interface MirCertModel extends CertificateModel {

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -201,15 +201,17 @@ describe('chain history mappers', () => {
         poolId: Cardano.PoolId(poolId)
       });
     });
-    test('map PoolUpdateCertModel to Cardano.PoolRegistrationCertificate', () => {
+    test('map PoolUpdateCertModel to Cardano.HydratedPoolRegistrationCertificate', () => {
       const result = mappers.mapCertificate({
         ...baseCertModel,
+        deposit: '500000000',
         pool_id: poolId,
         type: 'register'
       } as WithCertType<PoolRegisterCertModel>);
-      expect(result).toEqual<WithCertIndex<Cardano.PoolRegistrationCertificate>>({
+      expect(result).toEqual<WithCertIndex<Cardano.HydratedPoolRegistrationCertificate>>({
         __typename: Cardano.CertificateType.PoolRegistration,
         cert_index: 0,
+        deposit: 500_000_000n,
         poolParameters: null as unknown as Cardano.PoolParameters
       });
     });

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -1,7 +1,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { AuxiliaryData } from './AuxiliaryData';
 import { Base64Blob, HexBlob, OpaqueString } from '@cardano-sdk/util';
-import { Certificate } from './Certificate';
+import { Certificate, PoolRegistrationCertificate } from './Certificate';
 import { ExUnits, Update, ValidityInterval } from './ProtocolParameters';
 import { HydratedTxIn, TxIn, TxOut } from './Utxo';
 import { Lovelace, TokenMap } from './Value';
@@ -36,6 +36,12 @@ export interface Withdrawal {
   quantity: Lovelace;
 }
 
+export type HydratedPoolRegistrationCertificate = PoolRegistrationCertificate & { deposit?: Lovelace };
+
+export type HydratedCertificate =
+  | Exclude<Certificate, PoolRegistrationCertificate>
+  | HydratedPoolRegistrationCertificate;
+
 export interface HydratedTxBody {
   inputs: HydratedTxIn[];
   collaterals?: HydratedTxIn[];
@@ -43,7 +49,7 @@ export interface HydratedTxBody {
   fee: Lovelace;
   validityInterval?: ValidityInterval;
   withdrawals?: Withdrawal[];
-  certificates?: Certificate[];
+  certificates?: HydratedCertificate[];
   mint?: TokenMap;
   scriptIntegrityHash?: Crypto.Hash32ByteBase16;
   requiredExtraSignatures?: Crypto.Ed25519KeyHashHex[];
@@ -80,9 +86,10 @@ export interface HydratedTxBody {
   donation?: Lovelace;
 }
 
-export interface TxBody extends Omit<HydratedTxBody, 'inputs' | 'collaterals' | 'referenceInputs'> {
-  inputs: TxIn[];
+export interface TxBody extends Omit<HydratedTxBody, 'certificates' | 'inputs' | 'collaterals' | 'referenceInputs'> {
+  certificates?: Certificate[];
   collaterals?: TxIn[];
+  inputs: TxIn[];
   referenceInputs?: TxIn[];
 }
 

--- a/packages/core/src/Serialization/Certificates/PoolRegistration.ts
+++ b/packages/core/src/Serialization/Certificates/PoolRegistration.ts
@@ -170,7 +170,7 @@ export class PoolRegistration {
    * @param cert core PoolRegistrationCertificate object.
    */
   static fromCore(cert: Cardano.PoolRegistrationCertificate) {
-    return new PoolRegistration(PoolParams.fromCore(cert.poolParameters)); // TODO: Core type does not support script hash as credential, fix?
+    return new PoolRegistration(PoolParams.fromCore(cert.poolParameters));
   }
 
   /**

--- a/packages/projection/test/InMemory/storeStakePools.test.ts
+++ b/packages/projection/test/InMemory/storeStakePools.test.ts
@@ -3,7 +3,7 @@ import { InMemory, Mappers, ProjectionEvent } from '../../src';
 import { firstValueFrom, of } from 'rxjs';
 
 describe('InMemory.storeStakePools', () => {
-  it('adds pool updates and retirements on RollRorward, removes on RollBackward', async () => {
+  it('adds pool updates and retirements on RollForward, removes on RollBackward', async () => {
     const store = InMemory.createStore();
     const project = async (
       eventType: ChainSyncEventType,

--- a/packages/projection/test/operators/Mappers/certificates/withStakePools.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withStakePools.test.ts
@@ -70,7 +70,7 @@ describe('withStakePools', () => {
     expect(result.stakePools.retirements[0].epoch).toEqual(4);
   });
 
-  it("omits pool retirement if it's folowed by a pool registration", async () => {
+  it("omits pool retirement if it's followed by a pool registration", async () => {
     const data: Mappers.WithCertificates & WithEpochNo = {
       certificates: [
         {


### PR DESCRIPTION
# Context

Stake key de-registration certificates currently has a wrong deposit value (the value from relative epoch parameters rather than the value from epoch parameters relative to when stake key was registered).
Stake pool registration certificates doesn't show any deposit.

# Proposed Solution

- Fixed the deposit value for stake key de-registration certificates.
- Added the deposit for stake pool registration certificates.