### PR TITLE
chore: enable asset projector in remaining dev envs

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -351,7 +351,7 @@ in
           projectors = {
             handle.enabled = true;
             stake-pool.enabled = true;
-            # asset.enabled = true;
+            asset.enabled = true;
           };
 
           values = {
@@ -476,7 +476,7 @@ in
           projectors = {
             handle.enabled = true;
             stake-pool.enabled = true;
-            # asset.enabled = true;
+            asset.enabled = true;
           };
      
 


### PR DESCRIPTION
# Context

Enable asset projector in remaining dev envs to give time to initialise before enabling typeORM asset provider