### PR TITLE
chore(cardano-services-client): LW-10778 allow openapiVersion override when configuring client providers

### DIFF
--- a/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/AssetInfoProvider/assetInfoHttpProvider.ts
@@ -17,7 +17,7 @@ const paths: HttpProviderConfigPaths<AssetProvider> = {
 export const assetInfoHttpProvider = (config: CreateHttpProviderConfig<AssetProvider>): AssetProvider =>
   createHttpProvider<AssetProvider>({
     ...config,
-    apiVersion: apiVersion.assetInfo,
+    apiVersion: config.apiVersion || apiVersion.assetInfo,
     paths,
     serviceSlug: 'asset'
   });

--- a/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
+++ b/packages/cardano-services-client/src/ChainHistoryProvider/chainHistoryHttpProvider.ts
@@ -21,7 +21,7 @@ export const chainHistoryHttpProvider = (
 ): ChainHistoryProvider =>
   createHttpProvider<ChainHistoryProvider>({
     ...config,
-    apiVersion: apiVersion.chainHistory,
+    apiVersion: config.apiVersion || apiVersion.chainHistory,
     mapError: (error, method) => {
       if (method === 'healthCheck' && !error) {
         return { ok: false };

--- a/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
@@ -10,7 +10,7 @@ import { apiVersion } from '../version';
 export const handleHttpProvider = (config: CreateHttpProviderConfig<HandleProvider>): HandleProvider =>
   createHttpProvider<HandleProvider>({
     ...config,
-    apiVersion: apiVersion.handle,
+    apiVersion: config.apiVersion || apiVersion.handle,
     paths: handleProviderPaths,
     serviceSlug: 'handle'
   });

--- a/packages/cardano-services-client/src/HttpProvider.ts
+++ b/packages/cardano-services-client/src/HttpProvider.ts
@@ -45,7 +45,10 @@ export interface HttpProviderConfig<T extends Provider> {
 export type CreateHttpProviderConfig<T extends Provider> = Pick<
   HttpProviderConfig<T>,
   'baseUrl' | 'adapter' | 'logger'
->;
+> & {
+  /** Override the OpenApi version */
+  apiVersion?: string;
+};
 
 /**
  * Creates a HTTP client for specified provider type, following some conventions:

--- a/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
+++ b/packages/cardano-services-client/src/NetworkInfoProvider/networkInfoHttpProvider.ts
@@ -21,7 +21,7 @@ const paths: HttpProviderConfigPaths<NetworkInfoProvider> = {
 export const networkInfoHttpProvider = (config: CreateHttpProviderConfig<NetworkInfoProvider>): NetworkInfoProvider =>
   createHttpProvider<NetworkInfoProvider>({
     ...config,
-    apiVersion: apiVersion.networkInfo,
+    apiVersion: config.apiVersion || apiVersion.networkInfo,
     paths,
     serviceSlug: 'network-info'
   });

--- a/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
+++ b/packages/cardano-services-client/src/RewardsProvider/rewardsHttpProvider.ts
@@ -18,7 +18,7 @@ const paths: HttpProviderConfigPaths<RewardsProvider> = {
 export const rewardsHttpProvider = (config: CreateHttpProviderConfig<RewardsProvider>): RewardsProvider =>
   createHttpProvider<RewardsProvider>({
     ...config,
-    apiVersion: apiVersion.rewards,
+    apiVersion: config.apiVersion || apiVersion.rewards,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mapError: (error: any, method) => {
       if (method === 'healthCheck') {

--- a/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
+++ b/packages/cardano-services-client/src/StakePoolProvider/stakePoolHttpProvider.ts
@@ -17,7 +17,7 @@ const paths: HttpProviderConfigPaths<StakePoolProvider> = {
 export const stakePoolHttpProvider = (config: CreateHttpProviderConfig<StakePoolProvider>): StakePoolProvider =>
   createHttpProvider<StakePoolProvider>({
     ...config,
-    apiVersion: apiVersion.stakePool,
+    apiVersion: config.apiVersion || apiVersion.stakePool,
     paths,
     serviceSlug: 'stake-pool'
   });

--- a/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/txSubmitHttpProvider.ts
@@ -70,7 +70,7 @@ const codeToProviderFailure = (code: GeneralCardanoNodeErrorCode | TxSubmissionE
 export const txSubmitHttpProvider = (config: CreateHttpProviderConfig<TxSubmitProvider>): TxSubmitProvider =>
   createHttpProvider<TxSubmitProvider>({
     ...config,
-    apiVersion: apiVersion.txSubmit,
+    apiVersion: config.apiVersion || apiVersion.txSubmit,
     mapError: (error: any, method) => {
       switch (method) {
         case 'healthCheck': {

--- a/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
+++ b/packages/cardano-services-client/src/UtxoProvider/utxoHttpProvider.ts
@@ -17,7 +17,7 @@ const paths: HttpProviderConfigPaths<UtxoProvider> = {
 export const utxoHttpProvider = (config: CreateHttpProviderConfig<UtxoProvider>): UtxoProvider =>
   createHttpProvider<UtxoProvider>({
     ...config,
-    apiVersion: apiVersion.utxo,
+    apiVersion: config.apiVersion || apiVersion.utxo,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mapError: (error: any, method) => {
       if (method === 'healthCheck') {

--- a/packages/cardano-services-client/test/ChainHistoryProvider/chainHistoryProvider.test.ts
+++ b/packages/cardano-services-client/test/ChainHistoryProvider/chainHistoryProvider.test.ts
@@ -37,6 +37,17 @@ describe('chainHistoryProvider', () => {
         const provider = chainHistoryHttpProvider(config);
         await expect(provider.healthCheck()).resolves.toEqual({ ok: false });
       });
+
+      it('uses custom apiVersion', async () => {
+        axiosMock.onPost().replyOnce(200, { ok: true });
+        const provider = chainHistoryHttpProvider({ ...config, adapter: axiosMock.adapter(), apiVersion: '100' });
+        await provider.healthCheck();
+        expect(axiosMock.history).toEqual(
+          expect.objectContaining({
+            post: [expect.objectContaining({ baseURL: `${config.baseUrl}/v100/chain-history` })]
+          })
+        );
+      });
     });
 
     describe('blocks', () => {


### PR DESCRIPTION
LW-10778

openApi 3.1.0 version bump brought only two conway-era specific Redeemer purpose enum values: "vote" and "propose". Which makes it backwards compatible to 3.0.1 back-ends. But the version check does not allow querying 3.0.1 back-ends. 

This change will allow users to override the 3.1.0 version and perform requests with any custom version, in this case 3.0.1

