### PR TITLE
feat: remove async from fromBip39Entropy

### DIFF
--- a/packages/crypto/src/Bip32/Bip32PrivateKey.ts
+++ b/packages/crypto/src/Bip32/Bip32PrivateKey.ts
@@ -5,7 +5,7 @@ import { Bip32PublicKey } from './Bip32PublicKey';
 import { EXTENDED_ED25519_PRIVATE_KEY_LENGTH, Ed25519PrivateKey } from '../Ed25519e';
 import { InvalidArgumentError } from '@cardano-sdk/util';
 import { crypto_scalarmult_ed25519_base_noclamp, ready } from 'libsodium-wrappers-sumo';
-import { pbkdf2 } from 'pbkdf2';
+import { pbkdf2Sync } from 'pbkdf2';
 
 const SCALAR_INDEX = 0;
 const SCALAR_SIZE = 32;
@@ -75,17 +75,15 @@ export class Bip32PrivateKey {
    * @param password The second factor authentication password for the mnemonic phrase.
    * @returns The secret extended key.
    */
-  static fromBip39Entropy(entropy: Buffer, password: string): Promise<Bip32PrivateKey> {
-    return new Promise((resolve, reject) => {
-      pbkdf2(password, entropy, PBKDF2_ITERATIONS, PBKDF2_KEY_SIZE, PBKDF2_DIGEST_ALGORITHM, (err, xprv) => {
-        if (err) {
-          reject(err);
-        }
-
-        xprv = clampScalar(xprv);
-        resolve(Bip32PrivateKey.fromBytes(xprv));
-      });
-    });
+  static fromBip39Entropy(entropy: Buffer, password: string): Bip32PrivateKey {
+    const xprv = pbkdf2Sync(
+      password,
+      entropy,
+      PBKDF2_ITERATIONS,
+      PBKDF2_KEY_SIZE,
+      PBKDF2_DIGEST_ALGORITHM
+    );
+    return Bip32PrivateKey.fromBytes(clampScalar(xprv));
   }
 
   /**

--- a/packages/crypto/src/Bip32/Bip32PrivateKey.ts
+++ b/packages/crypto/src/Bip32/Bip32PrivateKey.ts
@@ -76,13 +76,7 @@ export class Bip32PrivateKey {
    * @returns The secret extended key.
    */
   static fromBip39Entropy(entropy: Buffer, password: string): Bip32PrivateKey {
-    const xprv = pbkdf2Sync(
-      password,
-      entropy,
-      PBKDF2_ITERATIONS,
-      PBKDF2_KEY_SIZE,
-      PBKDF2_DIGEST_ALGORITHM
-    );
+    const xprv = pbkdf2Sync(password, entropy, PBKDF2_ITERATIONS, PBKDF2_KEY_SIZE, PBKDF2_DIGEST_ALGORITHM);
     return Bip32PrivateKey.fromBytes(clampScalar(xprv));
   }
 

--- a/packages/crypto/src/Bip32Ed25519.ts
+++ b/packages/crypto/src/Bip32Ed25519.ts
@@ -29,7 +29,7 @@ export interface Bip32Ed25519 {
    * @param passphrase The second factor authentication passphrase for the mnemonic phrase.
    * @returns The secret extended key.
    */
-  fromBip39Entropy(entropy: Buffer, passphrase: string): Promise<Bip32PrivateKeyHex>;
+  fromBip39Entropy(entropy: Buffer, passphrase: string): Bip32PrivateKeyHex;
 
   /**
    * The function computes a public key from the provided private key.

--- a/packages/crypto/src/strategies/CmlBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/CmlBip32Ed25519.ts
@@ -20,14 +20,14 @@ export class CmlBip32Ed25519 implements Bip32Ed25519 {
   constructor(CML: CardanoMultiplatformLib) {
     this.#CML = CML;
   }
-
-  public fromBip39Entropy(entropy: Buffer, passphrase: string): Promise<Bip32PrivateKeyHex> {
+  
+  public fromBip39Entropy(entropy: Buffer, passphrase: string): Bip32PrivateKeyHex {
     const hexKey = usingAutoFree((scope) => {
       const cmlKey = scope.manage(this.#CML.Bip32PrivateKey.from_bip39_entropy(entropy, Buffer.from(passphrase)));
       return cmlKey.as_bytes();
     });
 
-    return Promise.resolve(Bip32PrivateKeyHex(Buffer.from(hexKey).toString('hex')));
+    return Bip32PrivateKeyHex(Buffer.from(hexKey).toString('hex'));
   }
 
   public getPublicKey(

--- a/packages/crypto/src/strategies/CmlBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/CmlBip32Ed25519.ts
@@ -20,7 +20,7 @@ export class CmlBip32Ed25519 implements Bip32Ed25519 {
   constructor(CML: CardanoMultiplatformLib) {
     this.#CML = CML;
   }
-  
+
   public fromBip39Entropy(entropy: Buffer, passphrase: string): Bip32PrivateKeyHex {
     const hexKey = usingAutoFree((scope) => {
       const cmlKey = scope.manage(this.#CML.Bip32PrivateKey.from_bip39_entropy(entropy, Buffer.from(passphrase)));

--- a/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
@@ -16,9 +16,9 @@ import { HexBlob } from '@cardano-sdk/util';
 const EXTENDED_KEY_HEX_LENGTH = 128;
 
 export class SodiumBip32Ed25519 implements Bip32Ed25519 {
-  public async fromBip39Entropy(entropy: Buffer, passphrase: string): Promise<Bip32PrivateKeyHex> {
-    return (await Bip32PrivateKey.fromBip39Entropy(entropy, passphrase)).hex();
-  }
+  public fromBip39Entropy(entropy: Buffer, passphrase: string): Bip32PrivateKeyHex {
+    return Bip32PrivateKey.fromBip39Entropy(entropy, passphrase).hex();
+  } 
 
   public async getPublicKey(
     privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex

--- a/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
@@ -18,7 +18,7 @@ const EXTENDED_KEY_HEX_LENGTH = 128;
 export class SodiumBip32Ed25519 implements Bip32Ed25519 {
   public fromBip39Entropy(entropy: Buffer, passphrase: string): Bip32PrivateKeyHex {
     return Bip32PrivateKey.fromBip39Entropy(entropy, passphrase).hex();
-  } 
+  }
 
   public async getPublicKey(
     privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex

--- a/packages/crypto/test/bip32/Bip32PrivateKey.test.ts
+++ b/packages/crypto/test/bip32/Bip32PrivateKey.test.ts
@@ -28,7 +28,7 @@ describe('Bip32PrivateKey', () => {
     expect.assertions(extendedVectors.length);
 
     for (const vector of extendedVectors) {
-      const bip32Key = await Crypto.Bip32PrivateKey.fromBip39Entropy(
+      const bip32Key = Crypto.Bip32PrivateKey.fromBip39Entropy(
         Buffer.from(vector.bip39Entropy, 'hex'),
         vector.password
       );

--- a/packages/crypto/test/strategies/Bip32Ed25519.test.ts
+++ b/packages/crypto/test/strategies/Bip32Ed25519.test.ts
@@ -23,7 +23,7 @@ const testBip32Ed25519 = (name: string, bip32Ed25519: Crypto.Bip32Ed25519) => {
       expect.assertions(extendedVectors.length);
 
       for (const vector of extendedVectors) {
-        const bip32Key = await bip32Ed25519.fromBip39Entropy(Buffer.from(vector.bip39Entropy, 'hex'), vector.password);
+        const bip32Key = bip32Ed25519.fromBip39Entropy(Buffer.from(vector.bip39Entropy, 'hex'), vector.password);
         expect(bip32Key).toBe(vector.rootKey);
       }
     });

--- a/packages/key-management/src/InMemoryKeyAgent.ts
+++ b/packages/key-management/src/InMemoryKeyAgent.ts
@@ -101,7 +101,7 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
     const validMnemonic = validateMnemonic(mnemonic);
     if (!validMnemonic) throw new errors.InvalidMnemonicError();
     const entropy = Buffer.from(mnemonicWordsToEntropy(mnemonicWords), 'hex');
-    const rootPrivateKey = await dependencies.bip32Ed25519.fromBip39Entropy(entropy, mnemonic2ndFactorPassphrase);
+    const rootPrivateKey = dependencies.bip32Ed25519.fromBip39Entropy(entropy, mnemonic2ndFactorPassphrase);
     const passphrase = await getPassphraseRethrowTypedError(getPassphrase);
     const encryptedRootPrivateKey = await emip3encrypt(Buffer.from(rootPrivateKey, 'hex'), passphrase);
     const accountPrivateKey = await deriveAccountPrivateKey({


### PR DESCRIPTION
# Context

functions like [`fromBip39Entropy()`](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/crypto/src/Bip32/Bip32PrivateKey.ts#L80) are essential for them to operate without being async, so upstream functions do not required async.

# Proposed Solution

`pbkdf2` replace with `pbkdf2Sync`

# Important Changes Introduced

- functions using `fromBip39Entropy()` can remove `await`