### PR TITLE
feat(core): add support for NMKR datum NFTs

### DIFF
--- a/packages/core/src/Asset/NftMetadata/fromPlutusData.ts
+++ b/packages/core/src/Asset/NftMetadata/fromPlutusData.ts
@@ -92,8 +92,9 @@ export const fromPlutusData = (
   parentLogger: Logger
 ): NftMetadata | null => {
   const logger = contextLogger(parentLogger, 'NftMetadata.fromPlutusData');
-  if (!isConstrPlutusData(plutusData) || plutusData.constructor !== 0n || plutusData.fields.items.length < 3) {
-    logger.debug('Invalid PlutusData: expecting ConstrPlutusData with 0th constructor and 3 items');
+  if (!isConstrPlutusData(plutusData) || plutusData.constructor !== 0n || plutusData.fields.items.length < 2) {
+    // Actually CIP-68 requires exactly 3 items, but it is not how NMKR mints it
+    logger.debug('Invalid PlutusData: expecting ConstrPlutusData with 0th constructor and 2 items');
     return null;
   }
 

--- a/packages/core/test/Asset/NftMetadata/fromPlutusData.test.ts
+++ b/packages/core/test/Asset/NftMetadata/fromPlutusData.test.ts
@@ -318,4 +318,19 @@ describe('NftMetadata.fromPlutusData', () => {
     expect(typeof nftMetadata.otherProperties?.get('og')).toBe('bigint');
     expect(nftMetadata.files).toBeUndefined();
   });
+
+  it('can convert NMKR datum', () => {
+    const nmkrDatum = HexBlob(
+      'd8799fa5446e616d654b6e6d6b724e4654386d617945696d6167655835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64496d656469615479706549696d6167652f706e674b6465736372697074696f6e404566696c65739fa3496d656469615479706549696d6167652f706e67446e616d654b6e6d6b724e4654386d6179437372635835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64ff01ff'
+    );
+    const datum = Serialization.Datum.newInlineData(
+      Serialization.PlutusData.fromCbor(nmkrDatum)
+    ).toCore() as Cardano.PlutusData;
+
+    const nftMetadata = Asset.NftMetadata.fromPlutusData(datum, logger)!;
+
+    expect(nftMetadata).toMatchObject({
+      name: 'nmkrNFT8may'
+    });
+  });
 });


### PR DESCRIPTION
# Context

CIP-68 assets ([example](https://preprod.cexplorer.io/asset/asset14w53nf5ghakjcp37ruj7a8ffavjpn2cxamdvsl)) minted with NMKR are not compliant with [CIP-68](https://cips.cardano.org/cip/CIP-0068), as datum is missing the 3rd `extra` item (must be set to `#6.121([])` if not used

![image](https://github.com/input-output-hk/cardano-js-sdk/assets/2457868/1907fcf4-2f33-4a80-9bda-8da657c89771)

# Proposed Solution

Loosen datum validation to allow missing field

# Important Changes Introduced
