### PR TITLE
feat(web-extension): add log of transaction id when signing

### DIFF
--- a/packages/e2e/test/web-extension/extension/ui.ts
+++ b/packages/e2e/test/web-extension/extension/ui.ts
@@ -224,7 +224,8 @@ const signingCoordinator = new SigningCoordinator(
     keyAgentFactory: createKeyAgentFactory({
       bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
       logger
-    })
+    }),
+    logger
   }
 );
 

--- a/packages/web-extension/README.md
+++ b/packages/web-extension/README.md
@@ -129,7 +129,8 @@ const signingCoordinator = new SigningCoordinator(
     keyAgentFactory: createKeyAgentFactory({
       bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
       logger
-    })
+    }),
+    logger
   }
 );
 

--- a/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
@@ -3,6 +3,7 @@ import { CustomError } from 'ts-custom-error';
 import { InMemoryWallet, WalletType } from '../types';
 import { KeyAgent, SignBlobResult, TrezorConfig, errors } from '@cardano-sdk/key-management';
 import { KeyAgentFactory } from './KeyAgentFactory';
+import { Logger } from 'ts-log';
 import {
   RequestBase,
   RequestContext,
@@ -17,6 +18,7 @@ import {
 } from './types';
 import { Subject } from 'rxjs';
 import { WrongTargetError } from '../../messaging';
+import { contextLogger } from '@cardano-sdk/util';
 
 export type HardwareKeyAgentOptions = TrezorConfig;
 
@@ -26,6 +28,7 @@ export type SigningCoordinatorProps = {
 
 export type SigningCoordinatorDependencies = {
   keyAgentFactory: KeyAgentFactory;
+  logger: Logger;
 };
 
 class NoRejectError extends CustomError {
@@ -72,10 +75,12 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
   readonly signDataRequest$ = new Subject<SignDataRequest<WalletMetadata, AccountMetadata>>();
   readonly #hwOptions: HardwareKeyAgentOptions;
   readonly #keyAgentFactory: KeyAgentFactory;
+  readonly #logger: Logger;
 
-  constructor(props: SigningCoordinatorProps, { keyAgentFactory }: SigningCoordinatorDependencies) {
+  constructor(props: SigningCoordinatorProps, { keyAgentFactory, logger }: SigningCoordinatorDependencies) {
     this.#hwOptions = props.hwOptions;
     this.#keyAgentFactory = keyAgentFactory;
+    this.#logger = contextLogger(logger, 'SigningCoordinator');
   }
 
   async signTransaction(
@@ -91,15 +96,18 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
         transaction,
         walletType: requestContext.wallet.type
       },
-      (keyAgent) =>
-        keyAgent.signTransaction(
+      (keyAgent) => {
+        const hash = transaction.getId();
+        this.#logger.info('Signing transaction', hash);
+        return keyAgent.signTransaction(
           {
             body: transaction.body().toCore(),
-            hash: transaction.getId()
+            hash
           },
           signContext,
           options
-        )
+        );
+      }
     );
   }
 

--- a/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
+++ b/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
@@ -13,6 +13,7 @@ import { Ed25519PublicKeyHex, Ed25519SignatureHex, Hash28ByteBase16 } from '@car
 import { HexBlob } from '@cardano-sdk/util';
 import { InMemoryWallet, KeyAgentFactory, SigningCoordinator, WalletType, WrongTargetError } from '../../src';
 import { createAccount } from './util';
+import { dummyLogger } from 'ts-log';
 import { firstValueFrom } from 'rxjs';
 
 describe('SigningCoordinator', () => {
@@ -54,7 +55,7 @@ describe('SigningCoordinator', () => {
           }
         }
       },
-      { keyAgentFactory }
+      { keyAgentFactory, logger: dummyLogger }
     );
   });
 


### PR DESCRIPTION
# Context

It's difficult to confirm that we don't have roundtrip issues when troubleshooting

# Proposed Solution

Add log of transaction id that is being signed

# Important Changes Introduced
