### PR TITLE
LW-9422 Conway era cherry pick

### DIFF
--- a/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
+++ b/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
@@ -22,7 +22,7 @@ yarn workspace @cardano-sdk/e2e local-network:up -d --build
 yarn workspace @cardano-sdk/e2e wait-for-network
 
 yarn workspace @cardano-sdk/e2e test:wallet
-yarn workspace @cardano-sdk/e2e test:long-running delegation-rewards.test.ts
+yarn workspace @cardano-sdk/e2e test:long-running simple-delegation-rewards.test.ts
 yarn workspace @cardano-sdk/e2e test:local-network register-pool.test.ts
 
 TL_LEVEL="${TL_LEVEL:=info}" node "$SCRIPT_DIR/mint-handles.js"

--- a/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
+++ b/packages/cardano-services/test/jest-setup/rebuild-test-db.sh
@@ -21,13 +21,9 @@ yarn workspace @cardano-sdk/e2e local-network:down
 yarn workspace @cardano-sdk/e2e local-network:up -d --build
 yarn workspace @cardano-sdk/e2e wait-for-network
 
-TEST1="yarn workspace @cardano-sdk/e2e test:wallet"
-TEST2="yarn workspace @cardano-sdk/e2e test:long-running delegation-rewards.test.ts"
-TEST3="yarn workspace @cardano-sdk/e2e test:local-network register-pool.test.ts"
-
-for test in "$TEST1" "$TEST2" "$TEST3"; do
-  while ! $test; do echo repeating...; done
-done
+yarn workspace @cardano-sdk/e2e test:wallet
+yarn workspace @cardano-sdk/e2e test:long-running delegation-rewards.test.ts
+yarn workspace @cardano-sdk/e2e test:local-network register-pool.test.ts
 
 TL_LEVEL="${TL_LEVEL:=info}" node "$SCRIPT_DIR/mint-handles.js"
 

--- a/packages/e2e/test/local-network/register-pool.test.ts
+++ b/packages/e2e/test/local-network/register-pool.test.ts
@@ -7,6 +7,7 @@ import {
   getEnv,
   getWallet,
   submitCertificate,
+  unDelegateWallet,
   waitForWalletStateSettle,
   walletReady,
   walletVariables
@@ -73,6 +74,8 @@ describe('local-network/register-pool', () => {
     wallet1.wallet.shutdown();
     wallet2.wallet.shutdown();
   });
+
+  beforeEach(() => unDelegateWallet(wallet1.wallet));
 
   test('does not meet pledge', async () => {
     const wallet = wallet1.wallet;

--- a/packages/e2e/test/long-running/shared-wallet-delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/shared-wallet-delegation-rewards.test.ts
@@ -84,7 +84,7 @@ const getPoolIds = async (stakePoolProvider: StakePoolProvider, count: number) =
   return poolIds;
 };
 
-describe('delegation rewards', () => {
+describe('shared wallet delegation rewards', () => {
   let fundingTx: Cardano.Tx<Cardano.TxBody>;
   let faucetWallet: BaseWallet;
   let faucetAddress: Cardano.PaymentAddress;

--- a/packages/e2e/test/long-running/simple-delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/simple-delegation-rewards.test.ts
@@ -75,7 +75,7 @@ const getPoolIds = async (stakePoolProvider: StakePoolProvider, count: number) =
   return poolIds;
 };
 
-describe('delegation rewards', () => {
+describe('simple delegation rewards', () => {
   let providers: TestWallet['providers'];
   let wallet1: BaseWallet;
   let wallet2: BaseWallet;


### PR DESCRIPTION
# Context

While working in `conway-era` for `LW-9422` I noticed:
- some change in that branch could be imported in `master` branch;
- some e2e test files has _conflicting names_.

The `rebuild-test-db.sh` file had following command:
```
yarn workspace @cardano-sdk/e2e test:long-running delegation-rewards.test.ts
```
this was making it to start more tests than required.

# Proposed Solution

- Cherry picked the _cross-branch changes_;
- Changed test file and case names to no longer be ambiguous.
