### PR TITLE
Increase stake pool metrics refresh rate

### DIFF
--- a/packages/cardano-services/docker-compose.yml
+++ b/packages/cardano-services/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      - CACHE_TTL=${CACHE_TTL:-1440}
+      - CACHE_TTL=${CACHE_TTL:-240}
       - CREATE_SCHEMA=${CREATE_SCHEMA:-true}
       - DROP_SCHEMA=${DROP_SCHEMA:-false}
       - LOGGER_MIN_SEVERITY=${LOGGER_MIN_SEVERITY:-info}

--- a/packages/cardano-services/src/Program/programs/blockfrostWorker.ts
+++ b/packages/cardano-services/src/Program/programs/blockfrostWorker.ts
@@ -8,7 +8,7 @@ import { createLogger } from 'bunyan';
 import { readFile } from 'fs/promises';
 
 export const BLOCKFROST_WORKER_API_URL_DEFAULT = new URL('http://localhost:3000');
-export const CACHE_TTL_DEFAULT = 24 * 60; // One day
+export const CACHE_TTL_DEFAULT = 4 * 60; // Four hours
 export const CREATE_SCHEMA_DEFAULT = false;
 export const DROP_SCHEMA_DEFAULT = false;
 export const DRY_RUN_DEFAULT = false;


### PR DESCRIPTION
# Context

While working on LW-10560 I realized we are refreshing stake pool metrics once per day, but recently I agreed with legal team we are refreshing them about every 5 hours.

# Proposed Solution

Increased the rate to six times per day (each four hours).