### PR TITLE
fix(input-selection): greedy input selector now correctly distributes assets among addresses

### DIFF
--- a/packages/input-selection/src/GreedySelection/util.ts
+++ b/packages/input-selection/src/GreedySelection/util.ts
@@ -40,6 +40,8 @@ const distributeAssets = (
 
   let i = 0;
   const availableOutputs = adjustedOutputs;
+  const alreadyFullOutputs = [];
+
   while (totalAssets.size > 0) {
     const splicedAsset = new Map([...totalAssets.entries()].splice(0, 1));
     const currentUtxoIndex = i % availableOutputs.length;
@@ -48,7 +50,7 @@ const distributeAssets = (
     currentValue.assets = addTokenMaps(currentValue.assets, splicedAsset);
 
     if (!isValidValue(currentValue, computeMinimumCoinQuantity, tokenBundleSizeExceedsLimit, fee)) {
-      availableOutputs.splice(currentUtxoIndex, 1);
+      alreadyFullOutputs.push(...availableOutputs.splice(currentUtxoIndex, 1));
     } else {
       availableOutputs[currentUtxoIndex].value = currentValue;
       totalAssets.delete([...splicedAsset.keys()][0]);
@@ -58,7 +60,7 @@ const distributeAssets = (
     ++i;
   }
 
-  return adjustedOutputs;
+  return [...adjustedOutputs, ...alreadyFullOutputs];
 };
 
 /**


### PR DESCRIPTION
# Context

There was a bug in the greedy input selector that was causing some of the change outputs to be discarded if the UTXO didn't have enough ADA to hold more native assets.

# Proposed Solution

When an UTXO can not hold any more native assets (due to its min value constraint), the UTXO needs to be removed from the list of UTXOs that can hold assets, but have to be later merged back with the rest of the assets before returning the selection.
