### PR TITLE
chore: register HTTP handlers with forward slashes on Windows

### DIFF
--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -175,7 +175,9 @@ export class HttpServer extends RunnableModule {
     };
 
     let handler: keyof typeof handlers;
-    for (handler in handlers) this.app.use(path.join(versionPath, handler), handlers[handler]);
+    // Note: `.replaceAll(path.sep, '/')` is needed on Windows:
+    for (handler in handlers)
+      this.app.use(path.join(versionPath, handler).replaceAll(path.sep, '/'), handlers[handler]);
   }
 
   static sendJSON<ResponseBody>(
@@ -268,7 +270,10 @@ export class HttpServer extends RunnableModule {
         includePath: true,
         promRegistry,
         ...this.#config.metrics?.options,
-        metricsPath: path.join(versionPath, this.#config.metrics?.options?.metricsPath || '/metrics')
+        // Note: `.replaceAll(path.sep, '/')` is needed on Windows:
+        metricsPath: path
+          .join(versionPath, this.#config.metrics?.options?.metricsPath || '/metrics')
+          .replaceAll(path.sep, '/')
       })
     );
     this.logger.info(

--- a/packages/cardano-services/test/Http/HttpServer.test.ts
+++ b/packages/cardano-services/test/Http/HttpServer.test.ts
@@ -188,13 +188,15 @@ describe('HttpServer', () => {
         {
           body: { bigint: 23n, check: 'ok', test: 42 },
           method: 'POST',
-          path: path.join(someServiceVersionPath, 'stake-pool', 'echo'),
+          // Note: `.replaceAll(path.sep, '/')` is needed on Windows:
+          path: path.join(someServiceVersionPath, 'stake-pool', 'echo').replaceAll(path.sep, '/'),
           query: {}
         },
         {
           body: {},
           method: 'GET',
-          path: path.join(someServiceVersionPath, 'stake-pool', 'echo'),
+          // Note: `.replaceAll(path.sep, '/')` is needed on Windows:
+          path: path.join(someServiceVersionPath, 'stake-pool', 'echo').replaceAll(path.sep, '/'),
           query: { bigint: '23', check: 'ok', test: '42' }
         }
       ]);


### PR DESCRIPTION
Found as a part of [LW-7619](https://input-output.atlassian.net/browse/LW-7619).

# Context

`path.join` is being used for constructing the HTTP paths when registering handlers. This is useful, because the developer doesn’t have to keep track of `../`, double slashes, no slashes, leading slashes, following slashes etc.

At the same time, Windows uses backslashes in its paths, and therefore in `path.join`.

# Proposed Solution

Let’s add a `.replaceAll`.

I tested this code on Windows and it works there.

# Important Changes Introduced

_n/a_

[LW-7619]: https://input-output.atlassian.net/browse/LW-7619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