### PR TITLE
test(projection-typeorm): skip flaky test

### DIFF
--- a/packages/projection-typeorm/test/createTypeormTipTracker.test.ts
+++ b/packages/projection-typeorm/test/createTypeormTipTracker.test.ts
@@ -134,7 +134,8 @@ describe('createTypeormTipTracker', () => {
     });
   });
 
-  describe('with failing connection', () => {
+  // TODO LW-9971
+  describe.skip('with failing connection', () => {
     it('reconnects and eventually emits the tip', async () => {
       connection$ = createStubObservable(
         throwError(() => new NoConnectionForRepositoryError('conn')),


### PR DESCRIPTION
# Context

Unit tests often fails with following error.

```
FAIL test/createTypeormTipTracker.test.ts
  ● createTypeormTipTracker › with failing connection › reconnects and eventually emits the tip

    QueryFailedError: relation "block" does not exist

      at PostgresQueryRunner.query (../../src/driver/postgres/PostgresQueryRunner.ts:299:19)
      at SelectQueryBuilder.loadRawResults (../../src/query-builder/SelectQueryBuilder.ts:3787:25)
      at SelectQueryBuilder.executeEntitiesAndRawResults (../../src/query-builder/SelectQueryBuilder.ts:3
      at SelectQueryBuilder.getRawAndEntities (../../src/query-builder/SelectQueryBuilder.ts:1669:29)
      at SelectQueryBuilder.getMany (../../src/query-builder/SelectQueryBuilder.ts:1759:25)
      at src/createTypeormTipTracker.ts:29:34
```

# Proposed Solution

Skipped the flaky test