### PR TITLE
Feat/lw 10619 make local testnet slower for lace

### DIFF
--- a/packages/e2e/.env.example
+++ b/packages/e2e/.env.example
@@ -43,3 +43,7 @@ SCHEDULES="/config/schedules.json"
 
 # Required by test:long-running
 STAKE_POOL_PROJECTOR_URL='http://localhost:4002/'
+
+# NETWORK_SPEED (fast|slow) determines the timeout tests will use when for blockchain events, like transaction confirmation.
+# It should be configured to 'slow' when running against real networks like preprod.
+NETWORK_SPEED=fast

--- a/packages/e2e/.env.example
+++ b/packages/e2e/.env.example
@@ -46,4 +46,5 @@ STAKE_POOL_PROJECTOR_URL='http://localhost:4002/'
 
 # NETWORK_SPEED (fast|slow) determines the timeout tests will use when for blockchain events, like transaction confirmation.
 # It should be configured to 'slow' when running against real networks like preprod.
+# The local-network slotLength is 0.2s when running in fast mode (default), and 1s when running in slow mode.
 NETWORK_SPEED=fast

--- a/packages/e2e/docker-compose.yml
+++ b/packages/e2e/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     environment:
       CARDANO_NODE_LOG_LEVEL: ${CARDANO_NODE_LOG_LEVEL:-Info}
       CARDANO_NODE_CHAINDB_LOG_LEVEL: ${CARDANO_NODE_CHAINDB_LOG_LEVEL:-Notice}
+      NETWORK_SPEED: ${NETWORK_SPEED:-fast}
     ports:
       - 3001:3001
     volumes:

--- a/packages/e2e/local-network/scripts/make-babbage.sh
+++ b/packages/e2e/local-network/scripts/make-babbage.sh
@@ -185,7 +185,14 @@ rm "${ROOT}/genesis/byron/genesis-wrong.json"
 
 cp "${ROOT}/genesis/shelley/genesis.json" "${ROOT}/genesis/shelley/copy-genesis.json"
 
-jq -M ". + {slotLength:0.2, activeSlotsCoeff:0.1, securityParam:10, epochLength:1000, maxLovelaceSupply:$((MAX_SUPPLY * 3)), updateQuorum:2}" "${ROOT}/genesis/shelley/copy-genesis.json" > "${ROOT}/genesis/shelley/copy2-genesis.json"
+if [[ "$NETWORK_SPEED" == "fast" ]]; then
+  SLOT_LENGTH=0.2
+else
+  SLOT_LENGTH=1
+fi
+
+
+jq -M ". + {slotLength:${SLOT_LENGTH}, activeSlotsCoeff:0.1, securityParam:10, epochLength:1000, maxLovelaceSupply:$((MAX_SUPPLY * 3)), updateQuorum:2}" "${ROOT}/genesis/shelley/copy-genesis.json" > "${ROOT}/genesis/shelley/copy2-genesis.json"
 jq --raw-output '.protocolParams.protocolVersion.major = 9 | .protocolParams.minFeeA = 44 | .protocolParams.minFeeB = 155381 | .protocolParams.minUTxOValue = 1000000 | .protocolParams.decentralisationParam = 0.7 | .protocolParams.rho = 0.1 | .protocolParams.tau = 0.1' "${ROOT}/genesis/shelley/copy2-genesis.json" > "${ROOT}/genesis/shelley/genesis.json"
 
 rm "${ROOT}/genesis/shelley/copy2-genesis.json"

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -32,7 +32,7 @@
     "test:pg-boss": "jest -c jest.config.js --forceExit --selectProjects pg-boss --runInBand --verbose",
     "test:providers": "jest -c jest.config.js --forceExit --selectProjects providers --runInBand --verbose",
     "test:wallet": "jest -c jest.config.js --forceExit --selectProjects wallet --runInBand --verbose",
-    "test:wallet-real-ada": "jest -c jest.config.js --forceExit --selectProjects wallet-real-ada --runInBand --verbose",
+    "test:wallet-real-ada": "NETWORK_SPEED=slow jest -c jest.config.js --forceExit --selectProjects wallet-real-ada --runInBand --verbose",
     "test:web-extension:build:sw": "tsc --build ./test && tsc --build ./test/web-extension && webpack -c test/web-extension/webpack.config.sw.js",
     "test:web-extension:build:other": "tsc --build ./test && tsc --build ./test/web-extension && webpack -c test/web-extension/webpack.config.js",
     "test:web-extension:build:sw:watch": "yarn test:web-extension:build:sw --watch",

