### PR TITLE
LW-7691 e2e tests on preprod adjustments

### DIFF
--- a/packages/e2e/.env.example
+++ b/packages/e2e/.env.example
@@ -43,3 +43,7 @@ SCHEDULES="/config/schedules.json"
 
 # Required by test:long-running
 STAKE_POOL_PROJECTOR_URL='http://localhost:4002/'
+
+# NETWORK_SPEED (fast|slow) determines the timeout tests will use when for blockchain events, like transaction confirmation.
+# It should be configured to 'slow' when running against real networks like preprod.
+NETWORK_SPEED=fast

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -32,7 +32,7 @@
     "test:pg-boss": "jest -c jest.config.js --forceExit --selectProjects pg-boss --runInBand --verbose",
     "test:providers": "jest -c jest.config.js --forceExit --selectProjects providers --runInBand --verbose",
     "test:wallet": "jest -c jest.config.js --forceExit --selectProjects wallet --runInBand --verbose",
-    "test:wallet-real-ada": "jest -c jest.config.js --forceExit --selectProjects wallet-real-ada --runInBand --verbose",
+    "test:wallet-real-ada": "NETWORK_SPEED=slow jest -c jest.config.js --forceExit --selectProjects wallet-real-ada --runInBand --verbose",
     "test:web-extension:build:sw": "tsc --build ./test && tsc --build ./test/web-extension && webpack -c test/web-extension/webpack.config.sw.js",
     "test:web-extension:build:other": "tsc --build ./test && tsc --build ./test/web-extension && webpack -c test/web-extension/webpack.config.js",
     "test:web-extension:build:sw:watch": "yarn test:web-extension:build:sw --watch",

