### PR TITLE
fix(crypto): replace variable in keylength error message

### DIFF
--- a/packages/crypto/src/Bip32/Bip32PrivateKey.ts
+++ b/packages/crypto/src/Bip32/Bip32PrivateKey.ts
@@ -2,7 +2,7 @@
 import * as Bip32KeyDerivation from './Bip32KeyDerivation';
 import { Bip32PrivateKeyHex } from '../hexTypes';
 import { Bip32PublicKey } from './Bip32PublicKey';
-import { EXTENDED_ED25519_PRIVATE_KEY_LENGTH, Ed25519PrivateKey, NORMAL_ED25519_PRIVATE_KEY_LENGTH } from '../Ed25519e';
+import { EXTENDED_ED25519_PRIVATE_KEY_LENGTH, Ed25519PrivateKey } from '../Ed25519e';
 import { InvalidArgumentError } from '@cardano-sdk/util';
 import { crypto_scalarmult_ed25519_base_noclamp, ready } from 'libsodium-wrappers-sumo';
 import { pbkdf2 } from 'pbkdf2';
@@ -97,7 +97,7 @@ export class Bip32PrivateKey {
     if (key.length !== BIP32_ED25519_PRIVATE_KEY_LENGTH)
       throw new InvalidArgumentError(
         'key',
-        `Key should be ${NORMAL_ED25519_PRIVATE_KEY_LENGTH} bytes; however ${key.length} bytes were provided.`
+        `Key should be ${BIP32_ED25519_PRIVATE_KEY_LENGTH} bytes; however ${key.length} bytes were provided.`
       );
     return new Bip32PrivateKey(key);
   }


### PR DESCRIPTION
# Context

While looking into how Cardano handles Bip32, specifically how it generates keys from Bip39-word entropy, I discovered that the error message in question kept correcting me for providing a 64-byte length key and not a 32-byte length key. However, the actual check is done against 96-bytes, i.e. the length of xprv after the pbkdf2 algorithm.

Perhaps the idea is that the original entropy should be 32-bytes and that's why NORMAL_ED25519_PRIVATE_KEY_LENGTH is set to that. However, that's not what the if-statement is actually checking against.

# Proposed Solution

Replace NORMAL_ED25519_PRIVATE_KEY_LENGTH with BIP32_ED25519_PRIVATE_KEY_LENGTH, the length that is actually checked against.

# Important Changes Introduced

None.