### PR TITLE
chore(cardano-services): enable typeorm asset provider for dev-preview

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -174,7 +174,7 @@ in
             env.OVERRIDE_FUZZY_OPTIONS = "true";
           };
           handle-provider.enabled = true;
-          # asset-provider.enabled = true;
+          asset-provider.enabled = true;
         };
 
         projectors = {


### PR DESCRIPTION
# Context

_Reason for the change? enable typeORM asset provider, ideally in all envs but starting with `dev-preview` to assess compatability and run tests which will facilitate cip68 nftMetadata fetching.

# Proposed Solution

# Important Changes Introduced
