### PR TITLE
fix: project datum nft metadata with missing extra field

### DIFF
--- a/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
@@ -21,7 +21,7 @@ import {
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { CIP67Asset, ProjectedNftMetadata } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { ChainSyncDataSet, chainSyncData, generateRandomHexString, logger } from '@cardano-sdk/util-dev';
-import { Observable, firstValueFrom, lastValueFrom, map, toArray } from 'rxjs';
+import { Observable, firstValueFrom, lastValueFrom, toArray } from 'rxjs';
 import { QueryRunner, Repository } from 'typeorm';
 import { connectionConfig$, initializeDataSource } from '../util';
 import {
@@ -31,7 +31,8 @@ import {
   createRollForwardEventBasedOn,
   createStubBlockHeader,
   createStubProjectionSource,
-  createStubRollForwardEvent
+  createStubRollForwardEvent,
+  filterAssets
 } from './util';
 import { dummyLogger } from 'ts-log';
 import omit from 'lodash/omit';
@@ -326,50 +327,9 @@ describe('storeNftMetadata', () => {
       const events = chainSyncData(ChainSyncDataSet.AssetNameUtf8Problem);
       await expect(
         lastValueFrom(
-          project$({
-            ...events,
-            cardanoNode: {
-              ...events.cardanoNode,
-              findIntersect: (points) =>
-                events.cardanoNode.findIntersect(points).pipe(
-                  map((observableChainSync) => ({
-                    ...observableChainSync,
-                    chainSync$: observableChainSync.chainSync$.pipe(
-                      // filter out Tokens that don't exist in the database with this dataset
-                      map((e) => ({
-                        ...e,
-                        ...(e.eventType === ChainSyncEventType.RollForward
-                          ? {
-                              block: {
-                                ...e.block,
-                                body: e.block.body.map((tx) => ({
-                                  ...tx,
-                                  body: {
-                                    ...tx.body,
-                                    outputs: tx.body.outputs.map((output) => ({
-                                      ...output,
-                                      value: {
-                                        ...output.value,
-                                        assets: new Map(
-                                          [...(output.value.assets?.entries() || [])].filter(
-                                            ([assetId]) =>
-                                              assetId ===
-                                              '00740069006e0079002000640069006e006f0073002000230035003600350032'
-                                          )
-                                        )
-                                      }
-                                    }))
-                                  }
-                                }))
-                              }
-                            }
-                          : {})
-                      }))
-                    )
-                  }))
-                )
-            }
-          })
+          project$(
+            filterAssets(events, [Cardano.AssetId('00740069006e0079002000640069006e006f0073002000230035003600350032')])
+          )
         )
         // throws 'invalid byte sequence for encoding "UTF8": 0x00'
         // when asset name is not sanitized
@@ -501,6 +461,19 @@ describe('storeNftMetadata', () => {
     expect(typeof file.src).toBe('string');
     expect(['object', 'undefined'].includes(typeof file.otherProperties)).toBe(true);
     expect(['string', 'undefined'].includes(typeof file.name)).toBe(true);
+  });
+
+  it('projects metadata with missing "extra" field', async () => {
+    const events = chainSyncData(ChainSyncDataSet.MissingExtraDatumMetadataProblem);
+    const userTokenAssetId = Cardano.AssetId(
+      'e51fbae37cc032eab73861f52ccfa3291e1f4746b7a471628ae27012000de1406e6d6b724e4654386d6179'
+    );
+    const referenceNftAssetId = Cardano.AssetId(
+      'e51fbae37cc032eab73861f52ccfa3291e1f4746b7a471628ae27012000643b06e6d6b724e4654386d6179'
+    );
+    await lastValueFrom(project$(filterAssets(events, [referenceNftAssetId, userTokenAssetId])));
+    const metadata = await nftMetadataRepo.findOneBy({ userTokenAssetId });
+    expect(metadata).toBeTruthy();
   });
 });
 

--- a/packages/projection/src/operators/Mappers/withNftMetadata.ts
+++ b/packages/projection/src/operators/Mappers/withNftMetadata.ts
@@ -25,12 +25,7 @@ const getNftMetadataFromCip67 = ({ cip67 }: WithCIP67, logger: Logger) =>
   (cip67.byLabel[Asset.AssetNameLabelNum.ReferenceNFT] || []).map(
     ({ decoded, assetId, policyId, utxo }): ProjectedNftMetadata | null => {
       const datum = utxo?.[1].datum;
-      if (
-        !datum ||
-        !Cardano.util.isConstrPlutusData(datum) ||
-        datum.constructor !== 0n ||
-        datum.fields.items.length < 3
-      ) {
+      if (!datum || !Cardano.util.isConstrPlutusData(datum)) {
         return null;
       }
       const nftMetadata = Asset.NftMetadata.fromPlutusData(datum, logger);

--- a/packages/util-dev/src/chainSync/data/missing-extra-datum-metadata-problem.json
+++ b/packages/util-dev/src/chainSync/data/missing-extra-datum-metadata-problem.json
@@ -1,0 +1,1599 @@
+{
+  "body": [
+    {
+      "block": {
+        "body": [
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": []
+              },
+              "scripts": []
+            },
+            "body": {
+              "auxiliaryDataHash": "bdaa99eb158414dea0a91d6c727e2268574b23efe6e08ab3b841abe8059a030c",
+              "certificates": [],
+              "collaterals": [],
+              "fee": {
+                "__type": "bigint",
+                "value": "181825"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "25f3a07f0151933ef7ae8bdfd79e7a624fcc7c9340cf3db91a49a83680c39d58"
+                },
+                {
+                  "index": 0,
+                  "txId": "ca2bde326bdd8b86c188c6ca3ee5e69df5643980b8175f6f8c5e13696841bdbc"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": []
+              },
+              "outputs": [
+                {
+                  "address": "addr_test1qpwuyw7xke0687xnz742hc7n8h9kdh7hjl7r6ry79d4epp7q5ncg7ck44ep2upgexamxa6a9qgau5k4e7mg33x8zk3vs8a09dh",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "63f01fe6cd68ec6438c95a46cea4a6cd27efb791b5e8cc1fa92af3294962696c65636f696e3137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1168010"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1qpxdn2uz6llh4kel0yrrdraycrshxjpqn76mvdp2cd8wzl3ndmzpdfwx608lk2p0wly8zfh65wguqyuv4qhu96wcwutsmfj27h",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "06b913e3a939a9228b5f72ce08f488305e1907f2034d9fbb58d468ae486f736b794b69636b3733",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5c677ba4dd295d9286e0e22786fea9ed735a6ae9c07e7a45ae4d95c84962696c65636f696e",
+                          {
+                            "__type": "bigint",
+                            "value": "227"
+                          }
+                        ],
+                        [
+                          "63f01fe6cd68ec6438c95a46cea4a6cd27efb791b5e8cc1fa92af3294c616365204e46542050726570726f643133",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "aa8fb4358cfc9a167738d45d770cc4d777a05d5a2afa7f7840609f1e7431",
+                          {
+                            "__type": "bigint",
+                            "value": "10000000000000000"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "6709483753"
+                    }
+                  }
+                }
+              ],
+              "requiredExtraSignatures": [],
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 59486213
+              },
+              "withdrawals": []
+            },
+            "id": "d52efaf53650c90bc50f9f01ce1d51cb463e7e7d3152be5a70c0ccc0c3a59fc5",
+            "inputSource": "inputs",
+            "witness": {
+              "bootstrap": [],
+              "datums": [],
+              "redeemers": [],
+              "scripts": [],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "71b4f2bc41ba7bda507dc2aaef162763b6438c27224e1c6b76543b2957a8fb53",
+                    "6ed92db9f229def9f2286ef9a469d343b79f6f6e564db3d80593647077e9d9d11dd2f871fce865f078e5469c49c8c50a70c4f448a6ccd8f8f052d56a1b123500"
+                  ]
+                ]
+              }
+            }
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [],
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "4645cbb9524a1702703bf9614496865ee81eeb3b156620f9c276cc0f60fb342a"
+                }
+              ],
+              "fee": {
+                "__type": "bigint",
+                "value": "294369"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "b255801ea95164f0a85d1b20c92563f35b08f6824035565f280f2e1814ce14f7"
+                },
+                {
+                  "index": 2,
+                  "txId": "d10c519213d7a26562d23878df9882c988b0c1ea73eaa38b3ebf19550aa44923"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": []
+              },
+              "outputs": [
+                {
+                  "address": "addr_test1qqwxne57v0ahe04dy3jjpxqmp8ewmtaypx0tfu46c8h6wkg7659tg5e2hjvkapfq8pph66kau3vc06c04gu3drjcgnhshmzl0z",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "10000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1qqayue6h7fxemhdktj9w7cxsnxv40vm9q3f7temjr7606s3j0xykpud5ms6may9d6rf34mgwxqv75rj89zpfdftn0esq3pcfjg",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "969750"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1qqwxne57v0ahe04dy3jjpxqmp8ewmtaypx0tfu46c8h6wkg7659tg5e2hjvkapfq8pph66kau3vc06c04gu3drjcgnhshmzl0z",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "969750"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1qzwu6jcqk8f96fxq02pvq2h4a927ggn35f2gzdklfte4kwx0sd5zdvsat2chsyyjxkjxcg6uz2y46avd46mzqdgdy3dsckqxs4",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "cb2e7bf1fef88c0f8d679a2bd6cf9167f175e106063d6a16e457af446c6f676f486f6d65",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1155080"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1qzwu6jcqk8f96fxq02pvq2h4a927ggn35f2gzdklfte4kwx0sd5zdvsat2chsyyjxkjxcg6uz2y46avd46mzqdgdy3dsckqxs4",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "6214719123"
+                    }
+                  }
+                }
+              ],
+              "requiredExtraSignatures": [],
+              "scriptIntegrityHash": "7af341bfbbca4df8690718f7cd84ea4e7729231838a884a9dde5b5238d50b521",
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": {
+                  "__type": "undefined"
+                }
+              },
+              "withdrawals": []
+            },
+            "id": "e258dd8dbab2f6c665098cbdea938ace7c0f0dc9ff610368622b8e45a3dc32f9",
+            "inputSource": "inputs",
+            "witness": {
+              "bootstrap": [],
+              "datums": [],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fff",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 683186,
+                    "steps": 269676426
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "59043b01000032323232323232323232322223253330093232323232323232323253330133370e9001000899299980a0018a511323232323232323232533301d0011533301d3371e6eb8cc064c06c0612004375c6603260360309003099191919299981099b8948010c00400c4c8cdc4a40046004002660080064660180026eb4cc078c080075200814a0600200244a6660480022900009919b8048008cc00c00c004c09c004cc00403894ccc07ccc020004c028dd71980d980e80d240082660120026eb4cc06cc074069200a14a044646600200200644a666048002297ae01323253330233005002133027002330040040011330040040013028002302600114a229414ccc0714ccc0714ccc070cdd7801a6103d87a800014a2266ebc00930103d87a800014a2266ebc00530103d87a800014a02944ccc00c02c01d300150d8799fd8799f581c3a4e6757f24d9dddb65c8aef60d0999957b3650453e5e7721fb4fd42ffd8799fd8799fd8799f581c32798960f1b4dc35be90add0d31aed0e3019ea0e47288296a5737e60ffffffff0033300200a375a6602c603002a900518029bae33016301801548018ccc004024dd69980a980b80a2401060086eb8cc054c05c0512004222323300100100422533302000114c0103d87a800013232533301f533301f3300900200613300800200514a0266e952000330230024bd70099802002000981200118110009119baf3301530173301530170024800120003301530170014800088cdc480099191919299980e19b874800800452000132375a60440026034004603400264a66603666e1d200200114c103d87a800013232323300100100222533302200114c103d87a800013232323253330233371e9110000213374a9000198139ba80014bd700998030030019bad3024003375c6044004604c00460480026eacc084004c064008c064004c8cc004004008894ccc078004530103d87a8000132323232533301f3371e9110000213374a9000198119ba60014bd700998030030019bab3020003375c603c004604400460400026eaccc050c058009200223374a90001980d19ba548000cc068dd4800a5eb80cc06930103d87a80004bd7019b833370490011bad33010301200f4802120c801301100714a0602200c646644646600200200644a66603200229404c8c94ccc060cdc78010028a51133004004001301d002375c60360026eb0cc038c0400212010001375c6601a601e01890021bac301500130150013014001300b00330110013011002300f0013007002149858c94ccc024cdc3a40000022646464646464646464646464a66603060360042930b1bad30190013019002375a602e002602e0046eb8c054004c054008dd7180980098098011bae30110013011002375c601e002600e0082c600e0066600200290001111199980399b8700100300c233330050053370000890011807000801001118029baa001230033754002ae6955ceaab9e5573eae815d0aba21",
+                  "version": 1
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "dba747591ede0686b16c65b81403d99f04b64273f723e0829c434ce4a171cefb",
+                    "97758a4d99eb00bb0d97443c52dc97aaf8edce1d27312fb0e325b8a6412641515e27c517b68c9fd98467874785a5faf47dab9f241db8cfadad0bc0ae795b180f"
+                  ]
+                ]
+              }
+            }
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [],
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "d27a4eb264785cd3c59a1bd407e8106ff2df222fde4c818896cc878ed8599a50"
+                }
+              ],
+              "fee": {
+                "__type": "bigint",
+                "value": "278017"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "13e4ac00ce2dba9b4a122142aaf935f7dce0edf8a68f6ce4ac7180a410d3bc49"
+                },
+                {
+                  "index": 1,
+                  "txId": "13e4ac00ce2dba9b4a122142aaf935f7dce0edf8a68f6ce4ac7180a410d3bc49"
+                },
+                {
+                  "index": 2,
+                  "txId": "d27a4eb264785cd3c59a1bd407e8106ff2df222fde4c818896cc878ed8599a50"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": []
+              },
+              "outputs": [
+                {
+                  "address": "addr_test1wrant25nzh0e76xv7hk0yc4rwhxmhh7kwk7tk6nyegp62dqxwvaf9",
+                  "datum": {
+                    "cbor": "d87a9fd8799f581cb12bdcb45c6b5196cf226d3207e82458de71572e7ef834a308727653d8799fd8799f1a0006476c1b0000018f57a4bb27ffffffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799f581cb12bdcb45c6b5196cf226d3207e82458de71572e7ef834a308727653d8799fd8799f1a0006476c1b0000018f57a4bb27ffffffff",
+                      "items": [
+                        {
+                          "cbor": "d8799f581cb12bdcb45c6b5196cf226d3207e82458de71572e7ef834a308727653d8799fd8799f1a0006476c1b0000018f57a4bb27ffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581cb12bdcb45c6b5196cf226d3207e82458de71572e7ef834a308727653d8799fd8799f1a0006476c1b0000018f57a4bb27ffffff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "b12bdcb45c6b5196cf226d3207e82458de71572e7ef834a308727653"
+                              },
+                              {
+                                "cbor": "d8799fd8799f1a0006476c1b0000018f57a4bb27ffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f1a0006476c1b0000018f57a4bb27ffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f1a0006476c1b0000018f57a4bb27ff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f1a0006476c1b0000018f57a4bb27ff",
+                                        "items": [
+                                          {
+                                            "__type": "bigint",
+                                            "value": "411500"
+                                          },
+                                          {
+                                            "__type": "bigint",
+                                            "value": "1715162364711"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "4896b39741a54ed9500c5d0e0e9be35eea7626d6009725b60585c2764e6f646546656564",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vzcjhh95t344r9k0yfknyplgy3vduu2h9el0sd9rppe8v5cjqawl7",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "9000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vzcjhh95t344r9k0yfknyplgy3vduu2h9el0sd9rppe8v5cjqawl7",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "10294560"
+                    }
+                  }
+                }
+              ],
+              "requiredExtraSignatures": [
+                "b12bdcb45c6b5196cf226d3207e82458de71572e7ef834a308727653"
+              ],
+              "scriptIntegrityHash": "fa49d980094ef211d95e6e38125855683b5f6fdd10579e7c4af1828e96bf145a",
+              "validityInterval": {
+                "invalidBefore": 59479125,
+                "invalidHereafter": 59479245
+              },
+              "withdrawals": []
+            },
+            "id": "1599f2b5f337489011cf2ceb1f07eeee2ea12b7ecc5f531b83e444643a87a130",
+            "inputSource": "inputs",
+            "witness": {
+              "bootstrap": [],
+              "datums": [],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fff",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 1174941,
+                    "steps": 353603457
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "3565c563de4e55714aa9e0280a8cd4a4271ef8c8a261955446cc7b830021aef8",
+                    "bd5174221f578482f66f3844651f0ceb04b3ee9fc914d0dd2bb2888de3f115e399bef3d6de348cdb06cdcde3d73a54f380fd579fda1ee07684456a808d13430d"
+                  ]
+                ]
+              }
+            }
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [],
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "1d4509eef8306ee0d6bfe5d8b8857c3ebfa9b83371dc466639ee2d87d17b1d4a"
+                }
+              ],
+              "fee": {
+                "__type": "bigint",
+                "value": "283343"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "1d4509eef8306ee0d6bfe5d8b8857c3ebfa9b83371dc466639ee2d87d17b1d4a"
+                },
+                {
+                  "index": 0,
+                  "txId": "295037a3d75441c294998b1183b155ee34e70d4f1078c1c037e6b98595eec4db"
+                },
+                {
+                  "index": 2,
+                  "txId": "33d513c8471c5432526416d385f1cac2c2c8444d0efefc927501be314899bbc3"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": []
+              },
+              "outputs": [
+                {
+                  "address": "addr_test1wrant25nzh0e76xv7hk0yc4rwhxmhh7kwk7tk6nyegp62dqxwvaf9",
+                  "datum": {
+                    "cbor": "d87a9fd8799f581cf589d7ec4fc932e5d5e28e4127c5fb2089f587e5709dc50969a967fed8799fd8799f1a000648341b0000018f57a4d1c7ffffffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799f581cf589d7ec4fc932e5d5e28e4127c5fb2089f587e5709dc50969a967fed8799fd8799f1a000648341b0000018f57a4d1c7ffffffff",
+                      "items": [
+                        {
+                          "cbor": "d8799f581cf589d7ec4fc932e5d5e28e4127c5fb2089f587e5709dc50969a967fed8799fd8799f1a000648341b0000018f57a4d1c7ffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581cf589d7ec4fc932e5d5e28e4127c5fb2089f587e5709dc50969a967fed8799fd8799f1a000648341b0000018f57a4d1c7ffffff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "f589d7ec4fc932e5d5e28e4127c5fb2089f587e5709dc50969a967fe"
+                              },
+                              {
+                                "cbor": "d8799fd8799f1a000648341b0000018f57a4d1c7ffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f1a000648341b0000018f57a4d1c7ffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f1a000648341b0000018f57a4d1c7ff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f1a000648341b0000018f57a4d1c7ff",
+                                        "items": [
+                                          {
+                                            "__type": "bigint",
+                                            "value": "411700"
+                                          },
+                                          {
+                                            "__type": "bigint",
+                                            "value": "1715162370503"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "4896b39741a54ed9500c5d0e0e9be35eea7626d6009725b60585c2764e6f646546656564",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vr6cn4lvflyn9ew4u28yzf79lvsgnav8u4cfm3gfdx5k0ls5l8hv4",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "9000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vr6cn4lvflyn9ew4u28yzf79lvsgnav8u4cfm3gfdx5k0ls5l8hv4",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "88938c50773839037610c16536b830801b82484fdc4d74a7e4c21101546573744333",
+                          {
+                            "__type": "bigint",
+                            "value": "20"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "12131657"
+                    }
+                  }
+                }
+              ],
+              "requiredExtraSignatures": [
+                "f589d7ec4fc932e5d5e28e4127c5fb2089f587e5709dc50969a967fe"
+              ],
+              "scriptIntegrityHash": "2839c10add90522d2ac420d8225bf7c9517026c78456b4f5b402fa06b51f5d57",
+              "validityInterval": {
+                "invalidBefore": 59479125,
+                "invalidHereafter": 59479245
+              },
+              "withdrawals": []
+            },
+            "id": "df488f694299e7652e5c76f4d770a2546fe5302481c166bea5ca4148a780ef4f",
+            "inputSource": "inputs",
+            "witness": {
+              "bootstrap": [],
+              "datums": [],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fff",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 1219536,
+                    "steps": 366763995
+                  },
+                  "index": 1,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "f5ca5b53826d2be8b5ab5505c15dd10a498e6d1eee540ded51d52eb7083979f3",
+                    "ab71848df70b8891447997dfa93311477b621164f4c6725dd511ae97904d0a8720473686fe6c42e0c9830667fd582fcedc486dcf2236373feb8ebeea59791c02"
+                  ]
+                ]
+              }
+            }
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [],
+              "collaterals": [],
+              "fee": {
+                "__type": "bigint",
+                "value": "206993"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "68d751630fa3b0eef0b475d3f091a5c60a54967ff884cc8f353d09bf32ee4a80"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "e51fbae37cc032eab73861f52ccfa3291e1f4746b7a471628ae27012000643b06e6d6b724e4654386d6179",
+                    {
+                      "__type": "bigint",
+                      "value": "1"
+                    }
+                  ],
+                  [
+                    "e51fbae37cc032eab73861f52ccfa3291e1f4746b7a471628ae27012000de1406e6d6b724e4654386d6179",
+                    {
+                      "__type": "bigint",
+                      "value": "1"
+                    }
+                  ]
+                ]
+              },
+              "outputs": [
+                {
+                  "address": "addr_test1qz77a0a0kmugl0st7udkajlr4v5tdqvfdjryy9ph8g73tger3ta8f3k37skhx8xxh8gxulh2kpum5du6m4x7s6kmch9q8t3c9a",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "e51fbae37cc032eab73861f52ccfa3291e1f4746b7a471628ae27012000de1406e6d6b724e4654386d6179",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1430000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1qrauyhdfevrej7cx7g8h3nvg44ykp97d4eajrwwleukkfpwc6hw0l6egaygpwtw3fu8uvln8wnqvmzdh5uzmpq4smu9svr7jt2",
+                  "datum": {
+                    "cbor": "d8799fa5446e616d654b6e6d6b724e4654386d617945696d6167655835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64496d656469615479706549696d6167652f706e674b6465736372697074696f6e404566696c65739fa3496d656469615479706549696d6167652f706e67446e616d654b6e6d6b724e4654386d6179437372635835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64ff01ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fa5446e616d654b6e6d6b724e4654386d617945696d6167655835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64496d656469615479706549696d6167652f706e674b6465736372697074696f6e404566696c65739fa3496d656469615479706549696d6167652f706e67446e616d654b6e6d6b724e4654386d6179437372635835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64ff01ff",
+                      "items": [
+                        {
+                          "cbor": "a5446e616d654b6e6d6b724e4654386d617945696d6167655835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64496d656469615479706549696d6167652f706e674b6465736372697074696f6e404566696c65739fa3496d656469615479706549696d6167652f706e67446e616d654b6e6d6b724e4654386d6179437372635835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64ff",
+                          "data": {
+                            "__type": "Map",
+                            "value": [
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6e616d65"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6e6d6b724e4654386d6179"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "696d616765"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6d6564696154797065"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "696d6167652f706e67"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6465736372697074696f6e"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": ""
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "66696c6573"
+                                },
+                                {
+                                  "cbor": "9fa3496d656469615479706549696d6167652f706e67446e616d654b6e6d6b724e4654386d6179437372635835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64ff",
+                                  "items": [
+                                    {
+                                      "cbor": "a3496d656469615479706549696d6167652f706e67446e616d654b6e6d6b724e4654386d6179437372635835697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64",
+                                      "data": {
+                                        "__type": "Map",
+                                        "value": [
+                                          [
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "6d6564696154797065"
+                                            },
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "696d6167652f706e67"
+                                            }
+                                          ],
+                                          [
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "6e616d65"
+                                            },
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "6e6d6b724e4654386d6179"
+                                            }
+                                          ],
+                                          [
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "737263"
+                                            },
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "697066733a2f2f516d4e77566157314b655471424a4b4b6963355553443165424c41315a48396b596b455674535952423646314d64"
+                                            }
+                                          ]
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "e51fbae37cc032eab73861f52ccfa3291e1f4746b7a471628ae27012000643b06e6d6b724e4654386d6179",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2420000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vr2aj690wudh6f8y6qh64k809q7ryfhulkfr9uhyql3l2tg422urm",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "695429776"
+                    }
+                  }
+                }
+              ],
+              "requiredExtraSignatures": [],
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 59485125
+              },
+              "withdrawals": []
+            },
+            "id": "877d45341beb7dc8fc2991814c4e931b8d7063fbe071eee8c471872529b34bf4",
+            "inputSource": "inputs",
+            "witness": {
+              "bootstrap": [],
+              "datums": [],
+              "redeemers": [],
+              "scripts": [
+                {
+                  "__type": "native",
+                  "kind": 1,
+                  "scripts": [
+                    {
+                      "__type": "native",
+                      "keyHash": "4d0b2490a7037860342d9f43f5336f81a908a35d59fe220d18fe53e1",
+                      "kind": 0
+                    }
+                  ]
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "1d42eb995ce6dc34b0f1d9fae74bdbeb0a5079c36a28db9ef04357f53d9a7be7",
+                    "4596bd8e47687952c018e67a31b267342242c76d263ad8b5441e67b67c8b6b138296d2ce041794e346db6290390c6384361df2926a2d03fe7d3c16de41a23604"
+                  ],
+                  [
+                    "3a884cbb3a02092c6c7915a57fe381607ae415e12dd6d4e6283dc9319048eacd",
+                    "92c15bed9230c5e61ef1d503a2e4a3739e3998156b3e70416797c396bf62e4906d7f91375804dff4b1bdc7b2f27664fe162135b29fec6cdc7169e763db5d2203"
+                  ]
+                ]
+              }
+            }
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [],
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "5a94dc2407a44d80c0c387d038e9d9c51a43106a682877701c74d68352ae7d9f"
+                }
+              ],
+              "fee": {
+                "__type": "bigint",
+                "value": "284117"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "5a94dc2407a44d80c0c387d038e9d9c51a43106a682877701c74d68352ae7d9f"
+                },
+                {
+                  "index": 2,
+                  "txId": "c35e8a32453bec1c756c284b64eed60d6a56e3dcfceb3fcf90ed64bf249c219d"
+                },
+                {
+                  "index": 0,
+                  "txId": "ff0f1619ac7f0669e9865ee7fe72ac163b15a7185801fdbcce7b543eb9ef07ed"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": []
+              },
+              "outputs": [
+                {
+                  "address": "addr_test1wrant25nzh0e76xv7hk0yc4rwhxmhh7kwk7tk6nyegp62dqxwvaf9",
+                  "datum": {
+                    "cbor": "d87a9fd8799f581cdad699f810d1de25e7723085aa7078b863dbe82ab9c5c0c2bcff531ad8799fd8799f1a000647d01b0000018f57a4e9bcffffffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799f581cdad699f810d1de25e7723085aa7078b863dbe82ab9c5c0c2bcff531ad8799fd8799f1a000647d01b0000018f57a4e9bcffffffff",
+                      "items": [
+                        {
+                          "cbor": "d8799f581cdad699f810d1de25e7723085aa7078b863dbe82ab9c5c0c2bcff531ad8799fd8799f1a000647d01b0000018f57a4e9bcffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581cdad699f810d1de25e7723085aa7078b863dbe82ab9c5c0c2bcff531ad8799fd8799f1a000647d01b0000018f57a4e9bcffffff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "dad699f810d1de25e7723085aa7078b863dbe82ab9c5c0c2bcff531a"
+                              },
+                              {
+                                "cbor": "d8799fd8799f1a000647d01b0000018f57a4e9bcffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f1a000647d01b0000018f57a4e9bcffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f1a000647d01b0000018f57a4e9bcff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f1a000647d01b0000018f57a4e9bcff",
+                                        "items": [
+                                          {
+                                            "__type": "bigint",
+                                            "value": "411600"
+                                          },
+                                          {
+                                            "__type": "bigint",
+                                            "value": "1715162376636"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "4896b39741a54ed9500c5d0e0e9be35eea7626d6009725b60585c2764e6f646546656564",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vrdddx0czrgauf08wgcgt2ns0zux8klg92uutsxzhnl4xxs8jz7em",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "9000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vrdddx0czrgauf08wgcgt2ns0zux8klg92uutsxzhnl4xxs8jz7em",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "88938c50773839037610c16536b830801b82484fdc4d74a7e4c21101546573744333",
+                          {
+                            "__type": "bigint",
+                            "value": "10"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5863050"
+                    }
+                  }
+                }
+              ],
+              "requiredExtraSignatures": [
+                "dad699f810d1de25e7723085aa7078b863dbe82ab9c5c0c2bcff531a"
+              ],
+              "scriptIntegrityHash": "71f90fc779cfe4f8544ece6b3d2dc9c6a1c38f255f4d5ecf8bb233d164ceadd8",
+              "validityInterval": {
+                "invalidBefore": 59479125,
+                "invalidHereafter": 59479245
+              },
+              "withdrawals": []
+            },
+            "id": "7d1980ba1ed45081a576237ee2352d48d00ef21ec62523486b08a85fb2d53abe",
+            "inputSource": "inputs",
+            "witness": {
+              "bootstrap": [],
+              "datums": [],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fff",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 1229618,
+                    "steps": 369439488
+                  },
+                  "index": 2,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0ee1275bb5e6a95c702e44a26da102cb5399169289942bae2329c8da82cbbdde",
+                    "0a427242d7be462f4e889cdb211f8bccce0b96e969b524435966ffba723632d0001ebd6adc865bda02e823a3bb3dac44ce4b39995724729f6ea0dcd8c0019204"
+                  ]
+                ]
+              }
+            }
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [],
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "0870447cf9f9b991b3334b4a9cdf0ed5366b4966d2c99c0c891653e81bdee67a"
+                }
+              ],
+              "fee": {
+                "__type": "bigint",
+                "value": "278017"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "6d49941b7b0ccbf30154caa43588f847c2cd01d063bf2d74aae35db812949f29"
+                },
+                {
+                  "index": 2,
+                  "txId": "7db26b814bdc8d8f3735c0dba111ea78c1536029e96c252df13729177d70d0fb"
+                },
+                {
+                  "index": 1,
+                  "txId": "c9783e65b0e75a76a09891b7bac8c1e39a096b4f6fd6029c7022b01eb2ac28e7"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": []
+              },
+              "outputs": [
+                {
+                  "address": "addr_test1wrant25nzh0e76xv7hk0yc4rwhxmhh7kwk7tk6nyegp62dqxwvaf9",
+                  "datum": {
+                    "cbor": "d87a9fd8799f581c4370fa6a2550735dc748419287843073dfd7ac3cb83396629f058880d8799fd8799f1a000648981b0000018f57a4fee7ffffffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799f581c4370fa6a2550735dc748419287843073dfd7ac3cb83396629f058880d8799fd8799f1a000648981b0000018f57a4fee7ffffffff",
+                      "items": [
+                        {
+                          "cbor": "d8799f581c4370fa6a2550735dc748419287843073dfd7ac3cb83396629f058880d8799fd8799f1a000648981b0000018f57a4fee7ffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581c4370fa6a2550735dc748419287843073dfd7ac3cb83396629f058880d8799fd8799f1a000648981b0000018f57a4fee7ffffff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "4370fa6a2550735dc748419287843073dfd7ac3cb83396629f058880"
+                              },
+                              {
+                                "cbor": "d8799fd8799f1a000648981b0000018f57a4fee7ffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f1a000648981b0000018f57a4fee7ffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f1a000648981b0000018f57a4fee7ff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f1a000648981b0000018f57a4fee7ff",
+                                        "items": [
+                                          {
+                                            "__type": "bigint",
+                                            "value": "411800"
+                                          },
+                                          {
+                                            "__type": "bigint",
+                                            "value": "1715162382055"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "4896b39741a54ed9500c5d0e0e9be35eea7626d6009725b60585c2764e6f646546656564",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vpphp7n2y4g8xhw8fpqe9puyxpeal4av8jur89nznuzc3qq6tvksz",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "9000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr_test1vpphp7n2y4g8xhw8fpqe9puyxpeal4av8jur89nznuzc3qq6tvksz",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "8721983"
+                    }
+                  }
+                }
+              ],
+              "requiredExtraSignatures": [
+                "4370fa6a2550735dc748419287843073dfd7ac3cb83396629f058880"
+              ],
+              "scriptIntegrityHash": "fa49d980094ef211d95e6e38125855683b5f6fdd10579e7c4af1828e96bf145a",
+              "validityInterval": {
+                "invalidBefore": 59479125,
+                "invalidHereafter": 59479245
+              },
+              "withdrawals": []
+            },
+            "id": "98a8fca8844cbd6a23bf3aac5dcbbc1d21972a936ed1be0221ad8971ccb399fb",
+            "inputSource": "inputs",
+            "witness": {
+              "bootstrap": [],
+              "datums": [],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fff",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 1174941,
+                    "steps": 353603457
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "15de030b10aa382c6172a6f1cf67f0f1c75212f632279109264a8cbb22019b22",
+                    "ebe0987947e2a06302f05223ff67a484982db17cc0a725c8fcdb78f00c9784551ec3c07faa5312a0c4f32a0481b44513a1b087a30939388f0f0a8c71c6d2260d"
+                  ]
+                ]
+              }
+            }
+          }
+        ],
+        "fees": {
+          "__type": "bigint",
+          "value": "1806681"
+        },
+        "header": {
+          "blockNo": 2218275,
+          "hash": "fd5837948d5cb24f17dd677905791e9c493752e6c00d80a85833181e73936ec7",
+          "slot": 59479188
+        },
+        "issuerVk": "ac16ce463e6697d7b49bd22add462f092d9f6ceb808f74a4ecdbd8ed4ae1bbd7",
+        "previousBlock": "69d4950dce8e7823d716cf8b5d4a3b59af2213c97bfb9b944e57f84c198409cd",
+        "size": 6020,
+        "totalOutput": {
+          "__type": "bigint",
+          "value": "13718756492"
+        },
+        "txCount": 7,
+        "vrf": "vrf_vk1ykt25yt3pg8rr6dn4pszqpwlx4s2r4uw9at7pkkyprfqt6k3sdwqa3hhh6"
+      },
+      "eventType": 0,
+      "tip": {
+        "blockNo": 2218275,
+        "hash": "fd5837948d5cb24f17dd677905791e9c493752e6c00d80a85833181e73936ec7",
+        "slot": 59479188
+      }
+    }
+  ],
+  "metadata": {
+    "cardano": {
+      "compactGenesis": {
+        "systemStart": {
+          "__type": "Date",
+          "value": 1654041600000
+        },
+        "networkMagic": 1,
+        "network": "testnet",
+        "activeSlotsCoefficient": 0.05,
+        "securityParameter": 2160,
+        "epochLength": 432000,
+        "slotsPerKesPeriod": 129600,
+        "maxKesEvolutions": 62,
+        "slotLength": 1,
+        "updateQuorum": 5,
+        "maxLovelaceSupply": {
+          "__type": "bigint",
+          "value": "45000000000000000"
+        },
+        "networkId": 0
+      },
+      "intersection": {
+        "point": {
+          "slot": 59479125,
+          "hash": "69d4950dce8e7823d716cf8b5d4a3b59af2213c97bfb9b944e57f84c198409cd"
+        },
+        "tip": {
+          "slot": 60704095,
+          "hash": "a5a7a68dc7bc70ef9bbc92b3a6125c17e1292c3be831981fec5b06a54673e5da",
+          "blockNo": 2271231
+        }
+      }
+    },
+    "options": {
+      "blockHeights": "2218275"
+    },
+    "software": {
+      "commit": {
+        "hash": "94107b88f16a739c4754c99349724093b4e15882",
+        "tags": []
+      },
+      "name": "@cardano-sdk/golden-test-generator",
+      "version": "0.7.55"
+    }
+  }
+}

--- a/packages/util-dev/src/chainSync/index.ts
+++ b/packages/util-dev/src/chainSync/index.ts
@@ -98,6 +98,7 @@ const intersect = (events: ChainSyncData['body'], points: PointOrOrigin[]) => {
 export enum ChainSyncDataSet {
   PreviewStakePoolProblem = 'preview-stake-pool-problem.json',
   AssetNameUtf8Problem = 'asset-name-utf8-problem.json',
+  MissingExtraDatumMetadataProblem = 'missing-extra-datum-metadata-problem.json',
   WithPoolRetirement = 'with-pool-retirement.json',
   WithStakeKeyDeregistration = 'with-stake-key-deregistration.json',
   WithMint = 'with-mint.json',


### PR DESCRIPTION
# Context

Projecting NFT metadata does not project it for https://preprod.cexplorer.io/asset/asset14w53nf5ghakjcp37ruj7a8ffavjpn2cxamdvsl

LW-9799

# Proposed Solution

It was validating shape of the datum in 2 places

# Important Changes Introduced

Add a new chain sync events dataset
