### PR TITLE
chore: remove --trace-gc from provider-server

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -186,7 +186,6 @@ in
         providers = {
           backend = {
             enabled = true;
-            env.NODE_EXTRA_OPTIONS = "--trace-gc";
           };
           stake-pool-provider = {
             enabled = true;
@@ -331,7 +330,6 @@ in
           backend = {
             enabled = true;
             replicas = 3;
-            env.NODE_EXTRA_OPTIONS = "--trace-gc";
           };
           stake-pool-provider = {
             enabled = true;
@@ -404,7 +402,6 @@ in
         providers = {
           backend = {
             enabled = true;
-            env.NODE_EXTRA_OPTIONS = "--trace-gc";
           };
           stake-pool-provider = {
             enabled = true;


### PR DESCRIPTION
# Context

Some times ago we added `--trace-gc` option to try to identify if we had some garbage collector related problems.
Next we realized the problems had distinct sources.
Now we do not need this, while it is _flooding_ our logs in grafana with _useless_ information.

# Proposed Solution

Removed the `--trace-gc` option.