### PR TITLE
[LW-10173 ignore empty utf8 characters in asset names

### DIFF
--- a/packages/core/src/Cardano/types/Asset.ts
+++ b/packages/core/src/Cardano/types/Asset.ts
@@ -20,7 +20,10 @@ export const AssetName = (value: string): AssetName => {
 const utf8Decoder = new TextDecoder('utf8', { fatal: true });
 AssetName.toUTF8 = (assetName: AssetName) => {
   try {
-    return utf8Decoder.decode(Buffer.from(assetName, 'hex'));
+    // 'empty' control characters are valid utf8, but we don't want to use them, strip them out
+    const sanitizedBuffer = Buffer.from(assetName, 'hex').filter((v) => v > 31);
+    if (sanitizedBuffer.length > 0) return utf8Decoder.decode(sanitizedBuffer);
+    throw Error;
   } catch (error) {
     throw new InvalidStringError(`Cannot convert AssetName '${assetName}' to UTF8`, error);
   }

--- a/packages/core/test/Cardano/types/Asset.test.ts
+++ b/packages/core/test/Cardano/types/Asset.test.ts
@@ -104,12 +104,13 @@ describe('Cardano/types/Asset', () => {
       expect(() => AssetName('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5e0dbe461abc')).toThrow();
     });
 
-    describe('fromUTF8', () => {
+    describe('toUTF8', () => {
       it('decodes hex string (bytes) to utf8 string', () => {
         expect(AssetName.toUTF8(AssetName('737472'))).toEqual('str');
       });
       it('throws InvalidStringError when it cannot be decoded to utf8', () => {
         expect(() => AssetName.toUTF8(AssetName('e8'))).toThrowError(InvalidStringError);
+        expect(() => AssetName.toUTF8(AssetName('100000'))).toThrowError(InvalidStringError);
       });
     });
   });


### PR DESCRIPTION
# Context

When decoding asset names, some contain valid utf8 characters, but not ones we want to keep, line breaks, controls characters etc

# Proposed Solution
Strip the most common ones from the asset name when converting from hex to utf8

# Important Changes Introduced
