### PR TITLE
feat(core): nft metadata parsing loose mode

### DIFF
--- a/packages/core/src/Asset/NftMetadata/fromMetadatum.ts
+++ b/packages/core/src/Asset/NftMetadata/fromMetadatum.ts
@@ -96,6 +96,19 @@ const getAssetMetadata = (policy: Cardano.MetadatumMap, assetName: Cardano.Asset
       })()
   );
 
+type AssetIdParts = Pick<AssetInfo, 'policyId' | 'name'>;
+const getName = (assetMetadata: Cardano.MetadatumMap, version: string, asset: AssetIdParts, logger: Logger) => {
+  const name = asString(assetMetadata.get('name'));
+  if (name) return name;
+  if (version === '1.0') {
+    try {
+      return AssetName.toUTF8(asset.name);
+    } catch (error) {
+      logger.warn(error);
+    }
+  }
+};
+
 /**
  * @param asset try to parse NftMetadata for this asset
  * @param metadata transaction metadata (see CIP-0025)
@@ -103,9 +116,10 @@ const getAssetMetadata = (policy: Cardano.MetadatumMap, assetName: Cardano.Asset
  */
 // eslint-disable-next-line complexity
 export const fromMetadatum = (
-  asset: Pick<AssetInfo, 'policyId' | 'name'>,
+  asset: AssetIdParts,
   metadata: Cardano.TxMetadata | undefined,
-  logger: Logger
+  logger: Logger,
+  strict = false
 ): NftMetadata | null => {
   const cip25Metadata = metadata?.get(721n);
   if (!cip25Metadata) return null;
@@ -113,22 +127,14 @@ export const fromMetadatum = (
   if (!cip25MetadatumMap) return null;
   const policy = getPolicyMetadata(cip25MetadatumMap, asset.policyId);
   if (!policy) return null;
+  const version = asString(policy.get('version')) || '1.0';
   const assetMetadata = getAssetMetadata(policy, asset.name);
   if (!assetMetadata) return null;
-  const version = asString(policy.get('version')) || '1.0';
-  let name = asString(assetMetadata.get('name'));
+  const name = getName(assetMetadata, version, asset, logger);
   const image = metadatumToString(assetMetadata.get('image'));
   const assetId = Cardano.AssetId.fromParts(asset.policyId, asset.name);
 
-  if (version === '1.0' && !name) {
-    try {
-      name = AssetName.toUTF8(asset.name);
-    } catch (error) {
-      logger.warn(error);
-    }
-  }
-
-  if (!name || !image) {
+  if ((strict && !name) || !image) {
     logger.warn(missingFieldLogMessage(!name ? 'name' : 'image', assetId, true));
     return null;
   }
@@ -142,7 +148,7 @@ export const fromMetadatum = (
       files: files?.map((file) => mapFile(file, assetId, logger)).filter(isNotNil),
       image: Uri(image),
       mediaType: mediaType ? ImageMediaType(mediaType) : undefined,
-      name,
+      name: name || '',
       otherProperties: mapOtherProperties(assetMetadata, ['name', 'image', 'mediaType', 'description', 'files']),
       version
     };

--- a/packages/core/test/Asset/NftMetadata/fromMetadatum.test.ts
+++ b/packages/core/test/Asset/NftMetadata/fromMetadatum.test.ts
@@ -45,7 +45,7 @@ describe('NftMetadata.fromMetadatum', () => {
     new Map<bigint, Metadatum>([
       [721n, new Map([[policyIdString, new Map<Metadatum, Metadatum>([[assetNameStringUtf8, assetMetadatum]])]])]
     ]);
-  const createMetadataV2 = (assetMetadatum: Map<Metadatum, Metadatum>): TxMetadata =>
+  const createMetadataV2 = (assetMetadatum: Map<Metadatum, Metadatum>, version: Metadatum = 2n): TxMetadata =>
     new Map<bigint, Metadatum>([
       [
         721n,
@@ -54,7 +54,7 @@ describe('NftMetadata.fromMetadatum', () => {
             policyIdString,
             new Map<Metadatum, Metadatum>([
               [assetNameString, assetMetadatum],
-              ['version', '2.0']
+              ['version', version]
             ])
           ]
         ])
@@ -331,11 +331,30 @@ describe('NftMetadata.fromMetadatum', () => {
     expect(Asset.NftMetadata.fromMetadatum(asset, metadatum, logger)).toEqual(minimalConvertedMetadataV1);
   });
 
-  it('converts version', () => {
-    const metadatum: TxMetadata = createMetadataV2(minimalMetadata);
-    expect(Asset.NftMetadata.fromMetadatum(asset, metadatum, logger)).toEqual({
+  describe('version', () => {
+    const expectedMetadata = {
       ...minimalConvertedMetadataV1,
       version: '2.0'
+    };
+
+    it('can parse version as string that is a floating point number', () => {
+      const metadatum: TxMetadata = createMetadataV2(minimalMetadata, '2.0');
+      expect(Asset.NftMetadata.fromMetadatum(asset, metadatum, logger)).toEqual(expectedMetadata);
+    });
+
+    it('can parse version as string that is an integer number', () => {
+      const metadatum: TxMetadata = createMetadataV2(minimalMetadata, '2');
+      expect(Asset.NftMetadata.fromMetadatum(asset, metadatum, logger)).toEqual(expectedMetadata);
+    });
+
+    it('returns null if version is a string that has non-number characters', () => {
+      const metadatum: TxMetadata = createMetadataV2(minimalMetadata, '1a');
+      expect(Asset.NftMetadata.fromMetadatum(asset, metadatum, logger)).toBeNull();
+    });
+
+    it('can parse version as bigint', () => {
+      const metadatum: TxMetadata = createMetadataV2(minimalMetadata, 2n);
+      expect(Asset.NftMetadata.fromMetadatum(asset, metadatum, logger)).toEqual(expectedMetadata);
     });
   });
 

--- a/packages/core/test/Asset/NftMetadata/fromPlutusData.test.ts
+++ b/packages/core/test/Asset/NftMetadata/fromPlutusData.test.ts
@@ -60,7 +60,8 @@ const createFilesPlutusData = (files: Array<Partial<Asset.NftMetadataFile>>): Ca
 const createPlutusData = (
   nftMetadata: Partial<Omit<Asset.NftMetadata, 'files'>>,
   files?: Partial<Asset.NftMetadataFile>[],
-  constructor = 0n
+  constructor = 0n,
+  nameTuple = stringKeyValueTupleIfExists(nftMetadata, 'name')
 ): Cardano.ConstrPlutusData => ({
   constructor,
   fields: {
@@ -69,10 +70,10 @@ const createPlutusData = (
         data: new Map<Cardano.PlutusData, Cardano.PlutusData>([
           ...createPlutusMap(
             [
-              ...stringKeyValueTupleIfExists(nftMetadata, 'name'),
               ...stringKeyValueTupleIfExists(nftMetadata, 'image'),
               ...stringKeyValueTupleIfExists(nftMetadata, 'description'),
-              ...stringKeyValueTupleIfExists(nftMetadata, 'mediaType')
+              ...stringKeyValueTupleIfExists(nftMetadata, 'mediaType'),
+              ...nameTuple
             ],
             nftMetadata.otherProperties
           ).entries(),
@@ -153,6 +154,24 @@ describe('NftMetadata.fromPlutusData', () => {
 
   it('converts minimal metadata', () => {
     expect(Asset.NftMetadata.fromPlutusData(minimalPlutusMetadata, logger)).toEqual(minimalCoreMetadata);
+  });
+
+  describe('metadatum without name', () => {
+    const plutusData = createPlutusData(minimalCoreMetadata, [], 0n, []);
+
+    describe('loose mode', () => {
+      it('returns metadata with empty name string', () => {
+        expect(Asset.NftMetadata.fromPlutusData(plutusData, logger)).toMatchObject({
+          name: ''
+        });
+      });
+    });
+
+    describe('strict mode', () => {
+      it('returns null', () => {
+        expect(Asset.NftMetadata.fromPlutusData(plutusData, logger, true)).toBeNull();
+      });
+    });
   });
 
   it('supports base64 decoded image following data URL scheme standard', () => {
@@ -317,5 +336,20 @@ describe('NftMetadata.fromPlutusData', () => {
     expect(typeof nftMetadata.version).toBe('string');
     expect(typeof nftMetadata.otherProperties?.get('og')).toBe('bigint');
     expect(nftMetadata.files).toBeUndefined();
+  });
+
+  it('can convert NMKR datum', () => {
+    const nmkrDatum = HexBlob(
+      'd8799fa5446e616d654b6e6d6b724e4654386d617945696d6167655835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64496d656469615479706549696d6167652f706e674b6465736372697074696f6e404566696c65739fa3496d656469615479706549696d6167652f706e67446e616d654b6e6d6b724e4654386d6179437372635835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64ff01ff'
+    );
+    const datum = Serialization.Datum.newInlineData(
+      Serialization.PlutusData.fromCbor(nmkrDatum)
+    ).toCore() as Cardano.PlutusData;
+
+    const nftMetadata = Asset.NftMetadata.fromPlutusData(datum, logger)!;
+
+    expect(nftMetadata).toMatchObject({
+      name: 'nmkrNFT8may'
+    });
   });
 });


### PR DESCRIPTION
# Context

1. CIP-68 assets ([example](https://preprod.cexplorer.io/asset/asset14w53nf5ghakjcp37ruj7a8ffavjpn2cxamdvsl)) minted with NMKR are not compliant with [CIP-68](https://cips.cardano.org/cip/CIP-0068), as datum is missing the 3rd `extra` item (must be set to `#6.121([])` if not used

![image](https://github.com/input-output-hk/cardano-js-sdk/assets/2457868/1907fcf4-2f33-4a80-9bda-8da657c89771)

2. Some assets are minted without 'name' (only 'image')
3. [Current cip25 spec](https://cips.cardano.org/cip/CIP-0025) has an example of 'version' represented as a number (not string) and our current implementation expects a string. There are probably assets that we wouldn't be able to parse due to that. 

# Proposed Solution

- Loosen nft metadata validation by adding a 'strict' argument; loose by default
- Make version parsing more flexible, supporting both string and number

# Important Changes Introduced
