### PR TITLE
chore: unify envalid version

### DIFF
--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -104,7 +104,7 @@
     "death": "^1.1.0",
     "debug": "^4.3.4",
     "dotenv": "^16.0.0",
-    "envalid": "^7.3.0",
+    "envalid": "^7.3.1",
     "express": "^4.17.3",
     "express-openapi-validator": "^4.13.8",
     "express-prom-bundle": "^6.4.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -48,7 +48,7 @@
     "@types/node-hid": "^1.3.1",
     "@types/pouchdb": "^6.4.0",
     "bunyan": "^1.8.15",
-    "envalid": "^7.3.0",
+    "envalid": "^7.3.1",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",
     "jest-webextension-mock": "^3.7.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,7 +3164,7 @@ __metadata:
     dockerode: ^3.3.1
     dockerode-utils: ^0.0.7
     dotenv: ^16.0.0
-    envalid: ^7.3.0
+    envalid: ^7.3.1
     eslint: ^7.32.0
     express: ^4.17.3
     express-openapi-validator: ^4.13.8
@@ -3771,7 +3771,7 @@ __metadata:
     bunyan: ^1.8.15
     delay: ^5.0.0
     emittery: ^0.10.0
-    envalid: ^7.3.0
+    envalid: ^7.3.1
     eslint: ^7.32.0
     jest: ^28.1.3
     jest-webextension-mock: ^3.7.19
@@ -12753,7 +12753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envalid@npm:^7.3.0, envalid@npm:^7.3.1":
+"envalid@npm:^7.3.1":
   version: 7.3.1
   resolution: "envalid@npm:7.3.1"
   dependencies:


### PR DESCRIPTION
# Context

In some packages we are using `envalid` `v7.3.0`, in some others `envalid` `v7.3.1`.

# Proposed Solution

Bumped the version in those packages using the lower one.