### PR TITLE
chore(ci): fix "curl: Argument list too long"

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -263,15 +263,17 @@ jobs:
             | jq -r --arg commentMarker "$COMMENT_MARKER" 'first(.[] | select(.body | contains($commentMarker)) | .id)'
           )
           if [ -z "$existingCommentId" ]; then
-            gh pr comment "$prNumber" --body "$(cat pr-comment.md) <!-- $COMMENT_MARKER -->"
+            ( cat pr-comment.md && echo "<!-- $COMMENT_MARKER -->" ; ) >gh-pr-comment-data.md
+            gh pr comment "$prNumber" --body-file gh-pr-comment-data.md
           else
+            jq --null-input --rawfile body pr-comment.md --arg marker "<!-- $COMMENT_MARKER -->" '{body: ($body + $marker)}' >curl-patch-data.json
             curl --fail-with-body -sSL \
               -X PATCH \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments/${existingCommentId}" \
-              -d "$(jq --null-input --arg body "$(cat pr-comment.md) <!-- $COMMENT_MARKER -->" '{body: $body}')"
+              -d @curl-patch-data.json
           fi
 
 


### PR DESCRIPTION
# Context

This fixes the flaky `curl: Argument list too long` error.

E.g. [here](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/9578082666/job/26408697313?pr=1337#step:8:38), but @mkazlauskas has been seeing it for some time now. 

# Proposed Solution

Read the PR comment from a file, not from `argv`.

# Important Changes Introduced

_n/a_