### PR TITLE
chore: pass BUILD_INFO via deployments

### DIFF
--- a/nix/cardano-services/deployments.nix
+++ b/nix/cardano-services/deployments.nix
@@ -21,6 +21,12 @@ in {
         {
           name = "backend";
           image = cell.oci-images.cardano-services.image.name;
+          env = dmerge.append [
+            {
+              name = "BUILD_INFO";
+              value = cell.oci-images.cardano-services.meta.buildInfo;
+            }
+          ];
         }
       ];
     };
@@ -29,6 +35,12 @@ in {
         {
           name = "handle-provider";
           image = cell.oci-images.cardano-services.image.name;
+          env = dmerge.append [
+            {
+              name = "BUILD_INFO";
+              value = cell.oci-images.cardano-services.meta.buildInfo;
+            }
+          ];
         }
       ];
     };
@@ -37,6 +49,12 @@ in {
         {
           name = "handle-projector";
           image = cell.oci-images.cardano-services.image.name;
+          env = dmerge.append [
+            {
+              name = "BUILD_INFO";
+              value = cell.oci-images.cardano-services.meta.buildInfo;
+            }
+          ];
         }
       ];
     };
@@ -45,6 +63,12 @@ in {
         {
           name = "pg-boss-worker";
           image = cell.oci-images.cardano-services.image.name;
+          env = dmerge.append [
+            {
+              name = "BUILD_INFO";
+              value = cell.oci-images.cardano-services.meta.buildInfo;
+            }
+          ];
         }
       ];
     };
@@ -53,6 +77,12 @@ in {
         {
           name = "stake-pool-projector";
           image = cell.oci-images.cardano-services.image.name;
+          env = dmerge.append [
+            {
+              name = "BUILD_INFO";
+              value = cell.oci-images.cardano-services.meta.buildInfo;
+            }
+          ];
         }
       ];
     };
@@ -61,6 +91,12 @@ in {
         {
           name = "stake-pool-provider";
           image = cell.oci-images.cardano-services.image.name;
+          env = dmerge.append [
+            {
+              name = "BUILD_INFO";
+              value = cell.oci-images.cardano-services.meta.buildInfo;
+            }
+          ];
         }
       ];
     };

--- a/nix/cardano-services/oci-images.nix
+++ b/nix/cardano-services/oci-images.nix
@@ -2,7 +2,7 @@ let
   inherit (inputs) std self;
 
   # TODO: express this as OCI labels (what they are for)
-  BUILD_INFO = builtins.toJSON {
+  buildInfo = builtins.toJSON {
     inherit (self) lastModified lastModifiedDate rev;
     shortRev = self.shortRev or "no rev";
     extra = {
@@ -15,10 +15,8 @@ in {
   cardano-services = std.lib.ops.mkStandardOCI {
     name = "926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services";
     operable = cell.operables.cardano-services;
-    config.Env = [
-      "BUILD_INFO=${BUILD_INFO}"
-    ];
     meta.description = "Minimal Cardano Services OCI Image";
     meta.versions = builtins.fromJSON (builtins.readFile (self + /packages/cardano-services-client/version.json));
+    meta.buildInfo = buildInfo;
   };
 }


### PR DESCRIPTION
# Context

Keeps OCI image from rebuilding on each commit by taking into account only sources and not commit hash. Fixes https://github.com/input-output-hk/lace-ops/issues/29

## Impact
commit has is no longer part of OCI image, it is passed separately 


