### PR TITLE
LW-10511 Increase pg-boss jobs retention to one yaer

### DIFF
--- a/packages/projection-typeorm/src/pgBoss.ts
+++ b/packages/projection-typeorm/src/pgBoss.ts
@@ -48,6 +48,7 @@ export interface StakePoolRewardsJob {
 }
 
 export const defaultJobOptions: SendOptions = {
+  retentionDays: 365, // keep the job in a state that can be retried for one year
   retryDelay: 6 * 3600, // 6 hours
   retryLimit: 1_000_000 // retry forever
 };

--- a/packages/projection-typeorm/test/operators/storeStakePoolRewardsJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePoolRewardsJob.test.ts
@@ -48,17 +48,17 @@ describe('storeStakePoolRewardsJob', () => {
     expect(send).toBeCalledWith(
       STAKE_POOL_REWARDS,
       { epochNo: 0 },
-      { expireInHours: 6, retryDelay: 30, retryLimit: 1_000_000, singletonKey: '0', slot: 1010 }
+      { expireInHours: 6, retentionDays: 365, retryDelay: 30, retryLimit: 1_000_000, singletonKey: '0', slot: 1010 }
     );
     expect(send).toBeCalledWith(
       STAKE_POOL_REWARDS,
       { epochNo: 0 },
-      { expireInHours: 6, retryDelay: 30, retryLimit: 1_000_000, singletonKey: '0', slot: 1030 }
+      { expireInHours: 6, retentionDays: 365, retryDelay: 30, retryLimit: 1_000_000, singletonKey: '0', slot: 1030 }
     );
     expect(send).toBeCalledWith(
       STAKE_POOL_REWARDS,
       { epochNo: 1 },
-      { expireInHours: 6, retryDelay: 30, retryLimit: 1_000_000, singletonKey: '1', slot: 2010 }
+      { expireInHours: 6, retentionDays: 365, retryDelay: 30, retryLimit: 1_000_000, singletonKey: '1', slot: 2010 }
     );
   });
 });


### PR DESCRIPTION
# Context

pg-boss jobs have their own (well handled by pg-boss itself) retry strategy.
Recently we were warried about some edge cases:

-  what happens when the `pg-boss-worker` dies (so the final `UPDATE` is not performed)?
-  what happens when the DB server dies so `pg-boss-worker` has no chances to perform final `UPDATE`?

pg-boss handles these case as well: jobs have an expiry timeout, once expired, they are retried anyway.

Another interesting pg-boss option in this field is the job retention time (by default two weeks): a job, till not successfully completed, is retried for two weeks.

# Proposed Solution

Increased the retention time to one year, to have a chance to address problems even if spotted later than the default two weeks.
