### PR TITLE
fix(core): cbor encoding of witnessSet is now preserved upon re-serialization

### DIFF
--- a/packages/core/src/Serialization/Common/CborSet.ts
+++ b/packages/core/src/Serialization/Common/CborSet.ts
@@ -16,6 +16,7 @@ interface CborSerializable<C> {
  */
 export class CborSet<C, T extends CborSerializable<C>> {
   #values: T[];
+  #originalBytes: HexBlob | undefined = undefined;
 
   // Prevent users from directly creating an instance. Only allow creating via fromCore or fromCbor.
   private constructor(values: T[]) {
@@ -43,6 +44,8 @@ export class CborSet<C, T extends CborSerializable<C>> {
       cborSet.#values.push(fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
     }
 
+    cborSet.#originalBytes = cbor;
+
     return cborSet;
   }
 
@@ -53,6 +56,8 @@ export class CborSet<C, T extends CborSerializable<C>> {
    * or as an the array.
    */
   toCbor(): HexBlob {
+    if (this.#originalBytes) return this.#originalBytes;
+
     const writer = new CborWriter();
 
     if (inConwayEra) writer.writeTag(CborTag.Set);
@@ -92,6 +97,7 @@ export class CborSet<C, T extends CborSerializable<C>> {
   /** Returns the values of the set as an array */
   setValues(values: T[]): void {
     this.#values = [...values];
+    this.#originalBytes = undefined;
   }
 
   size() {

--- a/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/Redeemers.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/Redeemer/Redeemers.ts
@@ -12,6 +12,7 @@ const MAP_VALUE_EMBEDDED_GROUP_SIZE = 2;
 
 export class Redeemers {
   #values: Redeemer[];
+  #originalBytes: HexBlob | undefined = undefined;
 
   private constructor(redeemers: Redeemer[]) {
     this.#values = [...redeemers];
@@ -25,6 +26,8 @@ export class Redeemers {
    * @returns The Redeemers in CBOR format.
    */
   toCbor(): HexBlob {
+    if (this.#originalBytes) return this.#originalBytes;
+
     const writer = new CborWriter();
     // Encoding `redeemers` as `Map`:
     // https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/conway/impl/cddl-files/conway.cddl#L480
@@ -103,7 +106,12 @@ export class Redeemers {
 
       reader.readEndArray();
     }
-    return new Redeemers(redeemers);
+
+    const result = new Redeemers(redeemers);
+
+    result.#originalBytes = cbor;
+
+    return result;
   }
 
   /**
@@ -132,6 +140,7 @@ export class Redeemers {
   /** @param redeemers replace the existing redeemers with the ones provided here  */
   setValues(redeemers: Redeemer[]) {
     this.#values = [...redeemers];
+    this.#originalBytes = undefined;
   }
 
   size() {

--- a/packages/core/test/Serialization/TransactionWitnessSet/VkeyWitness.test.ts
+++ b/packages/core/test/Serialization/TransactionWitnessSet/VkeyWitness.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
-import { VkeyWitness } from '../../../src/Serialization';
+import { TransactionWitnessSet, VkeyWitness } from '../../../src/Serialization';
 
 // Test data used in the following tests was generated with the cardano-serialization-lib
 const cbor = HexBlob(
@@ -40,5 +40,27 @@ describe('VkeyWitness', () => {
   it('can encode VkeyWitness to Core', () => {
     const witness = VkeyWitness.fromCbor(cbor);
     expect(witness.toCore()).toEqual([vkey, signature]);
+  });
+
+  it('should preserve original CBOR encoding of properties that do not change', () => {
+    const combinedWitnesses = HexBlob(
+      'a40081825820cb845bb836d4baf4edffb9f76198072cbc70f0d8bb5402644ffd4db17e65259f5840af14dccbdbb1fc9d122ba240df264336a6543a44cd2207bc3e7f3c671c3ecb156a4e9902dc1f15277a933d8ce57dc77960eaf0f58e0b1581aa1810dd6300170c03814e4d01000033222220051200120011049f4b7375706572736563726574ff0581840000d87980821a006acfc01ab2d05e00'
+    );
+
+    const witnessWithDatum = TransactionWitnessSet.fromCbor(
+      HexBlob(
+        'a303814e4d01000033222220051200120011049f4b7375706572736563726574ff0581840000d87980821a006acfc01ab2d05e00'
+      )
+    );
+
+    const vkWitness = TransactionWitnessSet.fromCbor(
+      HexBlob(
+        'a10081825820cb845bb836d4baf4edffb9f76198072cbc70f0d8bb5402644ffd4db17e65259f5840af14dccbdbb1fc9d122ba240df264336a6543a44cd2207bc3e7f3c671c3ecb156a4e9902dc1f15277a933d8ce57dc77960eaf0f58e0b1581aa1810dd6300170c'
+      )
+    );
+
+    witnessWithDatum.setVkeys(vkWitness.vkeys()!);
+
+    expect(witnessWithDatum.toCbor()).toEqual(combinedWitnesses);
   });
 });


### PR DESCRIPTION
# Context

Witness set properties were not preserving original CBOR encoding upon re-serialization.

# Proposed Solution

CborSet and Reedemers types now implement a cache mechanism.

# Important Changes Introduced

CborSet and Redeemers now preserve their CBOR encoding unless changed.
