### PR TITLE
[LW-9880] ci: deploy dev-preprod & dev-mainnet on release

### DIFF
--- a/.github/workflows/std-release.yaml
+++ b/.github/workflows/std-release.yaml
@@ -9,3 +9,6 @@ jobs:
     if: startsWith(github.event.release.name, '@cardano-sdk/cardano-services@')
     steps:
       - uses: ./.github/workflows/std.yml
+        with:
+          deploy-dev-preprod: true
+          deploy-dev-mainnet: true

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -148,10 +148,9 @@ jobs:
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 
 
-  # TODO: decide if this is only ever for dev-preview? control with another diff-matrix?
-  diff-dev-preview:
+  diff:
     needs: images
-    name: Diff & Comment (dev-preview)
+    name: Diff & Comment
     if: github.event_name == 'pull_request' && (github.base_ref == 'master')
     permissions:
       contents: read
@@ -194,22 +193,34 @@ jobs:
             export AWS_PROFILE="lw"
             export AWS_REGION="us-east-1"
 
-            nix run -L ".#cardano-services.dev-preview@us-east-1.plan" | tee k8s-plan.diff
+            printf "" >pr-comment.md
+
+            for target in \
+              "dev-preview@us-east-1" \
+              "dev-preprod@us-east-1@v1" \
+              "dev-mainnet@us-east-1" \
+            ; do
+              nix run -L ".#cardano-services.${target}.plan" | tee k8s-plan.diff
+
+              (
+                echo "<details>"
+                echo "<summary><code>${target}</code> would change:</summary>"
+                echo
+                cat k8s-plan.diff \
+                  | sed -r "s|^[^ +-].*|\`\`\`\n\n\0\n\n\`\`\`diff|g" \
+                  | tail -n +3 \
+                  | sed -r "s|^([^ +-].*)has changed(.*)|\1would change\2|g"
+                echo "\`\`\`"
+                echo "</details>"
+              ) >>pr-comment.md
+            done
           '
       - name: Post Comment on the PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           prNumber=$(cut -d/ -f1 <<<'${{ github.ref_name }}')
-          gh pr comment "$prNumber" --body "$(
-            echo '<details>'
-            echo "<summary>$(head -n 1 k8s-plan.diff)</summary>"
-            echo
-            echo '```diff'
-            tail -n +2 k8s-plan.diff
-            echo '```'
-            echo '</details>'
-          )"
+          gh pr comment "$prNumber" --body "$(cat pr-comment.md)"
 
 
   deploy:
@@ -218,6 +229,7 @@ jobs:
       # Only one deployment at a time per environment, and wait for the previous one to finish:
       group: deploy-${{ matrix.environment }}
       cancel-in-progress: false
+    if: fromJSON(needs.discover.outputs.deployment-matrix) != '[]'
     strategy:
       matrix:
         include: ${{ fromJSON(fromJSON(needs.discover.outputs.deployment-matrix)) }}

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -3,22 +3,37 @@ name: STD
 on:
   workflow_dispatch:
     inputs:
-      deploy:
+      deploy-dev-preview:
         description: Deploy to dev-preview
         type: boolean
         required: true
         default: false
+      deploy-dev-preprod:
+        description: Deploy to dev-preprod
+        type: boolean
+        required: true
+        default: false
+      deploy-dev-mainnet:
+        description: Deploy to dev-mainnet
+        type: boolean
+        required: true
+        default: false
   workflow_call:
+    inputs:
+      deploy-dev-preprod:
+        type: boolean
+        required: true
+      deploy-dev-mainnet:
+        type: boolean
+        required: true
   pull_request:
     branches:
       - master
       - conway-era
-      - dev-preview
   push:
     branches:
       - master
       - conway-era
-      - dev-preview
     tags:
       - '@cardano-sdk/cardano-services**'
 env:
@@ -32,6 +47,7 @@ jobs:
   discover:
     outputs:
       hits: ${{ steps.discovery.outputs.hits }}
+      deployment-matrix: ${{ steps.deployment-matrix.outputs.deployment-matrix }}
     runs-on: [self-hosted, discovery]
     env:
       AWS_REGION: us-east-1
@@ -61,6 +77,25 @@ jobs:
         shell: bash
         run: |
           echo commit: ${{ github.sha }}
