### PR TITLE
chore: disable asset-provider-server in all dev envs

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -207,7 +207,7 @@ in
               env.OVERRIDE_FUZZY_OPTIONS = "true";
             };
             handle-provider.enabled = true;
-            asset-provider.enabled = true;
+            #asset-provider.enabled = true;
             chain-history-provider.enabled = true;
           };
 
@@ -356,7 +356,7 @@ in
               env.OVERRIDE_FUZZY_OPTIONS = "true";
             };
             handle-provider.enabled = true;
-            asset-provider.enabled = true;
+            #asset-provider.enabled = true;
             chain-history-provider = {
               enabled = true;
               replicas = 2;
@@ -409,7 +409,7 @@ in
               env.OVERRIDE_FUZZY_OPTIONS = "true";
             };
             handle-provider.enabled = true;
-            asset-provider.enabled = true;
+            #asset-provider.enabled = true;
             chain-history-provider.enabled = true;
           };
 


### PR DESCRIPTION
# Context

ATM asset-provider-server is unstable.

# Proposed Solution

Disabling it in all `dev` environments; it should be tests in `staging-preprod`.