### PR TITLE
feat(web-extension): added an optional parameter to WalletManager acivate to allow force reload

### DIFF
--- a/packages/web-extension/src/walletManager/walletManager.ts
+++ b/packages/web-extension/src/walletManager/walletManager.ts
@@ -116,10 +116,16 @@ export class WalletManager<WalletMetadata extends { name: string }, AccountMetad
   /**
    * Create and activate a new ObservableWallet.
    *
-   * @param props The properties of the wallet to activate.
+   * @param props - An object containing the necessary properties and configurations to activate the wallet.
+   * @param force - Optional. A boolean flag that determines the activation behavior. If set to `true`,
+   *                the wallet will be activated regardless of whether its properties have changed since
+   *                the last activation. This is useful for scenarios where reinitialization is needed
+   *                without changes to the properties. Defaults to `false`, meaning the wallet will only
+   *                be activated if there have been changes in the `props`.
+   * @returns A Promise that resolves once the wallet has been successfully activated.
    */
-  async activate(props: WalletManagerActivateProps): Promise<void> {
-    if (this.#isActive(props)) {
+  async activate(props: WalletManagerActivateProps, force?: boolean): Promise<void> {
+    if (!force && this.#isActive(props)) {
       return;
     }
 

--- a/packages/web-extension/src/walletManager/walletManager.types.ts
+++ b/packages/web-extension/src/walletManager/walletManager.types.ts
@@ -56,7 +56,7 @@ export interface WalletManagerApi {
    * Create and activate a new ObservableWallet.
    * Reuses the store if the wallet was previously deactivated but not destroyed.
    */
-  activate(props: WalletManagerActivateProps): Promise<void>;
+  activate(props: WalletManagerActivateProps, force?: boolean): Promise<void>;
 
   /**
    * Switches the network of the active wallet.


### PR DESCRIPTION
# Context

We want to be able to force the reloading of a wallet even if its properties haven't changed. this is useful when configuring wallet providers differently.

# Proposed Solution

Add a new optional field "force" that if set to true always re-activates the wallet.

# Important Changes Introduced

A new param 'force' has been added to the wallet manager