### PR TITLE
chore(ci): correct how `std.yml` enters the devshell

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
           echo 'export K8S_USER=eks-devs' >.envrc.local
 
-          nix develop .#x86_64-linux.local.envs.main -L --command bash -c '
+          nix develop -L --command bash -c '
             set -euo pipefail
 
             export AWS_PROFILE="lw"
@@ -323,7 +323,7 @@ jobs:
         run: |
           echo 'export K8S_USER=eks-devs' >.envrc.local
 
-          nix develop .#x86_64-linux.local.envs.main -L --command bash -c '
+          nix develop -L --command bash -c '
             set -euo pipefail
 
             export AWS_PROFILE="lw"


### PR DESCRIPTION
# Context

A follow-up to PR #1350

We missed a [failing check](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/9939246371/job/27453458427).

# Proposed Solution

Correct the attr path of the new devshell in `std.yml` – it’s the default one now.

# Important Changes Introduced

_n/a_