### PR TITLE
Deploy new live mainnet

### DIFF
--- a/nix/cardano-services/deployments/backend.provider.nix
+++ b/nix/cardano-services/deployments/backend.provider.nix
@@ -18,64 +18,66 @@
       };
     };
 
-    env = {
-      NETWORK = values.network;
-      ENABLE_METRICS = "true";
-      SERVICE_NAMES = "asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo";
-      OGMIOS_SRV_SERVICE_NAME = values.backend.ogmiosSrvServiceName;
-      LOGGER_MIN_SEVERITY = values.cardano-services.loggingLevel;
-      TOKEN_METADATA_SERVER_URL = values.cardano-services.tokenMetadataServerUrl;
-      HANDLE_POLICY_IDS = "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a";
-      USE_BLOCKFROST = "true";
-      USE_KORA_LABS = "true";
-      DISABLE_STAKE_POOL_METRIC_APY = "true";
-      PAGINATION_PAGE_SIZE_LIMIT = "5500";
+    env =
+      {
+        NETWORK = values.network;
+        ENABLE_METRICS = "true";
+        SERVICE_NAMES = "asset,chain-history,network-info,rewards,stake-pool,tx-submit,utxo";
+        OGMIOS_SRV_SERVICE_NAME = values.backend.ogmiosSrvServiceName;
+        LOGGER_MIN_SEVERITY = values.cardano-services.loggingLevel;
+        TOKEN_METADATA_SERVER_URL = values.cardano-services.tokenMetadataServerUrl;
+        HANDLE_POLICY_IDS = "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a";
+        USE_BLOCKFROST = "true";
+        USE_KORA_LABS = "true";
+        DISABLE_STAKE_POOL_METRIC_APY = "true";
+        PAGINATION_PAGE_SIZE_LIMIT = "5500";
 
-      HANDLE_PROVIDER_SERVER_URL =
-        if values.network == "mainnet"
-        then "https://api.handle.me"
-        else "https://${values.network}.api.handle.me";
+        HANDLE_PROVIDER_SERVER_URL =
+          if values.network == "mainnet"
+          then "https://api.handle.me"
+          else "https://${values.network}.api.handle.me";
 
-      BUILD_INFO = values.cardano-services.buildInfo;
-      ALLOWED_ORIGINS = values.backend.allowedOrigins;
+        BUILD_INFO = values.cardano-services.buildInfo;
+        ALLOWED_ORIGINS = values.backend.allowedOrigins;
 
-      POSTGRES_POOL_MAX_DB_SYNC = "50";
-      POSTGRES_HOST_DB_SYNC = values.postgresName;
-      POSTGRES_PORT_DB_SYNC = "5432";
-      POSTGRES_DB_DB_SYNC = "cardano";
-      POSTGRES_PASSWORD_DB_SYNC = {
-        valueFrom.secretKeyRef = {
-          name = "cardano-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
-          key = "password";
+        POSTGRES_POOL_MAX_DB_SYNC = "50";
+        POSTGRES_HOST_DB_SYNC = values.postgresName;
+        POSTGRES_PORT_DB_SYNC = "5432";
+        POSTGRES_DB_DB_SYNC = "cardano";
+        POSTGRES_PASSWORD_DB_SYNC = {
+          valueFrom.secretKeyRef = {
+            name = "cardano-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
+            key = "password";
+          };
         };
-      };
-      POSTGRES_USER_DB_SYNC = {
-        valueFrom.secretKeyRef = {
-          name = "cardano-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
-          key = "username";
+        POSTGRES_USER_DB_SYNC = {
+          valueFrom.secretKeyRef = {
+            name = "cardano-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
+            key = "username";
+          };
         };
-      };
-      POSTGRES_SSL_DB_SYNC = "true";
-      POSTGRES_SSL_CA_FILE_DB_SYNC = "/tls/ca.crt";
-    } // lib.optionalAttrs values.backend.passHandleDBArgs {
-      POSTGRES_POOL_MAX_HANDLE = "10";
-      POSTGRES_HOST_HANDLE = values.postgresName;
-      POSTGRES_PORT_HANDLE = "5432";
-      POSTGRES_DB_HANDLE = "handle";
-      POSTGRES_PASSWORD_HANDLE = {
-        valueFrom.secretKeyRef = {
-          name = "handle-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
-          key = "password";
+        POSTGRES_SSL_DB_SYNC = "true";
+        POSTGRES_SSL_CA_FILE_DB_SYNC = "/tls/ca.crt";
+      }
+      // lib.optionalAttrs values.backend.passHandleDBArgs {
+        POSTGRES_POOL_MAX_HANDLE = "10";
+        POSTGRES_HOST_HANDLE = values.postgresName;
+        POSTGRES_PORT_HANDLE = "5432";
+        POSTGRES_DB_HANDLE = "handle";
+        POSTGRES_PASSWORD_HANDLE = {
+          valueFrom.secretKeyRef = {
+            name = "handle-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
+            key = "password";
+          };
         };
-      };
-      POSTGRES_USER_HANDLE = {
-        valueFrom.secretKeyRef = {
-          name = "handle-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
-          key = "username";
+        POSTGRES_USER_HANDLE = {
+          valueFrom.secretKeyRef = {
+            name = "handle-owner-user.${values.postgresName}.credentials.postgresql.acid.zalan.do";
+            key = "username";
+          };
         };
+        POSTGRES_SSL_HANDLE = "true";
+        POSTGRES_SSL_CA_FILE_HANDLE = "/tls/ca.crt";
       };
-      POSTGRES_SSL_HANDLE = "true";
-      POSTGRES_SSL_CA_FILE_HANDLE = "/tls/ca.crt";
-    };
   };
 }

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -12,7 +12,7 @@
     us-east-2 = readJsonFile ./tf-outputs/lace-prod-us-east-2.json;
   };
   oci = inputs.self.x86_64-linux.cardano-services.oci-images.cardano-services;
