### PR TITLE
Fix/resubmit error handling

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -187,7 +187,7 @@ services:
     healthcheck:
       retries: 2000
     ports:
-      - ${OGMIOS_PORT:-1337}:1337
+      - ${OGMIOS_PORT:-1340}:1337
     restart: on-failure
     volumes:
       - node-ipc:/ipc
@@ -241,7 +241,7 @@ services:
       timeout: 5s
       retries: 10
     ports:
-      - ${POSTGRES_PORT:-5432}:5432
+      - ${POSTGRES_PORT:-5435}:5432
     restart: on-failure
     secrets:
       - postgres_db_db_sync

--- a/packages/cardano-services-client/test/HttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HttpProvider.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/cognitive-complexity */
 /* eslint-disable sonarjs/no-duplicate-string */
+import { CardanoNodeUtil, Provider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { HttpProviderConfig, createHttpProvider } from '../src';
-import { Provider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { Server } from 'http';
 import { fromSerializableObject, toSerializableObject } from '@cardano-sdk/util';
 import { getPort } from 'get-port-please';
@@ -115,7 +115,7 @@ describe('createHttpProvider', () => {
           await provider.noArgsEmptyReturn();
           throw new Error('Expected to throw');
         } catch (error) {
-          if (error instanceof ProviderError) {
+          if (CardanoNodeUtil.isProviderError(error)) {
             expect(error.reason).toBe(ProviderFailure.ConnectionFailure);
           } else {
             throw new TypeError('Invalid error type');
@@ -136,7 +136,7 @@ describe('createHttpProvider', () => {
           await provider.noArgsEmptyReturn();
           throw new Error('Expected to throw');
         } catch (error) {
-          if (error instanceof ProviderError) {
+          if (CardanoNodeUtil.isProviderError(error)) {
             expect(error.reason).toBe(ProviderFailure.ConnectionFailure);
           } else {
             throw new TypeError('Invalid error type');
@@ -160,7 +160,7 @@ describe('createHttpProvider', () => {
           await provider.noArgsEmptyReturn();
           throw new Error('Expected to throw');
         } catch (error) {
-          if (error instanceof ProviderError) {
+          if (CardanoNodeUtil.isProviderError(error)) {
             expect(error.innerError).toEqual(errorJson);
           } else {
             throw new TypeError('Expected ProviderError');

--- a/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
+++ b/packages/cardano-services/src/Asset/CardanoTokenRegistry.ts
@@ -1,4 +1,12 @@
-import { Asset, Cardano, Milliseconds, ProviderError, ProviderFailure, Seconds } from '@cardano-sdk/core';
+import {
+  Asset,
+  Cardano,
+  CardanoNodeUtil,
+  Milliseconds,
+  ProviderError,
+  ProviderFailure,
+  Seconds
+} from '@cardano-sdk/core';
 import { InMemoryCache } from '../InMemoryCache';
 import { Logger } from 'ts-log';
 import { TokenMetadataService } from './types';
@@ -38,7 +46,7 @@ export const toCoreTokenMetadata = (record: TokenMetadataServiceRecord): Asset.T
   ) as Asset.TokenMetadata;
 
 const toProviderError = (error: unknown, details: string) => {
-  if (error instanceof ProviderError) return error;
+  if (CardanoNodeUtil.isProviderError(error)) return error;
 
   const message = error instanceof Error ? `${error.message} ` : '';
 

--- a/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/DbSyncAssetProvider/DbSyncAssetProvider.ts
@@ -2,6 +2,7 @@ import {
   Asset,
   AssetProvider,
   Cardano,
+  CardanoNodeUtil,
   GetAssetArgs,
   GetAssetsArgs,
   ProviderError,
@@ -65,7 +66,7 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
       try {
         assetInfo.tokenMetadata = (await this.#dependencies.tokenMetadataService.getTokenMetadata([assetId]))[0];
       } catch (error) {
-        if (error instanceof ProviderError && error.reason === ProviderFailure.Unhealthy) {
+        if (CardanoNodeUtil.isProviderError(error) && error.reason === ProviderFailure.Unhealthy) {
           this.logger.error(`Failed to fetch token metadata for asset with ${assetId} due to: ${error.message}`);
           assetInfo.tokenMetadata = undefined;
         } else {
@@ -92,7 +93,7 @@ export class DbSyncAssetProvider extends DbSyncProvider() implements AssetProvid
       try {
         tokenMetadataList = await this.#dependencies.tokenMetadataService.getTokenMetadata(assetIds);
       } catch (error) {
-        if (error instanceof ProviderError && error.reason === ProviderFailure.Unhealthy) {
+        if (CardanoNodeUtil.isProviderError(error) && error.reason === ProviderFailure.Unhealthy) {
           this.logger.error(`Failed to fetch token metadata for assets ${assetIds} due to: ${error.message}`);
           tokenMetadataList = Array.from({ length: assetIds.length });
         } else {

--- a/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
@@ -2,6 +2,7 @@ import {
   Asset,
   AssetProvider,
   Cardano,
+  CardanoNodeUtil,
   GetAssetArgs,
   GetAssetsArgs,
   ProviderError,
@@ -81,7 +82,7 @@ export class TypeormAssetProvider extends TypeormProvider implements AssetProvid
     try {
       tokenMetadataList = await this.#dependencies.tokenMetadataService.getTokenMetadata(assetIds);
     } catch (error) {
-      if (error instanceof ProviderError && error.reason === ProviderFailure.Unhealthy) {
+      if (CardanoNodeUtil.isProviderError(error) && error.reason === ProviderFailure.Unhealthy) {
         this.logger.error(`Failed to fetch token metadata for assets ${assetIds} due to: ${error.message}`);
         tokenMetadataList = Array.from({ length: assetIds.length });
       } else {

--- a/packages/cardano-services/src/Http/HttpService.ts
+++ b/packages/cardano-services/src/Http/HttpService.ts
@@ -1,5 +1,6 @@
 import * as OpenApiValidator from 'express-openapi-validator';
 import {
+  CardanoNodeUtil,
   HealthCheckResponse,
   HttpProviderConfigPaths,
   Provider,
@@ -43,7 +44,7 @@ export abstract class HttpService extends RunnableModule {
         body = await this.healthCheck();
       } catch (error) {
         logger.error(error);
-        body = error instanceof ProviderError ? error.message : 'Unknown error';
+        body = CardanoNodeUtil.isProviderError(error) ? error.message : 'Unknown error';
         res.statusCode = 500;
       }
       res.send(body);
@@ -92,7 +93,7 @@ export abstract class HttpService extends RunnableModule {
       } catch (error) {
         logger.error(error);
 
-        if (error instanceof ProviderError) {
+        if (CardanoNodeUtil.isProviderError(error)) {
           const code = providerFailureToStatusCodeMap[error.reason];
 
           return HttpServer.sendJSON(res, error, code);

--- a/packages/cardano-services/src/PgBoss/stakePoolMetadataHandler.ts
+++ b/packages/cardano-services/src/PgBoss/stakePoolMetadataHandler.ts
@@ -1,4 +1,4 @@
-import { Cardano, NotImplementedError, ProviderError, ProviderFailure } from '@cardano-sdk/core';
+import { Cardano, CardanoNodeUtil, NotImplementedError, ProviderFailure } from '@cardano-sdk/core';
 import { CustomError } from 'ts-custom-error';
 import { DataSource, MoreThan } from 'typeorm';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
@@ -73,7 +73,7 @@ export const attachExtendedMetadata = (
   if (extMetadata instanceof CustomError) {
     const error = extMetadata;
 
-    if (error instanceof ProviderError && error.reason === ProviderFailure.NotFound) {
+    if (CardanoNodeUtil.isProviderError(error) && error.reason === ProviderFailure.NotFound) {
       return { ...metadataWithoutExt!, ext: null };
     }
     return metadataWithoutExt;

--- a/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
+++ b/packages/cardano-services/src/StakePool/DbSyncStakePoolProvider/DbSyncStakePoolProvider.ts
@@ -8,6 +8,7 @@ import {
 } from './util';
 import {
   Cardano,
+  CardanoNodeUtil,
   Paginated,
   ProviderError,
   ProviderFailure,
@@ -148,9 +149,9 @@ export class DbSyncStakePoolProvider extends DbSyncProvider(RunnableModule) impl
         try {
           pool.metadata.ext = await this.#metadataService.getStakePoolExtendedMetadata(pool.metadata);
         } catch (error) {
-          if (error instanceof ProviderError && error.reason === ProviderFailure.ConnectionFailure) {
+          if (CardanoNodeUtil.isProviderError(error) && error.reason === ProviderFailure.ConnectionFailure) {
             pool.metadata.ext = undefined;
-          } else if (error instanceof ProviderError && error.reason === ProviderFailure.NotFound) {
+          } else if (CardanoNodeUtil.isProviderError(error) && error.reason === ProviderFailure.NotFound) {
             pool.metadata.ext = null;
           } else {
             throw error;

--- a/packages/cardano-services/src/TxSubmit/TxSubmitHttpService.ts
+++ b/packages/cardano-services/src/TxSubmit/TxSubmitHttpService.ts
@@ -41,7 +41,7 @@ export class TxSubmitHttpService extends HttpService {
           } catch {
             isHealthy = false;
           }
-          if (error instanceof ProviderError) {
+          if (CardanoNodeUtil.isProviderError(error)) {
             return HttpServer.sendJSON(res, error, providerFailureToStatusCodeMap[error.reason]);
           }
           if (!isHealthy) {

--- a/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
+++ b/packages/cardano-services/test/TxSubmit/TxSubmitHttpService.test.ts
@@ -1,8 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { APPLICATION_JSON, CONTENT_TYPE, HttpServer, HttpServerConfig, TxSubmitHttpService } from '../../src';
+import {
+  CardanoNodeUtil,
+  ProviderError,
+  TxSubmissionError,
+  TxSubmissionErrorCode,
+  TxSubmitProvider
+} from '@cardano-sdk/core';
 import { CreateHttpProviderConfig, txSubmitHttpProvider } from '@cardano-sdk/cardano-services-client';
 import { FATAL, createLogger } from 'bunyan';
-import { ProviderError, TxSubmissionError, TxSubmissionErrorCode, TxSubmitProvider } from '@cardano-sdk/core';
 import { bufferToHexString, fromSerializableObject } from '@cardano-sdk/util';
 import { getPort } from 'get-port-please';
 import { logger } from '@cardano-sdk/util-dev';
@@ -199,7 +205,7 @@ describe('TxSubmitHttpService', () => {
         try {
           await clientProvider.submitTx({ signedTransaction: emptyUintArrayAsHexString });
         } catch (error: any) {
-          if (error instanceof ProviderError) {
+          if (CardanoNodeUtil.isProviderError(error)) {
             const innerError = error.innerError as TxSubmissionError;
             expect(innerError).toBeInstanceOf(TxSubmissionError);
             expect(innerError.code).toBe(stubErrors[0].code);

--- a/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
+++ b/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
@@ -13,6 +13,7 @@ import {
   UnknownOutputReferencesData,
   ValueNotConservedData
 } from '../types';
+import { ProviderError } from '../../errors';
 import { isProductionEnvironment, stripStackTrace } from '@cardano-sdk/util';
 
 type InferObjectType<T> = T extends new (...args: any[]) => infer O ? O : never;
@@ -103,6 +104,8 @@ export const asGeneralCardanoNodeErrorCode = (code: unknown): GeneralCardanoNode
   isGeneralCardanoNodeErrorCode(code) ? code : null;
 export const asTxSubmissionErrorCode = (code: unknown): TxSubmissionErrorCode | null =>
   isTxSubmissionErrorCode(code) ? code : null;
+
+export const isProviderError = (error: unknown): error is ProviderError<unknown> => error instanceof ProviderError;
 
 export const isOutsideOfValidityIntervalError = (
   error: unknown

--- a/packages/e2e/test/wallet_epoch_0/PersonalWallet/txChainHistory.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/PersonalWallet/txChainHistory.test.ts
@@ -1,5 +1,5 @@
 import { BaseWallet } from '@cardano-sdk/wallet';
-import { Cardano, CardanoNodeUtil, ProviderError } from '@cardano-sdk/core';
+import { Cardano, CardanoNodeUtil } from '@cardano-sdk/core';
 import { filter, firstValueFrom, map, take } from 'rxjs';
 import { getEnv, getWallet, normalizeTxBody, walletReady, walletVariables } from '../../../src';
 import { isNotNil } from '@cardano-sdk/util';
@@ -77,7 +77,7 @@ describe('PersonalWallet/txChainHistory', () => {
       // Submit the same transaction again.
       await wallet.submitTx(signedTx);
     } catch (error) {
-      if (error instanceof ProviderError) {
+      if (CardanoNodeUtil.isProviderError(error)) {
         expect(CardanoNodeUtil.isValueNotConservedError(error?.innerError)).toBeTruthy();
       }
     }

--- a/packages/wallet/src/Wallets/BaseWallet.ts
+++ b/packages/wallet/src/Wallets/BaseWallet.ts
@@ -49,7 +49,6 @@ import {
   EpochInfo,
   EraSummary,
   HandleProvider,
-  ProviderError,
   RewardsProvider,
   Serialization,
   StakePoolProvider,
@@ -656,10 +655,11 @@ export class BaseWallet implements ObservableWallet {
     } catch (error) {
       if (
         mightBeAlreadySubmitted &&
-        error instanceof ProviderError &&
+        CardanoNodeUtil.isProviderError(error) &&
         // Review: not sure if those 2 errors cover the original ones: there is no longer a CollectErrorsError or BadInputsError
-        ((CardanoNodeUtil.isValueNotConservedError(error.innerError) && !error.innerError.data) ||
-          error.innerError.data.produced.coins === 0n ||
+        ((CardanoNodeUtil.isValueNotConservedError(error.innerError) &&
+          // error.innerError.data is not set by cardano submit api. It is only set when error is coming from Ogmios.
+          (!error.innerError?.data || error.innerError.data.produced.coins === 0n)) ||
           // TODO: check if IncompleteWithdrawals available withdrawal amount === wallet's reward acc balance?
           // Not sure what the 'Withdrawals' in error data is exactly: value being withdrawed, or reward acc balance
           CardanoNodeUtil.isIncompleteWithdrawalsError(error.innerError) ||

--- a/packages/wallet/src/services/SmartTxSubmitProvider.ts
+++ b/packages/wallet/src/services/SmartTxSubmitProvider.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Cardano,
+  CardanoNodeUtil,
   HealthCheckResponse,
   OutsideOfValidityIntervalData,
   ProviderError,
@@ -88,7 +89,7 @@ export class SmartTxSubmitProvider implements TxSubmitProvider {
         retryBackoff({
           ...this.#retryBackoffConfig,
           shouldRetry: (error) =>
-            error instanceof ProviderError &&
+            CardanoNodeUtil.isProviderError(error) &&
             [ProviderFailure.Unhealthy, ProviderFailure.ConnectionFailure].includes(error.reason)
         })
       )


### PR DESCRIPTION
# Context

1. `test:ws` requires configuring `OGMIOS_URL` and `DB_SYNC_CONNECTION_STRING` to the values that `local:network` was started with.
  - align these ports with the ones configured in .nix for deployments
2. Fix unexpected error in resubmit logic: `if` statement tried to access produced.coins for non-ValueNotConserved errors 
  - improve `ProviderError` type guard

# Proposed Solution

# Important Changes Introduced
