### PR TITLE
chore: enable asset-{provider,projector}

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -422,13 +422,13 @@ in
               env.OVERRIDE_FUZZY_OPTIONS = "true";
             };
             handle-provider.enabled = true;
-          # asset-provider.enabled = true;
+            asset-provider.enabled = true;
           };
 
           projectors = {
             handle.enabled = true;
             stake-pool.enabled = true;
-          # asset.enabled = true;
+            asset.enabled = true;
           };
 
           values = {


### PR DESCRIPTION
# Context

It seems that asset services have been disabled by accident. they are still deployed tho. This PR more or less reconsiders the state

Current diff against current deployment:
- Image changed
- Monolithic backend has extra `SERVICE_NAMES` entry `asset
