### PR TITLE
chore(util-dev): copy the correct esm-package.json

### DIFF
--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -24,7 +24,7 @@
   "sideEffects": false,
   "license": "Apache-2.0",
   "scripts": {
-    "build": "yarn build:cjs && tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020 && tsc-alias -p src/tsconfig.json --outDir ./dist/esm && cp ../../build/esm-package.json ./dist/esm/package.json && cp -rf src/chainSync/data dist/esm/chainSync/",
+    "build": "yarn build:cjs && tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020 && tsc-alias -p src/tsconfig.json --outDir ./dist/esm && cp ./esm-package.json ./dist/esm/package.json && cp -rf src/chainSync/data dist/esm/chainSync/",
     "build:cjs": "tsc --build src && cp ../../build/cjs-package.json ./dist/cjs/package.json && cp -rf src/chainSync/data dist/cjs/chainSync/",
     "circular-deps:check": "madge --circular dist/cjs",
     "tscNoEmit": "echo typescript --noEmit command not implemented yet",


### PR DESCRIPTION
# Context

This package has it's own variant of esm-package.json, because it has to set the 'browser' field to omit docker.js from browser builds.
