### PR TITLE
feat: add support for cip 1854

### DIFF
--- a/packages/e2e/src/util/createMockKeyAgent.ts
+++ b/packages/e2e/src/util/createMockKeyAgent.ts
@@ -1,6 +1,6 @@
 import { Bip32PublicKeyHex, SodiumBip32Ed25519 } from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
-import { GroupedAddress, KeyAgent, KeyAgentType } from '@cardano-sdk/key-management';
+import { GroupedAddress, KeyAgent, KeyAgentType, KeyPurpose } from '@cardano-sdk/key-management';
 
 const accountIndex = 0;
 const chainId = Cardano.ChainIds.Preview;
@@ -18,12 +18,14 @@ export const createMockKeyAgent = (deriveAddressesReturn: GroupedAddress[] = [])
     derivePublicKey: jest.fn(),
     exportRootPrivateKey: jest.fn(),
     extendedAccountPublicKey,
+    purpose: KeyPurpose.STANDARD,
     serializableData: {
       __typename: KeyAgentType.InMemory,
       accountIndex,
       chainId,
       encryptedRootPrivateKeyBytes: [],
-      extendedAccountPublicKey
+      extendedAccountPublicKey,
+      purpose: KeyPurpose.STANDARD
     },
     signBlob: jest.fn(),
     signTransaction: jest.fn()

--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -18,7 +18,7 @@ import {
   timeout
 } from 'rxjs';
 import { FAST_OPERATION_TIMEOUT_DEFAULT, SYNC_TIMEOUT_DEFAULT } from '../defaults';
-import { InMemoryKeyAgent, TransactionSigner } from '@cardano-sdk/key-management';
+import { InMemoryKeyAgent, KeyPurpose, TransactionSigner } from '@cardano-sdk/key-management';
 import { InitializeTxProps } from '@cardano-sdk/tx-construction';
 import { TestWallet, networkInfoProviderFactory } from '../factories';
 import { getEnv, walletVariables } from '../environment';
