### PR TITLE
chore: disable submitapi sanchonet

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -252,6 +252,7 @@ in
           providers = {
             backend = {
               enabled = true;
+              env.USE_SUBMIT_API = "false";
             };
             stake-pool-provider = {
               enabled = true;


### PR DESCRIPTION
We do not need submitapi on sanchnet, setting "USE_SUBMIT_API=false " to make sure