### PR TITLE
fix: trezor bundler compatibility

### DIFF
--- a/packages/hardware-trezor/src/TrezorKeyAgent.ts
+++ b/packages/hardware-trezor/src/TrezorKeyAgent.ts
@@ -16,9 +16,12 @@ import {
   util
 } from '@cardano-sdk/key-management';
 import { txToTrezor } from './transformers/tx';
-import TrezorConnectWeb from '@trezor/connect-web';
+import _TrezorConnectWeb from '@trezor/connect-web';
 
 const TrezorConnectNode = Trezor.default;
+const TrezorConnectWeb = (_TrezorConnectWeb as any).default
+  ? ((_TrezorConnectWeb as any).default as typeof _TrezorConnectWeb)
+  : _TrezorConnectWeb;
 
 const transportTypedError = (error?: any) =>
   new errors.AuthenticationError(


### PR DESCRIPTION
# Context

Webpack exports ledger and trezor libaries under `{default: {...}}`.

# Proposed Solution

We're [already using a hack for this for Ledger](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/hardware-ledger/src/LedgerKeyAgent.ts#L35-L40). This PR applies the same for Trezor.

# Important Changes Introduced

Also fixed Ledger error mapping, when device is already open
