### PR TITLE
Feat/projector no pg transaction

### DIFF
--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -28,14 +28,24 @@ import {
   storeStakeKeyRegistrations,
   storeStakePoolRewardsJob,
   storeStakePools,
-  storeUtxo
+  storeUtxo,
+  willStoreAddresses,
+  willStoreAssets,
+  willStoreHandleMetadata,
+  willStoreHandles,
+  willStoreNftMetadata,
+  willStoreStakeKeyRegistrations,
+  willStoreStakePoolMetadataJob,
+  willStoreStakePoolRewardsJob,
+  willStoreStakePools,
+  willStoreUtxo
 } from '@cardano-sdk/projection-typeorm';
-import { Cardano } from '@cardano-sdk/core';
-import { Mappers as Mapper } from '@cardano-sdk/projection';
+import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Mappers as Mapper, ProjectionEvent } from '@cardano-sdk/projection';
+import { ObservableType, passthrough } from '@cardano-sdk/util-rxjs';
 import { POOLS_METRICS_INTERVAL_DEFAULT, POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT } from '../Program/programs/types';
 import { Sorter } from '@hapi/topo';
-import { WithLogger } from '@cardano-sdk/util';
-import { passthrough } from '@cardano-sdk/util-rxjs';
+import { WithLogger, isNotNil } from '@cardano-sdk/util';
 
 /** Used as mount segments, so must be URL-friendly */
 export enum ProjectionName {
@@ -117,6 +127,25 @@ export const storeOperators = {
 type StoreOperators = typeof storeOperators;
 type StoreName = keyof StoreOperators;
 type StoreOperator = StoreOperators[StoreName];
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InferArg0<F extends Function> = F extends (arg0: infer Args) => any ? Args : never;
+type WillStore = {
+  [k in keyof StoreOperators]: (args: ObservableType<InferArg0<StoreOperators[k]>>) => boolean;
+};
+
+const willStore: Partial<WillStore> = {
+  storeAddresses: willStoreAddresses,
+  storeAssets: willStoreAssets,
+  storeHandleMetadata: willStoreHandleMetadata,
+  storeHandles: willStoreHandles,
+  storeNftMetadata: willStoreNftMetadata,
+  storeStakeKeyRegistrations: willStoreStakeKeyRegistrations,
+  storeStakePoolMetadataJob: willStoreStakePoolMetadataJob,
+  storeStakePoolRewardsJob: willStoreStakePoolRewardsJob,
+  storeStakePools: willStoreStakePools,
+  storeUtxo: willStoreUtxo
+};
 
 const entities = {
   address: AddressEntity,
@@ -338,16 +367,24 @@ export const prepareTypeormProjection = (
   const selectedMappers = mapperSorter.nodes;
   const selectedStores = storeSorter.nodes;
   const extensions = requiredExtensions(projections);
+  const willStoreCheckers = selectedStores
+    .map((store) => Object.entries(storeOperators).find(([_, operator]) => store === operator)!)
+    .map(([storeName]) => willStore[storeName as keyof StoreOperators])
+    .filter(isNotNil);
   return {
     __debug: {
       entities: selectedEntities.map((Entity) => keyOf(entities, Entity)),
       mappers: selectedMappers.map((mapper) => keyOf(mapperOperators, mapper)),
-      stores: selectedStores.map((store) => keyOf(storeOperators, store))
+      stores: selectedStores.map((store) => keyOf(storeOperators, store)),
+      willStoreCheckers: willStoreCheckers.map((checker) => checker.name)
     },
     entities: selectedEntities,
     extensions,
     mappers: selectedMappers,
-    stores: selectedStores
+    stores: selectedStores,
+    willStore: <T extends ProjectionEvent>(evt: T) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      evt.eventType === ChainSyncEventType.RollBackward || willStoreCheckers.some((check) => check(evt as any))
   };
 };
 

--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -250,7 +250,7 @@ const storeMapperDependencies: Partial<Record<StoreName, MapperName[]>> = {
 };
 
 const storeInterDependencies: Partial<Record<StoreName, StoreName[]>> = {
-  storeAddresses: ['storeStakeKeyRegistrations'],
+  storeAddresses: ['storeBlock', 'storeStakeKeyRegistrations'],
   storeAssets: ['storeBlock'],
   storeHandleMetadata: ['storeUtxo'],
   storeHandles: ['storeUtxo', 'storeAddresses', 'storeHandleMetadata'],

--- a/packages/cardano-services/test/Projection/prepareTypeormProjection.test.ts
+++ b/packages/cardano-services/test/Projection/prepareTypeormProjection.test.ts
@@ -5,16 +5,20 @@ const prepare = (projections: ProjectionName[]) =>
   prepareTypeormProjection({ projections }, { logger: dummyLogger }).__debug;
 
 describe('prepareTypeormProjection', () => {
-  describe('computes required entities, mappers and stores based on selected projections and presence of a buffer', () => {
+  describe('computes required entities, mappers, predicates, and stores based on selected projections and presence of a buffer', () => {
     test('utxo', () => {
-      const { entities, mappers, stores } = prepare([ProjectionName.UTXO]);
+      const { entities, mappers, stores, willStoreCheckers } = prepare([ProjectionName.UTXO]);
       expect(new Set(entities)).toEqual(new Set(['tokens', 'block', 'asset', 'nftMetadata', 'output', 'blockData']));
       expect(mappers).toEqual(['withMint', 'withUtxo']);
       expect(stores).toEqual(['storeBlock', 'storeAssets', 'storeUtxo']);
+      expect(willStoreCheckers).toEqual(['willStoreAssets', 'willStoreUtxo']);
     });
 
     test('stake-pool,stake-pool-metadata', () => {
-      const { entities, mappers, stores } = prepare([ProjectionName.StakePool, ProjectionName.StakePoolMetadataJob]);
+      const { entities, mappers, stores, willStoreCheckers } = prepare([
+        ProjectionName.StakePool,
+        ProjectionName.StakePoolMetadataJob
+      ]);
       expect(new Set(entities)).toEqual(
         new Set([
           'block',
@@ -29,6 +33,7 @@ describe('prepareTypeormProjection', () => {
       );
       expect(mappers).toEqual(['withCertificates', 'withStakePools']);
       expect(stores).toEqual(['storeBlock', 'storeStakePools', 'storeStakePoolMetadataJob']);
+      expect(willStoreCheckers).toEqual(['willStoreStakePools', 'willStoreStakePoolMetadataJob']);
     });
   });
 });

--- a/packages/projection-typeorm/src/operators/storeAddresses.ts
+++ b/packages/projection-typeorm/src/operators/storeAddresses.ts
@@ -16,6 +16,8 @@ const lookupStakeKeyRegistration = async (pointer: Cardano.Pointer | undefined, 
   return Hash28ByteBase16.fromEd25519KeyHashHex(stakeKeyRegistration.stakeKeyHash);
 };
 
+export const willStoreAddresses = ({ addresses }: Mappers.WithAddresses) => addresses.length > 0;
+
 export const storeAddresses = typeormOperator<Mappers.WithAddresses>(async (evt) => {
   const { addresses, eventType, queryRunner } = evt;
   if (addresses.length === 0 || eventType !== ChainSyncEventType.RollForward) return;

--- a/packages/projection-typeorm/src/operators/storeAssets.ts
+++ b/packages/projection-typeorm/src/operators/storeAssets.ts
@@ -53,6 +53,8 @@ const rollBackward = async ({ mint, queryRunner }: StoreAssetEventParams): Promi
   return mintedAssetTotalSupplies;
 };
 
+export const willStoreAssets = ({ mint }: Mappers.WithMint) => mint.length > 0;
+
 export const storeAssets = typeormOperator<Mappers.WithMint, WithMintedAssetSupplies>(
   async ({ mint, block: { header }, eventType, queryRunner }) => {
     const storeAssetEventParams: StoreAssetEventParams = { header, mint, queryRunner };

--- a/packages/projection-typeorm/src/operators/storeHandleMetadata.ts
+++ b/packages/projection-typeorm/src/operators/storeHandleMetadata.ts
@@ -4,6 +4,8 @@ import { Mappers } from '@cardano-sdk/projection';
 import { WithStoredProducedUtxo } from './storeUtxo';
 import { typeormOperator } from './util';
 
+export const willStoreHandleMetadata = ({ handleMetadata }: Mappers.WithHandleMetadata) => handleMetadata.length > 0;
+
 export const storeHandleMetadata = typeormOperator<Mappers.WithHandleMetadata & WithStoredProducedUtxo>(
   async ({
     eventType,

--- a/packages/projection-typeorm/src/operators/storeHandles.ts
+++ b/packages/projection-typeorm/src/operators/storeHandles.ts
@@ -230,6 +230,8 @@ const withTotalSupplies = (
     )
   );
 
+export const willStoreHandles = ({ handles }: Mappers.WithHandles) => handles.length > 0;
+
 export const storeHandles = typeormOperator<Mappers.WithHandles & WithMintedAssetSupplies & Mappers.WithHandleMetadata>(
   async ({ handles, queryRunner, eventType, block, mintedAssetTotalSupplies, handleMetadata }) => {
     const handleEventParams: HandleEventParams = {

--- a/packages/projection-typeorm/src/operators/storeNftMetadata.ts
+++ b/packages/projection-typeorm/src/operators/storeNftMetadata.ts
@@ -104,6 +104,9 @@ const handleRollBackwardEvent = async (
   }
 };
 
+export const willStoreNftMetadata = ({ nftMetadata, cip67 }: Mappers.WithCIP67 & Mappers.WithNftMetadata) =>
+  nftMetadata.length > 0 || Object.keys(cip67.byLabel).length > 0;
+
 export const storeNftMetadata = typeormOperator<Mappers.WithCIP67 & Mappers.WithMint & Mappers.WithNftMetadata>(
   async (evt) => {
     const nftMetadataRepository = evt.queryRunner.manager.getRepository(NftMetadataEntity);

--- a/packages/projection-typeorm/src/operators/storeStakeKeyRegistrations.ts
+++ b/packages/projection-typeorm/src/operators/storeStakeKeyRegistrations.ts
@@ -3,6 +3,9 @@ import { Mappers } from '@cardano-sdk/projection';
 import { StakeKeyRegistrationEntity } from '../entity';
 import { certificatePointerToId, typeormOperator } from './util';
 
+export const willStoreStakeKeyRegistrations = ({ stakeKeyRegistrations }: Mappers.WithStakeKeyRegistrations) =>
+  stakeKeyRegistrations.length > 0;
+
 export const storeStakeKeyRegistrations = typeormOperator<Mappers.WithStakeKeyRegistrations>(
   async ({ eventType, queryRunner, block, stakeKeyRegistrations }) => {
     // Deleted by db with ON DELETE CASCADE

--- a/packages/projection-typeorm/src/operators/storeStakePoolMetadataJob.ts
+++ b/packages/projection-typeorm/src/operators/storeStakePoolMetadataJob.ts
@@ -4,6 +4,8 @@ import { STAKE_POOL_METADATA_QUEUE, StakePoolMetadataJob, defaultJobOptions } fr
 import { WithPgBoss } from './withTypeormTransaction';
 import { certificatePointerToId, typeormOperator } from './util';
 
+export const willStoreStakePoolMetadataJob = ({ stakePools }: Mappers.WithStakePools) => stakePools.updates.length > 0;
+
 export const createStoreStakePoolMetadataJob = (retryDelay = defaultJobOptions.retryDelay) =>
   typeormOperator<Mappers.WithStakePools & WithPgBoss>(async ({ block: { header }, eventType, pgBoss, stakePools }) => {
     const { slot } = header;

--- a/packages/projection-typeorm/src/operators/storeStakePoolRewardsJob.ts
+++ b/packages/projection-typeorm/src/operators/storeStakePoolRewardsJob.ts
@@ -3,6 +3,14 @@ import { STAKE_POOL_REWARDS, defaultJobOptions } from '../pgBoss';
 import { WithPgBoss } from './withTypeormTransaction';
 import { typeormOperator } from './util';
 
+export const willStoreStakePoolRewardsJob = ({
+  crossEpochBoundary,
+  epochNo
+}: {
+  crossEpochBoundary: boolean;
+  epochNo: Cardano.EpochNo;
+}) => crossEpochBoundary && epochNo !== 1;
+
 export const storeStakePoolRewardsJob = typeormOperator<WithPgBoss>(
   async ({ block: { header }, crossEpochBoundary, epochNo, eventType, pgBoss }) => {
     const { slot } = header;

--- a/packages/projection-typeorm/src/operators/storeStakePools.ts
+++ b/packages/projection-typeorm/src/operators/storeStakePools.ts
@@ -312,6 +312,9 @@ const rollBackward = async (evt: Event) => {
   await undoUpdateLatestCertificatesAndDeletePoolsWithZeroRegistrations(evt);
 };
 
+export const willStoreStakePools = ({ stakePools: { updates, retirements } }: Mappers.WithStakePools) =>
+  updates.length > 0 || retirements.length > 0;
+
 export const storeStakePools = typeormOperator<Mappers.WithStakePools>(async (evt) => {
   await (evt.eventType === ChainSyncEventType.RollForward ? rollForward(evt) : rollBackward(evt));
 });

--- a/packages/projection-typeorm/src/operators/storeUtxo.ts
+++ b/packages/projection-typeorm/src/operators/storeUtxo.ts
@@ -11,6 +11,9 @@ export interface WithStoredProducedUtxo {
   storedProducedUtxo: Map<Mappers.ProducedUtxo, ObjectLiteral>;
 }
 
+export const willStoreUtxo = ({ utxo: { produced, consumed } }: Mappers.WithUtxo) =>
+  produced.length > 0 || consumed.length > 0;
+
 export const storeUtxo = typeormOperator<Mappers.WithUtxo, WithStoredProducedUtxo>(
   async ({ utxo: { consumed, produced }, block: { header }, eventType, queryRunner }) => {
     const utxoRepository = queryRunner.manager.getRepository(OutputEntity);

--- a/packages/projection-typeorm/test/operators/storeAddresses.test.ts
+++ b/packages/projection-typeorm/test/operators/storeAddresses.test.ts
@@ -1,3 +1,4 @@
+import { Address } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import {
   AddressEntity,
   AssetEntity,
@@ -16,6 +17,7 @@ import {
   storeStakeKeyRegistrations,
   storeUtxo,
   typeormTransactionCommit,
+  willStoreAddresses,
   withTypeormTransaction
 } from '../../src';
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
@@ -193,5 +195,23 @@ describe('storeAddresses', () => {
         createStubProjectionSource([createRollForwardEventBasedOn(evt, (block) => block)]).pipe(applyOperators)
       )
     ).resolves.not.toThrow();
+  });
+});
+
+describe('willStoreAddresses', () => {
+  it('returns true if address are bigger than 1', () => {
+    expect(
+      willStoreAddresses({
+        addresses: [{} as Address]
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns false if there are no addresses', () => {
+    expect(
+      willStoreAddresses({
+        addresses: []
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storeAssets.test.ts
+++ b/packages/projection-typeorm/test/operators/storeAssets.test.ts
@@ -9,11 +9,13 @@ import {
   storeAssets,
   storeBlock,
   typeormTransactionCommit,
+  willStoreAssets,
   withTypeormTransaction
 } from '../../src';
 import { Bootstrap, Mappers, requestNext } from '@cardano-sdk/projection';
 import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
+import { Mint } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { QueryRunner } from 'typeorm';
 import { connectionConfig$, initializeDataSource } from '../util';
 import { createProjectorContext, createProjectorTilFirst } from './util';
@@ -107,5 +109,23 @@ describe('storeAssets', () => {
     expect(secondMintEvent.mint.length).toBeGreaterThan(0);
     expect(rollbackEvent.mintedAssetTotalSupplies[assetIdThatWasMintedTwice]).toBeLessThan(totalSupplyAfterSecondMint);
     expect(rollbackEvent.mintedAssetTotalSupplies[assetIdThatWasMintedTwice]).toBeGreaterThan(0);
+  });
+});
+
+describe('willStoreAssets', () => {
+  it('returns true if there are mints', () => {
+    expect(
+      willStoreAssets({
+        mint: [{} as Mint]
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns false if there are no mints', () => {
+    expect(
+      willStoreAssets({
+        mint: []
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storeHandleMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeHandleMetadata.test.ts
@@ -14,11 +14,13 @@ import {
   storeHandleMetadata,
   storeUtxo,
   typeormTransactionCommit,
+  willStoreHandleMetadata,
   withTypeormTransaction
 } from '../../src';
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { Cardano, ObservableCardanoNode } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
+import { HandleMetadata } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { Observable, firstValueFrom } from 'rxjs';
 import { QueryRunner, Repository } from 'typeorm';
 import { connectionConfig$, initializeDataSource } from '../util';
@@ -142,5 +144,23 @@ describe('storeHandleMetadata', () => {
         expect(typeof stored.output?.id).toBe('number');
       }
     );
+  });
+});
+
+describe('willStoreHandleMetadata', () => {
+  it('returns true if handleMetadata are bigger than 1', () => {
+    expect(
+      willStoreHandleMetadata({
+        handleMetadata: [{} as HandleMetadata]
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns false if there are no handleMetadata', () => {
+    expect(
+      willStoreHandleMetadata({
+        handleMetadata: []
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storeHandles/general.test.ts
+++ b/packages/projection-typeorm/test/operators/storeHandles/general.test.ts
@@ -1,5 +1,6 @@
 import { Asset, Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { AssetEntity, HandleEntity, OutputEntity } from '../../../src';
+import { AssetEntity, HandleEntity, OutputEntity, willStoreHandles } from '../../../src';
+import { HandleOwnership } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { ProjectorContext, createProjectorContext } from '../util';
 import { QueryRunner } from 'typeorm';
 import { createMultiTxProjectionSource, entities, mapAndStore, policyId, projectTilFirst } from './util';
@@ -85,5 +86,23 @@ describe('storeHandles', () => {
     await firstValueFrom(source$.pipe(mapAndStore(context)));
 
     expect(await repository.count()).toBe(numHandles);
+  });
+});
+
+describe('willStoreHandles', () => {
+  it('returns true if handles are bigger than 1', () => {
+    expect(
+      willStoreHandles({
+        handles: [{} as HandleOwnership]
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns false if there are no handles', () => {
+    expect(
+      willStoreHandles({
+        handles: []
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
@@ -15,9 +15,11 @@ import {
   storeNftMetadata,
   storeUtxo,
   typeormTransactionCommit,
+  willStoreNftMetadata,
   withTypeormTransaction
 } from '../../src';
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { CIP67Asset, ProjectedNftMetadata } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { ChainSyncDataSet, chainSyncData, generateRandomHexString, logger } from '@cardano-sdk/util-dev';
 import { Observable, firstValueFrom, lastValueFrom, toArray } from 'rxjs';
 import { QueryRunner, Repository } from 'typeorm';
@@ -445,5 +447,43 @@ describe('storeNftMetadata', () => {
     expect(typeof file.src).toBe('string');
     expect(['object', 'undefined'].includes(typeof file.otherProperties)).toBe(true);
     expect(['string', 'undefined'].includes(typeof file.name)).toBe(true);
+  });
+});
+
+describe('willStoreNftMetadata', () => {
+  it('returns true if there are nftMetadata', () => {
+    expect(
+      willStoreNftMetadata({
+        cip67: {
+          byAssetId: {},
+          byLabel: {}
+        },
+        nftMetadata: [{} as ProjectedNftMetadata]
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns true if there are cip67 tokens', () => {
+    expect(
+      willStoreNftMetadata({
+        cip67: {
+          byAssetId: { [{} as Cardano.AssetId]: {} as CIP67Asset },
+          byLabel: { [Asset.AssetNameLabelNum.UserNFT]: [{} as CIP67Asset] }
+        },
+        nftMetadata: []
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns false if there are no nftMetadata or cip67', () => {
+    expect(
+      willStoreNftMetadata({
+        cip67: {
+          byAssetId: {},
+          byLabel: {}
+        },
+        nftMetadata: []
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storePoolMetricsUpdateJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storePoolMetricsUpdateJob.test.ts
@@ -33,15 +33,17 @@ describe('createStorePoolMetricsUpdateJob', () => {
       createEvent(send, 7, 80),
       createEvent(send, 8), // generates first event once tip is reached
       createEvent(send, 9),
-      createEvent(send, 10), // generates a std event
+      createEvent(send, 10),
       createEvent(send, 11),
       createEvent(send, 10), // doesn't generate event due to rollback
       createEvent(send, 11),
       createEvent(send, 12),
-      createEvent(send, 13),
+      createEvent(send, 13), // generates a std event
       createEvent(send, 14),
-      createEvent(send, 15), // generates a std event
-      createEvent(send, 16)
+      createEvent(send, 15),
+      createEvent(send, 16),
+      createEvent(send, 17),
+      createEvent(send, 18) // generates a std event
     )
       .pipe(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,11 +55,58 @@ describe('createStorePoolMetricsUpdateJob', () => {
 
     expect(send).toBeCalledTimes(3);
     expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 80 }, { slot: 80 });
-    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 100 }, { slot: 100 });
-    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 150 }, { slot: 150 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 130 }, { slot: 130 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 180 }, { slot: 180 });
   });
 
   it('sends jobs only at expected blocks for outdated job', async () => {
+    let counter = 0;
+    const [promise, resolver] = testPromise();
+    const send = jest.fn(() => {
+      if (++counter === 6) resolver();
+      return Promise.resolve();
+    });
+
+    of(
+      createEvent(send, 2, 80),
+      createEvent(send, 3, 80), // doesn't generate event since tip is not reached & outdatedSlot is undefined yet
+      createEvent(send, 4, 80),
+      createEvent(send, 5, 80), // doesn't generate event since tip is not reached
+      createEvent(send, 6, 80), // doesn't generate event since tip is not reached & outdatedSlot is undefined yet
+      createEvent(send, 7, 80),
+      createEvent(send, 8), // generates first event once tip is reached
+      createEvent(send, 9),
+      createEvent(send, 10),
+      createEvent(send, 11), // generates a outdated event (3 blocks since first update)
+      createEvent(send, 10),
+      createEvent(send, 11), // doesn't generate event due to rollback
+      createEvent(send, 12),
+      createEvent(send, 13), // generates a std event (5 blocks since first update)
+      createEvent(send, 14), // generates outdated event (6 blocks since first update)
+      createEvent(send, 15),
+      createEvent(send, 16),
+      createEvent(send, 17), // generates outdated event (9 blocks since first update)
+      createEvent(send, 18), // generates a std event (10 blocks since first update)
+      createEvent(send, 19)
+    )
+      .pipe(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createStorePoolMetricsUpdateJob(5, 3)() as OperatorFunction<any, any>
+      )
+      .subscribe();
+
+    await promise;
+
+    expect(send).toBeCalledTimes(6);
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 80 }, { slot: 80 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 80, slot: 110 }, { slot: 110 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 130 }, { slot: 130 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 130, slot: 140 }, { slot: 140 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 130, slot: 170 }, { slot: 170 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 180 }, { slot: 180 });
+  });
+
+  it('sends jobs even if events have gaps on blocks', async () => {
     let counter = 0;
     const [promise, resolver] = testPromise();
     const send = jest.fn(() => {
@@ -73,16 +122,10 @@ describe('createStorePoolMetricsUpdateJob', () => {
       createEvent(send, 6, 80), // doesn't generate event since tip is not reached & outdatedSlot is undefined yet
       createEvent(send, 7, 80),
       createEvent(send, 8), // generates first event once tip is reached
-      createEvent(send, 9), // generates a outdated event
-      createEvent(send, 10), // generates a std event
-      createEvent(send, 11),
-      createEvent(send, 10), // doesn't generate event due to rollback
-      createEvent(send, 11),
-      createEvent(send, 12), // generates a outdated event
-      createEvent(send, 13),
-      createEvent(send, 14),
-      createEvent(send, 15), // generates a std event, doesn't generate outdated event
-      createEvent(send, 16)
+      createEvent(send, 11), // generates a outdated event
+      createEvent(send, 1008), // generates a std event
+      createEvent(send, 1012), // generates outdated event
+      createEvent(send, 2000) // generates a std event
     )
       .pipe(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -94,9 +137,9 @@ describe('createStorePoolMetricsUpdateJob', () => {
 
     expect(send).toBeCalledTimes(5);
     expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 80 }, { slot: 80 });
-    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 80, slot: 90 }, { slot: 90 });
-    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 100 }, { slot: 100 });
-    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 100, slot: 120 }, { slot: 120 });
-    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 150 }, { slot: 150 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 80, slot: 110 }, { slot: 110 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 10_080 }, { slot: 10_080 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { outdatedSlot: 10_080, slot: 10_120 }, { slot: 10_120 });
+    expect(send).toBeCalledWith(STAKE_POOL_METRICS_UPDATE, { slot: 20_000 }, { slot: 20_000 });
   });
 });

--- a/packages/projection-typeorm/test/operators/storeStakeKeyRegistrations.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakeKeyRegistrations.test.ts
@@ -9,12 +9,14 @@ import {
   storeBlock,
   storeStakeKeyRegistrations,
   typeormTransactionCommit,
+  willStoreStakeKeyRegistrations,
   withTypeormTransaction
 } from '../../src';
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { Observable, firstValueFrom, pairwise, takeWhile } from 'rxjs';
+import { StakeKeyRegistration } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { connectionConfig$, initializeDataSource } from '../util';
 import {
   createProjectorContext,
@@ -91,5 +93,23 @@ describe('storeStakeKeyRegistrations', () => {
       }
     });
     expect(registration?.stakeKeyHash).toEqual(stakeKeyRegistrations[0].stakeKeyHash);
+  });
+});
+
+describe('willStoreStakeKeyRegistrations', () => {
+  it('returns true if stakeKeyRegistrations are bigger than 1', () => {
+    expect(
+      willStoreStakeKeyRegistrations({
+        stakeKeyRegistrations: [{} as StakeKeyRegistration]
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns false if there are no stakeKeyRegistrations', () => {
+    expect(
+      willStoreStakeKeyRegistrations({
+        stakeKeyRegistrations: []
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storeStakePoolMetadataJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePoolMetadataJob.test.ts
@@ -8,12 +8,14 @@ import {
   createStoreStakePoolMetadataJob,
   storeBlock,
   typeormTransactionCommit,
+  willStoreStakePoolMetadataJob,
   withTypeormTransaction
 } from '../../src';
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { ChainSyncEventType } from '@cardano-sdk/core';
 import { Observable, filter, of } from 'rxjs';
+import { PoolUpdate } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { QueryRunner } from 'typeorm';
 import { StakePoolMetadataJob, createPgBoss } from '../../src/pgBoss';
 import { connectionConfig, initializeDataSource } from '../util';
@@ -139,5 +141,28 @@ describe('storeStakePoolMetadataJob', () => {
     await projectTilFirstPoolUpdateWithMetadata();
     await job2Complete;
     await boss.stop();
+  });
+});
+
+describe('willStoreStakePoolMetadataJob', () => {
+  it('returns true if has stake pool updates', () => {
+    expect(
+      willStoreStakePoolMetadataJob({
+        stakePools: {
+          retirements: [],
+          updates: [{} as PoolUpdate]
+        }
+      })
+    ).toBeTruthy();
+  });
+  it('returns false if no pool updates', () => {
+    expect(
+      willStoreStakePoolMetadataJob({
+        stakePools: {
+          retirements: [],
+          updates: []
+        }
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storeStakePoolRewardsJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePoolRewardsJob.test.ts
@@ -1,6 +1,6 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
 import { OperatorFunction, of } from 'rxjs';
-import { STAKE_POOL_REWARDS, storeStakePoolRewardsJob } from '../../src';
+import { STAKE_POOL_REWARDS, storeStakePoolRewardsJob, willStoreStakePoolRewardsJob } from '../../src';
 
 const testPromise = () => {
   let resolvePromise: Function;
@@ -60,5 +60,32 @@ describe('storeStakePoolRewardsJob', () => {
       { epochNo: 1 },
       { expireInHours: 6, retryDelay: 30, retryLimit: 1_000_000, singletonKey: '1', slot: 2010 }
     );
+  });
+});
+
+describe('willStoreStakePoolRewardsJob', () => {
+  it('returns true if is at epoch boundary and epoch is greater than 1', () => {
+    expect(
+      willStoreStakePoolRewardsJob({
+        crossEpochBoundary: true,
+        epochNo: Cardano.EpochNo(2)
+      })
+    ).toBeTruthy();
+  });
+  it('returns false if not at epoch boundary', () => {
+    expect(
+      willStoreStakePoolRewardsJob({
+        crossEpochBoundary: false,
+        epochNo: Cardano.EpochNo(2)
+      })
+    ).toBeFalsy();
+  });
+  it('returns false if at first epoch', () => {
+    expect(
+      willStoreStakePoolRewardsJob({
+        crossEpochBoundary: true,
+        epochNo: Cardano.EpochNo(1)
+      })
+    ).toBeFalsy();
   });
 });

--- a/packages/projection-typeorm/test/operators/storeStakePools.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePools.test.ts
@@ -12,6 +12,7 @@ import {
   storeBlock,
   storeStakePools,
   typeormTransactionCommit,
+  willStoreStakePools,
   withTypeormTransaction
 } from '../../src';
 import { Bootstrap, Mappers, requestNext } from '@cardano-sdk/projection';
@@ -215,5 +216,39 @@ describe('storeStakePools', () => {
     });
 
     it.todo('lastRegistration is always set to an entity representing the latest certificate');
+  });
+});
+
+describe('willStoreStakePools', () => {
+  it('returns true if there are both updates and retirements', () => {
+    expect(
+      willStoreStakePools({
+        stakePools: { retirements: [{} as never], updates: [{} as never] }
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns true if there are updates', () => {
+    expect(
+      willStoreStakePools({
+        stakePools: { retirements: [], updates: [{} as never] }
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns true if there are retirements', () => {
+    expect(
+      willStoreStakePools({
+        stakePools: { retirements: [{} as never], updates: [] }
+      })
+    ).toBeTruthy();
+  });
+
+  it('returns false if there are no updates or retirements', () => {
+    expect(
+      willStoreStakePools({
+        stakePools: { retirements: [], updates: [] }
+      })
+    ).toBeFalsy();
   });
 });


### PR DESCRIPTION
# Context

Initial projection implementation stored all blocks in stability window buffer, but it has been optimized to only store it once close to tip since then. We can optimize it further to not even write to Block table (headers). This is a low-hanging fruit with high potential for performance gains.

# Proposed Solution

Implement a set of predicates that determines where a specific store will apply changes to the database or not.