-  allowedOrigins =  [
+  allowedOrigins = [
     # Represents Chrome production version
     "chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk"
     # Represents Edge production version
@@ -23,10 +23,12 @@
     "chrome-extension://djcdfchkaijggdjokfomholkalbffgil"
   ];
 
-  allowedOriginsDev = allowedOrigins ++ [
-    "http://localhost/"
-    "http://localhost"
-  ];
+  allowedOriginsDev =
+    allowedOrigins
+    ++ [
+      "http://localhost/"
+      "http://localhost"
+    ];
 in
   nix-helm.builders.${pkgs.system}.mkHelmMultiTarget {
     defaults = final: let
@@ -114,13 +116,14 @@ in
           resources.requests = mkPodResources "150Mi" "100m";
         };
         pg-boss-worker = {
-           enabled = false;
-           metadata-fetch-mode = "smash";
-           smash-url = if values.network == "mainnet"
-                         then "https://smash.cardano-mainnet.iohk.io/api/v1"
-                         else "https://${values.network}-smash.world.dev.cardano.org/api/v1";
-           resources.limits = mkPodResources "300Mi" "300m";
-           resources.requests = mkPodResources "150Mi" "200m";
+          enabled = false;
+          metadata-fetch-mode = "smash";
+          smash-url =
+            if values.network == "mainnet"
+            then "https://smash.cardano-mainnet.iohk.io/api/v1"
+            else "https://${values.network}-smash.world.dev.cardano.org/api/v1";
+          resources.limits = mkPodResources "300Mi" "300m";
+          resources.requests = mkPodResources "150Mi" "200m";
         };
 
         backend = {
@@ -245,24 +248,23 @@ in
 
           backend.allowedOrigins = lib.concatStringsSep "," allowedOriginsDev;
           backend.routes = let
-              inherit (oci.meta) versions;
-            in
-              lib.concatLists [
-                (map (v: "/v${v}/health") versions.root)
-                (map (v: "/v${v}/live") versions.root)
-                (map (v: "/v${v}/meta") versions.root)
-                (map (v: "/v${v}/ready") versions.root)
-                (map (v: "/v${v}/asset") versions.assetInfo)
-                (map (v: "/v${v}/chain-history") versions.chainHistory)
-                (map (v: "/v${v}/network-info") versions.networkInfo)
-                (map (v: "/v${v}/rewards") versions.rewards)
-                (map (v: "/v${v}/tx-submit") versions.txSubmit)
-                (map (v: "/v${v}/utxo") versions.utxo)
-                (map (v: "/v${v}/handle") versions.handle)
-                (map (v: "/v${v}/provider-server") versions.stakePool)
-                (map (v: "/v${v}/stake-pool-provider-server") versions.stakePool)
-              ];
-
+            inherit (oci.meta) versions;
+          in
+            lib.concatLists [
+              (map (v: "/v${v}/health") versions.root)
+              (map (v: "/v${v}/live") versions.root)
+              (map (v: "/v${v}/meta") versions.root)
+              (map (v: "/v${v}/ready") versions.root)
+              (map (v: "/v${v}/asset") versions.assetInfo)
+              (map (v: "/v${v}/chain-history") versions.chainHistory)
+              (map (v: "/v${v}/network-info") versions.networkInfo)
+              (map (v: "/v${v}/rewards") versions.rewards)
+              (map (v: "/v${v}/tx-submit") versions.txSubmit)
+              (map (v: "/v${v}/utxo") versions.utxo)
+              (map (v: "/v${v}/handle") versions.handle)
+              (map (v: "/v${v}/provider-server") versions.stakePool)
+              (map (v: "/v${v}/stake-pool-provider-server") versions.stakePool)
+            ];
 
           cardano-services = {
             ingresOrder = 99;
@@ -448,12 +450,27 @@ in
           };
           backend.allowedOrigins = lib.concatStringsSep "," allowedOrigins;
           backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
+          backend.routes = let
+            inherit (oci.meta) versions;
+          in
+            lib.concatLists [
+              (map (v: "/v${v}/health") versions.root)
+              (map (v: "/v${v}/live") versions.root)
+              (map (v: "/v${v}/meta") versions.root)
+              (map (v: "/v${v}/ready") versions.root)
+              (map (v: "/v${v}/asset") versions.assetInfo)
+              (map (v: "/v${v}/chain-history") versions.chainHistory)
+              (map (v: "/v${v}/network-info") versions.networkInfo)
+              (map (v: "/v${v}/rewards") versions.rewards)
+              (map (v: "/v${v}/tx-submit") versions.txSubmit)
+              (map (v: "/v${v}/utxo") versions.utxo)
+              (map (v: "/v${v}/handle") versions.handle)
+            ];
 
           blockfrost-worker.enabled = true;
           pg-boss-worker.enabled = true;
         };
       };
