### PR TITLE
LW-9889 Re-enable skipped tests

### DIFF
--- a/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
+++ b/packages/cardano-services/test/ChainHistory/ChainHistoryHttpService.test.ts
@@ -516,8 +516,7 @@ describe('ChainHistoryHttpService', () => {
           expect(response.pageResults[0].body.inputs).toMatchShapeOf(DataMocks.Tx.inputs);
         });
 
-        // TODO: LW-9889 Empty genesis addresses returned by fixtureBuilder.getGenesisAddresses()
-        it.skip('finds transactions with address within outputs', async () => {
+        it('finds transactions with address within outputs', async () => {
           const addresses: Cardano.PaymentAddress[] = await fixtureBuilder.getGenesisAddresses();
           expect(() => Cardano.PaymentAddress(addresses[0] as unknown as string)).not.toThrow();
 

--- a/packages/cardano-services/test/ChainHistory/fixtures/queries.ts
+++ b/packages/cardano-services/test/ChainHistory/fixtures/queries.ts
@@ -76,10 +76,9 @@ export const genesisUtxoAddresses = `
    address
   FROM 
   tx_out WHERE
-    stake_address_id = 1 OR
-    stake_address_id = 2 OR
-    stake_address_id = 3
-  GROUP BY address`;
+    value = 500000000000
+  GROUP BY address
+  LIMIT 3`;
 
 export const transactionInBlockRange = `
   SELECT

--- a/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
+++ b/packages/cardano-services/test/StakePool/DbSyncStakePoolProvider/StakePoolBuilder.test.ts
@@ -270,8 +270,7 @@ describe('StakePoolBuilder', () => {
     });
   });
   describe('buildAndQuery', () => {
-    // TODO: LW-9889 Debug and reenable after Node 8.8 upgrade
-    it.skip('buildAndQuery, queryPoolHashes & queryTotalCount', async () => {
+    it('buildAndQuery, queryPoolHashes & queryTotalCount', async () => {
       const builtQuery = builder.buildAndQuery(filters);
       const { query, params } = builtQuery;
       const poolHashes = await builder.queryPoolHashes(query, params);


### PR DESCRIPTION
# Context

With the introduction of `cardano-node 8.8` some test was disabled: we need to re-enable them.

# Proposed Solution

- `buildAndQuery, queryPoolHashes & queryTotalCount`: was enough to re-enable it, most likely previously rebuild fixtures was enough;
- `finds transactions with address within outputs`: it uses `fixtureBuilder.getGenesisAddresses()`; I have no idea about what was changed from previous version to make genesis addresses no longer having ids starting from 1, but I know which is the value of their utxos: changed the `fixtureBuilder` to get genesis addresses regardless from their ids;
- `Ada handle`: it seems a bug was introduced in `cardano-submit-api`: submitting txs through `ogmios` fixes the problem.