### PR TITLE
Improve db selection through input parameters while connecting to deployed databases

### DIFF
--- a/.kube/eu-central-1
+++ b/.kube/eu-central-1
@@ -21,7 +21,7 @@ contexts:
     cluster: arn:aws:eks:eu-central-1:926093910549:cluster/lace-live-eu-central-1
     user: lace-ci
   name: lace-ci
-current-context: eks-devs
+current-context: eks-readonly
 kind: Config
 preferences: {}
 users:

--- a/.kube/us-east-1
+++ b/.kube/us-east-1
@@ -21,7 +21,7 @@ contexts:
     cluster: arn:aws:eks:us-east-1:926093910549:cluster/lace-dev-us-east-1
     user: lace-ci
   name: lace-ci
-current-context: eks-devs
+current-context: eks-readonly
 kind: Config
 preferences: {}
 users:

--- a/.kube/us-east-2
+++ b/.kube/us-east-2
@@ -21,7 +21,7 @@ contexts:
     cluster: arn:aws:eks:us-east-2:926093910549:cluster/lace-prod-us-east-2
     user: lace-ci
   name: lace-ci
-current-context: eks-devs
+current-context: eks-readonly
 kind: Config
 preferences: {}
 users:

--- a/scripts/deployed-db.sh
+++ b/scripts/deployed-db.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+usage() {
+  cat << EOF
+
+Usage:
+just db environment network [region] [database]
+
+environment - allowwed values:
+  d dev
+  l live
+  s staging
+
+network - allowwed values:
+  m mainnet
+  p preprod
+  s sanchonet
+  v preview
+
+region - allowwed values:
+  e eu-central-1
+  u us-east-2
+
+database - allowwed values:
+  a asset
+  c cardano db-sync (default)
+  h handle
+  s stakepool
+
+When "environment" is "dev" or "staging" the only avaible region is "us-east-1" and there is no need to specify it.
+
+Examples:
+- connect to dev-mainnet db-sync DB
+$ scripts/deployed-db.sh d m
+
+- connect to us-east-2 live-preprod stakepool DB
+$ scripts/deployed-db.sh live p us-east-2 stakepool
+EOF
+  exit 1
+}
+
+case $1 in
+  d | dev)
+    ENV=dev
+    ;;
+
+  l | live)
+    ENV=live
+    ;;
+
+  s | staging)
+    ENV=staging
+    ;;
+
+  *)
+    echo Unknown environemnt "\"$1\""
+    usage
+    ;;
+esac
+
+case $2 in
+  m | mainnet)
+    NETWORK=mainnet
+    ;;
+
+  p | preprod)
+    NETWORK=preprod
+    ;;
+
+  s | sanchonet)
+    NETWORK=sanchonet
+    ;;
+
+  v | preview)
+    NETWORK=preview
+    ;;
+
+  *)
+    echo Unknown network "\"$2\""
+    usage
+    ;;
+esac
+
+if [[ $ENV == live ]] ; then
+  INPUT_DB=$4
+
+  case $3 in
+    e | eu-central-1)
+      REGION=eu-central-1
+      ;;
+
+    u | us-east-2)
+      REGION=us-east-2
+      ;;
+
+    *)
+      echo Unknown region "\"$3\""
+      usage
+      ;;
+
+  esac
+else
+  INPUT_DB=$3
+  REGION=us-east-1
+fi
+
+case $INPUT_DB in
+  a | asset)
+    DATABASE=asset
+    ;;
+
+  c | cardano | db-sync | "")
+    DATABASE=cardano
+    ;;
+
+  h | handle)
+    DATABASE=handle
+    ;;
+
+  s | stakepool)
+    DATABASE=stakepool
+    ;;
+
+  *)
+    echo Unknown database "\"$INPUT_DB\""
+    usage
+    ;;
+esac
+
+NAMESPACE=$ENV-$NETWORK
+
+echo Connecting to $NAMESPACE $REGION $DATABASE ...
+
+export KUBECONFIG=$PRJ_ROOT/.kube/$REGION
+
+kubectl config use-context $K8S_USER
+kubectl port-forward --context eks-readonly -n $NAMESPACE pods/$NAMESPACE-postgresql-0 5440:5432 &
+export PGPASSWORD=$(kubectl get secrets --context eks-readonly -n $NAMESPACE readonly.$NAMESPACE-postgresql.credentials.postgresql.acid.zalan.do --template=\{\{.data.password}} | base64 -d)
+
+# Wait for port to be open
+while ! nc -z localhost 5440; do
+  sleep 0.1 # wait for 1/10 of the second before check again
+done
+
+psql -U readonly -h localhost -p 5440 $DATABASE
+
+kill $(jobs -p)


### PR DESCRIPTION
# Context

The script we have to connect to deployed DBs (thank you very much @gytis-ivaskevicius) requires some explicit data as input parameter, some of them must be kept in mind (as the name of the regions) some could be determined by the script itself (as the region for `dev` environments).

# Proposed Solution

Added a new scripts which performs some checks and computations and accepts shortened input parameters.

# Important Changes Introduced

I tried a first implementation through the `justfile` (nice tool!), but I had some problems with complex bash syntaxes as `cat << EOF`, so to make it fast, I added a new script outside of `justfile`.
We could improve this by moving the script inside the `justfile`.