### PR TITLE
chore(e2e): honor the .env.local file

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -44,7 +44,7 @@
     "test:web-extension:watch:run": "yarn test:web-extension:run --watch",
     "test:web-extension:watch": "run-s test:web-extension:build test:web-extension:watch:bg",
     "test:web-extension:watch:bg": "run-p test:web-extension:watch:build test:web-extension:watch:run",
-    "local-network:common": "DISABLE_DB_CACHE=${DISABLE_DB_CACHE:-true} SUBMIT_API_ARGS='--testnet-magic 888' USE_BLOCKFROST=false __FIX_UMASK__=$(chmod -R a+r ../../compose/placeholder-secrets) docker compose -p local-network-e2e -f docker-compose.yml -f ../../compose/common.yml -f ../../compose/$(uname -m).yml $FILES up",
+    "local-network:common": "DISABLE_DB_CACHE=${DISABLE_DB_CACHE:-true} SUBMIT_API_ARGS='--testnet-magic 888' USE_BLOCKFROST=false __FIX_UMASK__=$(chmod -R a+r ../../compose/placeholder-secrets) docker compose --env-file ../cardano-services/environments/.env.local -p local-network-e2e -f docker-compose.yml -f ../../compose/common.yml -f ../../compose/$(uname -m).yml $FILES up",
     "local-network:up": "FILES='' yarn local-network:common",
     "local-network:dev": "FILES='-f ../../compose/dev.yml' yarn local-network:common",
     "local-network:profile:up": "FILES='-f ../../compose/pg-agent.yml' yarn local-network:common",


### PR DESCRIPTION
# Context

While working on other tasks I realized in our `local-network` we are not honoring the `.env.local` file.

# Proposed Solution

Loaded it at `local-network` startup.