### PR TITLE
fix(wallet): tx not withdrawing all rewards

### DIFF
--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -83,6 +83,9 @@ export const normalizeTxBody = (body: Cardano.HydratedTxBody | Cardano.TxBody) =
   dehydratedTx.inputs = sortTxIn(dehydratedTx.inputs);
   dehydratedTx.collaterals = sortTxIn(dehydratedTx.collaterals);
   dehydratedTx.referenceInputs = sortTxIn(dehydratedTx.referenceInputs);
+  if (dehydratedTx.withdrawals) {
+    dehydratedTx.withdrawals = sortBy(dehydratedTx.withdrawals, ['stakeAddress']);
+  }
 
   return dehydratedTx;
 };


### PR DESCRIPTION
# Context

simple-delegation-rewards e2e test started failing due to transaction not withdrawing all rewards. Issue was exposed after the websocket networkInfo provider was implemented and activated for the e2e tests, making responses instant (as opposed to slower HTTP requests). Wallet syncStatus updates were debounced causing the syncStatus not to update in case of many bursting requests, effectively causing the TxBuilder to consider the providers synced.

# Proposed Solution
updates the pending requests observable to emit any pending requests updates immediately, while debouncing only non-pending updates

# Important Changes Introduced
