### PR TITLE
LW-10576 follow up

### DIFF
--- a/packages/e2e/local-network/scripts/pools/update-node-utils.sh
+++ b/packages/e2e/local-network/scripts/pools/update-node-utils.sh
@@ -73,6 +73,8 @@ updatePool() {
   delegatorPaymentSKey=network-files/stake-delegator-keys/payment"${SP_NODE_ID}".skey
   delegatorStakeSKey=network-files/stake-delegator-keys/staking"${SP_NODE_ID}".skey
 
+  keyDeposit=2000000
+
   POOL_ID=$(cardano-cli stake-pool id --cold-verification-key-file "$coldVKey" --output-format "hex")
 
   # funding pool owner stake address
@@ -128,7 +130,6 @@ updatePool() {
     --byron-witness-count 0 \
     --protocol-params-file ${SP_NODE_ID}/params.json | awk '{ print $1 }')
 
-  keyDeposit=2000000
   initialBalance=$(getAddressBalance "$genesisAddr")
   txOut=$((initialBalance - fee - keyDeposit))
 


### PR DESCRIPTION
# Context

`conway-era` branch introduces several changes in the `local-network` startup scripts.

# Proposed Solution

This small PR is aimed to slightly reduce the diff between the two main branches in order to facilitate next merges reducing the chances of merge conflicts.

# Important Changes Introduced

Changing the `--supply-delegated` option also helped to remove the ugly `sed` applied to the `genesis/shelley/genesis.json` file.