+      - name: Determine Deployment Matrix
+        id: deployment-matrix
+        run: |
+          (
+            if [ "true" == ${{ inputs.deploy-dev-preview || (github.event_name == 'push' && github.ref_name == 'master') }} ] ; then
+              echo '{"environment":"dev-preview", "target":"dev-preview@us-east-1",    "url": "https://dev-preview.lw.iog.io/"}'
+            fi
+            if [ "true" == ${{ inputs.deploy-dev-preprod || false }} ] ; then
+              echo '{"environment":"dev-preprod", "target":"dev-preprod@us-east-1@v1", "url": "https://dev-preprod.lw.iog.io/"}'
+            fi
+            if [ "true" == ${{ inputs.deploy-dev-mainnet || false }} ] ; then
+              echo '{"environment":"dev-mainnet", "target":"dev-mainnet@us-east-1",    "url": "https://dev-mainnet.lw.iog.io/"}'
+            fi
+          ) | jq --slurp >deployment-matrix.json
+
+          cat deployment-matrix.json
+
+          # TODO: should we remove the trailing double quotes?
+          echo "deployment-matrix=$(cat deployment-matrix.json | jq -c . | jq --raw-input)" >> "$GITHUB_OUTPUT"
       - uses: divnix/std-action/discover@main
         with: {ffBuildInstructions: true}
         id: discovery
@@ -113,8 +148,8 @@ jobs:
         with: {ffBuildInstructions: true, remoteStore: "ssh-ng://eu.nixbuild.net"}
 
 
-  # TODO: remove all hardcoded instances of `dev-preview` in the next iteration
-  diff-to-us:
+  # TODO: decide if this is only ever for dev-preview? control with another diff-matrix?
+  diff-dev-preview:
     needs: images
     name: Diff & Comment (dev-preview)
     if: github.event_name == 'pull_request' && (github.base_ref == 'master')
@@ -177,19 +212,20 @@ jobs:
           )"
 
 
-  # TODO: remove all hardcoded instances of `dev-preview` in the next iteration
-  deploy-to-us:
-    if: (github.event_name == 'push' && github.ref_name == 'master') || (github.event_name == 'workflow_dispatch' && inputs.deploy)
+  deploy:
     needs: [images]
     concurrency:
       # Only one deployment at a time per environment, and wait for the previous one to finish:
-      group: deploy-dev-preview
+      group: deploy-${{ matrix.environment }}
       cancel-in-progress: false
-    name: Deploy (dev-preview)
+    strategy:
+      matrix:
+        include: ${{ fromJSON(fromJSON(needs.discover.outputs.deployment-matrix)) }}
+    name: Deploy (${{ matrix.environment }})
     runs-on: ubuntu-22.04
     environment:
-      name: dev-preview
-      url: https://dev-preview.lw.iog.io/
+      name: ${{ matrix.environment }}
+      url: ${{ matrix.url }}
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v25
@@ -227,5 +263,5 @@ jobs:
             export AWS_PROFILE="lw"
             export AWS_REGION="us-east-1"
 
-            echo yes | nix run -L ".#cardano-services.dev-preview@us-east-1.apply"
+            echo yes | nix run -L ".#cardano-services.${{ matrix.target }}.apply"
           '

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ The [GETTING_STARTED](./GETTING_STARTED.md) guide provides a quick way to start 
 
 - [@cardano-sdk/golden-test-generator](./packages/golden-test-generator)
 
+## Deployments
+
+Automatic deployments are done for:
+
+- [dev-preview](https://dev-preview.lw.iog.io/v1.0.0/health) - On each push to master
+- [dev-preprod](https://dev-preprod.lw.iog.io/v1.0.0/health) - On each release
+- [dev-mainnet](https://dev-mainnet.lw.iog.io/v1.0.0/health) - On each release
+
 ## Development
 
 A Yarn Workspace maintaining a single version across all packages.


### PR DESCRIPTION
[LW-9880](https://input-output.atlassian.net/browse/LW-9880)

# Context

→ Jira

A [run that proves](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/8155419455) that the new deployment matrix works.

# Proposed Solution

→ Jira

# Important Changes Introduced

→ Jira

[LW-9880]: https://input-output.atlassian.net/browse/LW-9880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