### PR TITLE
[lw-10539] export isValidSharedWalletScript util

### DIFF
--- a/packages/wallet/src/Wallets/util.ts
+++ b/packages/wallet/src/Wallets/util.ts
@@ -11,7 +11,7 @@ import { Cardano } from '@cardano-sdk/core';
 
 export const DEFAULT_LOOK_AHEAD_SEARCH = 20;
 
-const isValidSharedWalletScript = (script: Cardano.NativeScript): boolean => {
+export const isValidSharedWalletScript = (script: Cardano.NativeScript): boolean => {
   switch (script.kind) {
     case Cardano.NativeScriptKind.RequireAllOf:
     case Cardano.NativeScriptKind.RequireAnyOf:


### PR DESCRIPTION
# Context

`isValidSharedWalletScript` is required on the ui side to hide some of the settings options.