### PR TITLE
ci: fix calling convention of std.yml from std-release.yml

### DIFF
--- a/.github/workflows/std-release.yaml
+++ b/.github/workflows/std-release.yaml
@@ -7,8 +7,7 @@ on:
 jobs:
   call-std:
     if: startsWith(github.event.release.name, '@cardano-sdk/cardano-services@')
-    steps:
-      - uses: ./.github/workflows/std.yml
-        with:
-          deploy-dev-preprod: true
-          deploy-dev-mainnet: true
+    uses: ./.github/workflows/std.yml
+    with:
+      deploy-dev-preprod: true
+      deploy-dev-mainnet: true


### PR DESCRIPTION
# Context

Deployment on release failed – https://github.com/input-output-hk/cardano-js-sdk/actions/runs/8249290630.

# Proposed Solution

You don’t use `steps:`, see <https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow>

~~I don’t know how this ever worked… (again)~~ — it [never has](https://github.com/input-output-hk/cardano-js-sdk/actions/workflows/std-release.yaml)

# Important Changes Introduced

n/a