@@ -228,17 +228,20 @@ export const submitCertificate = async (certificate: Cardano.Certificate, wallet
  * @param mnemonics The random set of mnemonics.
  * @param genesis Network genesis parameters
  * @param bip32Ed25519 The Ed25519 cryptography implementation.
+ * @param purpose The key purpose.
  */
 export const createStandaloneKeyAgent = async (
   mnemonics: string[],
   genesis: Cardano.CompactGenesis,
-  bip32Ed25519: Crypto.Bip32Ed25519
+  bip32Ed25519: Crypto.Bip32Ed25519,
+  purpose?: KeyPurpose
 ) =>
   await InMemoryKeyAgent.fromBip39MnemonicWords(
     {
       chainId: genesis,
       getPassphrase: async () => Buffer.from(''),
-      mnemonicWords: mnemonics
+      mnemonicWords: mnemonics,
+      purpose
     },
     { bip32Ed25519, logger }
   );

--- a/packages/e2e/test/wallet_epoch_0/PersonalWallet/multisignature.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/PersonalWallet/multisignature.test.ts
@@ -2,7 +2,7 @@
 import { BaseWallet, FinalizeTxProps } from '@cardano-sdk/wallet';
 import { Cardano, nativeScriptPolicyId } from '@cardano-sdk/core';
 import { InitializeTxProps } from '@cardano-sdk/tx-construction';
-import { KeyRole, util } from '@cardano-sdk/key-management';
+import { KeyPurpose, KeyRole, util } from '@cardano-sdk/key-management';
 import {
   bip32Ed25519Factory,
   burnTokens,
@@ -48,12 +48,14 @@ describe('PersonalWallet/multisignature', () => {
     const aliceKeyAgent = await createStandaloneKeyAgent(
       env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
-      bip32Ed25519
+      bip32Ed25519,
+      KeyPurpose.MULTI_SIG
     );
     const bobKeyAgent = await createStandaloneKeyAgent(
       env.KEY_MANAGEMENT_PARAMS.mnemonic.split(' '),
       genesis,
-      bip32Ed25519
+      bip32Ed25519,
+      KeyPurpose.MULTI_SIG
     );
 
     const aliceDerivationPath = {

--- a/packages/e2e/test/wallet_epoch_0/SharedWallet/utils.ts
+++ b/packages/e2e/test/wallet_epoch_0/SharedWallet/utils.ts
@@ -2,6 +2,7 @@ import * as Crypto from '@cardano-sdk/crypto';
 import {
   AccountKeyDerivationPath,
   KeyAgent,
+  KeyPurpose,
   KeyRole,
   SignBlobResult,
   SignDataContext,
@@ -30,7 +31,12 @@ const getKeyAgent = async (
   genesisParameters: Cardano.CompactGenesis,
   bip32Ed25519: Crypto.Bip32Ed25519
 ) => {
-  const keyAgent = await createStandaloneKeyAgent(mnemonics.split(' '), genesisParameters, bip32Ed25519);
+  const keyAgent = await createStandaloneKeyAgent(
+    mnemonics.split(' '),
+    genesisParameters,
+    bip32Ed25519,
+    KeyPurpose.MULTI_SIG
+  );
 
   const pubKey = await keyAgent.derivePublicKey(DERIVATION_PATH);
 

--- a/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
+++ b/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
@@ -3,7 +3,7 @@ import * as Crypto from '@cardano-sdk/crypto';
 import * as Ledger from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { Ada, InvalidDataReason } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { Cardano } from '@cardano-sdk/core';
-import { CardanoKeyConst, CommunicationType, util } from '@cardano-sdk/key-management';
+import { CardanoKeyConst, CommunicationType, KeyPurpose, util } from '@cardano-sdk/key-management';
 import { LedgerKeyAgent } from '../src';
 import { dummyLogger } from 'ts-log';
 import { poolId, poolParameters, pureAdaTxOut, stakeKeyHash, txIn, txOutWithDatum } from './testData';
@@ -379,7 +379,8 @@ describe('LedgerKeyAgent', () => {
           communicationType: CommunicationType.Node,
           extendedAccountPublicKey: Crypto.Bip32PublicKeyHex(
             '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-          )
+          ),
+          purpose: KeyPurpose.STANDARD
         },
         {
           bip32Ed25519: new Crypto.SodiumBip32Ed25519(),

--- a/packages/key-management/src/InMemoryKeyAgent.ts
+++ b/packages/key-management/src/InMemoryKeyAgent.ts
@@ -7,6 +7,7 @@ import {
   KeyAgentDependencies,
   KeyAgentType,
   KeyPair,
+  KeyPurpose,
   SerializableInMemoryKeyAgentData,
   SignBlobResult,
   SignTransactionContext,
@@ -37,6 +38,7 @@ export interface FromBip39MnemonicWordsProps {
   mnemonic2ndFactorPassphrase?: string;
   getPassphrase: GetPassphrase;
   accountIndex?: number;
+  purpose?: KeyPurpose;
 }
 
 const getPassphraseRethrowTypedError = async (getPassphrase: GetPassphrase) => {
@@ -60,6 +62,7 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
     const accountKey = await deriveAccountPrivateKey({
       accountIndex: this.accountIndex,
       bip32Ed25519: this.bip32Ed25519,
+      purpose: this.purpose,
       rootPrivateKey
     });
 
@@ -89,7 +92,8 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
       getPassphrase,
       mnemonicWords,
       mnemonic2ndFactorPassphrase = '',
-      accountIndex = 0
+      accountIndex = 0,
+      purpose = KeyPurpose.STANDARD
     }: FromBip39MnemonicWordsProps,
     dependencies: KeyAgentDependencies
   ): Promise<InMemoryKeyAgent> {
@@ -103,6 +107,7 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
     const accountPrivateKey = await deriveAccountPrivateKey({
       accountIndex,
       bip32Ed25519: dependencies.bip32Ed25519,
+      purpose,
       rootPrivateKey
     });
 
@@ -114,7 +119,8 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
         chainId,
         encryptedRootPrivateKeyBytes: [...encryptedRootPrivateKey],
         extendedAccountPublicKey,
-        getPassphrase
+        getPassphrase,
+        purpose
       },
       dependencies
     );

--- a/packages/key-management/src/KeyAgentBase.ts
+++ b/packages/key-management/src/KeyAgentBase.ts
@@ -5,6 +5,7 @@ import {
   GroupedAddress,
   KeyAgent,
   KeyAgentDependencies,
+  KeyPurpose,
   SerializableKeyAgentData,
   SignBlobResult,
   SignTransactionContext,
@@ -33,6 +34,10 @@ export abstract class KeyAgentBase implements KeyAgent {
   }
   get bip32Ed25519(): Crypto.Bip32Ed25519 {
     return this.#bip32Ed25519;
+  }
+
+  get purpose(): KeyPurpose {
+    return this.serializableData.purpose || KeyPurpose.STANDARD;
   }
 
   abstract signBlob(derivationPath: AccountKeyDerivationPath, blob: HexBlob): Promise<SignBlobResult>;

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -38,6 +38,10 @@ export enum KeyRole {
   DRep = 3
 }
 
+export enum KeyPurpose {
+  STANDARD = 1852,
+  MULTI_SIG = 1854
+}
 export interface AccountKeyDerivationPath {
   role: KeyRole;
   index: number;
@@ -93,6 +97,7 @@ export interface SerializableKeyAgentDataBase {
   chainId: Cardano.ChainId;
   accountIndex: number;
   extendedAccountPublicKey: Crypto.Bip32PublicKeyHex;
+  purpose?: KeyPurpose;
 }
 
 export interface SerializableInMemoryKeyAgentData extends SerializableKeyAgentDataBase {
@@ -184,6 +189,7 @@ export interface KeyAgent {
   get serializableData(): SerializableKeyAgentData;
   get extendedAccountPublicKey(): Crypto.Bip32PublicKeyHex;
   get bip32Ed25519(): Crypto.Bip32Ed25519;
+  get purpose(): KeyPurpose | undefined;
 
   /**
    * @throws AuthenticationError

--- a/packages/key-management/src/util/key.ts
+++ b/packages/key-management/src/util/key.ts
@@ -1,5 +1,13 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { AccountKeyDerivationPath, CardanoKeyConst, Ed25519KeyPair, GroupedAddress, KeyPair, KeyRole } from '../types';
+import {
+  AccountKeyDerivationPath,
+  CardanoKeyConst,
+  Ed25519KeyPair,
+  GroupedAddress,
+  KeyPair,
+  KeyPurpose,
+  KeyRole
+} from '../types';
 import { BIP32Path } from '@cardano-sdk/crypto';
 
 export const harden = (num: number): number => 0x80_00_00_00 + num;
@@ -26,15 +34,17 @@ export interface DeriveAccountPrivateKeyProps {
   rootPrivateKey: Crypto.Bip32PrivateKeyHex;
   accountIndex: number;
   bip32Ed25519: Crypto.Bip32Ed25519;
+  purpose?: KeyPurpose;
 }
 
 export const deriveAccountPrivateKey = async ({
   rootPrivateKey,
   accountIndex,
-  bip32Ed25519
+  bip32Ed25519,
+  purpose = KeyPurpose.STANDARD
 }: DeriveAccountPrivateKeyProps): Promise<Crypto.Bip32PrivateKeyHex> =>
   await bip32Ed25519.derivePrivateKey(rootPrivateKey, [
-    harden(CardanoKeyConst.PURPOSE),
+    harden(purpose),
     harden(CardanoKeyConst.COIN_TYPE),
     harden(accountIndex)
   ]);

--- a/packages/key-management/test/InMemoryKeyAgent.test.ts
+++ b/packages/key-management/test/InMemoryKeyAgent.test.ts
@@ -1,5 +1,13 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, GroupedAddress, InMemoryKeyAgent, KeyRole, SerializableInMemoryKeyAgentData, util } from '../src';
+import {
+  AddressType,
+  GroupedAddress,
+  InMemoryKeyAgent,
+  KeyPurpose,
+  KeyRole,
+  SerializableInMemoryKeyAgentData,
+  util
+} from '../src';
 import { Cardano } from '@cardano-sdk/core';
 import { HexBlob } from '@cardano-sdk/util';
 import { dummyLogger } from 'ts-log';
@@ -158,10 +166,12 @@ describe('InMemoryKeyAgent', () => {
             await util.deriveAccountPrivateKey({
               accountIndex: 0,
               bip32Ed25519,
+              purpose: KeyPurpose.STANDARD,
               rootPrivateKey: Crypto.Bip32PrivateKeyHex(yoroiRootPrivateKeyHex)
             })
           ),
-          getPassphrase
+          getPassphrase,
+          purpose: KeyPurpose.STANDARD
         },
         { bip32Ed25519, logger: dummyLogger }
       );
@@ -255,11 +265,14 @@ describe('InMemoryKeyAgent', () => {
             await util.deriveAccountPrivateKey({
               accountIndex: 0,
               bip32Ed25519,
+              purpose: KeyPurpose.STANDARD,
               rootPrivateKey: Crypto.Bip32PrivateKeyHex(daedalusRootPrivateKeyHex)
             })
           ),
           // daedelus enforces min length of 10
-          getPassphrase: jest.fn().mockResolvedValue(Buffer.from('nMmys*X002'))
+          getPassphrase: jest.fn().mockResolvedValue(Buffer.from('nMmys*X002')),
+
+          purpose: KeyPurpose.STANDARD
         },
         { bip32Ed25519, logger: dummyLogger }
       );

--- a/packages/key-management/test/KeyAgentBase.test.ts
+++ b/packages/key-management/test/KeyAgentBase.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, KeyAgentBase, KeyAgentType, KeyRole, SerializableInMemoryKeyAgentData } from '../src';
+import { AddressType, KeyAgentBase, KeyAgentType, KeyPurpose, KeyRole, SerializableInMemoryKeyAgentData } from '../src';
 import { Cardano } from '@cardano-sdk/core';
 import { dummyLogger } from 'ts-log';
 
@@ -35,7 +35,8 @@ describe('KeyAgentBase', () => {
       extendedAccountPublicKey: Crypto.Bip32PublicKeyHex(
         // eslint-disable-next-line max-len
         'fc5ab25e830b67c47d0a17411bf7fdabf711a597fb6cf04102734b0a2934ceaaa65ff5e7c52498d52c07b8ddfcd436fc2b4d2775e2984a49d0c79f65ceee4779'
-      )
+      ),
+      purpose: KeyPurpose.STANDARD
     });
   });
 

--- a/packages/wallet/test/services/KeyAgent/restoreKeyAgent.test.ts
+++ b/packages/wallet/test/services/KeyAgent/restoreKeyAgent.test.ts
@@ -5,6 +5,7 @@ import {
   GetPassphrase,
   KeyAgentDependencies,
   KeyAgentType,
+  KeyPurpose,
   SerializableInMemoryKeyAgentData,
   SerializableLedgerKeyAgentData,
   SerializableTrezorKeyAgentData,
@@ -41,7 +42,8 @@ describe('KeyManagement/restoreKeyAgent', () => {
       accountIndex: 0,
       chainId: Cardano.ChainIds.Preview,
       encryptedRootPrivateKeyBytes,
-      extendedAccountPublicKey
+      extendedAccountPublicKey,
+      purpose: KeyPurpose.STANDARD
     };
     // eslint-disable-next-line unicorn/consistent-function-scoping
     const getPassphrase: GetPassphrase = async () => Buffer.from('password');
@@ -76,7 +78,8 @@ describe('KeyManagement/restoreKeyAgent', () => {
       extendedAccountPublicKey: Crypto.Bip32PublicKeyHex(
         // eslint-disable-next-line max-len
         'fc5ab25e830b67c47d0a17411bf7fdabf711a597fb6cf04102734b0a2934ceaaa65ff5e7c52498d52c07b8ddfcd436fc2b4d2775e2984a49d0c79f65ceee4779'
-      )
+      ),
+      purpose: KeyPurpose.STANDARD
     };
 
     it('can restore key manager from valid data', async () => {
@@ -94,6 +97,7 @@ describe('KeyManagement/restoreKeyAgent', () => {
         // eslint-disable-next-line max-len
         'fc5ab25e830b67c47d0a17411bf7fdabf711a597fb6cf04102734b0a2934ceaaa65ff5e7c52498d52c07b8ddfcd436fc2b4d2775e2984a49d0c79f65ceee4779'
       ),
+      purpose: KeyPurpose.STANDARD,
       trezorConfig: {
         communicationType: CommunicationType.Node,
         manifest: {

--- a/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
@@ -1,7 +1,7 @@
 import { Cardano, Serialization } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 import { InMemoryWallet, WalletType } from '../types';
-import { KeyAgent, SignBlobResult, TrezorConfig, errors } from '@cardano-sdk/key-management';
+import { KeyAgent, KeyPurpose, SignBlobResult, TrezorConfig, errors } from '@cardano-sdk/key-management';
 import { KeyAgentFactory } from './KeyAgentFactory';
 import { Logger } from 'ts-log';
 import {
@@ -164,7 +164,8 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
                             ...Buffer.from(wallet.encryptedSecrets.rootPrivateKeyBytes, 'hex')
                           ],
                           extendedAccountPublicKey: account.extendedAccountPublicKey,
-                          getPassphrase: async () => passphrase
+                          getPassphrase: async () => passphrase,
+                          purpose: KeyPurpose.STANDARD
                         })
                       );
                       clearPassphrase(passphrase);
@@ -190,12 +191,14 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
                             accountIndex: request.requestContext.accountIndex,
                             chainId: request.requestContext.chainId,
                             communicationType: this.#hwOptions.communicationType,
-                            extendedAccountPublicKey: account.extendedAccountPublicKey
+                            extendedAccountPublicKey: account.extendedAccountPublicKey,
+                            purpose: KeyPurpose.STANDARD
                           })
                         : this.#keyAgentFactory.Trezor({
                             accountIndex: request.requestContext.accountIndex,
                             chainId: request.requestContext.chainId,
                             extendedAccountPublicKey: account.extendedAccountPublicKey,
+                            purpose: KeyPurpose.STANDARD,
                             trezorConfig: this.#hwOptions
                           })
                     ).catch((error) => throwMaybeWrappedWithNoRejectError(error, options)),

--- a/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
@@ -165,7 +165,7 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
                           ],
                           extendedAccountPublicKey: account.extendedAccountPublicKey,
                           getPassphrase: async () => passphrase,
-                          purpose: KeyPurpose.STANDARD
+                          purpose: account.purpose || KeyPurpose.STANDARD
                         })
                       );
                       clearPassphrase(passphrase);

--- a/packages/web-extension/src/walletManager/WalletRepository/types.ts
+++ b/packages/web-extension/src/walletManager/WalletRepository/types.ts
@@ -1,17 +1,20 @@
 import { AnyWallet, HardwareWallet, InMemoryWallet, ScriptWallet, WalletId } from '../types';
 import { Bip32PublicKeyHex } from '@cardano-sdk/crypto';
+import { KeyPurpose } from '@cardano-sdk/key-management';
 import { Observable } from 'rxjs';
 
 export type RemoveAccountProps = {
   walletId: WalletId;
   /** account' in cip1852 */
   accountIndex: number;
+  purpose?: KeyPurpose;
 };
 
 export type AddAccountProps<Metadata extends {}> = {
   walletId: WalletId;
   /** account' in cip1852 */
   accountIndex: number;
+  purpose?: KeyPurpose;
   metadata: Metadata;
   extendedAccountPublicKey: Bip32PublicKeyHex;
 };
@@ -24,6 +27,7 @@ export type UpdateWalletMetadataProps<Metadata extends {}> = {
 export type UpdateAccountMetadataProps<Metadata extends {}> = {
   /** account' in cip1852; must be specified for bip32 wallets */
   walletId: WalletId;
+  purpose?: KeyPurpose;
   accountIndex: number;
   metadata: Metadata;
 };

--- a/packages/web-extension/src/walletManager/types.ts
+++ b/packages/web-extension/src/walletManager/types.ts
@@ -1,4 +1,4 @@
-import { AccountKeyDerivationPath } from '@cardano-sdk/key-management';
+import { AccountKeyDerivationPath, KeyPurpose } from '@cardano-sdk/key-management';
 import { Bip32PublicKeyHex } from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { HexBlob } from '@cardano-sdk/util';
@@ -15,6 +15,7 @@ export type WalletId = string;
 
 export type Bip32WalletAccount<Metadata extends {}> = {
   accountIndex: number;
+  purpose?: KeyPurpose;
   /** e.g. account name, picture */
   metadata: Metadata;
   extendedAccountPublicKey: Bip32PublicKeyHex;
@@ -55,6 +56,7 @@ export type AnyBip32Wallet<WalletMetadata extends {}, AccountMetadata extends {}
 
 export type OwnSignerAccount = {
   walletId: WalletId;
+  purpose: KeyPurpose;
   accountIndex: number;
   stakingScriptKeyPath: AccountKeyDerivationPath;
   paymentScriptKeyPath: AccountKeyDerivationPath;

--- a/packages/web-extension/test/walletManager/util.ts
+++ b/packages/web-extension/test/walletManager/util.ts
@@ -1,5 +1,6 @@
 import { Bip32PublicKeyHex } from '@cardano-sdk/crypto';
 import { Bip32WalletAccount } from '../../src';
+import { KeyPurpose } from '@cardano-sdk/key-management';
 
 export type WalletMetadata = { name: string };
 export type AccountMetadata = { name: string };
@@ -9,8 +10,13 @@ export const createPubKey = (numWallet: number, accountIndex: number) =>
     `${numWallet}a4f80dea2632a17c99ae9d8b934abf02643db5426b889fef14709c85e294aa12ac1f1560a893ea7937c5bfbfdeab459b1a396f1174b9c5a673a640d01880c3${accountIndex}`
   );
 
-export const createAccount = (numWallet: number, accountIndex: number): Bip32WalletAccount<AccountMetadata> => ({
+export const createAccount = (
+  numWallet: number,
+  accountIndex: number,
+  purpose: KeyPurpose = KeyPurpose.STANDARD
+): Bip32WalletAccount<AccountMetadata> => ({
   accountIndex,
   extendedAccountPublicKey: createPubKey(numWallet, accountIndex),
-  metadata: { name: `Wallet ${numWallet} Account #${accountIndex}` }
+  metadata: { name: `Wallet ${numWallet} Account #${accountIndex}` },
+  purpose
 });


### PR DESCRIPTION
# Context
Key agent only supported CIP1852 which would make it impossible to create multi-sig keys complaint with CIP-1954

# Proposed Solution
Add support for CIP 1854 to key agent and wallet repository.