--- a/packages/e2e/src/environment.ts
+++ b/packages/e2e/src/environment.ts
@@ -91,6 +91,7 @@ const validators = {
   LOGGER_MIN_SEVERITY: str({ default: 'info' }),
   NETWORK_INFO_PROVIDER: str(),
   NETWORK_INFO_PROVIDER_PARAMS: providerParams(),
+  NETWORK_SPEED: str({ choices: ['fast', 'slow'], default: 'fast' }),
   OGMIOS_URL: str(),
   REWARDS_PROVIDER: str(),
   REWARDS_PROVIDER_PARAMS: providerParams(),
@@ -158,5 +159,6 @@ export const walletVariables = [
   'TX_SUBMIT_PROVIDER_PARAMS',
   'UTXO_PROVIDER',
   'UTXO_PROVIDER_PARAMS',
-  'ADDRESS_DISCOVERY'
+  'ADDRESS_DISCOVERY',
+  'NETWORK_SPEED'
 ] as const;

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -331,7 +331,8 @@ const patchInitializeTxToRespectEpochBoundary = <T extends ObservableWallet>(
  * @returns an object containing the wallet and providers passed to it
  */
 export const getWallet = async (props: GetWalletProps) => {
-  const { env, idx, logger, name, polling, stores, customKeyParams, keyAgent, witnesser } = props;
+  const { env, idx, logger, name, stores, customKeyParams, keyAgent, witnesser } = props;
+  let polling = props.polling;
   const providers = {
     addressDiscovery: await addressDiscoveryFactory.create(
       env.ADDRESS_DISCOVERY,
@@ -382,6 +383,10 @@ export const getWallet = async (props: GetWalletProps) => {
       logger
     }));
   const bip32Account = await Bip32Account.fromAsyncKeyAgent(asyncKeyAgent);
+  if (!polling?.interval && env.NETWORK_SPEED === 'fast') {
+    polling = { ...polling, interval: 50 };
+  }
+
   const wallet = createPersonalWallet(
     { name, polling },
     {

--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -121,7 +121,7 @@ export const txConfirmed = (
       )
     ),
     `Tx confirmation timeout: ${id}`,
-    SYNC_TIMEOUT_DEFAULT / 5
+    env.NETWORK_SPEED === 'fast' ? SYNC_TIMEOUT_DEFAULT / 5 : SYNC_TIMEOUT_DEFAULT
   );
 
 export const submitAndConfirm = (wallet: ObservableWallet, tx: Cardano.Tx, numConfirmations?: number) =>

--- a/packages/e2e/test/long-running/shared-wallet-delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/shared-wallet-delegation-rewards.test.ts
@@ -101,7 +101,7 @@ describe('shared wallet delegation rewards', () => {
     ({
       wallet: faucetWallet,
       providers: { stakePoolProvider }
-    } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    } = await getWallet({ env, logger, name: 'Sending Wallet' }));
 
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(faucetWallet, initialFunds);

--- a/packages/e2e/test/long-running/simple-delegation-rewards.test.ts
+++ b/packages/e2e/test/long-running/simple-delegation-rewards.test.ts
@@ -87,7 +87,7 @@ describe('simple delegation rewards', () => {
       name: 'Sending Wallet',
       polling: { interval: 50 }
     }));
-    ({ wallet: wallet2 } = await getWallet({ env, logger, name: 'Receiving Wallet', polling: { interval: 50 } }));
+    ({ wallet: wallet2 } = await getWallet({ env, logger, name: 'Receiving Wallet' }));
 
     await waitForWalletStateSettle(wallet1);
     await waitForWalletStateSettle(wallet2);

--- a/packages/e2e/test/wallet/PersonalWallet/byron.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/byron.test.ts
@@ -14,7 +14,7 @@ describe('PersonalWallet/byron', () => {
   let wallet: BaseWallet;
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet' })).wallet;
   });
 
   afterAll(() => {

--- a/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/delegationDistribution.test.ts
@@ -25,8 +25,7 @@ const fundWallet = async (wallet: BaseWallet) => {
     logger.info(
       `Insufficient funds in wallet account index 1. Missing ${coinDeficit}. Transferring from wallet account index 0`
     );
-    const fundingWallet = (await getWallet({ env, idx: 0, logger, name: 'WalletAcct0', polling: { interval: 50 } }))
-      .wallet;
+    const fundingWallet = (await getWallet({ env, idx: 0, logger, name: 'WalletAcct0' })).wallet;
     await walletReady(fundingWallet);
     const fundingTxBuilder = fundingWallet.createTxBuilder();
     const { tx } = await fundingTxBuilder
@@ -125,7 +124,7 @@ describe('PersonalWallet/delegationDistribution', () => {
   let wallet: BaseWallet;
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, idx: 3, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 3, logger, name: 'Wallet' })).wallet;
     await fundWallet(wallet);
     await deregisterAllStakeKeys(wallet);
   });

--- a/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/handle.test.ts
@@ -44,7 +44,7 @@ describe('Ada handle', () => {
   const coins = coinsRequiredByHandleMint + 10_000_000n; // maximum number of coins to use in each transaction
 
   const initPolicyId = async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Handle Init Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Handle Init Wallet' })).wallet;
     await walletReady(wallet, coins);
 
     keyAgent = await createStandaloneKeyAgent(

--- a/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/mint.test.ts
@@ -27,7 +27,7 @@ describe('PersonalWallet/mint', () => {
   });
 
   it('can mint a token with no asset name', async () => {
-    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet' })).wallet;
 
     const coins = 3_000_000n;
     await walletReady(wallet, coins);

--- a/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multiAddress.test.ts
@@ -26,7 +26,7 @@ describe('PersonalWallet/multiAddress', () => {
   let wallet: BaseWallet;
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, idx: 0, logger, name: 'Wallet' })).wallet;
   });
 
   afterAll(() => {

--- a/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/multisignature.test.ts
@@ -28,7 +28,7 @@ describe('PersonalWallet/multisignature', () => {
   });
 
   it('can create a transaction with multiple signatures to mint an asset', async () => {
-    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet' })).wallet;
 
     const coins = 3_000_000n;
     await walletReady(wallet, coins);

--- a/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/nft.test.ts
@@ -52,7 +52,7 @@ describe('PersonalWallet.assets/nft', () => {
   const coins = 10_000_000n; // number of coins to use in each transaction
 
   beforeAll(async () => {
-    wallet = (await getWallet({ env, logger, name: 'Minting Wallet', polling: { interval: 50 } })).wallet;
+    wallet = (await getWallet({ env, logger, name: 'Minting Wallet' })).wallet;
 
     await walletReady(wallet, coins);
 

--- a/packages/e2e/test/wallet/PersonalWallet/txChainHistory.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/txChainHistory.test.ts
@@ -12,7 +12,7 @@ describe('PersonalWallet/txChainHistory', () => {
   let signedTx: Cardano.Tx<Cardano.TxBody>;
 
   beforeEach(async () => {
-    ({ wallet } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    ({ wallet } = await getWallet({ env, logger, name: 'Sending Wallet' }));
     const tAdaToSend = 10_000_000n;
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(wallet, tAdaToSend);

--- a/packages/e2e/test/wallet/PersonalWallet/unspendableUtxos.test.ts
+++ b/packages/e2e/test/wallet/PersonalWallet/unspendableUtxos.test.ts
@@ -21,8 +21,8 @@ describe('PersonalWallet/unspendableUtxos', () => {
   // eslint-disable-next-line max-statements
   it.skip('unsets unspendable UTxOs when no longer in the wallets UTxO set', async () => {
     // Here we will simulate the scenario of collateral consumption by spending it from another wallet instance.
-    wallet1 = (await getWallet({ env, logger, name: 'Wallet 1', polling: { interval: 50 } })).wallet;
-    wallet2 = (await getWallet({ env, logger, name: 'Wallet 2', polling: { interval: 50 } })).wallet;
+    wallet1 = (await getWallet({ env, logger, name: 'Wallet 1' })).wallet;
+    wallet2 = (await getWallet({ env, logger, name: 'Wallet 2' })).wallet;
 
     const coins = 5_000_000n;
     await walletReady(wallet1, coins);

--- a/packages/e2e/test/wallet/SharedWallet/delegation.test.ts
+++ b/packages/e2e/test/wallet/SharedWallet/delegation.test.ts
@@ -70,7 +70,7 @@ describe('SharedWallet/delegation', () => {
     ({
       wallet: faucetWallet,
       providers: { stakePoolProvider }
-    } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    } = await getWallet({ env, logger, name: 'Sending Wallet' }));
 
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(faucetWallet, initialFunds);

--- a/packages/e2e/test/wallet/SharedWallet/simpleTx.test.ts
+++ b/packages/e2e/test/wallet/SharedWallet/simpleTx.test.ts
@@ -25,7 +25,7 @@ describe('SharedWallet/simpleTx', () => {
   const initialFunds = 10_000_000n;
 
   beforeAll(async () => {
-    ({ wallet: faucetWallet } = await getWallet({ env, logger, name: 'Sending Wallet', polling: { interval: 50 } }));
+    ({ wallet: faucetWallet } = await getWallet({ env, logger, name: 'Sending Wallet' }));
 
     // Make sure the wallet has sufficient funds to run this test
     await walletReady(faucetWallet, initialFunds);


### PR DESCRIPTION
# Context

Have the option of running the local-network at a slower pace (slotLength=1), to use it for conway-era testing with Lace.

# Proposed Solution

# Important Changes Introduced
For now, I cherry-picked the NETWORK_SPEED commit from master, because the merge is causing some issues.
