### PR TITLE
fix(cardano-services): drep_hash can be null when delegating to abstain or no confidence

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -112,7 +112,7 @@ jobs:
               echo '{"environment":"dev-preview", "target":"dev-preview@us-east-1",    "url": "https://dev-preview.lw.iog.io/"}'
             fi
             if [ "true" == ${{ inputs.deploy-dev-sanchonet || (github.event_name == 'push' && github.ref_name == 'conway-era') }} ] ; then
-              echo '{"environment":"dev-sanchonet", "target":"dev-sanchonet@us-east-1@v1",    "url": "https://dev-sanchonet.lw.iog.io/"}'
+              echo '{"environment":"dev-sanchonet", "target":"dev-sanchonet@us-east-1",    "url": "https://dev-sanchonet.lw.iog.io/"}'
             fi
             if [ "true" == ${{ inputs.deploy-dev-preprod || false }} ] ; then
               echo '{"environment":"dev-preprod", "target":"dev-preprod@us-east-1@v2", "url": "https://dev-preprod.lw.iog.io/"}'

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/mappers.ts
@@ -18,6 +18,7 @@ import {
   TxOutput,
   TxOutputModel,
   TxTokenMap,
+  VoteDelegationCertModel,
   WithCertIndex,
   WithCertType,
   WithdrawalModel
@@ -172,6 +173,24 @@ export const mapAnchor = (anchorUrl: string, anchorDataHash: string): Cardano.An
   return null;
 };
 
+const mapDrepDelegation = ({
+  drep_hash,
+  drep_view,
+  has_script
+}: Pick<VoteDelegationCertModel, 'drep_hash' | 'drep_view' | 'has_script'>): Cardano.DelegateRepresentative =>
+  drep_hash
+    ? {
+        hash: drep_hash.toString('hex') as Hash28ByteBase16,
+        type: Number(has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
+      }
+    : drep_view === 'drep_always_no_confidence'
+    ? {
+        __typename: 'AlwaysNoConfidence'
+      }
+    : {
+        __typename: 'AlwaysAbstain'
+      };
+
 // eslint-disable-next-line complexity
 export const mapCertificate = (
   certModel: WithCertType<CertificateModel>
@@ -268,15 +287,11 @@ export const mapCertificate = (
         type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
       }
     };
-
   if (isVoteDelegationCertModel(certModel))
     return {
       __typename: Cardano.CertificateType.VoteDelegation,
       cert_index: certModel.cert_index,
-      dRep: {
-        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
-        type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
-      },
+      dRep: mapDrepDelegation(certModel),
       stakeCredential: {
         hash: Cardano.RewardAccount.toHash(
           Cardano.RewardAccount(certModel.address)
@@ -289,10 +304,7 @@ export const mapCertificate = (
     return {
       __typename: Cardano.CertificateType.VoteRegistrationDelegation,
       cert_index: certModel.cert_index,
-      dRep: {
-        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
-        type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
-      },
+      dRep: mapDrepDelegation(certModel),
       deposit: BigInt(certModel.deposit),
       stakeCredential: {
         hash: Cardano.RewardAccount.toHash(
@@ -306,10 +318,7 @@ export const mapCertificate = (
     return {
       __typename: Cardano.CertificateType.StakeVoteDelegation,
       cert_index: certModel.cert_index,
-      dRep: {
-        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
-        type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
-      },
+      dRep: mapDrepDelegation(certModel),
       poolId: certModel.pool_id as unknown as Cardano.PoolId,
       stakeCredential: {
         hash: Cardano.RewardAccount.toHash(
@@ -337,10 +346,7 @@ export const mapCertificate = (
     return {
       __typename: Cardano.CertificateType.StakeVoteRegistrationDelegation,
       cert_index: certModel.cert_index,
-      dRep: {
-        hash: certModel.drep_hash.toString('hex') as Hash28ByteBase16,
-        type: Number(certModel.has_script) ? Cardano.CredentialType.ScriptHash : Cardano.CredentialType.KeyHash
-      },
+      dRep: mapDrepDelegation(certModel),
       deposit: BigInt(certModel.deposit),
       poolId: certModel.pool_id as unknown as Cardano.PoolId,
       stakeCredential: {

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/queries.ts
@@ -355,6 +355,7 @@ export const findVoteDelegationCertsByTxIds = `
 		tx.hash AS tx_id,
 		has_script,
 		drep.raw AS drep_hash,
+		drep.view AS drep_view,
 		addr.view AS address
 	FROM tx
 	JOIN delegation_vote AS cert ON cert.tx_id = tx.id

--- a/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
+++ b/packages/cardano-services/src/ChainHistory/DbSyncChainHistory/types.ts
@@ -208,7 +208,10 @@ export interface DrepCertModel extends CertificateModel {
 
 export interface VoteDelegationCertModel extends CertificateModel {
   has_script: boolean;
-  drep_hash: Buffer;
+  // empty when no confidence or abstain
+  drep_hash: Buffer | null;
+  // has the drep Bech32 representation when not always no confidence or abstain
+  drep_view: 'drep_always_no_confidence' | 'drep_always_abstain';
   address: string;
 }
 

--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -307,6 +307,7 @@ export const burnTokens = async ({
 };
 
 export const unDelegateWallet = async (wallet: BaseWallet) => {
+  await waitForWalletStateSettle(wallet);
   const rewardAccounts = await firstValueFrom(wallet.delegation.rewardAccounts$);
 
   if (!rewardAccounts.some((acct) => acct.credentialStatus === Cardano.StakeCredentialStatus.Unregistered)) {

--- a/packages/e2e/test/wallet_epoch_3/PersonalWallet/conwayTransactions.test.ts
+++ b/packages/e2e/test/wallet_epoch_3/PersonalWallet/conwayTransactions.test.ts
@@ -409,10 +409,18 @@ describe('PersonalWallet/conwayTransactions', () => {
       );
     });
 
-    it('can delegate vote', async () => {
+    it.each([
+      dRepCredential,
+      { __typename: 'AlwaysAbstain' },
+      { __typename: 'AlwaysNoConfidence' }
+    ] as Cardano.DelegateRepresentative[])('can delegate vote %s', async (dRep) => {
+      // dRepCredential is initialized in beforeAll, and it.each runs before `beforeAll`,
+      // so it is not available in the .each scope.
+      // Use this workaround to pass the dRepCredential to the test
+      dRep = dRep ?? dRepCredential;
       const voteDelegCert: Cardano.VoteDelegationCertificate = {
         __typename: CertificateType.VoteDelegation,
-        dRep: dRepCredential,
+        dRep,
         stakeCredential
       };
       const signedTx = await wallet
@@ -423,7 +431,6 @@ describe('PersonalWallet/conwayTransactions', () => {
       const [, confirmedTx] = await submitAndConfirm(wallet, signedTx.tx, 1);
 
       assertTxHasCertificate(confirmedTx, voteDelegCert);
-      await assertWalletIsDelegating();
     });
 
     it('can delegate stake and vote using combo certificate', async () => {


### PR DESCRIPTION
# Context

LW-11110

DbSyncChainHistoryProvider will crash if it encounters an AlwaysAbstain or AlwaysNoConfidence vote delegation certificate.

# Proposed Solution
If drep_hash is null, check the value of `drep_view` which will indicate in which of the 2 scenarios we are in.

# Important Changes Introduced
