### PR TITLE
chore: pass fake chromedriver to package build to avoid IFD

### DIFF
--- a/nix/cardano-services/packages.nix
+++ b/nix/cardano-services/packages.nix
@@ -42,25 +42,6 @@ in {
         runHook postInstall
       '';
     });
-
-    chromedriverVersion = builtins.unsafeDiscardStringContext (builtins.readFile (
-      project.overrideAttrs (oldAttrs: {
-        name = "chromedriver-version";
-        buildInputs = oldAttrs.buildInputs ++ [ nixpkgs.unzip ];
-        buildPhase = "";
-        preConfigure = ''
-          unzip .yarn/cache/chromedriver-*.zip
-          cat node_modules/chromedriver/lib/chromedriver.js \
-            | grep -E '^\s*const version' | grep -Eo '[0-9]+(\.[0-9]+)+' \
-            | tr -d '\n' >$out
-          exit 0
-        '';
-      })));
-    chromedriver = nixpkgs.fetchurl {
-      name = "chromedriver-bin-${chromedriverVersion}.zip";  # Note: triggers hash check on version changes.
-      url = "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chromedriverVersion}/linux64/chromedriver-linux64.zip";
-      hash = "sha256-X8bia1BaLQm5WKn5vdShpQ4A7sPNZ8lgmeXoYj2earc=";
-    };
   in
     project.overrideAttrs (oldAttrs: {
       # A bunch of deps build binaries using node-gyp that requires Python
@@ -68,7 +49,7 @@ in {
       # playwright build fixes
       PLAYWRIGHT_BROWSERS_PATH = nixpkgs.playwright-driver.browsers;
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1;
-      CHROMEDRIVER_FILEPATH = chromedriver;
+      CHROMEDRIVER_FILEPATH = builtins.toFile "fake-chromedriver" "";
       # node-hid uses pkg-config to find sources
       buildInputs = oldAttrs.buildInputs ++ [nixpkgs.pkg-config nixpkgs.libusb1];
       # run actual build


### PR DESCRIPTION
# Context

During OCI image build there is an IFD which is super annoying during deployments, this PR attempts to fix it

# Proposed Solution
Pass empty file instead of chromedriver since it is unused during build anyways

# Important Changes Introduced
