### PR TITLE
chore: remove kubeconfig dependency on ~/.aws/credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ source
 /.data
 /.config
 /.local
+
+# Auto generated
+.kube

--- a/nix/local/envs.nix
+++ b/nix/local/envs.nix
@@ -60,10 +60,12 @@
 
       devshell.startup.setup.text = ''
         [ -e $PRJ_ROOT/.envrc.local ] && source $PRJ_ROOT/.envrc.local
+        rm -rf $PRJ_ROOT/.kube
+        cp -R $PRJ_ROOT/nix/local/kubeconfig $PRJ_ROOT/.kube
+        chmod 600 $PRJ_ROOT/.kube/*
         kubectl config use-context $K8S_USER
         kubectl config use-context $K8S_USER --kubeconfig $PRJ_ROOT/.kube/us-east-2
         kubectl config use-context $K8S_USER --kubeconfig $PRJ_ROOT/.kube/eu-central-1
-        chmod 600 $PRJ_ROOT/.kube/*
       '';
     };
   };

--- a/nix/local/kubeconfig/eu-central-1
+++ b/nix/local/kubeconfig/eu-central-1
@@ -41,9 +41,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-admin
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: eks-devs
@@ -62,9 +60,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-devs
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: eks-readonly
@@ -83,9 +79,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-readonly
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: lace-ci
@@ -104,8 +98,6 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/lace-ci
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false

--- a/nix/local/kubeconfig/us-east-1
+++ b/nix/local/kubeconfig/us-east-1
@@ -41,9 +41,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-admin
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: eks-devs
@@ -62,9 +60,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-devs
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: eks-readonly
@@ -83,9 +79,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-readonly
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: lace-ci
@@ -104,8 +98,6 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/lace-ci
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false

--- a/nix/local/kubeconfig/us-east-2
+++ b/nix/local/kubeconfig/us-east-2
@@ -41,9 +41,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-admin
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: eks-devs
@@ -62,9 +60,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-devs
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: eks-readonly
@@ -83,9 +79,7 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/eks-readonly
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false
 - name: lace-ci
@@ -104,8 +98,6 @@ users:
       - --role
       - arn:aws:iam::926093910549:role/lace-ci
       command: aws
-      env:
-      - name: AWS_PROFILE
-        value: lw
+      env: null
       interactiveMode: IfAvailable
       provideClusterInfo: false


### PR DESCRIPTION
# Context

Now kubeconfig files are being copied to git ignored directory to avoid untracked changes and it no longer depends on `~/.aws/credentials` configuration