-
 
       "live-preprod@us-east-2@v2" = final: {
         name = "${final.namespace}-cardanojs-v2";
@@ -491,6 +508,22 @@ in
           cardano-services = {
             ingresOrder = 98;
           };
+          backend.routes = let
+            inherit (oci.meta) versions;
+          in
+            lib.concatLists [
+              (map (v: "/v${v}/health") versions.root)
+              (map (v: "/v${v}/live") versions.root)
+              (map (v: "/v${v}/meta") versions.root)
+              (map (v: "/v${v}/ready") versions.root)
+              (map (v: "/v${v}/asset") versions.assetInfo)
+              (map (v: "/v${v}/chain-history") versions.chainHistory)
+              (map (v: "/v${v}/network-info") versions.networkInfo)
+              (map (v: "/v${v}/rewards") versions.rewards)
+              (map (v: "/v${v}/tx-submit") versions.txSubmit)
+              (map (v: "/v${v}/utxo") versions.utxo)
+              (map (v: "/v${v}/handle") versions.handle)
+            ];
         };
       };
 
@@ -530,6 +563,22 @@ in
           cardano-services = {
             ingresOrder = 98;
           };
+          backend.routes = let
+            inherit (oci.meta) versions;
+          in
+            lib.concatLists [
+              (map (v: "/v${v}/health") versions.root)
+              (map (v: "/v${v}/live") versions.root)
+              (map (v: "/v${v}/meta") versions.root)
+              (map (v: "/v${v}/ready") versions.root)
+              (map (v: "/v${v}/asset") versions.assetInfo)
+              (map (v: "/v${v}/chain-history") versions.chainHistory)
+              (map (v: "/v${v}/network-info") versions.networkInfo)
+              (map (v: "/v${v}/rewards") versions.rewards)
+              (map (v: "/v${v}/tx-submit") versions.txSubmit)
+              (map (v: "/v${v}/utxo") versions.utxo)
+              (map (v: "/v${v}/handle") versions.handle)
+            ];
         };
       };
 
