### PR TITLE
Reduce logs

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -103,7 +103,7 @@ in
           versions = oci.meta.versions;
           httpPrefix = "/v${lib.last (lib.sort lib.versionOlder oci.meta.versions.root)}";
 
-          loggingLevel = "debug";
+          loggingLevel = "info";
           tokenMetadataServerUrl = "http://${final.namespace}-cardano-stack-metadata.${final.namespace}.svc.cluster.local";
           ingresOrder = 0;
           certificateArn = tf-outputs.${values.region}.acm_arn;


### PR DESCRIPTION
# Context

As of creating this PR we have 3.29TB of logs since beginning of the month, sometimes they are getting discarded due to the Grafana rate limit

# Proposed Solution
Set logging severity to `info` instead of `debug` to optimize for cost and avoid discarding logs. This can be easily temporarily switched back if there is a need



# Important Changes Introduced
