### PR TITLE
test(wallet): fix failling plutus script mint unit test for ledger devices

### DIFF
--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -272,6 +272,9 @@ describe('LedgerKeyAgent', () => {
               }
             }
           ]),
+          redeemersByType: {
+            mint: [scriptRedeemer]
+          },
           scriptIntegrityHash: scriptDataHash,
           witness: { redeemers: [scriptRedeemer], scripts: [script] }
         };


### PR DESCRIPTION
# Context

This PR fixes a broken unit test that mints using plutus scripts with ledger devices.