@@ -571,7 +620,6 @@ in
       };
 
       "live-sanchonet@us-east-2@v1" = final: {
-
         namespace = "live-sanchonet";
         name = "${final.namespace}-cardanojs-v1";
 
@@ -597,23 +645,23 @@ in
           blockfrost-worker.enabled = false;
           pg-boss-worker.enabled = true;
           backend.routes = let
-              inherit (oci.meta) versions;
-            in
-              lib.concatLists [
-                (map (v: "/v${v}/health") versions.root)
-                (map (v: "/v${v}/live") versions.root)
-                (map (v: "/v${v}/meta") versions.root)
-                (map (v: "/v${v}/ready") versions.root)
-                (map (v: "/v${v}/asset") versions.assetInfo)
-                (map (v: "/v${v}/chain-history") versions.chainHistory)
-                (map (v: "/v${v}/network-info") versions.networkInfo)
-                (map (v: "/v${v}/rewards") versions.rewards)
-                (map (v: "/v${v}/tx-submit") versions.txSubmit)
-                (map (v: "/v${v}/utxo") versions.utxo)
-                (map (v: "/v${v}/handle") versions.handle)
-                (map (v: "/v${v}/provider-server") versions.stakePool)
-                (map (v: "/v${v}/stake-pool-provider-server") versions.stakePool)
-              ];
+            inherit (oci.meta) versions;
+          in
+            lib.concatLists [
+              (map (v: "/v${v}/health") versions.root)
+              (map (v: "/v${v}/live") versions.root)
+              (map (v: "/v${v}/meta") versions.root)
+              (map (v: "/v${v}/ready") versions.root)
+              (map (v: "/v${v}/asset") versions.assetInfo)
+              (map (v: "/v${v}/chain-history") versions.chainHistory)
+              (map (v: "/v${v}/network-info") versions.networkInfo)
+              (map (v: "/v${v}/rewards") versions.rewards)
+              (map (v: "/v${v}/tx-submit") versions.txSubmit)
+              (map (v: "/v${v}/utxo") versions.utxo)
+              (map (v: "/v${v}/handle") versions.handle)
+              (map (v: "/v${v}/provider-server") versions.stakePool)
+              (map (v: "/v${v}/stake-pool-provider-server") versions.stakePool)
+            ];
 
           cardano-services = {
             ingresOrder = 99;

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -288,56 +288,6 @@ in
         };
       };
 
