### PR TITLE
LW-10739 Make db cache and cardano node config common options

### DIFF
--- a/packages/cardano-services/src/Program/programs/providerServer.ts
+++ b/packages/cardano-services/src/Program/programs/providerServer.ts
@@ -9,6 +9,7 @@ import {
 } from '../../Asset';
 import { CardanoNode, HandleProvider, Seconds } from '@cardano-sdk/core';
 import { ChainHistoryHttpService, DbSyncChainHistoryProvider } from '../../ChainHistory';
+import { CommonOptionsDescriptions } from '../options';
 import { ConnectionNames, PostgresOptionDescriptions, suffixType2Cli } from '../options/postgres';
 import { DbPools, DbSyncEpochPollService } from '../../util';
 import { DbSyncNetworkInfoProvider, NetworkInfoHttpService } from '../../NetworkInfo';
@@ -41,7 +42,6 @@ import { isNotNil } from '@cardano-sdk/util';
 import memoize from 'lodash/memoize.js';
 
 export const ALLOWED_ORIGINS_DEFAULT = false;
-export const DISABLE_DB_CACHE_DEFAULT = false;
 export const DISABLE_STAKE_POOL_METRIC_APY_DEFAULT = false;
 export const PROVIDER_SERVER_API_URL_DEFAULT = new URL('http://localhost:3000');
 export const PAGINATION_PAGE_SIZE_LIMIT_DEFAULT = 25;
