### PR TITLE
ci: don’t run `std.yml` on PRs from forks

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -45,6 +45,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   discover:
+    # Don’t run on PRs from forks (no access to secrets):
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       hits: ${{ steps.discovery.outputs.hits }}
       deployment-matrix: ${{ steps.deployment-matrix.outputs.deployment-matrix }}


### PR DESCRIPTION
Discovered in #1162

# Context

In those runs, the workflow doesn’t have access to our secrets, so they fail.

# Proposed Solution

@mkazlauskas wants to not run the workflow then.

# Important Changes Introduced

n/a
