### PR TITLE
fix(cardano-services): use a single QueryRunner/connection for getAssets

### DIFF
--- a/packages/cardano-services/src/Asset/TypeOrmNftMetadataService.ts
+++ b/packages/cardano-services/src/Asset/TypeOrmNftMetadataService.ts
@@ -1,6 +1,7 @@
 import { Asset, Cardano } from '@cardano-sdk/core';
 import { AssetPolicyIdAndName, NftMetadataService } from './types';
 import { NftMetadataEntity } from '@cardano-sdk/projection-typeorm';
+import { QueryRunner } from 'typeorm';
 import { TypeormProviderDependencies, TypeormService } from '../util';
 
 export class TypeOrmNftMetadataService extends TypeormService implements NftMetadataService {
@@ -9,36 +10,40 @@ export class TypeOrmNftMetadataService extends TypeormService implements NftMeta
   }
 
   async getNftMetadata(assetInfo: AssetPolicyIdAndName): Promise<Asset.NftMetadata | null> {
-    const assetId = Cardano.AssetId.fromParts(assetInfo.policyId, assetInfo.name);
     return this.withDataSource(async (dataSource) => {
       const queryRunner = dataSource.createQueryRunner();
-      let asset: NftMetadataEntity | null;
-
-      try {
-        const nftMetadataRepository = queryRunner.manager.getRepository(NftMetadataEntity);
-        asset = await nftMetadataRepository.findOneBy({
-          userTokenAsset: { id: assetId }
-        });
-      } catch (error) {
-        this.logger.error(error);
-        asset = null;
-      } finally {
-        await queryRunner.release();
-      }
-
-      if (!asset) {
-        return null;
-      }
-
-      return {
-        image: asset.image!,
-        name: asset.name!,
-        ...(asset.description && { description: asset.description }),
-        ...(asset.files && { files: asset.files }),
-        ...(asset.mediaType && { mediaType: asset.mediaType as Asset.ImageMediaType }),
-        ...(asset.otherProperties && { otherProperties: asset.otherProperties }),
-        version: asset.otherProperties?.get('version') as string
-      };
+      return this.getNftMetadataWith(assetInfo, queryRunner);
     });
+  }
+
+  async getNftMetadataWith(assetInfo: AssetPolicyIdAndName, queryRunner: QueryRunner) {
+    const assetId = Cardano.AssetId.fromParts(assetInfo.policyId, assetInfo.name);
+    let asset: NftMetadataEntity | null;
+
+    try {
+      const nftMetadataRepository = queryRunner.manager.getRepository(NftMetadataEntity);
+      asset = await nftMetadataRepository.findOneBy({
+        userTokenAsset: { id: assetId }
+      });
+    } catch (error) {
+      this.logger.error(error);
+      asset = null;
+    } finally {
+      await queryRunner.release();
+    }
+
+    if (!asset) {
+      return null;
+    }
+
+    return {
+      image: asset.image!,
+      name: asset.name!,
+      ...(asset.description && { description: asset.description }),
+      ...(asset.files && { files: asset.files }),
+      ...(asset.mediaType && { mediaType: asset.mediaType as Asset.ImageMediaType }),
+      ...(asset.otherProperties && { otherProperties: asset.otherProperties }),
+      version: asset.otherProperties?.get('version') as string
+    };
   }
 }


### PR DESCRIPTION
# Context

TypeormAssetProvider creates a query runner per asset in 'getAssets' call. It can be up to 100 assets per call, which creates a lot of query runners.

LW-11038

# Proposed Solution

This fix makes it use a single query runner.

# Important Changes Introduced
