### PR TITLE
chore: whitelist all device models

### DIFF
--- a/packages/hardware-ledger/src/LedgerKeyAgent.ts
+++ b/packages/hardware-ledger/src/LedgerKeyAgent.ts
@@ -98,8 +98,6 @@ const stakeCredentialCert = (cert: Certificate) =>
   cert.type === CertificateType.STAKE_REGISTRATION ||
   cert.type === CertificateType.STAKE_DEREGISTRATION ||
   cert.type === CertificateType.STAKE_DELEGATION;
-const isLedgerModelSupported = (deviceModelId: string): deviceModelId is 'nanoS' | 'nanoX' | 'nanoSP' =>
-  ['nanoS', 'nanoX', 'nanoSP'].includes(deviceModelId);
 
 const establishDeviceConnectionMethodName = 'establishDeviceConnection';
 
@@ -383,9 +381,6 @@ export class LedgerKeyAgent extends KeyAgentBase {
 
       if (!transport || !transport.deviceModel) {
         throw new errors.TransportError('Missing transport');
-      }
-      if (!isLedgerModelSupported(transport.deviceModel.id)) {
-        throw new errors.TransportError(`Ledger device model: "${transport.deviceModel.id}" is not supported`);
       }
 
       const newConnection = await LedgerKeyAgent.createDeviceConnection(transport);

--- a/packages/hardware-trezor/src/TrezorKeyAgent.ts
+++ b/packages/hardware-trezor/src/TrezorKeyAgent.ts
@@ -129,9 +129,6 @@ export class TrezorKeyAgent extends KeyAgentBase {
       if (!deviceFeatures.success) {
         throw new errors.TransportError('Failed to get device', deviceFeatures.payload);
       }
-      if (deviceFeatures.payload.model !== 'T') {
-        throw new errors.TransportError(`Trezor device model "${deviceFeatures.payload.model}" is not supported.`);
-      }
       return deviceFeatures.payload;
     } catch (error) {
       throw transportTypedError(error);


### PR DESCRIPTION
# Context

This PR removes the device model's guard. All the possible Trezor and Ledger devices are whitelisted now. It is up to the end app to restrict usage.
[Jira](https://input-output.atlassian.net/browse/LW-10698)

# Important Changes Introduced
- All Trezor and Ledger device models are whitelisted now

# TODO:
- [X] Remove Trezor device models guard
- [x] Remove Ledger device models guard