--- a/packages/e2e/src/environment.ts
+++ b/packages/e2e/src/environment.ts
@@ -91,6 +91,7 @@ const validators = {
   LOGGER_MIN_SEVERITY: str({ default: 'info' }),
   NETWORK_INFO_PROVIDER: str(),
   NETWORK_INFO_PROVIDER_PARAMS: providerParams(),
+  NETWORK_SPEED: str({ choices: ['fast', 'slow'], default: 'fast' }),
   OGMIOS_URL: str(),
   REWARDS_PROVIDER: str(),
   REWARDS_PROVIDER_PARAMS: providerParams(),
@@ -158,5 +159,6 @@ export const walletVariables = [
   'TX_SUBMIT_PROVIDER_PARAMS',
   'UTXO_PROVIDER',
   'UTXO_PROVIDER_PARAMS',
-  'ADDRESS_DISCOVERY'
+  'ADDRESS_DISCOVERY',
+  'NETWORK_SPEED'
 ] as const;

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -321,7 +321,8 @@ const patchInitializeTxToRespectEpochBoundary = <T extends ObservableWallet>(
  * @returns an object containing the wallet and providers passed to it
  */
 export const getWallet = async (props: GetWalletProps) => {
-  const { env, idx, logger, name, polling, stores, customKeyParams, keyAgent, witnesser } = props;
+  const { env, idx, logger, name, stores, customKeyParams, keyAgent, witnesser } = props;
+  let polling = props.polling;
   const providers = {
     addressDiscovery: await addressDiscoveryFactory.create(
       env.ADDRESS_DISCOVERY,
@@ -372,6 +373,10 @@ export const getWallet = async (props: GetWalletProps) => {
       logger
     }));
   const bip32Account = await Bip32Account.fromAsyncKeyAgent(asyncKeyAgent);
+  if (!polling?.interval && env.NETWORK_SPEED === 'fast') {
+    polling = { ...polling, interval: 50 };
+  }
+
   const wallet = createPersonalWallet(
     { name, polling },
     {

--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -121,7 +121,7 @@ export const txConfirmed = (
       )
     ),
     `Tx confirmation timeout: ${id}`,
-    SYNC_TIMEOUT_DEFAULT / 5
+    env.NETWORK_SPEED === 'fast' ? SYNC_TIMEOUT_DEFAULT / 5 : SYNC_TIMEOUT_DEFAULT
   );
 
 export const submitAndConfirm = (wallet: ObservableWallet, tx: Cardano.Tx, numConfirmations?: number) =>

--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
 import { BaseWallet, FinalizeTxProps, ObservableWallet } from '@cardano-sdk/wallet';
-import { Cardano, Serialization, createSlotEpochCalc } from '@cardano-sdk/core';
+import { Cardano, Serialization, createSlotEpochCalc, nativeScriptPolicyId } from '@cardano-sdk/core';
 import {
   EMPTY,
   Observable,
@@ -257,15 +257,23 @@ export const burnTokens = async ({
 }: {
   wallet: BaseWallet;
   tokens?: Cardano.TokenMap;
-  scripts: Cardano.Script[];
+  scripts: Cardano.NativeScript[];
   policySigners: TransactionSigner[];
 }) => {
   if (!tokens) {
     tokens = (await firstValueFrom(wallet.balance.utxo.available$)).assets;
   }
 
-  if (!tokens?.size) {
+  if (!tokens) {
     return; // nothing to burn
+  }
+
+  // Filter by policyId
+  const policyIds = new Set([...scripts].map((script) => nativeScriptPolicyId(script)));
+  tokens = new Map([...tokens].filter(([assetId]) => policyIds.has(Cardano.AssetId.getPolicyId(assetId))));
+
+  if (tokens.size === 0) {
+    return; // no tokens for this policy
   }
 
   const negativeTokens = new Map([...tokens].map(([assetId, value]) => [assetId, -value]));

--- a/packages/e2e/test/long-running/shared-wallet-delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/shared-wallet-delegation-rewards.test.ts
@@ -101,7 +101,7 @@ describe('shared wallet delegation rewards', () => {
     ({
       wallet: faucetWallet,
       providers: { stakePoolProvider }
-    } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    } = await getWallet({ env, logger, name: 'Sending Wallet' }));
 
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(faucetWallet, initialFunds);

--- a/packages/e2e/test/long-running/simple-delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/simple-delegation-rewards.test.ts
@@ -87,7 +87,7 @@ describe('simple delegation rewards', () => {
       name: 'Sending Wallet',
       polling: { interval: 50 }
     }));
-    ({ wallet: wallet2 } = await getWallet({ env, logger, name: 'Receiving Wallet', polling: { interval: 50 } }));
+    ({ wallet: wallet2 } = await getWallet({ env, logger, name: 'Receiving Wallet' }));
 
     await waitForWalletStateSettle(wallet1);
     await waitForWalletStateSettle(wallet2);

--- a/packages/e2e/test/wallet/PersonalWallet/byron.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/byron.test.ts
@@ -14,7 +14,7 @@ describe('PersonalWallet/byron', () => {
   let wallet: BaseWallet;
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet' })).wallet;
   });
 
   afterAll(() => {

--- a/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
@@ -25,8 +25,7 @@ const fundWallet = async (wallet: BaseWallet) => {
     logger.info(
       `Insufficient funds in wallet account index 1. Missing ${coinDeficit}. Transferring from wallet account index 0`
     );
-    const fundingWallet = (await getWallet({ env, idx: 0, logger, name: 'WalletAcct0', polling: { interval: 50 } }))
-      .wallet;
+    const fundingWallet = (await getWallet({ env, idx: 0, logger, name: 'WalletAcct0' })).wallet;
     await walletReady(fundingWallet);
     const fundingTxBuilder = fundingWallet.createTxBuilder();
     const { tx } = await fundingTxBuilder
@@ -125,7 +124,7 @@ describe('PersonalWallet/delegationDistribution', () => {
   let wallet: BaseWallet;
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, idx: 3, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 3, logger, name: 'Wallet' })).wallet;
     await fundWallet(wallet);
     await deregisterAllStakeKeys(wallet);
   });

--- a/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
@@ -44,7 +44,7 @@ describe('Ada handle', () => {
   const coins = coinsRequiredByHandleMint + 10_000_000n; // maximum number of coins to use in each transaction
 
   const initPolicyId = async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Handle Init Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Handle Init Wallet' })).wallet;
     await walletReady(wallet, coins);
 
     keyAgent = await createStandaloneKeyAgent(

--- a/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
@@ -30,7 +30,7 @@ describe('PersonalWallet/mint', () => {
   });
 
   it('can mint a token with no asset name', async () => {
-    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet' })).wallet;
 
     const coins = 3_000_000n;
     await walletReady(wallet, coins);

--- a/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
@@ -21,8 +21,11 @@ const logger = createLogger();
 
 describe('PersonalWallet/mint', () => {
   let wallet: BaseWallet;
+  let alicePolicySigner: util.KeyAgentTransactionSigner;
+  let policyScript: Cardano.NativeScript;
 
-  afterAll(() => {
+  afterAll(async () => {
+    await burnTokens({ policySigners: [alicePolicySigner], scripts: [policyScript], wallet });
     wallet.shutdown();
   });
 
@@ -48,9 +51,9 @@ describe('PersonalWallet/mint', () => {
     const alicePubKey = await aliceKeyAgent.derivePublicKey(derivationPath);
     const aliceKeyHash = await aliceKeyAgent.bip32Ed25519.getPubKeyHash(alicePubKey);
 
-    const alicePolicySigner = new util.KeyAgentTransactionSigner(aliceKeyAgent, derivationPath);
+    alicePolicySigner = new util.KeyAgentTransactionSigner(aliceKeyAgent, derivationPath);
 
-    const policyScript: Cardano.NativeScript = {
+    policyScript = {
       __type: Cardano.ScriptType.Native,
       kind: Cardano.NativeScriptKind.RequireAllOf,
       scripts: [
@@ -118,7 +121,5 @@ describe('PersonalWallet/mint', () => {
     expect(value!.assets!.has(assetId)).toBeTruthy();
     expect(value!.assets!.get(assetId)).toBe(1n);
     expect(txFoundInHistory.inputSource).toBe(Cardano.InputSource.inputs);
-
-    await burnTokens({ policySigners: [alicePolicySigner], scripts: [policyScript], wallet });
   });
 });

--- a/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
@@ -26,7 +26,7 @@ describe('PersonalWallet/multiAddress', () => {
   let wallet: BaseWallet;
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet' })).wallet;
   });
 
   afterAll(() => {

--- a/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
@@ -22,8 +22,17 @@ const logger = createLogger();
 describe('PersonalWallet/multisignature', () => {
   let wallet: BaseWallet;
   const assetName = '3030303030';
+  let alicePolicySigner: util.KeyAgentTransactionSigner;
+  let bobPolicySigner: util.KeyAgentTransactionSigner;
+  let policyScript: Cardano.NativeScript;
 
-  afterAll(() => {
+  afterAll(async () => {
+    await burnTokens({
+      policySigners: [alicePolicySigner, bobPolicySigner],
+      scripts: [policyScript],
+      wallet
+    });
+
     wallet.shutdown();
   });
 
@@ -63,10 +72,10 @@ describe('PersonalWallet/multisignature', () => {
     const bobPubKey = await bobKeyAgent.derivePublicKey(bobDerivationPath);
     const bobKeyHash = await bobKeyAgent.bip32Ed25519.getPubKeyHash(bobPubKey);
 
-    const alicePolicySigner = new util.KeyAgentTransactionSigner(aliceKeyAgent, aliceDerivationPath);
-    const bobPolicySigner = new util.KeyAgentTransactionSigner(bobKeyAgent, bobDerivationPath);
+    alicePolicySigner = new util.KeyAgentTransactionSigner(aliceKeyAgent, aliceDerivationPath);
+    bobPolicySigner = new util.KeyAgentTransactionSigner(bobKeyAgent, bobDerivationPath);
 
-    const policyScript: Cardano.NativeScript = {
+    policyScript = {
       __type: Cardano.ScriptType.Native,
       kind: Cardano.NativeScriptKind.RequireAllOf,
       scripts: [
@@ -127,11 +136,5 @@ describe('PersonalWallet/multisignature', () => {
     expect(value).toBeDefined();
     expect(value!.assets!.has(assetId)).toBeTruthy();
     expect(value!.assets!.get(assetId)).toBe(10n);
-
-    await burnTokens({
-      policySigners: [alicePolicySigner, bobPolicySigner],
-      scripts: [policyScript],
-      wallet
-    });
   });
 });

--- a/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
@@ -37,7 +37,7 @@ describe('PersonalWallet/multisignature', () => {
   });
 
   it('can create a transaction with multiple signatures to mint an asset', async () => {
-    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet' })).wallet;
 
     const coins = 3_000_000n;
     await walletReady(wallet, coins);

--- a/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
@@ -52,7 +52,7 @@ describe('PersonalWallet.assets/nft', () => {
   const coins = 10_000_000n; // number of coins to use in each transaction
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet' })).wallet;
 
     await walletReady(wallet, coins);
 

--- a/packages/e2e/test/wallet/PersonalWallet/txChainHistory.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/txChainHistory.test.ts
@@ -12,7 +12,7 @@ describe('PersonalWallet/txChainHistory', () => {
   let signedTx: Cardano.Tx<Cardano.TxBody>;
 
   beforeEach(async () => {
-    ({ wallet } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    ({ wallet } = await getWallet({ env, logger, name: 'Sending Wallet' }));
     const tAdaToSend = 10_000_000n;
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(wallet, tAdaToSend);

--- a/packages/e2e/test/wallet/PersonalWallet/unspendableUtxos.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/unspendableUtxos.test.ts
@@ -21,8 +21,8 @@ describe('PersonalWallet/unspendableUtxos', () => {
   // eslint-disable-next-line max-statements
   it.skip('unsets unspendable UTxOs when no longer in the wallets UTxO set', async () => {
     // Here we will simulate the scenario of collateral consumption by spending it from another wallet instance.
-    wallet1 = (await getWallet({ env, logger, name: 'Wallet 1', polling: { interval: 50 } })).wallet;
-    wallet2 = (await getWallet({ env, logger, name: 'Wallet 2', polling: { interval: 50 } })).wallet;
+    wallet1 = (await getWallet({ env, logger, name: 'Wallet 1' })).wallet;
+    wallet2 = (await getWallet({ env, logger, name: 'Wallet 2' })).wallet;
 
     const coins = 5_000_000n;
     await walletReady(wallet1, coins);

--- a/packages/e2e/test/wallet/SharedWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SharedWallet/delegation.test.ts
@@ -70,7 +70,7 @@ describe('SharedWallet/delegation', () => {
     ({
       wallet: faucetWallet,
       providers: { stakePoolProvider }
-    } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    } = await getWallet({ env, logger, name: 'Sending Wallet' }));
 
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(faucetWallet, initialFunds);

--- a/packages/e2e/test/wallet/SharedWallet/simpleTx.test.ts
+++ b/packages/e2e/test/wallet/SharedWallet/simpleTx.test.ts
@@ -25,7 +25,7 @@ describe('SharedWallet/simpleTx', () => {
   const initialFunds = 10_000_000n;
 
   beforeAll(async () => {
-    ({ wallet: faucetWallet } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    ({ wallet: faucetWallet } = await getWallet({ env, logger, name: 'Sending Wallet' }));
 
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(faucetWallet, initialFunds);


### PR DESCRIPTION
# Context

- To run e2e tests against networks like preprod/preview/mainnet, we need to adjust the timeouts to be more generous.
- Fix mint test to burn tokens only from the test policyId, to avoid signing issues.
 
# Proposed Solution

Introduced a new env variable `NETWORK_SPEED=slow|fast`. Default is `fast`, for running e2e tests against the local-testnet.

# Important Changes Introduced
