### PR TITLE
[LW-8192] chore: enable running on AArch64 (`conway-era`)

### DIFF
--- a/compose/aarch64.yml
+++ b/compose/aarch64.yml
@@ -2,10 +2,10 @@
 
 services:
   cardano-db-sync:
-    image: ghcr.io/input-output-hk/ogmios-tracker/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.1.0.0}
+    image: ghcr.io/input-output-hk/ogmios-tracker/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-sancho-4-0-0}
   cardano-node:
-    image: ghcr.io/input-output-hk/ogmios-tracker/cardano-node:${CARDANO_NODE_VERSION:-1.35.5}
+    image: ghcr.io/input-output-hk/ogmios-tracker/cardano-node:${CARDANO_NODE_VERSION:-8.9.1}
   ogmios:
-    image: ghcr.io/input-output-hk/ogmios-tracker/ogmios:v${OGMIOS_VERSION:-5.6.0}
+    image: ghcr.io/input-output-hk/ogmios-tracker/ogmios:v${OGMIOS_VERSION:-6.2.0}
   cardano-submit-api:
-    image: ghcr.io/input-output-hk/ogmios-tracker/cardano-submit-api:${CARDANO_NODE_VERSION:-1.35.5}
+    image: ghcr.io/input-output-hk/ogmios-tracker/cardano-submit-api:${CARDANO_NODE_VERSION:-8.9.1}


### PR DESCRIPTION
# Context

[LW-8192](https://input-output.atlassian.net/browse/LW-8192)

PR analogous to #1171 – look there for details.

# Proposed Solution

`yarn sanchonet:up` works 😌 

<img width="1208" alt="315598217-cdfa2749-e2b2-484d-914d-985388c50de6" src="https://github.com/input-output-hk/cardano-js-sdk/assets/4366292/5c6ea34f-53b7-4a87-8c71-97de8e4d352a">

[LW-8192]: https://input-output.atlassian.net/browse/LW-8192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