### PR TITLE
LW-10842 Add the web socket load test GHA skeleton to make it appear on the website

### DIFF
--- a/.github/workflows/k6-web-socket.yaml
+++ b/.github/workflows/k6-web-socket.yaml
@@ -1,0 +1,11 @@
+name: K6 WebSocket server load tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  web-socket:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3


### PR DESCRIPTION
# Context

Newly added `workflow_dispatch` workflow are not shown in the `Actions` tab unless merged in the default branch.

# Proposed Solution

Added an empty skeleton just to make it appear on the website, next I can select the right branch... etc...