### PR TITLE
chore: prefer asset provider route if it is deployed

### DIFF
--- a/nix/cardano-services/deployments/backend-ingress.nix
+++ b/nix/cardano-services/deployments/backend-ingress.nix
@@ -42,7 +42,17 @@
         map (hostname: {
           host = hostname;
           http.paths =
-            [
+            (lib.optionals config.providers.asset-provider.enabled [
+              {
+                pathType = "Prefix";
+                path = "/v${lib.last (lib.sort lib.versionOlder values.cardano-services.versions.handle)}/asset";
+                backend.service = {
+                  name = "${chart.name}-asset-provider";
+                  port.name = "http";
+                };
+              }
+            ])
+            ++ [
               {
                 pathType = "Prefix";
                 path = "/";
@@ -79,16 +89,6 @@
                 path = "/v${lib.last (lib.sort lib.versionOlder values.cardano-services.versions.handle)}/handle";
                 backend.service = {
                   name = "${chart.name}-handle-provider";
-                  port.name = "http";
-                };
-              }
-            ]
-            ++ lib.optionals config.providers.asset-provider.enabled [
-              {
-                pathType = "Prefix";
-                path = "/v${lib.last (lib.sort lib.versionOlder values.cardano-services.versions.handle)}/asset";
-                backend.service = {
-                  name = "${chart.name}-asset-provider";
                   port.name = "http";
                 };
               }


### PR DESCRIPTION
# Context

Probably all provider routes should be configured above monolithic ones so they would overwrite it without any additional configuration
