### PR TITLE
LW-9418 Add Conway era txs e2e tests

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -107,8 +107,8 @@ services:
       RESTORE_SNAPSHOT: ${RESTORE_SNAPSHOT:-}
       RESTORE_RECREATE_DB: N
     depends_on:
-      ogmios:
-        condition: service_healthy
+      cardano-node:
+        condition: service_started
     healthcheck:
       test: ['CMD', '/scripts/is-db-synced.sh']
       interval: 5s
@@ -164,6 +164,9 @@ services:
     image: cardanosolutions/ogmios:v${OGMIOS_VERSION:-6.1.0}
     command:
       ['--host', '0.0.0.0', '--node-socket', '/ipc/node.socket', '--node-config', '/config/cardano-node/config.json']
+    depends_on:
+      cardano-node:
+        condition: service_started
     healthcheck:
       retries: 2000
     ports:
@@ -174,7 +177,7 @@ services:
 
   cardano-submit-api:
     command: --config /config/cardano-submit-api/config.json --listen-address 0.0.0.0 --socket-path /ipc/node.socket $SUBMIT_API_ARGS
-    image: ghcr.io/intersectmbo/cardano-submit-api:${CARDANO_NODE_VERSION:-8.8.0-pre} 
+    image: ghcr.io/intersectmbo/cardano-submit-api:${CARDANO_NODE_VERSION:-8.8.0-pre}
     ports:
       - 8090:8090
     restart: on-failure

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
@@ -128,7 +128,11 @@ const getGovernanceAction = ({
       };
 
     case 'NewConstitution':
-      return { __typename: GovernanceActionType.new_constitution, constitution: contents[1], governanceActionId };
+      return {
+        __typename: GovernanceActionType.new_constitution,
+        constitution: { scriptHash: null, ...contents[1] },
+        governanceActionId
+      };
 
     case 'NoConfidence':
       return { __typename: GovernanceActionType.no_confidence, governanceActionId };

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/ChainHistoryBuilder.ts
@@ -458,9 +458,13 @@ export class ChainHistoryBuilder {
       ...stakeCertsArr.map((cert): WithCertType<StakeCertModel> => ({ ...cert, type: 'stake' })),
       ...delegationCertsArr.map((cert): WithCertType<DelegationCertModel> => ({ ...cert, type: 'delegation' })),
       ...drepCerts.rows.map(
-        (cert): WithCertType<DrepCertModel> => ({
+        ({ deposit, ...cert }): WithCertType<DrepCertModel> => ({
           ...cert,
-          type: cert.deposit === null ? 'updateDrep' : BigInt(cert.deposit) >= 0n ? 'registerDrep' : 'unregisterDrep'
+          ...(deposit === null
+            ? { deposit, type: 'updateDrep' }
+            : deposit.startsWith('-')
+            ? { deposit: deposit.slice(1), type: 'unregisterDrep' }
+            : { deposit, type: 'registerDrep' })
         })
       ),
       ...voteDelegationCertsArr.map(

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -215,10 +215,11 @@ export const mapCertificate = (
   if (isDrepRegistrationCertModel(certModel))
     return {
       __typename: Cardano.CertificateType.RegisterDelegateRepresentative,
-      anchor: mapAnchor(certModel.url, certModel.data_hash),
+      anchor:
+        certModel.url && certModel.data_hash ? mapAnchor(certModel.url, certModel.data_hash.toString('hex')) : null,
       cert_index: certModel.cert_index,
       dRepCredential: {
-        hash: certModel.drep_hash as Hash28ByteBase16,
+        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       },
       deposit: BigInt(certModel.deposit)
@@ -229,7 +230,7 @@ export const mapCertificate = (
       __typename: Cardano.CertificateType.UnregisterDelegateRepresentative,
       cert_index: certModel.cert_index,
       dRepCredential: {
-        hash: certModel.drep_hash as Hash28ByteBase16,
+        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       },
       deposit: BigInt(certModel.deposit)
@@ -238,10 +239,11 @@ export const mapCertificate = (
   if (isUpdateDrepCertModel(certModel))
     return {
       __typename: Cardano.CertificateType.UpdateDelegateRepresentative,
-      anchor: mapAnchor(certModel.url, certModel.data_hash),
+      anchor:
+        certModel.url && certModel.data_hash ? mapAnchor(certModel.url, certModel.data_hash.toString('hex')) : null,
       cert_index: certModel.cert_index,
       dRepCredential: {
-        hash: certModel.drep_hash as Hash28ByteBase16,
+        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       }
     };
@@ -251,7 +253,7 @@ export const mapCertificate = (
       __typename: Cardano.CertificateType.VoteDelegation,
       cert_index: certModel.cert_index,
       dRep: {
-        hash: certModel.drep_hash as Hash28ByteBase16,
+        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       },
       stakeCredential: {
@@ -267,7 +269,7 @@ export const mapCertificate = (
       __typename: Cardano.CertificateType.VoteRegistrationDelegation,
       cert_index: certModel.cert_index,
       dRep: {
-        hash: certModel.drep_hash as Hash28ByteBase16,
+        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       },
       deposit: BigInt(certModel.deposit),
@@ -284,7 +286,7 @@ export const mapCertificate = (
       __typename: Cardano.CertificateType.StakeVoteDelegation,
       cert_index: certModel.cert_index,
       dRep: {
-        hash: certModel.drep_hash as Hash28ByteBase16,
+        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       },
       poolId: certModel.pool_id as unknown as Cardano.PoolId,
@@ -315,7 +317,7 @@ export const mapCertificate = (
       __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
       cert_index: certModel.cert_index,
       dRep: {
-        hash: certModel.drep_hash as Hash28ByteBase16,
+        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       },
       deposit: BigInt(certModel.deposit),

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -345,7 +345,7 @@ export const findDrepCertsByTxIds = `
 		cert_index,
 		tx.hash AS tx_id,
 		has_script,
-		drep.view AS drep_hash,
+		drep.raw AS drep_hash,
 		url,
 		data_hash,
 		cert.deposit
@@ -361,7 +361,7 @@ export const findVoteDelegationCertsByTxIds = `
 		cert_index,
 		tx.hash AS tx_id,
 		has_script,
-		drep.view AS drep_hash,
+		drep.raw AS drep_hash,
 		addr.view AS address
 	FROM tx
 	JOIN delegation_vote AS cert ON cert.tx_id = tx.id

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -188,15 +188,15 @@ export interface DelegationCertModel extends CertificateModel {
 
 export interface DrepCertModel extends CertificateModel {
   has_script: boolean;
-  drep_hash: string;
-  url: string;
-  data_hash: string;
+  drep_hash: Buffer;
+  url: string | null;
+  data_hash: Buffer | null;
   deposit: string;
 }
 
 export interface VoteDelegationCertModel extends CertificateModel {
   has_script: boolean;
-  drep_hash: string;
+  drep_hash: Buffer;
   address: string;
 }
 

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/mappers.ts
@@ -65,7 +65,7 @@ export const toProtocolParams = ({
   min_committee_size,
   committee_term_limit,
   governance_action_validity_period,
-  governance_action_deposit,
+  gov_action_deposit,
   drep_deposit,
   drep_inactivity_period
 }: ProtocolParamsModel): Cardano.ProtocolParameters => ({
@@ -78,7 +78,7 @@ export const toProtocolParams = ({
   dRepVotingThresholds: drep_voting_thresholds,
   decentralizationParameter: String(decentralisation),
   desiredNumberOfPools: optimal_pool_count,
-  governanceActionDeposit: governance_action_deposit,
+  governanceActionDeposit: Number(gov_action_deposit),
   governanceActionValidityPeriod: Cardano.EpochNo(governance_action_validity_period),
   maxBlockBodySize: max_block_size,
   maxBlockHeaderSize: max_bh_size,

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/queries.ts
@@ -52,6 +52,8 @@ export const findProtocolParams = `
     max_block_ex_mem,
     max_block_ex_steps,
     max_epoch,
+    gov_action_deposit,
+    drep_deposit,
     cost_model.costs
     FROM epoch_param
     LEFT JOIN cost_model

--- a/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
+++ b/packages/cardano-services/src/NetworkInfo/DbSyncNetworkInfoProvider/types.ts
@@ -59,7 +59,7 @@ export interface ProtocolParamsModel {
   min_committee_size: number;
   committee_term_limit: number;
   governance_action_validity_period: number;
-  governance_action_deposit: number;
+  gov_action_deposit: number;
   drep_deposit: number;
   drep_inactivity_period: number;
 }

--- a/packages/e2e/local-network/scripts/make-babbage.sh
+++ b/packages/e2e/local-network/scripts/make-babbage.sh
@@ -167,7 +167,7 @@ rm "${ROOT}/genesis/byron/genesis-wrong.json"
 cp "${ROOT}/genesis/shelley/genesis.json" "${ROOT}/genesis/shelley/copy-genesis.json"
 
 jq -M ". + {slotLength:0.2, activeSlotsCoeff:0.1, securityParam:10, epochLength:1000, maxLovelaceSupply:$((MAX_SUPPLY * 3)), updateQuorum:2}" "${ROOT}/genesis/shelley/copy-genesis.json" > "${ROOT}/genesis/shelley/copy2-genesis.json"
-jq --raw-output '.protocolParams.protocolVersion.major = 7 | .protocolParams.minFeeA = 44 | .protocolParams.minFeeB = 155381 | .protocolParams.minUTxOValue = 1000000 | .protocolParams.decentralisationParam = 0.7 | .protocolParams.rho = 0.1 | .protocolParams.tau = 0.1' "${ROOT}/genesis/shelley/copy2-genesis.json" > "${ROOT}/genesis/shelley/genesis.json"
+jq --raw-output '.protocolParams.protocolVersion.major = 9 | .protocolParams.minFeeA = 44 | .protocolParams.minFeeB = 155381 | .protocolParams.minUTxOValue = 1000000 | .protocolParams.decentralisationParam = 0.7 | .protocolParams.rho = 0.1 | .protocolParams.tau = 0.1' "${ROOT}/genesis/shelley/copy2-genesis.json" > "${ROOT}/genesis/shelley/genesis.json"
 
 rm "${ROOT}/genesis/shelley/copy2-genesis.json"
 rm "${ROOT}/genesis/shelley/copy-genesis.json"

--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -121,10 +121,8 @@ export const txConfirmed = (
     SYNC_TIMEOUT_DEFAULT / 5
   );
 
-const submit = (wallet: ObservableWallet, tx: Cardano.Tx) => wallet.submitTx(tx);
-const confirm = (wallet: ObservableWallet, tx: Cardano.Tx) => txConfirmed(wallet, tx);
-export const submitAndConfirm = (wallet: ObservableWallet, tx: Cardano.Tx) =>
-  Promise.all([submit(wallet, tx), confirm(wallet, tx)]);
+export const submitAndConfirm = (wallet: ObservableWallet, tx: Cardano.Tx, numConfirmations?: number) =>
+  Promise.all([wallet.submitTx(tx), txConfirmed(wallet, tx, numConfirmations)]);
 
 export type RequestCoinsProps = {
   wallet: ObservableWallet;

--- a/packages/e2e/test/wallet/PersonalWallet/conwayTransactions.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/conwayTransactions.test.ts
@@ -1,0 +1,450 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { Cardano } from '@cardano-sdk/core';
+import { PersonalWallet } from '@cardano-sdk/wallet';
+import { logger } from '@cardano-sdk/util-dev';
+
+import { firstValueFrom, map } from 'rxjs';
+import { getEnv, getWallet, submitAndConfirm, walletReady, walletVariables } from '../../../src';
+
+/*
+Use cases not covered by specific tests because covered by (before|after)(All|Each) hooks
+- send RegisterDelegateRepresentative certificate
+  sent in beforeAll as a registered DRep is required to some other test cases
+- send UnregisterDelegateRepresentative certificate
+  sent in afterAll as test suite tear down
+- send Conway Registration certificate
+  sent in beforeEach in nested describe with tests requiring it
+- send ProposalProcedure
+  sent in beforeAll in nested describe to check VotingProcedure
+- send AuthorizeCommitteeHot
+  sent in beforeAll in nested describe to check UpdateDelegateRepresentative
+*/
+
+const {
+  CertificateType,
+  CredentialType,
+  GovernanceActionType,
+  RewardAccount,
+  StakeKeyStatus,
+  StakePoolStatus,
+  Vote,
+  VoterType
+} = Cardano;
+
+const env = getEnv(walletVariables);
+
+const anchor = {
+  dataHash: '3e33018e8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80d' as Crypto.Hash32ByteBase16,
+  url: 'https://testing.this'
+};
+
+const assertTxHasCertificate = (tx: Cardano.HydratedTx, certificate: Cardano.Certificate) =>
+  expect(tx.body.certificates![0]).toEqual(certificate);
+
+const getTestWallet = async (idx: number, name: string, minCoinBalance?: bigint) => {
+  const { wallet } = await getWallet({ env, idx, logger, name, polling: { interval: 50 } });
+
+  await walletReady(wallet, minCoinBalance);
+
+  return wallet;
+};
+
+describe('PersonalWallet/conwayTransactions', () => {
+  let dRepWallet: PersonalWallet;
+  let wallet: PersonalWallet;
+
+  let dRepCredential: Cardano.Credential & { type: Cardano.CredentialType.KeyHash };
+  let poolId: Cardano.PoolId;
+  let rewardAccount: Cardano.RewardAccount;
+  let stakeCredential: Cardano.Credential;
+
+  let dRepDeposit: bigint;
+  let governanceActionDeposit: bigint;
+  let stakeKeyDeposit: bigint;
+
+  const assertWalletIsDelegating = async () =>
+    expect((await firstValueFrom(wallet.delegation.rewardAccounts$))[0].delegatee?.nextNextEpoch?.id).toEqual(poolId);
+
+  const cleanWallet = async () => {
+    const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
+
+    if (!rewardAccounts.some((acct) => acct.keyStatus === StakeKeyStatus.Unregistered)) {
+      const { tx } = await wallet.createTxBuilder().delegatePortfolio(null).build().sign();
+
+      await submitAndConfirm(wallet, tx, 1);
+    }
+  };
+
+  const getDRepCredential = async () => {
+    const drepPubKey = await dRepWallet.getPubDRepKey();
+    const dRepKeyHash = Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(
+      (await Crypto.Ed25519PublicKey.fromHex(drepPubKey).hash()).hex()
+    );
+
+    return { hash: dRepKeyHash, type: CredentialType.KeyHash } as typeof dRepCredential;
+  };
+
+  const getDeposits = async () => {
+    const protocolParameters = await wallet.networkInfoProvider.protocolParameters();
+
+    return [
+      BigInt(protocolParameters.dRepDeposit),
+      BigInt(protocolParameters.governanceActionDeposit),
+      BigInt(protocolParameters.stakeKeyDeposit)
+    ];
+  };
+
+  const getPoolId = async () => {
+    const activePools = await wallet.stakePoolProvider.queryStakePools({
+      filters: { status: [StakePoolStatus.Active] },
+      pagination: { limit: 1, startAt: 0 }
+    });
+
+    return activePools.pageResults[0].id;
+  };
+
+  const getStakeCredential = async () => {
+    rewardAccount = await firstValueFrom(wallet.addresses$.pipe(map((addresses) => addresses[0].rewardAccount)));
+
+    return {
+      hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(RewardAccount.toHash(rewardAccount)),
+      type: CredentialType.KeyHash
+    };
+  };
+
+  const feedDRepWallet = async () => {
+    const balance = await firstValueFrom(dRepWallet.balance.utxo.total$);
+
+    if (balance.coins > 10_000_000n) return;
+
+    const address = await firstValueFrom(dRepWallet.addresses$.pipe(map((addresses) => addresses[0].address)));
+
+    const signedTx = await wallet
+      .createTxBuilder()
+      .addOutput({ address, value: { coins: 20_000_000n } })
+      .build()
+      .sign();
+
+    await submitAndConfirm(wallet, signedTx.tx, 1);
+  };
+
+  const sendDRepRegCert = async (register: boolean) => {
+    const common = { dRepCredential, deposit: dRepDeposit };
+    const dRepUnRegCert: Cardano.UnRegisterDelegateRepresentativeCertificate = {
+      __typename: CertificateType.UnregisterDelegateRepresentative,
+      ...common
+    };
+    const dRepRegCert: Cardano.RegisterDelegateRepresentativeCertificate = {
+      __typename: CertificateType.RegisterDelegateRepresentative,
+      anchor,
+      ...common
+    };
+    const certificate = register ? dRepRegCert : dRepUnRegCert;
+    const signedTx = await dRepWallet
+      .createTxBuilder()
+      .customize(({ txBody }) => ({ ...txBody, certificates: [certificate] }))
+      .build()
+      .sign();
+    const [, confirmedTx] = await submitAndConfirm(dRepWallet, signedTx.tx, 1);
+
+    assertTxHasCertificate(confirmedTx, certificate);
+  };
+
+  beforeAll(async () => {
+    [wallet, dRepWallet] = await Promise.all([
+      getTestWallet(0, 'Conway Wallet', 100_000_000n),
+      getTestWallet(1, 'Conway DRep Wallet', 0n)
+    ]);
+
+    [, dRepCredential, [dRepDeposit, governanceActionDeposit, stakeKeyDeposit], poolId, stakeCredential] =
+      await Promise.all([feedDRepWallet(), getDRepCredential(), getDeposits(), getPoolId(), getStakeCredential()]);
+
+    try {
+      await sendDRepRegCert(true);
+    } catch (error) {
+      // TODO LW-9898 Remove this try / catch and register only if not yet registered
+      if (error instanceof Error && error.message.includes('ConwayDRepAlreadyRegistered'))
+        // eslint-disable-next-line no-console
+        console.log('DRepAlreadyRegistered');
+      else throw error;
+    }
+  });
+
+  beforeEach(cleanWallet);
+
+  afterAll(async () => {
+    await sendDRepRegCert(false);
+    await cleanWallet();
+
+    wallet.shutdown();
+    dRepWallet.shutdown();
+  });
+
+  it('can register a stake key and delegate stake using a combo certificate', async () => {
+    const regAndDelegCert: Cardano.StakeRegistrationDelegationCertificate = {
+      __typename: CertificateType.StakeRegistrationDelegation,
+      deposit: stakeKeyDeposit,
+      poolId,
+      stakeCredential
+    };
+    const signedTx = await wallet
+      .createTxBuilder()
+      .customize(({ txBody }) => ({ ...txBody, certificates: [regAndDelegCert] }))
+      .build()
+      .sign();
+    const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+    assertTxHasCertificate(confirmedTx, regAndDelegCert);
+    await assertWalletIsDelegating();
+  });
+
+  it('can register a stake key and delegate vote using a combo certificate', async () => {
+    const regAndVoteDelegCert: Cardano.VoteRegistrationDelegationCertificate = {
+      __typename: CertificateType.VoteRegistrationDelegation,
+      dRep: dRepCredential,
+      deposit: stakeKeyDeposit,
+      stakeCredential
+    };
+    const signedTx = await wallet
+      .createTxBuilder()
+      .customize(({ txBody }) => ({ ...txBody, certificates: [regAndVoteDelegCert] }))
+      .build()
+      .sign();
+    const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+    assertTxHasCertificate(confirmedTx, regAndVoteDelegCert);
+  });
+
+  it('can register a stake key and delegate stake and vote using a combo certificate', async () => {
+    const regStakeVoteDelegCert: Cardano.StakeVoteRegistrationDelegationCertificate = {
+      __typename: CertificateType.StakeVoteRegistrationDelegation,
+      dRep: dRepCredential,
+      deposit: stakeKeyDeposit,
+      poolId,
+      stakeCredential
+    };
+    const signedTx = await wallet
+      .createTxBuilder()
+      .customize(({ txBody }) => ({ ...txBody, certificates: [regStakeVoteDelegCert] }))
+      .build()
+      .sign();
+    const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+    assertTxHasCertificate(confirmedTx, regStakeVoteDelegCert);
+    await assertWalletIsDelegating();
+  });
+
+  it('can update delegation representatives', async () => {
+    const updateDRepCert: Cardano.UpdateDelegateRepresentativeCertificate = {
+      __typename: CertificateType.UpdateDelegateRepresentative,
+      anchor: null,
+      dRepCredential
+    };
+    const signedTx = await dRepWallet
+      .createTxBuilder()
+      .customize(({ txBody }) => ({ ...txBody, certificates: [updateDRepCert] }))
+      .build()
+      .sign();
+    const [, confirmedTx] = await submitAndConfirm(dRepWallet, signedTx.tx, 1);
+
+    assertTxHasCertificate(confirmedTx, updateDRepCert);
+  });
+
+  // TODO LW-9962
+  describe.skip('with constitutional committee', () => {
+    beforeAll(async () => {
+      const regCCCert: Cardano.AuthorizeCommitteeHotCertificate = {
+        __typename: CertificateType.AuthorizeCommitteeHot,
+        coldCredential: stakeCredential,
+        hotCredential: stakeCredential
+      };
+      const signedTx = await dRepWallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, certificates: [regCCCert] }))
+        .build()
+        .sign();
+      const [, confirmedTx] = await submitAndConfirm(dRepWallet, signedTx.tx, 1);
+
+      assertTxHasCertificate(confirmedTx, regCCCert);
+    });
+
+    it('can update delegation representatives', async () => {
+      const updateDRepCert: Cardano.UpdateDelegateRepresentativeCertificate = {
+        __typename: CertificateType.UpdateDelegateRepresentative,
+        anchor,
+        dRepCredential
+      };
+      const signedTx = await dRepWallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, certificates: [updateDRepCert] }))
+        .build()
+        .sign();
+      const [, confirmedTx] = await submitAndConfirm(dRepWallet, signedTx.tx, 1);
+
+      assertTxHasCertificate(confirmedTx, updateDRepCert);
+    });
+  });
+
+  describe('with Conway Registration certificate', () => {
+    beforeEach(async () => {
+      const newRegCert: Cardano.NewStakeAddressCertificate = {
+        __typename: CertificateType.Registration,
+        deposit: stakeKeyDeposit,
+        stakeCredential
+      };
+      const signedTx = await wallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, certificates: [newRegCert] }))
+        .build()
+        .sign();
+      const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+      assertTxHasCertificate(confirmedTx, newRegCert);
+      expect((await firstValueFrom(wallet.delegation.rewardAccounts$))[0].keyStatus).toBe(StakeKeyStatus.Registered);
+    });
+
+    it('can un-register stake key through the new Conway certificates', async () => {
+      const newUnRegCert: Cardano.NewStakeAddressCertificate = {
+        __typename: CertificateType.Unregistration,
+        deposit: stakeKeyDeposit,
+        stakeCredential
+      };
+      const signedTx = await wallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, certificates: [newUnRegCert] }))
+        .build()
+        .sign();
+      const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+      assertTxHasCertificate(confirmedTx, newUnRegCert);
+      expect((await firstValueFrom(wallet.delegation.rewardAccounts$))[0].keyStatus).toBe(StakeKeyStatus.Unregistered);
+    });
+
+    it('can delegate vote', async () => {
+      const voteDelegCert: Cardano.VoteDelegationCertificate = {
+        __typename: CertificateType.VoteDelegation,
+        dRep: dRepCredential,
+        stakeCredential
+      };
+      const signedTx = await wallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, certificates: [voteDelegCert] }))
+        .build()
+        .sign();
+      const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+      assertTxHasCertificate(confirmedTx, voteDelegCert);
+      await assertWalletIsDelegating();
+    });
+
+    it('can delegate stake and vote using combo certificate', async () => {
+      const stakeVoteDelegCert: Cardano.StakeVoteDelegationCertificate = {
+        __typename: CertificateType.StakeVoteDelegation,
+        dRep: dRepCredential,
+        poolId,
+        stakeCredential
+      };
+      const signedTx = await wallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, certificates: [stakeVoteDelegCert] }))
+        .build()
+        .sign();
+      const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+      assertTxHasCertificate(confirmedTx, stakeVoteDelegCert);
+      await assertWalletIsDelegating();
+    });
+  });
+
+  describe('with proposal procedure', () => {
+    let actionId: Cardano.GovernanceActionId;
+
+    beforeAll(async () => {
+      const proposalProcedures: Cardano.ProposalProcedure[] = [
+        {
+          anchor,
+          deposit: governanceActionDeposit,
+          governanceAction: {
+            __typename: GovernanceActionType.parameter_change_action,
+            governanceActionId: null,
+            policyHash: null,
+            protocolParamUpdate: { maxTxSize: 2000 }
+          },
+          rewardAccount
+        },
+        {
+          anchor,
+          deposit: governanceActionDeposit,
+          governanceAction: {
+            __typename: GovernanceActionType.hard_fork_initiation_action,
+            governanceActionId: null,
+            protocolVersion: { major: 10, minor: 0 }
+          },
+          rewardAccount
+        },
+        {
+          anchor,
+          deposit: governanceActionDeposit,
+          governanceAction: {
+            __typename: GovernanceActionType.treasury_withdrawals_action,
+            policyHash: null,
+            withdrawals: new Set([{ coin: 10_000_000n, rewardAccount }])
+          },
+          rewardAccount
+        },
+        {
+          anchor,
+          deposit: governanceActionDeposit,
+          governanceAction: {
+            __typename: GovernanceActionType.no_confidence,
+            governanceActionId: null
+          },
+          rewardAccount
+        },
+        {
+          anchor,
+          deposit: governanceActionDeposit,
+          governanceAction: {
+            __typename: GovernanceActionType.new_constitution,
+            constitution: { anchor, scriptHash: null },
+            governanceActionId: null
+          },
+          rewardAccount
+        },
+        {
+          anchor,
+          deposit: governanceActionDeposit,
+          governanceAction: { __typename: GovernanceActionType.info_action },
+          rewardAccount
+        }
+      ];
+      const signedTx = await wallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, proposalProcedures }))
+        .build()
+        .sign();
+      const [id, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
+
+      expect(confirmedTx.body.proposalProcedures).toEqual(proposalProcedures);
+
+      actionId = { actionIndex: 0, id };
+    });
+
+    it('delegation representatives can vote proposal procedure', async () => {
+      const votingProcedures: Cardano.VotingProcedures = [
+        {
+          voter: { __typename: VoterType.dRepKeyHash, credential: dRepCredential },
+          votes: [{ actionId, votingProcedure: { anchor, vote: Vote.abstain } }]
+        }
+      ];
+      const signedTx = await dRepWallet
+        .createTxBuilder()
+        .customize(({ txBody }) => ({ ...txBody, votingProcedures }))
+        .build()
+        .sign();
+      const [, confirmedTx] = await submitAndConfirm(dRepWallet, signedTx.tx, 1);
+
+      expect(confirmedTx.body.votingProcedures).toEqual(votingProcedures);
+    });
+  });
+});


### PR DESCRIPTION
# Context

We need to cover Conway era transactions in our e2e test.

# Proposed Solution

Added a test suite with many (hopefully all) transactions with new features in Conway era

# Important Changes Introduced

- Fixed DRep representation in related certificates
- Fixed newly added deposits in Conway era in `DbSyncChainHistoryProvider`
- Fixed `NewConstitution` proposal representation in `DbSyncChainHistoryProvider`
- Bumped protocol major version in local-testnet
- Fixed containers dependencies in docker compose infrastructure