-      "live-mainnet@us-east-2@v2" = final: {
-        name = "${final.namespace}-cardanojs-v2";
-        namespace = "live-mainnet";
-        context = "eks-admin";
-
-        providers = {
-          backend = {
-            enabled = true;
-            replicas = 3;
-            env.NODE_ENV = "production";
-          };
-          stake-pool-provider = {
-            enabled = true;
-            env.OVERRIDE_FUZZY_OPTIONS = "true";
-            env.NODE_ENV = "production";
-          };
-          # handle-provider.enabled = true;
-          # asset-provider.enabled = true;
-        };
-
-        projectors = {
-          handle.enabled = true;
-          stake-pool.enabled = true;
-          # asset.enabled = true;
-        };
-
-        values = {
-          network = "mainnet";
-          region = "us-east-2";
-          cardano-services = {
-            ingresOrder = 98;
-            additionalRoutes = [
-              {
-                pathType = "Prefix";
-                path = "/v1.0.0/stake-pool";
-                backend.service = {
-                  name = "${final.namespace}-cardanojs-stake-pool-provider";
-                  port.name = "http";
-                };
-              }
-            ];
-          };
-          backend.allowedOrigins = lib.concatStringsSep "," allowedOrigins;
-          backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
-
-          blockfrost-worker.enabled = true;
-          pg-boss-worker.enabled = true;
-        };
-      };
-
       "dev-mainnet@us-east-1" = final: {
         namespace = "dev-mainnet";
 
@@ -451,6 +401,56 @@ in
           cardano-services = {
             ingresOrder = 98;
           };
+        };
+      };
+
+      "live-mainnet@us-east-2@v2" = final: {
+        name = "${final.namespace}-cardanojs-v2";
+        namespace = "live-mainnet";
+        context = "eks-admin";
+
+        providers = {
+          backend = {
+            enabled = true;
+            replicas = 3;
+            env.NODE_ENV = "production";
+          };
+          stake-pool-provider = {
+            enabled = true;
+            env.OVERRIDE_FUZZY_OPTIONS = "true";
+            env.NODE_ENV = "production";
+          };
+          # handle-provider.enabled = true;
+          # asset-provider.enabled = true;
+        };
+
+        projectors = {
+          handle.enabled = true;
+          stake-pool.enabled = true;
+          # asset.enabled = true;
+        };
+
+        values = {
+          network = "mainnet";
+          region = "us-east-2";
+          cardano-services = {
+            ingresOrder = 98;
+            additionalRoutes = [
+              {
+                pathType = "Prefix";
+                path = "/v1.0.0/stake-pool";
+                backend.service = {
+                  name = "${final.namespace}-cardanojs-stake-pool-provider";
+                  port.name = "http";
+                };
+              }
+            ];
+          };
+          backend.allowedOrigins = lib.concatStringsSep "," allowedOrigins;
+          backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
+
+          blockfrost-worker.enabled = true;
+          pg-boss-worker.enabled = true;
         };
       };
 

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -472,7 +472,7 @@ in
             env.NODE_ENV = "production";
           };
           handle-provider = {
-            enabled = true;
+            enabled = false;
             env.NODE_ENV = "production";
           };
         };
@@ -511,7 +511,7 @@ in
             env.NODE_ENV = "production";
           };
           handle-provider = {
-            enabled = true;
+            enabled = false;
             env.NODE_ENV = "production";
           };
         };

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -384,47 +384,6 @@ in
         };
       };
 
