### PR TITLE
Fix lw-10852 Ledger hw sign voting proposals

### DIFF
--- a/packages/hardware-ledger/src/LedgerKeyAgent.ts
+++ b/packages/hardware-ledger/src/LedgerKeyAgent.ts
@@ -552,10 +552,12 @@ export class LedgerKeyAgent extends KeyAgentBase {
     { knownAddresses, txInKeyPathMap }: SignTransactionContext
   ): Promise<Cardano.Signatures> {
     try {
+      const dRepPublicKey = await this.derivePublicKey(util.DREP_KEY_DERIVATION_PATH);
+      const dRepKeyHashHex = (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex();
       const ledgerTxData = await toLedgerTx(body, {
         accountIndex: this.accountIndex,
         chainId: this.chainId,
-        dRepPublicKey: await this.derivePublicKey(util.DREP_KEY_DERIVATION_PATH),
+        dRepKeyHashHex,
         knownAddresses,
         txInKeyPathMap
       });

--- a/packages/hardware-ledger/src/transformers/tx.ts
+++ b/packages/hardware-ledger/src/transformers/tx.ts
@@ -16,7 +16,7 @@ import { mapWithdrawals } from './withdrawals';
 
 export const LedgerTxTransformer: Transformer<Cardano.TxBody, Ledger.Transaction, LedgerTxTransformerContext> = {
   auxiliaryData: ({ auxiliaryDataHash }) => mapAuxiliaryData(auxiliaryDataHash),
-  certificates: async ({ certificates }, context) => await mapCerts(certificates, context!),
+  certificates: ({ certificates }, context) => mapCerts(certificates, context!),
   collateralInputs: ({ collaterals }, context) => mapCollateralTxIns(collaterals, context!),
   collateralOutput: ({ collateralReturn }, context) => mapCollateralTxOut(collateralReturn, context!),
   donation: ({ donation }) => donation,

--- a/packages/hardware-ledger/src/transformers/tx.ts
+++ b/packages/hardware-ledger/src/transformers/tx.ts
@@ -36,7 +36,7 @@ export const LedgerTxTransformer: Transformer<Cardano.TxBody, Ledger.Transaction
   treasury: ({ treasuryValue }) => treasuryValue,
   ttl: ({ validityInterval }) => validityInterval?.invalidHereafter,
   validityIntervalStart: ({ validityInterval }) => validityInterval?.invalidBefore,
-  votingProcedures: ({ votingProcedures }) => mapVotingProcedures(votingProcedures),
+  votingProcedures: ({ votingProcedures }, context) => mapVotingProcedures(votingProcedures, context!),
   withdrawals: ({ withdrawals }, context) => mapWithdrawals(withdrawals, context!)
 };
 

--- a/packages/hardware-ledger/test/testData.ts
+++ b/packages/hardware-ledger/test/testData.ts
@@ -342,7 +342,7 @@ export const CONTEXT_WITH_KNOWN_ADDRESSES: LedgerTxTransformerContext = {
     networkId: Cardano.NetworkId.Testnet,
     networkMagic: 999
   },
-  dRepPublicKey: Crypto.Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01'),
+  dRepKeyHashHex: Crypto.Ed25519KeyHashHex(dRepCredential.hash),
   knownAddresses: [
     {
       accountIndex: 0,

--- a/packages/hardware-ledger/test/testData.ts
+++ b/packages/hardware-ledger/test/testData.ts
@@ -409,7 +409,7 @@ export const votes = [
 export const dRepKeyHashVoter: Cardano.Voter = {
   __typename: Cardano.VoterType.dRepKeyHash,
   credential: {
-    hash: stakeCredential.hash,
+    hash: dRepCredential.hash,
     type: Cardano.CredentialType.KeyHash
   }
 };

--- a/packages/hardware-ledger/test/transformers/certificates.test.ts
+++ b/packages/hardware-ledger/test/transformers/certificates.test.ts
@@ -73,7 +73,7 @@ export const createTxInKeyPathMapMock = (knownAddresses: GroupedAddress[]): TxIn
 const mockContext: LedgerTxTransformerContext = {
   accountIndex: 0,
   chainId: createChainId(1, 764_824_073),
-  dRepPublicKey: undefined,
+  dRepKeyHashHex: undefined,
 
   handleResolutions: [],
 
@@ -93,15 +93,15 @@ const DNS_NAME = 'example.com';
 
 describe('certificates', () => {
   describe('mapCerts', () => {
-    it('returns null when given an undefined token map', async () => {
+    it('returns null when given an undefined token map', () => {
       const certs: Cardano.Certificate | undefined = undefined;
-      const ledgerCerts = await mapCerts(certs, CONTEXT_WITHOUT_KNOWN_ADDRESSES);
+      const ledgerCerts = mapCerts(certs, CONTEXT_WITHOUT_KNOWN_ADDRESSES);
 
       expect(ledgerCerts).toEqual(null);
     });
 
-    it('can map a script hash stake registration certificate', async () => {
-      const ledgerCerts = await mapCerts(
+    it('can map a script hash stake registration certificate', () => {
+      const ledgerCerts = mapCerts(
         [
           {
             __typename: Cardano.CertificateType.StakeRegistration,
@@ -124,8 +124,8 @@ describe('certificates', () => {
       ]);
     });
 
-    it('can map a stake key stake registration certificate', async () => {
-      const ledgerCerts = await mapCerts(
+    it('can map a stake key stake registration certificate', () => {
+      const ledgerCerts = mapCerts(
         [
           {
             __typename: Cardano.CertificateType.StakeRegistration,
@@ -154,8 +154,8 @@ describe('certificates', () => {
       ]);
     });
 
-    it('can map a script hash stake deregistration certificate', async () => {
-      const ledgerCerts = await mapCerts(
+    it('can map a script hash stake deregistration certificate', () => {
+      const ledgerCerts = mapCerts(
         [
           {
             __typename: Cardano.CertificateType.StakeDeregistration,
@@ -178,8 +178,8 @@ describe('certificates', () => {
       ]);
     });
 
-    it('can map a stake key stake deregistration certificate', async () => {
-      const ledgerCerts = await mapCerts(
+    it('can map a stake key stake deregistration certificate', () => {
+      const ledgerCerts = mapCerts(
         [
           {
             __typename: Cardano.CertificateType.StakeDeregistration,
@@ -208,9 +208,9 @@ describe('certificates', () => {
       ]);
     });
 
-    it('can map a pool registration certificate with known keys', async () => {
+    it('can map a pool registration certificate with known keys', () => {
       expect(
-        await mapCerts(
+        mapCerts(
           [
             {
               __typename: Cardano.CertificateType.PoolRegistration,
@@ -299,9 +299,9 @@ describe('certificates', () => {
       ]);
     });
 
-    it('can map a pool registration certificate with unknown keys', async () => {
+    it('can map a pool registration certificate with unknown keys', () => {
       expect(
-        await mapCerts(
+        mapCerts(
           [
             {
               __typename: Cardano.CertificateType.PoolRegistration,
@@ -372,8 +372,8 @@ describe('certificates', () => {
       ]);
     });
 
-    it('throws if its given a pool retirement certificate but the signing key cant be found', async () => {
-      await expect(
+    it('throws if its given a pool retirement certificate but the signing key cant be found', () => {
+      expect(() =>
         mapCerts(
           [
             {
@@ -384,11 +384,11 @@ describe('certificates', () => {
           ],
           CONTEXT_WITHOUT_KNOWN_ADDRESSES
         )
-      ).rejects.toThrow("Invalid argument 'certificate': Missing key matching pool retirement certificate.");
+      ).toThrow("Invalid argument 'certificate': Missing key matching pool retirement certificate.");
     });
 
-    it('can map a stake pool retirement certificate', async () => {
-      const ledgerCerts = await mapCerts(
+    it('can map a stake pool retirement certificate', () => {
+      const ledgerCerts = mapCerts(
         [
           {
             __typename: Cardano.CertificateType.PoolRetirement,
@@ -416,8 +416,8 @@ describe('certificates', () => {
       ]);
     });
 
-    it('can map a delegation certificate with unknown stake key', async () => {
-      const ledgerCerts = await mapCerts(
+    it('can map a delegation certificate with unknown stake key', () => {
+      const ledgerCerts = mapCerts(
         [
           {
             __typename: Cardano.CertificateType.StakeDelegation,
@@ -442,8 +442,8 @@ describe('certificates', () => {
       ]);
     });
 
-    it('can map a delegation certificate with known stake key', async () => {
-      const ledgerCerts = await mapCerts(
+    it('can map a delegation certificate with known stake key', () => {
+      const ledgerCerts = mapCerts(
         [
           {
             __typename: Cardano.CertificateType.StakeDelegation,
@@ -512,8 +512,8 @@ describe('certificates', () => {
   });
   describe('conway-era', () => {
     describe('Cardano.CertificateType.Registration', () => {
-      it('can map a script hash type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a script hash type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.Registration,
@@ -538,8 +538,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it('can map a key path type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a key path type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.Registration,
@@ -573,8 +573,8 @@ describe('certificates', () => {
       it.todo('can map a key hash type of params');
     });
     describe('Cardano.CertificateType.Unregistration', () => {
-      it('can map a script hash type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a script hash type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.Unregistration,
@@ -599,8 +599,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it('can map a key path type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a key path type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.Unregistration,
@@ -635,8 +635,8 @@ describe('certificates', () => {
     });
 
     describe('Cardano.CertificateType.VoteDelegation', () => {
-      it('can map always abstain type of drep', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map always abstain type of drep', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.VoteDelegation,
@@ -660,8 +660,8 @@ describe('certificates', () => {
           }
         ]);
       });
-      it('can map always no confidence type of drep', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map always no confidence type of drep', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.VoteDelegation,
@@ -685,8 +685,8 @@ describe('certificates', () => {
           }
         ]);
       });
-      it('can map dRep credential type of drep', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map dRep credential type of drep', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.VoteDelegation,
@@ -722,8 +722,8 @@ describe('certificates', () => {
     });
 
     describe('Cardano.CertificateType.RegisterDelegateRepresentative', () => {
-      it('can map a key path type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a key path type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.RegisterDelegateRepresentative,
@@ -753,8 +753,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it('can map a script hash type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a script hash type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.RegisterDelegateRepresentative,
@@ -787,8 +787,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it("it throws if public key doesn't match credential", async () => {
-        await expect(
+      it("it throws if public key doesn't match credential", () => {
+        expect(() =>
           mapCerts(
             [
               {
@@ -806,11 +806,11 @@ describe('certificates', () => {
             ],
             CONTEXT_WITHOUT_KNOWN_ADDRESSES
           )
-        ).rejects.toThrowError('dRepPublicKey does not match certificate drep credential.');
+        ).toThrowError('dRepPublicKey does not match certificate drep credential.');
       });
 
-      it("it throws if public key wasn't provided", async () => {
-        await expect(
+      it("it throws if public key wasn't provided", () => {
+        expect(() =>
           mapCerts(
             [
               {
@@ -826,15 +826,15 @@ describe('certificates', () => {
                 deposit: 5n
               }
             ],
-            { ...CONTEXT_WITHOUT_KNOWN_ADDRESSES, dRepPublicKey: undefined }
+            { ...CONTEXT_WITHOUT_KNOWN_ADDRESSES, dRepKeyHashHex: undefined }
           )
-        ).rejects.toThrowError('dRepPublicKey does not match certificate drep credential.');
+        ).toThrowError('dRepPublicKey does not match certificate drep credential.');
       });
     });
 
     describe('Cardano.CertificateType.UnregisterDelegateRepresentative', () => {
-      it('can map a key path type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a key path type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.UnregisterDelegateRepresentative,
@@ -859,8 +859,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it('can map a script hash type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a script hash type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.UnregisterDelegateRepresentative,
@@ -888,8 +888,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it("it throws if public key doesn't match credential", async () => {
-        await expect(
+      it("it throws if public key doesn't match credential", () => {
+        expect(() =>
           mapCerts(
             [
               {
@@ -903,11 +903,11 @@ describe('certificates', () => {
             ],
             CONTEXT_WITHOUT_KNOWN_ADDRESSES
           )
-        ).rejects.toThrowError('dRepPublicKey does not match certificate drep credential.');
+        ).toThrowError('dRepPublicKey does not match certificate drep credential.');
       });
 
-      it("it throws if public key wasn't provided", async () => {
-        await expect(
+      it("it throws if public key wasn't provided", () => {
+        expect(() =>
           mapCerts(
             [
               {
@@ -919,15 +919,15 @@ describe('certificates', () => {
                 deposit: 5n
               }
             ],
-            { ...CONTEXT_WITHOUT_KNOWN_ADDRESSES, dRepPublicKey: undefined }
+            { ...CONTEXT_WITHOUT_KNOWN_ADDRESSES, dRepKeyHashHex: undefined }
           )
-        ).rejects.toThrowError('dRepPublicKey does not match certificate drep credential.');
+        ).toThrowError('dRepPublicKey does not match certificate drep credential.');
       });
     });
 
     describe('Cardano.CertificateType.UpdateDelegateRepresentative', () => {
-      it('can map a key path type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a key path type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.UpdateDelegateRepresentative,
@@ -955,8 +955,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it('can map a script hash type of params', async () => {
-        const ledgerCerts = await mapCerts(
+      it('can map a script hash type of params', () => {
+        const ledgerCerts = mapCerts(
           [
             {
               __typename: Cardano.CertificateType.UpdateDelegateRepresentative,
@@ -987,8 +987,8 @@ describe('certificates', () => {
         ]);
       });
 
-      it("it throws if public key doesn't match credential", async () => {
-        await expect(
+      it("it throws if public key doesn't match credential", () => {
+        expect(() =>
           mapCerts(
             [
               {
@@ -1005,11 +1005,11 @@ describe('certificates', () => {
             ],
             CONTEXT_WITHOUT_KNOWN_ADDRESSES
           )
-        ).rejects.toThrowError('dRepPublicKey does not match certificate drep credential.');
+        ).toThrowError('dRepPublicKey does not match certificate drep credential.');
       });
 
-      it("it throws if public key wasn't provided", async () => {
-        await expect(
+      it("it throws if public key wasn't provided", () => {
+        expect(() =>
           mapCerts(
             [
               {
@@ -1024,9 +1024,9 @@ describe('certificates', () => {
                 }
               }
             ],
-            { ...CONTEXT_WITHOUT_KNOWN_ADDRESSES, dRepPublicKey: undefined }
+            { ...CONTEXT_WITHOUT_KNOWN_ADDRESSES, dRepKeyHashHex: undefined }
           )
-        ).rejects.toThrowError('dRepPublicKey does not match certificate drep credential.');
+        ).toThrowError('dRepPublicKey does not match certificate drep credential.');
       });
     });
   });

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -172,7 +172,7 @@ export interface SignTransactionContext {
   txInKeyPathMap: TxInKeyPathMap;
   knownAddresses: GroupedAddress[];
   handleResolutions?: HandleResolution[];
-  dRepPublicKey?: Crypto.Ed25519PublicKeyHex;
+  dRepKeyHashHex?: Crypto.Ed25519KeyHashHex;
   sender?: MessageSender;
 }
 

--- a/packages/key-management/src/util/stubSignTransaction.ts
+++ b/packages/key-management/src/util/stubSignTransaction.ts
@@ -18,14 +18,13 @@ export interface StubSignTransactionProps {
 
 export const stubSignTransaction = async ({
   txBody,
-  context: { knownAddresses, txInKeyPathMap, dRepPublicKey },
+  context: { knownAddresses, txInKeyPathMap, dRepKeyHashHex: dRepKeyHash },
   signTransactionOptions: { extraSigners, additionalKeyPaths = [] } = {}
 }: StubSignTransactionProps): Promise<Cardano.Signatures> => {
   const mockSignature = Crypto.Ed25519SignatureHex(
     // eslint-disable-next-line max-len
     'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
   );
-  const dRepKeyHash = dRepPublicKey ? (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex() : undefined;
   const signatureKeyPaths = uniqWith(
     [...ownSignatureKeyPaths(txBody, knownAddresses, txInKeyPathMap, dRepKeyHash), ...additionalKeyPaths],
     deepEquals

--- a/packages/key-management/test/util/stubSignTransaction.test.ts
+++ b/packages/key-management/test/util/stubSignTransaction.test.ts
@@ -17,7 +17,7 @@ describe('KeyManagement.util.stubSignTransaction', () => {
     expect(
       (
         await util.stubSignTransaction({
-          context: { dRepPublicKey, knownAddresses, txInKeyPathMap },
+          context: { dRepKeyHashHex: dRepKeyHash, knownAddresses, txInKeyPathMap },
           txBody
         })
       ).size
@@ -25,7 +25,7 @@ describe('KeyManagement.util.stubSignTransaction', () => {
     expect(
       (
         await util.stubSignTransaction({
-          context: { dRepPublicKey, knownAddresses, txInKeyPathMap },
+          context: { dRepKeyHashHex: dRepKeyHash, knownAddresses, txInKeyPathMap },
           txBody
         })
       ).size

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -18,4 +18,4 @@ export * from './patchObject';
 export * from './isPromise';
 export * from './transformer';
 export * from './Percent';
-export { PromiseOrValue, resolveObjectValues } from './util';
+export * from './util';

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -651,7 +651,7 @@ describe('LedgerKeyAgent', () => {
             };
 
             const txBuilder = wallet.createTxBuilder();
-            const builtTx = await txBuilder
+            const builtTx = txBuilder
               .customize(({ txBody }) => {
                 const votingProcedures: Cardano.TxBody['votingProcedures'] = [
                   ...(txBody.votingProcedures || []),
@@ -665,7 +665,9 @@ describe('LedgerKeyAgent', () => {
                 };
               })
               .build();
-            expect(await builtTx.sign()).toBeTruthy();
+            const signedTx = await builtTx.sign();
+            // Payment witness + staking witness for withdrawals + DRep witness for voting
+            expect(signedTx.tx.witness.signatures.size).toBe(3);
           });
         });
       });


### PR DESCRIPTION
# Context

Signing a vote proposal with Ledger HW device returns MissingVKeyWitnessesUTXOW.
This was due to attempting to sign with DRep key hash which is not supported.

# Proposed Solution
Compare wallet DRep key hash to voter DRep key hash. If they are match, sign with `VoterType.DREP_KEY_PATH`

# Important Changes Introduced
