### PR TITLE
fix(core): plutus list now encodes to canonical CBOR

### DIFF
--- a/packages/core/src/Serialization/PlutusData/PlutusList.ts
+++ b/packages/core/src/Serialization/PlutusData/PlutusList.ts
@@ -6,7 +6,7 @@ import { bytesToHex, hexToBytes } from '../../util/misc';
 /** A list of plutus data. */
 export class PlutusList {
   readonly #array = new Array<PlutusData>();
-  #useIndefiniteEncoding = true;
+  #useIndefiniteEncoding = false;
 
   /**
    * Serializes this PlutusList instance into its CBOR representation as a Uint8Array.

--- a/packages/core/test/Serialization/PlutusData.test.ts
+++ b/packages/core/test/Serialization/PlutusData.test.ts
@@ -142,7 +142,7 @@ describe('PlutusData', () => {
       data.add(Serialization.PlutusData.newInteger(4n));
       data.add(Serialization.PlutusData.newInteger(5n));
 
-      expect(data.toCbor()).toEqual('9f0102030405ff');
+      expect(data.toCbor()).toEqual('850102030405');
     });
 
     it('can encode a list of plutus list', () => {
@@ -162,7 +162,7 @@ describe('PlutusData', () => {
       outer.add(Serialization.PlutusData.newList(innerList));
       outer.add(Serialization.PlutusData.newInteger(5n));
 
-      expect(outer.toCbor()).toEqual('9f01029f0102030405ff9f0102030405ff05ff');
+      expect(outer.toCbor()).toEqual('85010285010203040585010203040505');
     });
   });
 
@@ -292,7 +292,7 @@ describe('PlutusData', () => {
 
       const data = new Serialization.ConstrPlutusData(0n, args);
 
-      expect(data.toCbor()).toEqual('d8799f0102030405ff');
+      expect(data.toCbor()).toEqual('d879850102030405');
     });
   });
 


### PR DESCRIPTION
# Context

PlutusList is not encoding following canonical CBOR (uses indefinite length array rather than the definite length form). see https://github.com/input-output-hk/cardano-js-sdk/issues/1318

# Proposed Solution

PlutusList should encode by default using definite length CBOR arrays.
