### PR TITLE
LW-10426 db-sync, cardano-node and cardano-submit-api docker images

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -149,7 +149,7 @@ services:
 
   cardano-node:
     <<: *logging
-    image: inputoutput/cardano-node:${CARDANO_NODE_VERSION:-1.35.5}
+    image: public.ecr.aws/e8d0p1a5/cardano-node:${CARDANO_NODE_VERSION:-1.35.5}
     command:
       [
         'run',
@@ -182,7 +182,7 @@ services:
 
   cardano-submit-api:
     command: --config /config/cardano-submit-api/config.json --listen-address 0.0.0.0 --socket-path /ipc/node.socket $SUBMIT_API_ARGS
-    image: inputoutput/cardano-submit-api:${CARDANO_NODE_VERSION:-1.35.5}
+    image: public.ecr.aws/e8d0p1a5/cardano-submit-api:${CARDANO_NODE_VERSION:-1.35.5}
     ports:
       - 8090:8090
     restart: on-failure

--- a/compose/common.yml
+++ b/compose/common.yml
@@ -116,7 +116,7 @@ services:
       timeout: 1s
       retries: 120
       start_period: 100ms
-    image: inputoutput/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.1.0.0}
+    image: ghcr.io/intersectmbo/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.1.0.2}
     restart: on-failure
     stop_signal: SIGINT
     volumes:


### PR DESCRIPTION
# Context

CI no longer works as `db-sync`, `cardano-node` and `cardano-submit-api` docker images are no longer available on Docker hub.

# Proposed Solution

- Changes the `db-sync` docker repository to `ghcr.io/intersectmbo`.
- Changes the `cardano-node` and `cardano-submit-api` docker repository to `public.ecr.aws/e8d0p1a5` (thanks to @gytis-ivaskevicius ).

# Important Changes Introduced

Bumped `db-sync` version from `13.1.0.0` to `13.1.0.2` because the one used before this change is no available in the new repository.