### PR TITLE
chore(e2e): add config options to internal dapp [LW-10134]

### DIFF
--- a/packages/e2e/test/web-extension/dapp-sdk/dapp-sdk.html
+++ b/packages/e2e/test/web-extension/dapp-sdk/dapp-sdk.html
@@ -17,10 +17,38 @@
         <div class="actions-container">
           <h4>Actions</h4>
           <button id="connect-to-lace" class="action">Connect Lace</button>
-          <button id="send-coins" class="action">Send 10 ADA to Rhys</button>
-          <button id="send-several-assets" class="action">Send Asset and Tokens to Rhys</button>
-          <button id="single-delegation" class="action">Delegate</button>
-          <button id="single-undelegation" class="action">Undelegate</button>
+          <div class="sent-tx">
+            <h4>Send TX w/wo tokens</h4>
+            <label for="receiver">Receiver Address:</label>
+            <input type="text" id="receiver" name="receiver" value='addr_test1qqhfdzcw0ns60n25u2ka7w4hrushtflxlmjh8khx044t9vz4suwvtyu5dtr02wtcyjuc3lwdvlzaczrwaypgxgfk4hrq4cxwqm'>
+            
+            <label for="ada-amount">Amount (in Lovelace):</label>
+            <input type="number" id="ada-amount" name="ada-amount" value=3000000>
+            
+            <label for="asset-amount">Amount of Assets to send</label>
+            <input type="number" id="asset-amount" name="asset-amount" value=5>
+
+            <label for="asset-policy-id">Asset PolicyId:</label>
+            <input type="text" id="asset-policy-id" name="asset-policy-id" value='648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff198'>
+            
+            <label for="asset-name">Asset Name:</label>
+            <input type="text" id="asset-name" name="asset-name" value='444149'>
+
+            <button id="send-coins" class="action">Send</button>
+          </div>
+
+          <div class="delegation">
+            <h4>Delegate / Undelegate</h4>
+            <label for="pool-name">Pool Name:</label>
+            <input type="text" id="pool-name" name="pool-name" value='SMAUG'>
+            
+            <label for="pool-id">Pool ID:</label>
+            <input type="text" id="pool-id" name="pool-id" value='pool1pzdqdxrv0k74p4q33y98f2u7vzaz95et7mjeedjcfy0jcgk754f'>
+            
+            <button id="single-delegation" class="action">Delegate</button>
+
+            <button id="single-undelegation" class="action">Undelegate</button>
+          </div>
         </div>
 
         <div class="details-container">

