### PR TITLE
[LW-9469] Cache signed transactions

### DIFF
--- a/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
+++ b/packages/wallet/src/persistence/inMemoryStores/inMemoryWalletStores.ts
@@ -6,6 +6,7 @@ import { InMemoryCollectionStore } from './InMemoryCollectionStore';
 import { InMemoryDocumentStore } from './InMemoryDocumentStore';
 import { InMemoryKeyValueStore } from './InMemoryKeyValueStore';
 import { OutgoingOnChainTx, TxInFlight } from '../../services';
+import { SignedTx } from '@cardano-sdk/tx-construction';
 import { WalletStores } from '../types';
 
 export class InMemoryTipStore extends InMemoryDocumentStore<Cardano.Tip> {}
@@ -18,6 +19,7 @@ export class InMemoryAssetsStore extends InMemoryDocumentStore<Assets> {}
 export class InMemoryAddressesStore extends InMemoryDocumentStore<GroupedAddress[]> {}
 export class InMemoryInFlightTransactionsStore extends InMemoryDocumentStore<TxInFlight[]> {}
 export class InMemoryVolatileTransactionsStore extends InMemoryDocumentStore<OutgoingOnChainTx[]> {}
+export class InMemorySignedTransactionsStore extends InMemoryDocumentStore<SignedTx[]> {}
 
 export class InMemoryTransactionsStore extends InMemoryCollectionStore<Cardano.HydratedTx> {}
 export class InMemoryUtxoStore extends InMemoryCollectionStore<Cardano.Utxo> {}
