### PR TITLE
fix(cardano-services): correct mapping of chain history redeemer purpose

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -217,7 +217,7 @@ jobs:
 
             for target in \
               "dev-preview@us-east-1" \
-              "dev-preprod@us-east-1@v1" \
+              "dev-preprod@us-east-1@v2" \
               "dev-mainnet@us-east-1" \
             ; do
               nix run -L ".#cardano-services.${target}.plan" | tee k8s-plan.diff

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -20,7 +20,7 @@ import {
   WithCertType,
   WithdrawalModel
 } from './types';
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, NotImplementedError } from '@cardano-sdk/core';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import {
   isDelegationCertModel,
@@ -105,6 +105,21 @@ export const mapWithdrawal = (withdrawalModel: WithdrawalModel): Cardano.Withdra
 // Remove this and select the actual redeemer data from `redeemer_data` table.
 const stubRedeemerData = Buffer.from('not implemented');
 
+const redeemerPurposeMap: Record<RedeemerModel['purpose'], Cardano.RedeemerPurpose> = {
+  cert: Cardano.RedeemerPurpose.certificate,
+  mint: Cardano.RedeemerPurpose.mint,
+  proposing: Cardano.RedeemerPurpose.propose,
+  reward: Cardano.RedeemerPurpose.withdrawal,
+  spend: Cardano.RedeemerPurpose.spend,
+  voting: Cardano.RedeemerPurpose.vote
+};
+
+const mapRedeemerPurpose = (purpose: RedeemerModel['purpose']): Cardano.RedeemerPurpose =>
+  redeemerPurposeMap[purpose] ||
+  (() => {
+    throw new NotImplementedError(`Failed to map redeemer "purpose": ${purpose}`);
+  })();
+
 export const mapRedeemer = (redeemerModel: RedeemerModel): Cardano.Redeemer => ({
   data: stubRedeemerData,
   executionUnits: {
@@ -112,7 +127,7 @@ export const mapRedeemer = (redeemerModel: RedeemerModel): Cardano.Redeemer => (
     steps: Number(redeemerModel.unit_steps)
   },
   index: redeemerModel.index,
-  purpose: redeemerModel.purpose as Cardano.RedeemerPurpose
+  purpose: mapRedeemerPurpose(redeemerModel.purpose)
 });
 
 export const mapCertificate = (

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -95,7 +95,7 @@ export interface WithdrawalModel {
 
 export interface RedeemerModel {
   index: number;
-  purpose: string;
+  purpose: 'cert' | 'mint' | 'spend' | 'reward' | 'voting' | 'proposing';
   script_hash: Buffer;
   unit_mem: string;
   unit_steps: string;

--- a/packages/cardano-services/src/ChainHistory/openApi.json
+++ b/packages/cardano-services/src/ChainHistory/openApi.json
@@ -361,7 +361,9 @@
               "spend",
               "mint",
               "certificate",
-              "withdrawal"
+              "withdrawal",
+              "vote",
+              "propose"
             ]
           },
           "data": {

--- a/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
+++ b/packages/cardano-services/test/ChainHistory/DbSyncChainHistoryProvider/mappers.test.ts
@@ -294,16 +294,22 @@ describe('chain history mappers', () => {
     });
   });
   describe('mapRedeemer', () => {
-    const redeemerModel: RedeemerModel = {
+    const redeemerModel: Omit<RedeemerModel, 'purpose'> = {
       index: 1,
-      purpose: 'mint',
       script_hash: Buffer.from(hash28ByteBase16, 'hex'),
       tx_id: Buffer.from(transactionHash, 'hex'),
       unit_mem: '2000',
       unit_steps: '5000'
     };
-    test('map RedeemerModel to Cardano.Redeemer', () => {
-      const result = mappers.mapRedeemer(redeemerModel);
+    test.each([
+      ['spend' as const, Cardano.RedeemerPurpose.spend],
+      ['mint' as const, Cardano.RedeemerPurpose.mint],
+      ['cert' as const, Cardano.RedeemerPurpose.certificate],
+      ['reward' as const, Cardano.RedeemerPurpose.withdrawal],
+      ['voting' as const, Cardano.RedeemerPurpose.vote],
+      ['proposing' as const, Cardano.RedeemerPurpose.propose]
+    ])("maps '%p' redeemer", (dbSyncRedeemerPurpose, sdkRedeemerPurpose) => {
+      const result = mappers.mapRedeemer({ ...redeemerModel, purpose: dbSyncRedeemerPurpose });
       expect(result).toEqual<Cardano.Redeemer>({
         data: Buffer.from('not implemented'),
         executionUnits: {
@@ -311,7 +317,7 @@ describe('chain history mappers', () => {
           steps: 5000
         },
         index: 1,
-        purpose: Cardano.RedeemerPurpose.mint
+        purpose: sdkRedeemerPurpose
       });
     });
   });

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -96,7 +96,6 @@ export enum RedeemerPurpose {
   mint = 'mint',
   certificate = 'certificate',
   withdrawal = 'withdrawal',
-  delegateRepresentative = 'representative',
   propose = 'propose',
   vote = 'vote'
 }


### PR DESCRIPTION
# Context

This fails:
```
curl 'https://live-mainnet.lw.iog.io/v2.0.0/chain-history/txs/by-addresses' \
  -H 'authority: dev-mainnet.lw.iog.io' \
  -H 'accept: application/json, text/plain, */*' \
  -H 'accept-language: en-US,en;q=0.9' \
  -H 'content-type: application/json' \
  -H 'origin: chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk/' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: none' \
  -H 'sec-gpc: 1' \
  -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36' \
  -H 'version-api: "3.0.0"' \
  -H 'version-software: 0.17.9' \
  --data-raw '{"addresses":["addr1qyf9jlvjr6en2wjkyrcdge0c8xrhgflkg4m5kwhl4yfw7g4yw2z95kepz8urcn8gl425e2jqm2pv94rm959yvqvcg32q286tna"],"blockRange":{"lowerBound":{"__type":"undefined"}},"pagination":{"limit":25,"startAt":108}}
```
with
```
 {
            "path":".response.pageResults[0].witness.redeemers",
            "message":"should be object",
            "errorCode":"type.openapi.validation"
         },
         {
            "path":".response.pageResults[0].witness.redeemers[4].purpose",
            "message":"should be equal to one of the allowed values: spend, mint, certificate, withdrawal",
            "errorCode":"enum.openapi.validation"
         },
         {
            "path":".response.pageResults[0].witness.redeemers",
            "message":"should match some schema in anyOf",
            "errorCode":"anyOf.openapi.validation"
         }
```

# Proposed Solution

Correctly map redeemer purpose based on [values documented in db-sync schema](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/schema.md#redeemer)

# Important Changes Introduced
