### PR TITLE
ci: fix `dev-preprod` deployment

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -224,7 +224,7 @@ jobs:
 
 
   deploy:
-    needs: [images]
+    needs: [images,discover]
     concurrency:
       # Only one deployment at a time per environment, and wait for the previous one to finish:
       group: deploy-${{ matrix.environment }}


### PR DESCRIPTION
# Context

Triggering `dev-preprod` manually [failed with a JSON error](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/8232153217).

Looking at the error, the `fromJSON` function got an empty string:

```
Error when evaluating 'strategy' for job 'deploy'. .github/workflows/std.yml (Line: 235, Col: 18): 
Error parsing fromJson,.github/workflows/std.yml (Line: 235, Col: 18): 
Error parsing fromJson,.github/workflows/std.yml (Line: 235, Col: 18): 
Error reading JToken from JsonReader. Path '', line 0, position 0.,.github/workflows/std.yml (Line: 235, Col: 18): 
Unexpected value ''
```

I don't get how it's possible that `dev-preview` _ever_ worked, if `needs`' outputs are only available when you specify `needs:` explicitly?

Or maybe they are available indeterministically 😕 

# Proposed Solution

Successful `dev-preprod` deployment: https://github.com/input-output-hk/cardano-js-sdk/actions/runs/8232305561

# Important Changes Introduced