@@ -61,6 +63,7 @@ export const createInMemoryWalletStores = (): WalletStores => ({
   protocolParameters: new InMemoryProtocolParametersStore(),
   rewardsBalances: new InMemoryRewardsBalancesStore(),
   rewardsHistory: new InMemoryRewardsHistoryStore(),
+  signedTransactions: new InMemorySignedTransactionsStore(),
   stakePools: new InMemoryStakePoolsStore(),
   tip: new InMemoryTipStore(),
   transactions: new InMemoryTransactionsStore(),

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -7,6 +7,7 @@ import { OutgoingOnChainTx, TxInFlight } from '../../services';
 import { PouchDbCollectionStore } from './PouchDbCollectionStore';
 import { PouchDbDocumentStore } from './PouchDbDocumentStore';
 import { PouchDbKeyValueStore } from './PouchDbKeyValueStore';
+import { SignedTx } from '@cardano-sdk/tx-construction';
 import { WalletStores } from '../types';
 
 export class PouchDbTipStore extends PouchDbDocumentStore<Cardano.Tip> {}
@@ -19,6 +20,7 @@ export class PouchDbAddressesStore extends PouchDbDocumentStore<GroupedAddress[]
 export class PouchDbInFlightTransactionsStore extends PouchDbDocumentStore<TxInFlight[]> {}
 export class PouchDbVolatileTransactionsStore extends PouchDbDocumentStore<OutgoingOnChainTx[]> {}
 export class PouchDbPolicyIdsStore extends PouchDbDocumentStore<Cardano.PolicyId[]> {}
+export class PouchDbSignedTransactionsStore extends PouchDbDocumentStore<SignedTx[]> {}
 
 export class PouchDbTransactionsStore extends PouchDbCollectionStore<Cardano.HydratedTx> {}
 export class PouchDbUtxoStore extends PouchDbCollectionStore<Cardano.Utxo> {}
@@ -65,6 +67,7 @@ export const createPouchDbWalletStores = (
     protocolParameters: new PouchDbProtocolParametersStore(docsDbName, 'protocolParameters', logger),
     rewardsBalances: new PouchDbRewardsBalancesStore(`${baseDbName}RewardsBalances`, logger),
     rewardsHistory: new PouchDbRewardsHistoryStore(`${baseDbName}RewardsHistory`, logger),
+    signedTransactions: new PouchDbSignedTransactionsStore(docsDbName, 'signedTransactions', logger),
     stakePools: new PouchDbStakePoolsStore(`${baseDbName}StakePools`, logger),
     tip: new PouchDbTipStore(docsDbName, 'tip', logger),
     transactions: new PouchDbTransactionsStore(

--- a/packages/wallet/src/persistence/types.ts
+++ b/packages/wallet/src/persistence/types.ts
@@ -3,6 +3,7 @@ import { Cardano, EraSummary, Reward, StakeSummary, SupplySummary } from '@carda
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { Observable } from 'rxjs';
 import { OutgoingOnChainTx, TxInFlight } from '../services';
+import { SignedTx } from '@cardano-sdk/tx-construction';
 
 export interface Destroyable {
   destroyed: boolean;
@@ -88,6 +89,7 @@ export interface WalletStores extends Destroyable {
   assets: DocumentStore<Assets>;
   addresses: DocumentStore<GroupedAddress[]>;
   policyIds: DocumentStore<Cardano.PolicyId[]>;
+  signedTransactions: DocumentStore<SignedTx[]>;
 }
 
 export interface SupplyDistributionStores extends Destroyable {

--- a/packages/wallet/src/services/types.ts
+++ b/packages/wallet/src/services/types.ts
@@ -83,6 +83,7 @@ export interface TransactionsTracker {
     readonly inFlight$: Observable<TxInFlight[]>;
     readonly submitting$: Observable<OutgoingTx>;
     readonly pending$: Observable<OutgoingTx>;
+    readonly signed$: Observable<SignedTx[]>;
     readonly failed$: Observable<FailedTx>;
     readonly onChain$: Observable<OutgoingOnChainTx>;
   };

--- a/packages/wallet/src/services/util/equals.ts
+++ b/packages/wallet/src/services/util/equals.ts
@@ -1,6 +1,7 @@
 import { Cardano, EpochInfo, EraSummary } from '@cardano-sdk/core';
 import { DelegatedStake } from '../types';
 import { GroupedAddress } from '@cardano-sdk/key-management';
+import { SignedTx } from '@cardano-sdk/tx-construction';
 import { sameArrayItems } from '@cardano-sdk/util';
 
 export const tipEquals = (a: Cardano.Tip, b: Cardano.Tip) => a.hash === b.hash;
@@ -26,3 +27,7 @@ export const epochInfoEquals = (a: EpochInfo, b: EpochInfo) => a.epochNo === b.e
 
 export const delegatedStakeEquals = (a: DelegatedStake, b: DelegatedStake) =>
   a.pool.id === b.pool.id && a.stake === b.stake && a.percentage === b.percentage;
+
+const signedTxEquals = (a: SignedTx, b: SignedTx) => a.tx.id === b.tx.id;
+
+export const signedTxsEquals = (a: SignedTx[], b: SignedTx[]) => sameArrayItems(a, b, signedTxEquals);

--- a/packages/wallet/src/services/util/index.ts
+++ b/packages/wallet/src/services/util/index.ts
@@ -2,3 +2,4 @@ export * from './persistentTrackerSubjects';
 export * from './equals';
 export * from './trigger';
 export * from './connectionStatusTracker';
+export * from './newAndStoredMulticast';

--- a/packages/wallet/src/services/util/newAndStoredMulticast.ts
+++ b/packages/wallet/src/services/util/newAndStoredMulticast.ts
@@ -1,0 +1,32 @@
+import { Logger } from 'ts-log';
+import { Observable, from, groupBy, map, merge, mergeMap, share, tap } from 'rxjs';
+
+interface NewAndStoredMulticast<T, K> {
+  new$: Observable<T>;
+  stored$: Observable<T[]>;
+  storedFilterfn?: (value: T, index: number, array: T[]) => boolean;
+  logger: Logger;
+  logStringfn?: (stored: T[]) => string;
+  groupByFn: (value: T) => K;
+}
+
+export const newAndStoredMulticast = <T, K>({
+  new$,
+  stored$,
+  logger,
+  storedFilterfn = () => true,
+  logStringfn = () => '',
+  groupByFn
+}: NewAndStoredMulticast<T, K>) =>
+  merge<Array<T>>(
+    new$.pipe(map((evt) => evt)),
+    stored$.pipe(
+      tap((stored) => logger.debug(logStringfn(stored))),
+      map((stored) => stored.filter(storedFilterfn)),
+      mergeMap((stored) => from(stored))
+    )
+  ).pipe(
+    groupBy(groupByFn),
+    map((group$) => group$.pipe(share())),
+    share()
+  );

--- a/packages/wallet/test/services/UtxoTracker.test.ts
+++ b/packages/wallet/test/services/UtxoTracker.test.ts
@@ -84,6 +84,7 @@ describe('createUtxoTracker', () => {
         b: [inFlightTx1],
         c: [inFlightTx1, inFlightTx2]
       });
+
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [ownAddress!] }),

--- a/packages/wallet/test/services/util/equals.test.ts
+++ b/packages/wallet/test/services/util/equals.test.ts
@@ -6,6 +6,7 @@ import {
   epochInfoEquals,
   eraSummariesEquals,
   groupedAddressesEquals,
+  signedTxsEquals,
   tipEquals,
   transactionsEquals,
   txEquals,
@@ -13,6 +14,7 @@ import {
 } from '../../../src';
 import { GroupedAddress } from '@cardano-sdk/key-management';
 import { Percent } from '@cardano-sdk/util';
+import { SignedTx } from '@cardano-sdk/tx-construction';
 
 describe('equals', () => {
   const txId1 = Cardano.TransactionId('4123d70f66414cc921f6ffc29a899aafc7137a99a0fd453d6b200863ef5702d6');
@@ -79,5 +81,12 @@ describe('equals', () => {
     expect(delegatedStakeEquals(pool1, { ...pool1, pool: { id: 'cde' } as Cardano.StakePool })).toBe(false);
     expect(delegatedStakeEquals(pool1, { ...pool1, percentage: Percent(0.22) })).toBe(false);
     expect(delegatedStakeEquals(pool1, { ...pool1, stake: 101n })).toBe(false);
+  });
+
+  test('signedTxsEquals compares signed tx id', () => {
+    const signedTxs1 = [{ tx: { id: txId1 } } as SignedTx];
+    const signedTxs2 = [{ tx: { id: txId2 } } as SignedTx];
+    expect(signedTxsEquals(signedTxs1, [...signedTxs1.map((signedTx) => ({ ...signedTx }))])).toBe(true);
+    expect(signedTxsEquals(signedTxs1, signedTxs2)).toBe(false);
   });
 });

--- a/packages/wallet/test/services/util/newAndStoredMulticast.test.ts
+++ b/packages/wallet/test/services/util/newAndStoredMulticast.test.ts
@@ -1,0 +1,71 @@
+import { Cardano } from '@cardano-sdk/core';
+import { createTestScheduler, logger, mockProviders } from '@cardano-sdk/util-dev';
+
+import { OutgoingTx, TxInFlight } from '../../../src';
+import { dummyCbor, toOutgoingTx } from '../../util';
+import { mergeMap } from 'rxjs';
+import { newAndStoredMulticast } from '../../../src/services/util';
+const { generateTxAlonzo, queryTransactionsResult } = mockProviders;
+
+describe('newAndStoredMulticast', () => {
+  it('emit from new and stored', () => {
+    const [outgoingTx] = generateTxAlonzo(1).map(toOutgoingTx);
+    const storedInFlightTx: TxInFlight = {
+      body: {} as Cardano.TxBody,
+      cbor: dummyCbor,
+      id: queryTransactionsResult.pageResults[0].id,
+      submittedAt: Cardano.Slot(1)
+    };
+
+    createTestScheduler().run(({ hot, expectObservable }) => {
+      const storedInFlight$ = hot<TxInFlight[]>('-a|', {
+        a: [storedInFlightTx]
+      });
+
+      const submitting$ = hot<OutgoingTx>('a-|', {
+        a: outgoingTx
+      });
+      const newAndStoredMulticast$ = newAndStoredMulticast<TxInFlight, Cardano.TransactionId>({
+        groupByFn: (tx) => tx.id,
+        logger,
+        new$: submitting$,
+        stored$: storedInFlight$
+      }).pipe(mergeMap((signedTx$) => signedTx$));
+
+      expectObservable(newAndStoredMulticast$).toBe('ab|', {
+        a: outgoingTx,
+        b: storedInFlightTx
+      });
+    });
+  });
+
+  it('filter stored unsubmitted transactions', () => {
+    const [outgoingTx] = generateTxAlonzo(1).map(toOutgoingTx);
+    const storedInFlightTx: TxInFlight = {
+      body: {} as Cardano.TxBody,
+      cbor: dummyCbor,
+      id: queryTransactionsResult.pageResults[0].id
+    };
+
+    createTestScheduler().run(({ hot, expectObservable }) => {
+      const storedInFlight$ = hot<TxInFlight[]>('-a|', {
+        a: [storedInFlightTx]
+      });
+
+      const submitting$ = hot<OutgoingTx>('a-|', {
+        a: outgoingTx
+      });
+      const newAndStoredMulticast$ = newAndStoredMulticast<TxInFlight, Cardano.TransactionId>({
+        groupByFn: (tx) => tx.id,
+        logger,
+        new$: submitting$,
+        stored$: storedInFlight$,
+        storedFilterfn: ({ submittedAt }) => !!submittedAt
+      }).pipe(mergeMap((signedTx$) => signedTx$));
+
+      expectObservable(newAndStoredMulticast$).toBe('a-|', {
+        a: outgoingTx
+      });
+    });
+  });
+});

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -128,6 +128,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
       inFlight$: RemoteApiPropertyType.HotObservable,
       onChain$: RemoteApiPropertyType.HotObservable,
       pending$: RemoteApiPropertyType.HotObservable,
+      signed$: RemoteApiPropertyType.HotObservable,
       submitting$: RemoteApiPropertyType.HotObservable
     },
     rollback$: RemoteApiPropertyType.HotObservable


### PR DESCRIPTION
# Context

LW-9469 - Support for transaction chaining

# Proposed Solution
Created `ObservableWallet.transactions.outgoing.signed$` which is an Observable of an array of transactions.

- New transactions are added to it as they are signed
- Removed from it when they are either
  - inFlight$
  - tip is > validityInterval.invalidHereafter
  - any input utxo is consumed by other transaction in history$
  - ~~explicitly dismissed~~

~~Consumed utxo from signed transactions are removed from `ObservableWallet.utxo.available$`~~

# Important Changes Introduced

Created `signTx` util function to replace usage of observable wallet `finalizeTx` as it was interfering with tests expectation of utxos to be present in `wallet.utxo.total$`.