-      "dev-preprod@us-east-1@v1" = final: {
-        name = "${final.namespace}-cardanojs-v1";
-        namespace = "dev-preprod";
-        context = "eks-devs";
-
-        providers = {
-          backend = {
-            enabled = true;
-          };
-        };
-
-        values = {
-          network = "preprod";
-          region = "us-east-1";
-
-
-          backend.hostnames = ["${final.namespace}.${baseUrl}"];
-          backend.passHandleDBArgs = false;
-          backend.routes = [
-            "/v1.0.0/health"
-            "/v1.0.0/live"
-            "/v1.0.0/meta"
-            "/v1.0.0/ready"
-            "/v1.0.0/asset"
-            "/v2.0.0/chain-history"
-            "/v1.0.0/handle"
-            "/v1.0.0/network-info"
-            "/v1.0.0/rewards"
-            "/v1.0.0/stake-pool"
-            "/v2.0.0/tx-submit"
-            "/v2.0.0/utxo"
-          ];
-          backend.allowedOrigins = lib.concatStringsSep "," allowedOriginsDev;
-          # blockfrost-worker.enabled = true;
-          cardano-services = {
-            ingresOrder = 99;
-            image = "926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services:s8j5nx9x2naar194pr58kpmlr5s4xn7b";
-          };
-        };
-      };
-
       "dev-preprod@us-east-1@v2" = final: {
         name = "${final.namespace}-cardanojs-v2";
         namespace = "dev-preprod";
@@ -458,46 +417,6 @@ in
           blockfrost-worker.enabled = true;
           cardano-services = {
             ingresOrder = 98;
-          };
-        };
-      };
-
-
-      "staging-preprod@us-east-1@v1" = final: {
-        name = "${final.namespace}-cardanojs-v1";
-        namespace = "staging-preprod";
-        context = "eks-devs";
-
-        providers = {
-          backend = {
-            enabled = true;
-          };
-        };
-
-        values = {
-          network = "preprod";
-          region = "us-east-1";
-
-          backend.hostnames = ["${final.namespace}.${baseUrl}"];
-          backend.passHandleDBArgs = false;
-          backend.routes = [
-            "/v1.0.0/health"
-            "/v1.0.0/live"
-            "/v1.0.0/meta"
-            "/v1.0.0/ready"
-            "/v1.0.0/asset"
-            "/v2.0.0/chain-history"
-            "/v1.0.0/handle"
-            "/v1.0.0/network-info"
-            "/v1.0.0/rewards"
-            "/v1.0.0/stake-pool"
-            "/v2.0.0/tx-submit"
-            "/v2.0.0/utxo"
-          ];
-          # blockfrost-worker.enabled = true;
-          cardano-services = {
-            ingresOrder = 99;
-            image = "926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services:s8j5nx9x2naar194pr58kpmlr5s4xn7b";
           };
         };
       };
@@ -537,46 +456,6 @@ in
       };
 
 
-      "live-preprod@us-east-2@v1" = final: {
-        name = "${final.namespace}-cardanojs-v1";
-        namespace = "live-preprod";
-        context = "eks-admin";
-
-        providers = {
-          backend = {
-            enabled = true;
-            env.NODE_ENV = "production";
-          };
-        };
-
-        values = {
-          network = "preprod";
-          region = "us-east-2";
-
-          backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
-          backend.passHandleDBArgs = false;
-          backend.routes = [
-            "/v1.0.0/health"
-            "/v1.0.0/live"
-            "/v1.0.0/meta"
-            "/v1.0.0/ready"
-            "/v1.0.0/asset"
-            "/v2.0.0/chain-history"
-            "/v1.0.0/handle"
-            "/v1.0.0/network-info"
-            "/v1.0.0/rewards"
-            "/v1.0.0/stake-pool"
-            "/v2.0.0/tx-submit"
-            "/v2.0.0/utxo"
-          ];
-          # blockfrost-worker.enabled = true;
-          cardano-services = {
-            ingresOrder = 99;
-            image = "926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services:s8j5nx9x2naar194pr58kpmlr5s4xn7b";
-          };
-        };
-      };
-
       "live-preprod@us-east-2@v2" = final: {
         name = "${final.namespace}-cardanojs-v2";
         namespace = "live-preprod";
@@ -612,47 +491,6 @@ in
           pg-boss-worker.enabled = true;
           cardano-services = {
             ingresOrder = 98;
-          };
-        };
-      };
-
-
-      "live-preview@us-east-2@v1" = final: {
-        name = "${final.namespace}-cardanojs-v1";
-        namespace = "live-preview";
-        context = "eks-admin";
-
-        providers = {
-          backend = {
-            enabled = true;
-            env.NODE_ENV = "production";
-          };
-        };
-
-        values = {
-          network = "preview";
-          region = "us-east-2";
-
-          backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
-          backend.passHandleDBArgs = false;
-          backend.routes = [
-            "/v1.0.0/health"
-            "/v1.0.0/live"
-            "/v1.0.0/meta"
-            "/v1.0.0/ready"
-            "/v1.0.0/asset"
-            "/v2.0.0/chain-history"
-            "/v1.0.0/handle"
-            "/v1.0.0/network-info"
-            "/v1.0.0/rewards"
-            "/v1.0.0/stake-pool"
-            "/v2.0.0/tx-submit"
-            "/v2.0.0/utxo"
-          ];
-          # blockfrost-worker.enabled = true;
-          cardano-services = {
-            ingresOrder = 99;
-            image = "926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services:s8j5nx9x2naar194pr58kpmlr5s4xn7b";
           };
         };
       };

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -83,7 +83,7 @@ in
         };
 
         handle = {
-          resources.limits = mkPodResources "300Mi" "500m";
+          resources.limits = mkPodResources "300Mi" "700m";
           resources.requests = mkPodResources "150Mi" "100m";
         };
 
