### PR TITLE
test(e2e): run conway era e2e tests with new serialization enabled

### DIFF
--- a/packages/e2e/test/wallet/PersonalWallet/conwayTransactions.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/conwayTransactions.test.ts
@@ -1,6 +1,6 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { BaseWallet } from '@cardano-sdk/wallet';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Serialization } from '@cardano-sdk/core';
 import { logger } from '@cardano-sdk/util-dev';
 
 import { firstValueFrom, map } from 'rxjs';
@@ -151,6 +151,10 @@ describe('PersonalWallet/conwayTransactions', () => {
   };
 
   beforeAll(async () => {
+    // TODO: remove once mainnet hardforks to conway-era, and this becomes "the norm"
+    Serialization.CborSet.useConwaySerialization = true;
+    Serialization.Redeemers.useConwaySerialization = true;
+
     [wallet, dRepWallet] = await Promise.all([
       getTestWallet(0, 'Conway Wallet', 100_000_000n),
       getTestWallet(1, 'Conway DRep Wallet', 0n)
@@ -178,6 +182,10 @@ describe('PersonalWallet/conwayTransactions', () => {
 
     wallet.shutdown();
     dRepWallet.shutdown();
+
+    // TODO: remove once mainnet hardforks to conway-era, and this becomes "the norm"
+    Serialization.CborSet.useConwaySerialization = false;
+    Serialization.Redeemers.useConwaySerialization = false;
   });
 
   it('can register a stake key and delegate stake using a combo certificate', async () => {


### PR DESCRIPTION
# Context

enable set and redeemers map serialisation in conway-era e2e tests.

# Proposed Solution

# Important Changes Introduced
