### PR TITLE
fix: allow unauthorized postgres connections

### DIFF
--- a/nix/cardano-services/deployments/asset.nix
+++ b/nix/cardano-services/deployments/asset.nix
@@ -48,8 +48,6 @@
           key = "username";
         };
       };
-      POSTGRES_SSL_ASSET = "true";
-      POSTGRES_SSL_CA_FILE_ASSET = "/tls/ca.crt";
     };
   };
 
@@ -88,8 +86,6 @@
           key = "username";
         };
       };
-      POSTGRES_SSL = "true";
-      POSTGRES_SSL_CA_FILE = "/tls/ca.crt";
     };
   };
 }

--- a/nix/cardano-services/deployments/backend.provider.nix
+++ b/nix/cardano-services/deployments/backend.provider.nix
@@ -56,8 +56,6 @@
             key = "username";
           };
         };
-        POSTGRES_SSL_DB_SYNC = "true";
-        POSTGRES_SSL_CA_FILE_DB_SYNC = "/tls/ca.crt";
       }
       // lib.optionalAttrs values.backend.passHandleDBArgs {
         POSTGRES_POOL_MAX_HANDLE = "10";
@@ -76,8 +74,6 @@
             key = "username";
           };
         };
-        POSTGRES_SSL_HANDLE = "true";
-        POSTGRES_SSL_CA_FILE_HANDLE = "/tls/ca.crt";
       };
   };
 }

--- a/nix/cardano-services/deployments/blockfrost-worker-deployment.nix
+++ b/nix/cardano-services/deployments/blockfrost-worker-deployment.nix
@@ -75,21 +75,7 @@
                     key = "username";
                   };
                 };
-                POSTGRES_SSL_DB_SYNC = "true";
-                POSTGRES_SSL_CA_FILE_DB_SYNC = "/tls/ca.crt";
               };
-              volumeMounts = [
-                {
-                  mountPath = "/tls";
-                  name = "tls";
-                }
-              ];
-            }
-          ];
-          volumes = [
-            {
-              name = "tls";
-              secret.secretName = "postgresql-server-cert";
             }
           ];
         };

--- a/nix/cardano-services/deployments/deployment.resource.nix
+++ b/nix/cardano-services/deployments/deployment.resource.nix
@@ -94,6 +94,7 @@ in {
 
                 volumeMounts = mkOption {
                   type = types.anything;
+                  default = {};
                 };
               };
             });

--- a/nix/cardano-services/deployments/handle.nix
+++ b/nix/cardano-services/deployments/handle.nix
@@ -46,8 +46,6 @@
           key = "username";
         };
       };
-      POSTGRES_SSL_HANDLE = "true";
-      POSTGRES_SSL_CA_FILE_HANDLE = "/tls/ca.crt";
     };
   };
 
@@ -87,8 +85,6 @@
           key = "username";
         };
       };
-      POSTGRES_SSL = "true";
-      POSTGRES_SSL_CA_FILE = "/tls/ca.crt";
     };
   };
 }

--- a/nix/cardano-services/deployments/pg-boss-worker-deployment.nix
+++ b/nix/cardano-services/deployments/pg-boss-worker-deployment.nix
@@ -79,8 +79,6 @@
                       key = "username";
                     };
                   };
-                  POSTGRES_SSL_STAKE_POOL = "true";
-                  POSTGRES_SSL_CA_FILE_STAKE_POOL = "/tls/ca.crt";
 
                   POSTGRES_POOL_MAX_DB_SYNC = "5";
                   POSTGRES_HOST_DB_SYNC = values.postgresName;
@@ -98,25 +96,11 @@
                       key = "username";
                     };
                   };
-                  POSTGRES_SSL_DB_SYNC = "true";
-                  POSTGRES_SSL_CA_FILE_DB_SYNC = "/tls/ca.crt";
                 }
                 // lib.optionalAttrs (values.pg-boss-worker ? env) values.pg-boss-worker.env
                 // lib.optionalAttrs (values.pg-boss-worker.metadata-fetch-mode == "smash") {
                   SMASH_URL = values.pg-boss-worker.smash-url;
                 });
-              volumeMounts = [
-                {
-                  mountPath = "/tls";
-                  name = "tls";
-                }
-              ];
-            }
-          ];
-          volumes = [
-            {
-              name = "tls";
-              secret.secretName = "postgresql-server-cert";
             }
           ];
         };

--- a/nix/cardano-services/deployments/projector.resource.nix
+++ b/nix/cardano-services/deployments/projector.resource.nix
@@ -76,10 +76,7 @@ in {
               runAsUser = 0;
               runAsGroup = 0;
             };
-
-            volumeMounts.tls.mountPath = "/tls";
           };
-          volumes.tls.secret.secretName = "postgresql-server-cert";
         };
       })
       config.projectors;

--- a/nix/cardano-services/deployments/provider.resource.nix
+++ b/nix/cardano-services/deployments/provider.resource.nix
@@ -132,19 +132,6 @@ in {
                       runAsGroup = 0;
                     };
                     env = utils.mkPodEnv value.env;
-
-                    volumeMounts = [
-                      {
-                        mountPath = "/tls";
-                        name = "tls";
-                      }
-                    ];
-                  }
-                ];
-                volumes = [
-                  {
-                    name = "tls";
-                    secret.secretName = "postgresql-server-cert";
                   }
                 ];
               };

--- a/nix/cardano-services/deployments/stake-pool.nix
+++ b/nix/cardano-services/deployments/stake-pool.nix
@@ -49,8 +49,6 @@
           key = "username";
         };
       };
-      POSTGRES_SSL_STAKE_POOL = "true";
-      POSTGRES_SSL_CA_FILE_STAKE_POOL = "/tls/ca.crt";
     };
   };
 
@@ -89,8 +87,6 @@
           key = "username";
         };
       };
-      POSTGRES_SSL = "true";
-      POSTGRES_SSL_CA_FILE = "/tls/ca.crt";
     };
   };
 }


### PR DESCRIPTION
# Context

We would like to avoid force-specifying certificates in deployments since it is causing us some headaches, this change fixes our issue

This PR points to the release branch, but since the next release is coming soon I would be okay with changing it to the master

Tested on ops-preview-1
I noticed that `cardano-services` tests were failing, I think it's because I don't have Postgres running locally. I will see how CI run goes
