### PR TITLE
[LW-10173] fix utf8 decoding asset name

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -78,16 +78,19 @@ x-sdk-environment: &sdk-environment
   POSTGRES_DB_FILE_HANDLE: /run/secrets/postgres_db_handle
   POSTGRES_DB_FILE_STAKE_POOL: /run/secrets/postgres_db_stake_pool
   POSTGRES_HOST_DB_SYNC: postgres
+  POSTGRES_HOST_ASSET: postgres
   POSTGRES_HOST_HANDLE: postgres
   POSTGRES_HOST_STAKE_POOL: postgres
   POSTGRES_POOL_MAX_DB_SYNC: ${POSTGRES_POOL_MAX:-10}
   POSTGRES_POOL_MAX_HANDLE: ${POSTGRES_POOL_MAX:-10}
+  POSTGRES_POOL_MAX_ASSET: ${POSTGRES_POOL_MAX:-10}
   POSTGRES_POOL_MAX_STAKE_POOL: ${POSTGRES_POOL_MAX:-10}
   POSTGRES_PASSWORD_FILE_ASSET: /run/secrets/postgres_password
   POSTGRES_PASSWORD_FILE_DB_SYNC: /run/secrets/postgres_password
   POSTGRES_PASSWORD_FILE_HANDLE: /run/secrets/postgres_password
   POSTGRES_PASSWORD_FILE_STAKE_POOL: /run/secrets/postgres_password
   POSTGRES_PORT_DB_SYNC: 5432
+  POSTGRES_PORT_ASSET: 5432
   POSTGRES_PORT_HANDLE: 5432
   POSTGRES_PORT_STAKE_POOL: 5432
   POSTGRES_USER_FILE_ASSET: /run/secrets/postgres_user
@@ -341,6 +344,7 @@ services:
         - *sdk-environment
         - *provider-server-environment
       SERVICE_NAMES: asset
+      USE_TYPEORM_ASSET_PROVIDER: true
     ports:
       - ${HANDLE_API_PORT:-4014}:3000
 