@@ -285,6 +285,57 @@ in
               }
             ];
           };
+        };
+      };
+
+      "live-mainnet@us-east-2@v2" = final: {
+        name = "${final.namespace}-cardanojs-v2";
+        namespace = "live-mainnet";
+        context = "eks-admin";
+
+        providers = {
+          backend = {
+            enabled = true;
+            replicas = 3;
+            env.NODE_ENV = "production";
+          };
+          stake-pool-provider = {
+            enabled = true;
+            env.OVERRIDE_FUZZY_OPTIONS = "true";
+            env.NODE_ENV = "production";
+          };
+          # handle-provider.enabled = true;
+          # asset-provider.enabled = true;
+        };
+
+        projectors = {
+          handle.enabled = true;
+          stake-pool.enabled = true;
+          # asset.enabled = true;
+        };
+
+        values = {
+          network = "mainnet";
+          region = "us-east-2";
+          cardano-services = {
+            ingresOrder = 98;
+            additionalRoutes = [
+              {
+                pathType = "Prefix";
+                path = "/v1.0.0/stake-pool";
+                backend.service = {
+                  name = "${final.namespace}-cardanojs-stake-pool-provider";
+                  port.name = "http";
+                };
+              }
+            ];
+          };
+          backend.allowedOrigins = lib.concatStringsSep "," allowedOrigins;
+          # backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
+          backend.hostnames = ["tmp-${final.namespace}.${baseUrl}"];
+
+          blockfrost-worker.enabled = true;
+          pg-boss-worker.enabled = true;
         };
       };
 

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -331,8 +331,7 @@ in
             ];
           };
           backend.allowedOrigins = lib.concatStringsSep "," allowedOrigins;
-          # backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
-          backend.hostnames = ["tmp-${final.namespace}.${baseUrl}"];
+          backend.hostnames = ["backend.${final.namespace}.eks.${baseUrl}" "${final.namespace}.${baseUrl}"];
 
           blockfrost-worker.enabled = true;
           pg-boss-worker.enabled = true;

--- a/nix/cardano-services/deployments/stake-pool.nix
+++ b/nix/cardano-services/deployments/stake-pool.nix
@@ -30,7 +30,6 @@
       SERVICE_NAMES = "stake-pool";
       USE_TYPEORM_STAKE_POOL_PROVIDER = "true";
       TOKEN_METADATA_SERVER_URL = values.cardano-services.tokenMetadataServerUrl;
-      USE_BLOCKFROST = "true";
 
       BUILD_INFO = values.cardano-services.buildInfo;
       ALLOWED_ORIGINS = values.backend.allowedOrigins;

--- a/nix/local/envs.nix
+++ b/nix/local/envs.nix
@@ -37,7 +37,6 @@ let
     name = "k9s-${region}";
     category = "direct access";
   };
-
 in {
   checks = mkShell {
     imports = [formattingModule];


### PR DESCRIPTION
# Context

**This PR implements:**
- Migration of live-mainnet from legacy us-east-1 to us-east-2 cluster
- Removal of Lace 1.8 compatible deployments
- As recently discussed disabling of handle provider in `live-pre*` deployments

This PR is expected to be merged to `release/cardano-services/0.27.x` branch which will be merged back to master
