### PR TITLE
fix(cardano-services): phase-2 failure tx mapper

### DIFF
--- a/packages/cardano-services-client/src/version.ts
+++ b/packages/cardano-services-client/src/version.ts
@@ -1,7 +1,7 @@
 // auto-generated using ../scripts/createVersionSource.js
 export const apiVersion = {
   assetInfo: '1.0.0',
-  chainHistory: '3.0.0',
+  chainHistory: '3.0.1',
   handle: '1.0.0',
   networkInfo: '1.0.0',
   rewards: '1.0.0',

--- a/packages/cardano-services-client/version.json
+++ b/packages/cardano-services-client/version.json
@@ -1,6 +1,6 @@
 {
   "assetInfo": "1.0.0",
-  "chainHistory": "3.0.0",
+  "chainHistory": "3.0.1",
   "handle": "1.0.0",
   "networkInfo": "1.0.0",
   "rewards": "1.0.0",

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -215,13 +215,25 @@ export const mapTxAlonzo = (
     slot: Cardano.Slot(Number(txModel.block_slot_no))
   },
   body: {
+    ...(inputSource === Cardano.InputSource.collaterals
+      ? {
+          collateralReturn: outputs.length > 0 ? outputs[0] : undefined,
+          collaterals: inputs,
+          fee: BigInt(0),
+          inputs: [],
+          outputs: [],
+          totalCollateral: BigInt(txModel.fee)
+        }
+      : {
+          collateralReturn: collateralOutputs.length > 0 ? collateralOutputs[0] : undefined,
+          collaterals,
+          fee: BigInt(txModel.fee),
+          inputs,
+          outputs
+        }),
     certificates,
-    collateralReturn: collateralOutputs.length > 0 ? collateralOutputs[0] : undefined,
-    collaterals,
-    fee: BigInt(txModel.fee),
-    inputs,
     mint,
-    outputs,
+    totalCollateral: inputSource === Cardano.InputSource.collaterals ? BigInt(txModel.fee) : undefined,
     validityInterval: {
       invalidBefore: Cardano.Slot(Number(txModel.invalid_before)) || undefined,
       invalidHereafter: Cardano.Slot(Number(txModel.invalid_hereafter)) || undefined

--- a/packages/cardano-services/src/ChainHistory/openApi.json
+++ b/packages/cardano-services/src/ChainHistory/openApi.json
@@ -6,13 +6,13 @@
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "3.0.0"
+    "version": "3.0.1"
   },
   "paths": {
-    "/v3.0.0/chain-history/health": {
+    "/v3.0.1/chain-history/health": {
       "$ref": "../Http/schema.json#/paths/Health"
     },
-    "/v3.0.0/chain-history/blocks/by-hashes": {
+    "/v3.0.1/chain-history/blocks/by-hashes": {
       "post": {
         "summary": "block history by hashes",
         "operationId": "blocksByHashes",
@@ -50,7 +50,7 @@
         }
       }
     },
-    "/v3.0.0/chain-history/txs/by-hashes": {
+    "/v3.0.1/chain-history/txs/by-hashes": {
       "post": {
         "summary": "transaction history by hashes",
         "operationId": "transactionsByHashes",
@@ -88,7 +88,7 @@
         }
       }
     },
-    "/v3.0.0/chain-history/txs/by-addresses": {
+    "/v3.0.1/chain-history/txs/by-addresses": {
       "post": {
         "summary": "transaction history by addresses",
         "operationId": "transactionsByAddresses",

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -398,6 +398,36 @@ describe('chain history mappers', () => {
         witness: { ...expected.witness, redeemers }
       });
     });
+    test('map collaterals input source TxModel to Cardano.HydratedTx', () => {
+      const result = mappers.mapTxAlonzo(txModel, {
+        certificates,
+        inputSource: Cardano.InputSource.collaterals,
+        inputs,
+        metadata,
+        mint: assets,
+        outputs,
+        redeemers,
+        withdrawals
+      });
+      expect(result).toEqual<Cardano.HydratedTx>({
+        ...expected,
+        auxiliaryData: { blob: metadata },
+        body: {
+          ...expected.body,
+          certificates,
+          collateralReturn: outputs[0],
+          collaterals: inputs,
+          fee: 0n,
+          inputs: [],
+          mint: assets,
+          outputs: [],
+          totalCollateral: 170_000n,
+          withdrawals
+        },
+        inputSource: Cardano.InputSource.collaterals,
+        witness: { ...expected.witness, redeemers }
+      });
+    });
   });
   describe('mapTxInModel', () => {
     test('map txInputModel to TxInput', () => {

--- a/packages/e2e/test/wallet/PersonalWallet/phase2validation.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/phase2validation.test.ts
@@ -150,6 +150,6 @@ describe('PersonalWallet/phase2validation', () => {
     expect([TransactionFailure.Phase2Validation, TransactionFailure.FailedToSubmit].includes(failedTx.reason)).toBe(
       true
     );
-    expect(txFoundInHistory.body.fee).toEqual(collateralCoinValue);
+    expect(txFoundInHistory.body.totalCollateral).toEqual(collateralCoinValue);
   });
 });


### PR DESCRIPTION
# Context

_Reason for the change? If an issue exists, reference it here using a [keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)_

# Proposed Solution

- db-sync chain-history provider maps consumed collateral amount to fee property. It should be setting totalCollateral instead, and (if the original fee property of transaction body is unavailable), set fee: 0n

- similarly, we seem to be mapping the consumed collateral inputs into body.inputs. Test this, and update the mapping to map to body.collaterals (leaving inputs as an empty array, like with the fee)

- lastly, same for outputs and collateralOutput
