### PR TITLE
[LW-10288] - Added missing comparison from audit in IOHKCYB-596

### DIFF
--- a/packages/hardware-trezor/src/transformers/withdrawals.ts
+++ b/packages/hardware-trezor/src/transformers/withdrawals.ts
@@ -1,6 +1,6 @@
 import * as Trezor from '@trezor/connect';
 import { Cardano } from '@cardano-sdk/core';
-import { InvalidArgumentError, Transform } from '@cardano-sdk/util';
+import { InvalidArgumentError, Transform, areNumbersEqualInConstantTime } from '@cardano-sdk/util';
 import { TrezorTxTransformerContext } from '../types';
 import { resolveStakeKeyPath } from './keyPaths';
 
@@ -21,7 +21,7 @@ export const toTrezorWithdrawal: Transform<Cardano.Withdrawal, Trezor.CardanoWit
    * - The stake key hash or payment key hash, blake2b-224 hash digests of Ed25519 verification keys.
    * - The script hash, blake2b-224 hash digests of serialized monetary scripts.
    */
-  if (rewardAddress.getPaymentCredential().type === Cardano.CredentialType.KeyHash) {
+  if (areNumbersEqualInConstantTime(rewardAddress.getPaymentCredential().type, Cardano.CredentialType.KeyHash)) {
     const keyPath = context?.knownAddresses ? resolveStakeKeyPath(rewardAddress, context.knownAddresses) : null;
     trezorWithdrawal = keyPath
       ? {


### PR DESCRIPTION
# Context

This is a continuation of https://github.com/input-output-hk/cardano-js-sdk/pull/1216 adding a missing safe comparison to mitigate CWE-208 vulnerability 