### PR TITLE
fix(core): make the projector not exit on asset name error

### DIFF
--- a/packages/core/src/Asset/NftMetadata/fromMetadatum.ts
+++ b/packages/core/src/Asset/NftMetadata/fromMetadatum.ts
@@ -121,7 +121,11 @@ export const fromMetadatum = (
   const assetId = Cardano.AssetId.fromParts(asset.policyId, asset.name);
 
   if (version === '1.0' && !name) {
-    name = AssetName.toUTF8(asset.name);
+    try {
+      name = AssetName.toUTF8(asset.name);
+    } catch (error) {
+      logger.warn(error);
+    }
   }
 
   if (!name || !image) {

--- a/packages/core/src/Cardano/types/Asset.ts
+++ b/packages/core/src/Cardano/types/Asset.ts
@@ -22,7 +22,7 @@ AssetName.toUTF8 = (assetName: AssetName) => {
   try {
     return utf8Decoder.decode(Buffer.from(assetName, 'hex'));
   } catch (error) {
-    throw new InvalidStringError('Cannot convert AssetName to UTF8', error);
+    throw new InvalidStringError(`Cannot convert AssetName '${assetName}' to UTF8`, error);
   }
 };
 


### PR DESCRIPTION
# Context

The `asset-projector` exit with error while projecting.

# Proposed Solution

Wrapped the line throwing in a `try / catch` block.