--- a/packages/cardano-services/src/Asset/TypeOrmNftMetadataService.ts
+++ b/packages/cardano-services/src/Asset/TypeOrmNftMetadataService.ts
@@ -10,15 +10,18 @@ export class TypeOrmNftMetadataService extends TypeormService implements NftMeta
 
   async getNftMetadata(assetInfo: AssetPolicyIdAndName): Promise<Asset.NftMetadata | null> {
     const assetId = Cardano.AssetId.fromParts(assetInfo.policyId, assetInfo.name);
-    const stringAssetName = Buffer.from(assetInfo.name, 'hex').toString('utf8');
     return this.withDataSource(async (dataSource) => {
       const queryRunner = dataSource.createQueryRunner();
       const nftMetadataRepository = queryRunner.manager.getRepository(NftMetadataEntity);
 
-      const asset = await nftMetadataRepository.findOneBy({
-        name: stringAssetName,
-        userTokenAsset: { id: assetId }
-      });
+      const asset = await nftMetadataRepository
+        .findOneBy({
+          userTokenAsset: { id: assetId }
+        })
+        .catch((error) => {
+          this.logger.error(error);
+          return null;
+        });
 
       if (!asset) {
         return null;

--- a/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
@@ -110,12 +110,15 @@ export class TypeormAssetProvider extends TypeormProvider implements AssetProvid
 
     return this.withDataSource(async (dataSource) => {
       const queryRunner = dataSource.createQueryRunner();
-      const assetRepository = queryRunner.manager.getRepository(AssetEntity);
-
-      const asset = await assetRepository.findOneBy({ id: assetId });
-
-      if (!asset) throw new ProviderError(ProviderFailure.NotFound, undefined, `Asset not found '${assetId}'`);
-      const supply = asset.supply!;
+      let supply: bigint;
+      try {
+        const assetRepository = queryRunner.manager.getRepository(AssetEntity);
+        const asset = await assetRepository.findOneBy({ id: assetId });
+        if (!asset) throw new ProviderError(ProviderFailure.NotFound, undefined, `Asset not found '${assetId}'`);
+        supply = asset.supply!;
+      } finally {
+        await queryRunner.release();
+      }
 
       return {
         assetId,

--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -204,7 +204,7 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
       : new CardanoTokenRegistry({ logger }, args);
 
     return new TypeormAssetProvider(
-      { paginationPageSizeLimit: args.paginationPageSizeLimit! },
+      { paginationPageSizeLimit: Math.min(args.paginationPageSizeLimit! * 10, PAGINATION_PAGE_SIZE_LIMIT_ASSETS) },
       {
         connectionConfig$,
         entities: getEntities(['asset']),

--- a/packages/core/src/Asset/NftMetadata/fromMetadatum.ts
+++ b/packages/core/src/Asset/NftMetadata/fromMetadatum.ts
@@ -98,12 +98,18 @@ const getAssetMetadata = (policy: Cardano.MetadatumMap, assetName: Cardano.Asset
   );
 
 type AssetIdParts = Pick<AssetInfo, 'policyId' | 'name'>;
-const getName = (assetMetadata: Cardano.MetadatumMap, version: string, asset: AssetIdParts, logger: Logger) => {
+const getName = (
+  assetMetadata: Cardano.MetadatumMap,
+  version: string,
+  asset: AssetIdParts,
+  logger: Logger,
+  stripInvisibleCharacters = false
+) => {
   const name = asString(assetMetadata.get('name'));
   if (name) return name;
   if (version === '1.0') {
     try {
-      return AssetName.toUTF8(asset.name);
+      return AssetName.toUTF8(asset.name, stripInvisibleCharacters);
     } catch (error) {
       logger.warn(error);
     }
@@ -143,7 +149,7 @@ export const fromMetadatum = (
   if (!version) return null;
   const assetMetadata = getAssetMetadata(policy, asset.name);
   if (!assetMetadata) return null;
-  const name = getName(assetMetadata, version, asset, logger);
+  const name = getName(assetMetadata, version, asset, logger, true);
   const image = metadatumToString(assetMetadata.get('image'));
   const assetId = Cardano.AssetId.fromParts(asset.policyId, asset.name);
 

--- a/packages/core/src/Cardano/types/Asset.ts
+++ b/packages/core/src/Cardano/types/Asset.ts
@@ -18,9 +18,14 @@ export const AssetName = (value: string): AssetName => {
 };
 
 const utf8Decoder = new TextDecoder('utf8', { fatal: true });
-AssetName.toUTF8 = (assetName: AssetName) => {
+AssetName.toUTF8 = (assetName: AssetName, stripInvisibleCharacters = false) => {
+  const assetNameBuffer = Buffer.from(assetName, 'hex');
   try {
-    return utf8Decoder.decode(Buffer.from(assetName, 'hex'));
+    if (stripInvisibleCharacters) {
+      // 'invisible' control characters are valid utf8, but we don't want to use them, strip them out
+      return utf8Decoder.decode(assetNameBuffer.filter((v) => v > 31));
+    }
+    return utf8Decoder.decode(assetNameBuffer);
   } catch (error) {
     throw new InvalidStringError(`Cannot convert AssetName '${assetName}' to UTF8`, error);
   }

--- a/packages/core/test/Cardano/types/Asset.test.ts
+++ b/packages/core/test/Cardano/types/Asset.test.ts
@@ -104,12 +104,15 @@ describe('Cardano/types/Asset', () => {
       expect(() => AssetName('0dbe461fb5f981c0d01615332b8666340eb1a692b3034f46bcb5f5e0dbe461abc')).toThrow();
     });
 
-    describe('fromUTF8', () => {
+    describe('toUTF8', () => {
       it('decodes hex string (bytes) to utf8 string', () => {
         expect(AssetName.toUTF8(AssetName('737472'))).toEqual('str');
       });
       it('throws InvalidStringError when it cannot be decoded to utf8', () => {
         expect(() => AssetName.toUTF8(AssetName('e8'))).toThrowError(InvalidStringError);
+      });
+      it('strips invisible characters when requested', () => {
+        expect(AssetName.toUTF8(AssetName('100000'), true)).toEqual('');
       });
     });
   });


### PR DESCRIPTION
# Context

Some characters in asset names are valid utf-8, but not ones we want to store in database, add the ability to strip these.

# Proposed Solution

- Add param `stripInvisibleCharacters` to `AssetName.toUTF8` function to remove control/invisible characters
- Remove check on asset name when fetching nft metadata

# Important Changes Introduced
