### PR TITLE
test(e2e): re-enable previously skipped test

### DIFF
--- a/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
@@ -32,8 +32,7 @@ const toHex = (value: string) =>
     .map((s) => s.charCodeAt(0).toString(16))
     .join('');
 
-// TODO: LW-9889 Ada handle tests fail intermittently with `DeserialiseFailure 56 "expected word"` returned by cardano-submit-api
-describe.skip('Ada handle', () => {
+describe('Ada handle', () => {
   let wallet: BaseWallet;
   let keyAgent: KeyAgent;
   let receivingWallet: BaseWallet;


### PR DESCRIPTION
# Context

`Ada handle` test suite was skipped due to a tx deserialization problem in `cardano-submit-api` which was solved in the latest version.

# Proposed Solution

Un-skipped the test suite
