### PR TITLE
feat(core): cbor ser/des handle 128 bytes anchors

### DIFF
--- a/packages/core/src/Serialization/Common/Anchor.ts
+++ b/packages/core/src/Serialization/Common/Anchor.ts
@@ -4,7 +4,7 @@ import { CborReader, CborWriter } from '../CBOR';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 
 const EMBEDDED_GROUP_SIZE = 2;
-const MAX_URL_SIZE_STR_LENGTH = 64;
+const MAX_URL_SIZE_STR_LENGTH = 128;
 
 /**
  * An anchor is a pair of:

--- a/packages/core/test/Serialization/Common/Anchor.test.ts
+++ b/packages/core/test/Serialization/Common/Anchor.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
 import { Anchor } from '../../../src/Serialization';
+import { Cardano } from '../../../src';
 import { HexBlob } from '@cardano-sdk/util';
 
 // Test data used in the following tests was generated with the cardano-serialization-lib
@@ -38,5 +39,17 @@ describe('Anchor', () => {
     const anchor = Anchor.fromCbor(cbor);
 
     expect(anchor.toCore()).toEqual(core);
+  });
+
+  it('can handle 128bytes Anchor', () => {
+    const coreUrlLen = core.url.length;
+    const url128 = `${core.url}/${'a'.repeat(128 - coreUrlLen - 1)}`;
+    const core128byte: Cardano.Anchor = { ...core, url: url128 };
+
+    const anchor = Anchor.fromCore(core128byte);
+    expect(anchor.url()).toEqual(url128);
+
+    const anchorCbor = anchor.toCbor();
+    expect(Anchor.fromCbor(anchorCbor)).toEqual(anchor);
   });
 });


### PR DESCRIPTION
# Context

For cardano-node-8.8 the length of urls will be increased from 64 -> 128 bytes - see in CDDL here.
This will allow much more flexibility in URLs which can be used for governance metadata anchors and pool metadata anchors.
For examples, IPFS links will be able to be used to store off-chain metadata. (edited).

# Important Changes Introduced
Master branch (pre-conway) does not support the 128bytes anchors. Even so, usage of >64bytes anchors will result in a failed anchor, until `master` branch also uses Cardano Node 8.8+