### PR TITLE
fix(cardano-services): stake pool fuzzy search empty result

### DIFF
--- a/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.ts
@@ -198,7 +198,7 @@ export class TypeormStakePoolProvider extends TypeormProvider implements StakePo
             [
               'DROP TABLE IF EXISTS tmp_fuzzy',
               'CREATE TEMPORARY TABLE tmp_fuzzy (pool_id VARCHAR, score NUMERIC) WITHOUT OIDS',
-              `INSERT INTO tmp_fuzzy VALUES ${values}`
+              ...(values === '' ? [] : [`INSERT INTO tmp_fuzzy VALUES ${values}`])
             ].join(';')
           );
         }

--- a/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
+++ b/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
@@ -646,6 +646,14 @@ describe('TypeormStakePoolProvider', () => {
             });
             expect(response.pageResults.map(({ metadata }) => metadata?.ticker)).toEqual(['SP11', 'SP10', 'SP1']);
           });
+
+          it('returns an empty array on empty search result', async () => {
+            const response = await provider.queryStakePools({
+              filters: { text: 'no one match this search' },
+              pagination
+            });
+            expect(response.pageResults).toEqual([]);
+          });
         });
 
         describe('stake pools sort', () => {


### PR DESCRIPTION
# Context

The fuzzy stage pools search of `TypeormStakePoolProvider` throws an error in case of empty search result.

# Proposed Solution

Fixed the SQL in this edge case.
