### PR TITLE
feat(util-dev): adjust stakePoolProviderStub with text filters option

### DIFF
--- a/packages/util-dev/src/createStubStakePoolProvider.ts
+++ b/packages/util-dev/src/createStubStakePoolProvider.ts
@@ -36,14 +36,18 @@ export const createStubStakePoolProvider = (
   queryStakePools: async (options) => {
     if (delayMs) await delay(delayMs);
     const identifierFilters = options?.filters?.identifier;
+    const textSearchValue = options?.filters?.text;
     const filterValues = identifierFilters ? identifierFilters.values : [];
-    const pageResults = stakePools.filter(({ id, metadata }) =>
-      filterValues.some(
-        (value) =>
-          (value.id && id.includes(value.id)) ||
-          (value.name && metadata?.name.includes(value.name)) ||
-          (value.ticker && metadata?.ticker.includes(value.ticker))
-      )
+    const pageResults = stakePools.filter(
+      ({ id, metadata }) =>
+        (textSearchValue && metadata?.name.includes(textSearchValue)) ||
+        (textSearchValue && metadata?.ticker.includes(textSearchValue)) ||
+        filterValues.some(
+          (value) =>
+            (value.id && id.includes(value.id)) ||
+            (value.name && metadata?.name.includes(value.name)) ||
+            (value.ticker && metadata?.ticker.includes(value.ticker))
+        )
     );
     return {
       pageResults,


### PR DESCRIPTION
# Context

Fuzzy search on text metadata fields has been implemented on StakePoolsProvider.
StakePoolProviderStub should mimic the same functionality.

# Proposed Solution

Adjust `queryStakePools` method in `packages/util-dev/src/createStubStakePoolProvider.ts` so it could query proper pools matching `text` filtering option.

