### PR TITLE
fix: use drep key hash in stubSignTransaction

### DIFF
--- a/packages/key-management/src/util/stubSignTransaction.ts
+++ b/packages/key-management/src/util/stubSignTransaction.ts
@@ -11,7 +11,6 @@ const randomPublicKey = () => Crypto.Ed25519PublicKeyHex(Array.from({ length: 64
 
 export interface StubSignTransactionProps {
   txBody: Cardano.TxBody;
-  dRepPublicKey?: Crypto.Ed25519PublicKeyHex;
   context: SignTransactionContext;
   signTransactionOptions?: SignTransactionOptions;
 }


### PR DESCRIPTION
# Context

This is a followup fix for "Cannot submit "vote on info action" with Ledger device".
`StubSignTransactionProps` still accepted `drepPublicKey`, but did not use it for witnessing.

# Proposed Solution
Remove `drepPublicKey` and rely on the `drepKeyHashHex` from the sign transactionContext.

# Important Changes Introduced