--- a/packages/e2e/test/web-extension/dapp-sdk/dapp-sdk.ts
+++ b/packages/e2e/test/web-extension/dapp-sdk/dapp-sdk.ts
@@ -44,8 +44,20 @@ document.querySelector('#send-coins')?.addEventListener('click', async () => {
   if (!connectedWallet) {
     return logger.warn(CONNECT_WALLET);
   }
+  const receiverAddress = (document.querySelector('#receiver') as HTMLInputElement).value;
+  const adaAmount = (document.querySelector('#ada-amount') as HTMLInputElement).value;
+  const assetAmount = (document.querySelector('#asset-amount') as HTMLInputElement)?.value;
+  const assetPolicyId = (document.querySelector('#asset-policy-id') as HTMLInputElement)?.value;
+  const assetName = (document.querySelector('#asset-name') as HTMLInputElement)?.value;
 
-  await sendCoins({ connectedWallet });
+  const dataToSend = {
+    adaAmount,
+    assetAmount,
+    assetName,
+    assetPolicyId,
+    receiverAddress
+  };
+  await sendCoins({ connectedWallet, dataToSend, logger });
 });
 
 document.querySelector('#send-several-assets')?.addEventListener('click', () => {
@@ -63,10 +75,16 @@ document.querySelector('#single-delegation')?.addEventListener('click', () => {
   if (!connectedWallet) {
     return logger.warn(CONNECT_WALLET);
   }
-
+  const poolName = (document.querySelector('#pool-name') as HTMLInputElement)?.value;
+  const poolId = (document.querySelector('#pool-id') as HTMLInputElement)?.value;
+  const poolData = {
+    poolId,
+    poolName
+  };
   singleDelegation({
     connectedWallet,
-    logger
+    logger,
+    poolData
   });
 });
 

--- a/packages/e2e/test/web-extension/dapp-sdk/dapp.css
+++ b/packages/e2e/test/web-extension/dapp-sdk/dapp.css
@@ -1,3 +1,23 @@
+label {
+    margin: 12px 0 6px;
+}
+
+input {
+    appearance: none;
+    background: #fff;
+    border: none;
+    border-radius: 3px;
+    box-shadow: 0 0 0 0 rgba(19, 124, 189, 0), 0 0 0 0 rgba(19, 124, 189, 0), inset 0 0 0 1px rgba(16, 22, 26, .15), inset 0 1px 1px rgba(16, 22, 26, .2);
+    color: #182026;
+    font-size: 14px;
+    font-weight: 400;
+    height: 30px;
+    line-height: 30px;
+    outline: none;
+    padding: 0 10px;
+    transition: box-shadow .1s cubic-bezier(.4,1,.75,.9);
+    vertical-align: middle;
+}
 
 .container {
     display: flex;
@@ -5,12 +25,12 @@
     padding: 20px;
 }
 
-
-.actions-container {
+.actions-container,
+.delegation {
     display: flex;
     flex-direction: column;
-    min-width: fit-content;
     padding-right: 20px;
+    min-width: 600px;
 }
 
 .details-container {
@@ -29,4 +49,10 @@
 .action { 
     margin: 10px;
     padding: 10px;
+}
+
+.sent-tx {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }

--- a/packages/e2e/test/web-extension/dapp-sdk/features/sendCoins.ts
+++ b/packages/e2e/test/web-extension/dapp-sdk/features/sendCoins.ts
@@ -1,12 +1,96 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-explicit-any, sonarjs/no-nested-template-literals */
+import { Cardano } from '@cardano-sdk/core';
+import { EMPTY, catchError, take, tap } from 'rxjs';
+import { Logger } from '@cardano-sdk/util-dev';
 import { inspectAndSignTx } from '../utils';
 import type { ObservableWallet } from '@cardano-sdk/wallet';
 
-export const sendCoins = async ({ connectedWallet }: { connectedWallet: ObservableWallet }) => {
+type DataToSend = {
+  receiverAddress: string;
+  adaAmount: string;
+  assetAmount?: string;
+  assetPolicyId?: string;
+  assetName?: string;
+};
+
+const buildAndSendTxWithAssets = async ({
+  connectedWallet,
+  logger,
+  dataToSend
+}: {
+  connectedWallet: ObservableWallet;
+  logger: Logger;
+  dataToSend: DataToSend;
+}) => {
+  const addressAssetsElement = document.querySelector('#info-send')!;
+  const transactionInfoElement = document.querySelector('#info-several-assets-tokens-transaction')!;
+  const { receiverAddress, adaAmount, assetAmount, assetPolicyId, assetName } = dataToSend;
+
+  connectedWallet.balance.utxo.available$
+    .pipe(
+      take(1),
+      tap(async (availableBalance) => {
+        if (!availableBalance.assets || availableBalance.assets?.size === 0) {
+          throw new Error('Your wallet has no assets');
+        }
+
+        const assetId = Cardano.AssetId.fromParts(assetPolicyId! as Cardano.PolicyId, assetName! as Cardano.AssetName);
+        const selectedAsset = [...availableBalance.assets].find(([key]) => key === assetId);
+
+        const selectedAssetMap = new Map();
+        if (!selectedAsset) {
+          throw new Error(`Asset with ID ${assetId} doesn't exist`);
+        } else {
+          selectedAssetMap.set(assetId, BigInt(assetAmount!));
+        }
+        const txBuilder = connectedWallet.createTxBuilder();
+        const output = await txBuilder
+          .buildOutput()
+          .address(receiverAddress as Cardano.PaymentAddress)
+          .coin(BigInt(adaAmount))
+          .assets(selectedAssetMap)
+          .build();
+        const builtTx = txBuilder.addOutput(output).build();
+        await inspectAndSignTx({ builtTx, connectedWallet, textElement: transactionInfoElement });
+        addressAssetsElement.textContent += `Assets and quantity: ${[...selectedAssetMap]
+          .map(([key, value]) => `- ${key} : ${value}`)
+          .join('\r\n')}`;
+      }),
+      catchError((error) => {
+        logger.error('Error fetching assets:', error);
+        return EMPTY;
+      })
+    )
+    .subscribe();
+};
+
+export const sendCoins = async ({
+  connectedWallet,
+  logger,
+  dataToSend
+}: {
+  connectedWallet: ObservableWallet;
+  logger: Logger;
+  dataToSend: DataToSend;
+}) => {
   const sendInfoElement = document.querySelector('#info-send')!;
+  const { receiverAddress, adaAmount, assetAmount, assetPolicyId, assetName } = dataToSend;
 
   const builder = connectedWallet.createTxBuilder();
-  const output = await builder.buildOutput().handle('rhys').coin(10_000_000n).build();
-  const builtTx = builder.addOutput(output).build();
-  await inspectAndSignTx({ builtTx, connectedWallet, textElement: sendInfoElement });
+
+  if (assetAmount && assetPolicyId && assetName) {
+    await buildAndSendTxWithAssets({
+      connectedWallet,
+      dataToSend,
+      logger
+    });
+  } else {
+    const txOut = await builder
+      .buildOutput()
+      .address(receiverAddress as Cardano.PaymentAddress)
+      .coin(BigInt(adaAmount))
+      .build();
+    const builtTx = builder.addOutput(txOut).build();
+    await inspectAndSignTx({ builtTx, connectedWallet, textElement: sendInfoElement });
+  }
 };

--- a/packages/e2e/test/web-extension/dapp-sdk/features/singleDelegation.ts
+++ b/packages/e2e/test/web-extension/dapp-sdk/features/singleDelegation.ts
@@ -5,15 +5,26 @@ import { ObservableWallet } from '@cardano-sdk/wallet';
 import { inspectAndSignTx } from '../utils';
 import { toSerializableObject } from '@cardano-sdk/util';
 
+type PoolData = {
+  poolName: string;
+  poolId: string;
+};
+
 export const singleDelegation = ({
   connectedWallet,
-  logger
+  logger,
+  poolData
 }: {
   logger: Logger;
   connectedWallet: ObservableWallet;
+  poolData: PoolData;
 }) => {
   const delegateElement = document.querySelector('#info-delegate-assets')!;
   const delegateAssetsElement = document.querySelector('#info-delegate-asset-id')!;
+  const { poolName, poolId } = poolData;
+  if (!poolName || !poolId) {
+    throw new Error('Missing poolId and / or poolName');
+  }
 
   connectedWallet.balance.utxo.available$
     .pipe(
@@ -23,13 +34,11 @@ export const singleDelegation = ({
           throw new Error('Your wallet has no coins');
         }
 
-        const poolId = Cardano.PoolId.toKeyHash(
-          Cardano.PoolId('pool1pzdqdxrv0k74p4q33y98f2u7vzaz95et7mjeedjcfy0jcgk754f')
-        );
-        const poolIdHex = Cardano.PoolIdHex(poolId);
+        const poolIdHash = Cardano.PoolId.toKeyHash(Cardano.PoolId(poolId));
+        const poolIdHex = Cardano.PoolIdHex(poolIdHash);
         const txBuilder = connectedWallet.createTxBuilder();
         const portfolio = {
-          name: 'SMAUG',
+          name: poolName,
           pools: [
             {
               id: Cardano.PoolIdHex(poolIdHex),


### PR DESCRIPTION
# Context

[JIRA Ticket](https://input-output.atlassian.net/browse/LW-10134)
Currently everything in our custom cardano-js-sdk dapp is hardcoded: https://github.com/input-output-hk/cardano-js-sdk/tree/feat/dapp-connector-client-poc 
We need to add feasibility to customize Dapp transactions

# Proposed Solution

- Specify amount/recipient for send tx
- Specify staking pool id for staking transaction
