### PR TITLE
[LW-10042] fix: routing versions

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -131,17 +131,27 @@ in
           };
           routes = let
             inherit (oci.meta) versions;
-          in [
-            "/v${versions.root}/health"
-            "/v${versions.root}/live"
-            "/v${versions.root}/meta"
-            "/v${versions.root}/ready"
-            "/v${versions.assetInfo}/asset"
-            "/v${versions.chainHistory}/chain-history"
-            "/v${versions.networkInfo}/network-info"
-            "/v${versions.rewards}/rewards"
-            "/v${versions.txSubmit}/tx-submit"
-            "/v${versions.utxo}/utxo"
+            mk = version: mkEndpoint: let
+              major = __fromJSON (__elemAt (__splitVersion version) 0);
+              minor = __fromJSON (__elemAt (__splitVersion version) 1);
+              patch = __fromJSON (__elemAt (__splitVersion version) 2);
+            in
+            map (minor':
+              map (patch':
+                mkEndpoint "${toString major}.${toString minor'}.${toString patch'}"
+              ) (__genList (a: a) (patch + 1))
+            ) (__genList (a: a) (minor + 1));
+          in __concatLists [
+            (mk versions.root (v: "/v${v}/health"))
+            (mk versions.root (v: "/v${v}/live"))
+            (mk versions.root (v: "/v${v}/meta"))
+            (mk versions.root (v: "/v${v}/ready"))
+            (mk versions.assetInfo (v: "/v${v}/asset"))
+            (mk versions.chainHistory (v: "/v${v}/chain-history"))
+            (mk versions.networkInfo (v: "/v${v}/network-info"))
+            (mk versions.rewards (v: "/v${v}/rewards"))
+            (mk versions.txSubmit (v: "/v${v}/tx-submit"))
+            (mk versions.utxo (v: "/v${v}/utxo"))
           ];
         };
       };


### PR DESCRIPTION
[LW-10042](https://input-output.atlassian.net/browse/LW-10042)

# Context

[Slack thread](https://input-output-rnd.slack.com/archives/C032DECBR6G/p1710223845458309)

# Proposed Solution

I think it’s slightly wrong. Let’s say you had these versions:

* `1.0.{1..9}`
* `1.1.3`

By only generating `major.{0..minor}.{0..patch}` , we would miss `1.0.{4..9}`

Now, we could go up to 9, but how do we know there are at most 9 patches possible? 🤔

# Important Changes Introduced

n/a

[LW-10042]: https://input-output.atlassian.net/browse/LW-10042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