### PR TITLE
LW-10308 New fuzzy options

### DIFF
--- a/packages/cardano-services/src/PgBoss/stakePoolRewardsQueries.ts
+++ b/packages/cardano-services/src/PgBoss/stakePoolRewardsQueries.ts
@@ -28,4 +28,5 @@ WHERE pool_hash_id = $2
 export const poolRewards = `
 SELECT amount, type FROM reward
 WHERE earned_epoch = $1
-  AND pool_id = $2`;
+  AND pool_id = $2
+  AND type IN ('leader', 'member')`;

--- a/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/util.test.ts
+++ b/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/util.test.ts
@@ -30,7 +30,7 @@ describe('TypeormStakePoolProvider utils', () => {
     it('correctly parse a valid options object', () =>
       expect(
         validateFuzzyOptions(
-          '{"threshold":0.4,"weights":{"description":1,"homepage":2,"name":3,"poolId":4,"ticker":4}}'
+          '{"distance":100,"location":0,"threshold":0.4,"weights":{"description":1,"homepage":2,"name":3,"poolId":4,"ticker":4}}'
         )
       ).toStrictEqual(DEFAULT_FUZZY_SEARCH_OPTIONS));
   });

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -854,7 +854,8 @@ describe('CLI', () => {
     });
 
     describe('fuzzyOptions', () => {
-      const FUZZY_OPTIONS = '{"threshold":0.4,"weights":{"description":1,"homepage":2,"name":3,"poolId":4,"ticker":4}}';
+      const FUZZY_OPTIONS =
+        '{"distance":100,"location":0,"threshold":0.4,"weights":{"description":1,"homepage":2,"name":3,"poolId":4,"ticker":4}}';
 
       testCli('has a default value', 'provider', {
         expectedArgs: { args: { fuzzyOptions: DEFAULT_FUZZY_SEARCH_OPTIONS } }

--- a/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
+++ b/packages/core/src/Provider/StakePoolProvider/types/StakePoolProvider.ts
@@ -1,4 +1,5 @@
 import { Cardano, Provider } from '../../..';
+import { DeepPartial } from '@cardano-sdk/util';
 import { Paginated, PaginationArgs } from '../../types/Pagination';
 import { SortFields } from '../util';
 
@@ -24,6 +25,12 @@ export interface MultipleChoiceSearchFilter<T> {
 
 /** Options for the fuzzy search on stake pool metadata */
 export interface FuzzyOptions {
+  /** Determines how close the match must be to the location. */
+  distance: number;
+
+  /** Determines approximately where in the text is the pattern expected to be found. */
+  location: number;
+
   /** Maximum threshold. `0`: exact match; `1`: match everything. */
   threshold: number;
 
@@ -55,7 +62,7 @@ export interface QueryStakePoolsArgs {
   };
 
   /** Overrides default fuzzy options. Ignored in _live_ environments. */
-  fuzzyOptions?: FuzzyOptions;
+  fuzzyOptions?: DeepPartial<FuzzyOptions>;
 
   /**
    * Used for APY metric computation. It will take 3 epochs back if not specified.


### PR DESCRIPTION
# Context

We need to tweak default fuzzy search options to find better ones for our use case.

# Proposed Solution

Added `location` and `distance` to the set of used fuzzy options.

# Important Changes Introduced

Ensure `stake-pool-rewards` job selects only `leader` and `member` rewards: exclude `refunds` and eventual newly added types.