### PR TITLE
chore: increase asset-projector mem

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -74,7 +74,7 @@ in
         };
 
         asset-provider = {
-          resources.limits = mkPodResources "300Mi" "500m";
+          resources.limits = mkPodResources "1024Mi" "500m";
           resources.requests = mkPodResources "150Mi" "100m";
         };
 


### PR DESCRIPTION
Increase asset-projector memory to avoid OOM kill