### PR TITLE
[LW-10154] ci: make `secrets` available through `workflow_call:`

### DIFF
--- a/.github/workflows/std-release.yaml
+++ b/.github/workflows/std-release.yaml
@@ -11,3 +11,8 @@ jobs:
     with:
       deploy-dev-preprod: true
       deploy-dev-mainnet: true
+    # Secrets have to be passed explicitly even if callee is in the same repo:
+    secrets:
+      AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -26,6 +26,13 @@ on:
       deploy-dev-mainnet:
         type: boolean
         required: true
+    secrets:
+      AWS_ACCESS_KEY:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      SSH_PRIVATE_KEY:
+        required: true
   pull_request:
     branches:
       - master


### PR DESCRIPTION
[LW-10154](https://input-output.atlassian.net/browse/LW-10154)

# Context

See Jira.

# Proposed Solution

Here’s a commit (6c82af41bdc7c6984bdc17f7925180204576354e) that proves that [the secrets are being passed now](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/8434171309/job/23096848796#step:2:1).

# Important Changes Introduced

n/a

[LW-10154]: https://input-output.atlassian.net/browse/LW-10154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