### PR TITLE
chore: enable chain-history dev-main*

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -512,6 +512,7 @@ in
               env.NODE_ENV = "production";
             };
             handle-provider.enabled = true;
+            chain-history-provider.enabled = true;
             # asset-provider = {
             #   enabled = true;
             #   env.NODE_ENV = "production";
@@ -583,6 +584,7 @@ in
               env.NODE_ENV = "production";
             };
             handle-provider.enabled = true;
+            chain-history-provider.enabled = true;
             #asset-provider = {
             #  enabled = true;
             #  env.NODE_ENV = "production";
@@ -655,6 +657,7 @@ in
               enabled = true;
               env.NODE_ENV = "production";
             };
+            chain-history-provider.enabled = true;
             #asset-provider = {
             #  enabled = true;
             #  env.NODE_ENV = "production";
@@ -716,6 +719,7 @@ in
               enabled = true;
               env.NODE_ENV = "production";
             };
+            chain-history-provider.enabled = true;
             #asset-provider = {
             #  enabled = true;
             #  env.NODE_ENV = "production";
@@ -777,6 +781,7 @@ in
               enabled = true;
               env.NODE_ENV = "production";
             };
+            chain-history-provider.enabled = true;
             #asset-provider = {
             #  enabled = true;
             #  env.NODE_ENV = "production";
@@ -839,6 +844,7 @@ in
               enabled = true;
               env.NODE_ENV = "production";
             };
+            chain-history-provider.enabled = true;
             #asset-provider = {
             #  enabled = true;
             #  env.NODE_ENV = "production";

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -345,6 +345,7 @@ in
             };
             handle-provider.enabled = true;
             # asset-provider.enabled = true;
+            chain-history-provider.enabled = true;
           };
 
           projectors = {


### PR DESCRIPTION
This PR promotes the chain-history service separation through the rest of the environments. It was already added to staging and dev-pre* I  manually deployed the dev-mainnet contained in this PR. 

NOTE: This PR blocks the release of @cardano-sdk/cardano-services@0.28.12 . I did not consider the patch when I started testing and merging this work. If there are concerns with the overlapping work this can be made configurable.

The separation included here is low risk as it uses existing infra, just isolating one service to its own resources.