@@ -107,9 +107,8 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
   const getEpochMonitor = memoize((dbPool: Pool) => new DbSyncEpochPollService(dbPool, args.epochPollInterval!));
 
   const getDbSyncStakePoolProvider = withDbSyncProvider((dbPools, cardanoNode) => {
-    if (!genesisData) {
-      throw new MissingProgramOption(ServiceNames.StakePool, ProviderServerOptionDescriptions.CardanoNodeConfigPath);
-    }
+    if (!genesisData)
+      throw new MissingProgramOption(ServiceNames.StakePool, CommonOptionsDescriptions.CardanoNodeConfigPath);
 
     return new DbSyncStakePoolProvider(
       {
@@ -146,7 +145,7 @@ const serviceMapFactory = (options: ServiceMapFactoryOptions) => {
     }
 
     if (!genesisData)
-      throw new MissingProgramOption(ServiceNames.NetworkInfo, ProviderServerOptionDescriptions.CardanoNodeConfigPath);
+      throw new MissingProgramOption(ServiceNames.NetworkInfo, CommonOptionsDescriptions.CardanoNodeConfigPath);
 
     networkInfoProvider = new DbSyncNetworkInfoProvider({
       cache: {

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -46,9 +46,6 @@ export enum ProjectorOptionDescriptions {
 export enum ProviderServerOptionDescriptions {
   AllowedOrigins = 'List of allowed CORS origins separated by comma',
   AssetCacheTtl = 'Asset info and NFT Metadata cache TTL in seconds (600 by default)',
-  CardanoNodeConfigPath = 'Cardano node config path',
-  DbCacheTtl = 'Cache TTL in seconds between 60 and 172800 (two days), an option for database related operations',
-  DisableDbCache = 'Disable DB cache',
   DisableStakePoolMetricApy = 'Omit this metric for improved query performance',
   EpochPollInterval = 'Epoch poll interval',
   FuzzyOptions = 'Options for the fuzzy search on stake pool metadata',
@@ -78,9 +75,6 @@ export type ProviderServerArgs = CommonProgramOptions &
   TypeOrmStakePoolProviderProps & {
     allowedOrigins?: string[];
     assetCacheTTL?: Seconds;
-    cardanoNodeConfigPath?: string;
-    dbCacheTtl: Seconds | 0;
-    disableDbCache?: boolean;
     disableStakePoolMetricApy?: boolean;
     epochPollInterval: number;
     handleProviderServerUrl?: string;

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -10,7 +10,6 @@ import {
   CACHE_TTL_DEFAULT,
   CREATE_SCHEMA_DEFAULT,
   DEFAULT_HEALTH_CHECK_CACHE_TTL,
-  DISABLE_DB_CACHE_DEFAULT,
   DISABLE_STAKE_POOL_METRIC_APY_DEFAULT,
   DROP_SCHEMA_DEFAULT,
   DRY_RUN_DEFAULT,
@@ -241,26 +240,6 @@ addOptions(withOgmiosOptions(withHandlePolicyIdsOptions(providerServerWithCommon
     'ASSET_CACHE_TTL',
     dbCacheValidator(ProviderServerOptionDescriptions.AssetCacheTtl),
     DB_CACHE_TTL_DEFAULT
-  ),
-  newOption(
-    '--cardano-node-config-path <cardanoNodeConfigPath>',
-    ProviderServerOptionDescriptions.CardanoNodeConfigPath,
-    'CARDANO_NODE_CONFIG_PATH'
-  ),
-  newOption(
-    '--db-cache-ttl <dbCacheTtl>',
-    ProviderServerOptionDescriptions.DbCacheTtl,
-    'DB_CACHE_TTL',
-    dbCacheValidator(ProviderServerOptionDescriptions.DbCacheTtl),
-    DB_CACHE_TTL_DEFAULT
-  ),
-  newOption(
-    '--disable-db-cache <true/false>',
-    ProviderServerOptionDescriptions.DisableDbCache,
-    'DISABLE_DB_CACHE',
-    (disableDbCache) =>
-      stringOptionToBoolean(disableDbCache, Programs.ProviderServer, ProviderServerOptionDescriptions.DisableDbCache),
-    DISABLE_DB_CACHE_DEFAULT
   ),
   newOption(
     '--disable-stake-pool-metric-apy <true/false>',
@@ -513,7 +492,7 @@ if (process.argv.slice(2).length === 0) {
   program.outputHelp();
   process.exit(1);
 } else {
-  program.parseAsync(process.argv).catch((error) => {
+  program.parseAsync().catch((error) => {
     // eslint-disable-next-line no-console
     console.error(error);
     process.exit(1);

--- a/packages/cardano-services/test/Program/programs/httpServer.test.ts
+++ b/packages/cardano-services/test/Program/programs/httpServer.test.ts
@@ -1,17 +1,17 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { DB_CACHE_TTL_DEFAULT } from '../../../src/InMemoryCache';
 import {
+  CommonOptionsDescriptions,
   DEFAULT_HEALTH_CHECK_CACHE_TTL,
   OgmiosOptionDescriptions,
   PostgresOptionDescriptions,
   StakePoolMetadataFetchMode
 } from '../../../src/Program/options';
+import { DB_CACHE_TTL_DEFAULT } from '../../../src/InMemoryCache';
 import { EPOCH_POLL_INTERVAL_DEFAULT } from '../../../src/util';
 import {
   HttpServer,
   MissingCardanoNodeOption,
   MissingProgramOption,
-  ProviderServerOptionDescriptions,
   SERVICE_DISCOVERY_BACKOFF_FACTOR_DEFAULT,
   SERVICE_DISCOVERY_TIMEOUT_DEFAULT,
   ServiceNames,
@@ -251,9 +251,7 @@ describe('HTTP Server', () => {
             postgresConnectionStringDbSync: 'postgres',
             serviceNames: [serviceName]
           })
-        ).rejects.toThrow(
-          new MissingProgramOption(serviceName, ProviderServerOptionDescriptions.CardanoNodeConfigPath)
-        );
+        ).rejects.toThrow(new MissingProgramOption(serviceName, CommonOptionsDescriptions.CardanoNodeConfigPath));
 
       it('with network-info provider', () => test(ServiceNames.NetworkInfo));
       it('with stake-pool provider', () => test(ServiceNames.StakePool));

--- a/packages/cardano-services/test/Program/services/pgboss.test.ts
+++ b/packages/cardano-services/test/Program/services/pgboss.test.ts
@@ -118,6 +118,7 @@ describe('PgBossHttpService', () => {
     service = new PgBossHttpService(
       {
         apiUrl: new URL('http://unused/'),
+        dbCacheTtl: 0,
         lastRosEpochs: 10,
         metadataFetchMode: StakePoolMetadataFetchMode.DIRECT,
         parallelJobs: 3,
@@ -151,6 +152,7 @@ describe('PgBossHttpService', () => {
     service = new PgBossHttpService(
       {
         apiUrl: new URL('http://unused/'),
+        dbCacheTtl: 0,
         lastRosEpochs: 10,
         metadataFetchMode: StakePoolMetadataFetchMode.DIRECT,
         parallelJobs: 3,

--- a/packages/cardano-services/test/util/validators.test.ts
+++ b/packages/cardano-services/test/util/validators.test.ts
@@ -1,34 +1,33 @@
 import { OutsideRangeError } from '@cardano-sdk/util';
-import { ProviderServerOptionDescriptions } from '../../src';
 import { cacheTtlValidator } from '../../src/util/validators';
+
+const testDescription = 'test';
 
 describe('utils/validators', () => {
   describe('cacheTtlValidator', () => {
     it('returns TTL in seconds with a valid value within the range', async () => {
-      expect(
-        cacheTtlValidator('240', { lowerBound: 0, upperBound: 500 }, ProviderServerOptionDescriptions.DbCacheTtl)
-      ).toEqual(240);
+      expect(cacheTtlValidator('240', { lowerBound: 0, upperBound: 500 }, testDescription)).toEqual(240);
     });
 
     it('throws a validation error if TTL is not a valid number', async () => {
       const ttl = 'not a number';
       const range = { lowerBound: 0, upperBound: 1 };
-      expect(() => cacheTtlValidator(ttl, range, ProviderServerOptionDescriptions.DbCacheTtl)).toThrow(TypeError);
+      expect(() => cacheTtlValidator(ttl, range, testDescription)).toThrow(TypeError);
     });
 
     it('throws a validation error if TTL is lower than the lower limit', async () => {
       const ttl = '9';
       const range = { lowerBound: 10, upperBound: 15 };
-      expect(() => cacheTtlValidator(ttl, range, ProviderServerOptionDescriptions.DbCacheTtl)).toThrowError(
-        new OutsideRangeError(ttl, range, ProviderServerOptionDescriptions.DbCacheTtl)
+      expect(() => cacheTtlValidator(ttl, range, testDescription)).toThrowError(
+        new OutsideRangeError(ttl, range, testDescription)
       );
     });
 
     it('throws a validation error if TTL is higher than the upper limit', async () => {
       const ttl = '16';
       const range = { lowerBound: 10, upperBound: 15 };
-      expect(() => cacheTtlValidator(ttl, range, ProviderServerOptionDescriptions.DbCacheTtl)).toThrowError(
-        new OutsideRangeError(ttl, range, ProviderServerOptionDescriptions.DbCacheTtl)
+      expect(() => cacheTtlValidator(ttl, range, testDescription)).toThrowError(
+        new OutsideRangeError(ttl, range, testDescription)
       );
     });
   });


### PR DESCRIPTION
# Context

Dba cache and cardano node configuration options are specific of the provider-server, but working LW-10739 I noticed they can be useful for other services.

# Proposed Solution

Moved the options to common options section.
