### PR TITLE
fix: increase the size of pledge column of stake pool rewards table

### DIFF
--- a/packages/cardano-services/src/Projection/migrations/1715157190230-rewards-pledge-numeric.ts
+++ b/packages/cardano-services/src/Projection/migrations/1715157190230-rewards-pledge-numeric.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { PoolRewardsEntity } from '@cardano-sdk/projection-typeorm';
+
+export class RewardsPledgeNumericMigration1715157190230 implements MigrationInterface {
+  static entity = PoolRewardsEntity;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "pool_rewards" ALTER COLUMN "pledge" TYPE numeric(20,0) USING pledge::numeric'
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "pool_rewards" ALTER COLUMN "pledge" TYPE bigint USING pledge::bigint');
+  }
+}

--- a/packages/cardano-services/src/Projection/migrations/index.ts
+++ b/packages/cardano-services/src/Projection/migrations/index.ts
@@ -18,6 +18,7 @@ import { PoolMetricsMigrations1685011799580 } from './1685011799580-stake-pool-m
 import { PoolRegistrationTableMigration1682519108360 } from './1682519108360-pool-registration-table';
 import { PoolRetirementTableMigration1682519108361 } from './1682519108361-pool-retirement-table';
 import { PoolRewardsTableMigrations1698175956871 } from './1698175956871-pool-rewards-table';
+import { RewardsPledgeNumericMigration1715157190230 } from './1715157190230-rewards-pledge-numeric';
 import { StakeKeyRegistrationsTableMigrations1690964880195 } from './1690964880195-stake-key-registrations-table';
 import { StakePoolTableMigration1682519108362 } from './1682519108362-stake-pool-table';
 import { TokensQuantityNumericMigrations1691042603934 } from './1691042603934-tokens-quantity-numeric';
@@ -51,5 +52,6 @@ export const migrations: ProjectionMigration[] = [
   PoolDelistedTableMigration1695899010515,
   CurrentStakePollMetricsAttributesMigrations1698174358997,
   PoolRewardsTableMigrations1698175956871,
-  HandleParentMigration1700556589063
+  HandleParentMigration1700556589063,
+  RewardsPledgeNumericMigration1715157190230
 ];

--- a/packages/projection-typeorm/src/entity/PoolRewards.entity.ts
+++ b/packages/projection-typeorm/src/entity/PoolRewards.entity.ts
@@ -1,7 +1,7 @@
-import { BigIntColumnOptions, UInt64ColumnOptions } from './util';
 import { Cardano } from '@cardano-sdk/core';
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 import { StakePoolEntity } from './StakePool.entity';
+import { UInt64ColumnOptions } from './util';
 
 @Entity()
 @Unique(['epochNo', 'stakePoolId'])
@@ -25,7 +25,7 @@ export class PoolRewardsEntity {
   @Column({ type: 'integer' })
   delegators?: number;
 
-  @Column(BigIntColumnOptions)
+  @Column(UInt64ColumnOptions)
   pledge?: Cardano.Lovelace;
 
   @Column(UInt64ColumnOptions)


### PR DESCRIPTION
# Context

Working on LW-10287 I noticed some `mainnet` stake pool has a `pledge` greater than the maximum `int8`.

# Proposed Solution

Changed the type of `PoolRewardsEntity.pledge` column to accept those values as well.