### PR TITLE
feat!: add a new function to generate and track unused addresses in ObservableWallets

### DIFF
--- a/packages/wallet/src/Wallets/BaseWallet.ts
+++ b/packages/wallet/src/Wallets/BaseWallet.ts
@@ -41,6 +41,7 @@ import {
   distinctBlock,
   distinctEraSummaries
 } from '../services';
+import { AddressType, Bip32Account, GroupedAddress, WitnessedTx, Witnesser, util } from '@cardano-sdk/key-management';
 import {
   AssetProvider,
   Cardano,
@@ -64,6 +65,7 @@ import {
   SignDataProps,
   SyncStatus,
   UpdateWitnessProps,
+  WalletAddress,
   WalletNetworkInfoProvider
 } from '../types';
 import { BehaviorObservable, TrackerSubject, coldObservableProvider } from '@cardano-sdk/util-rxjs';
@@ -86,7 +88,6 @@ import {
   tap,
   throwError
 } from 'rxjs';
-import { Bip32Account, GroupedAddress, WitnessedTx, Witnesser, util } from '@cardano-sdk/key-management';
 import { ChangeAddressResolver, InputSelector, roundRobinRandomImprove } from '@cardano-sdk/input-selection';
 import { Cip30DataSignature } from '@cardano-sdk/dapp-connector';
 import { Ed25519PublicKey, Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
@@ -141,6 +142,27 @@ export const isScriptPublicCredentialsManager = (
 export const isBip32PublicCredentialsManager = (
   credManager: PublicCredentialsManager
 ): credManager is Bip32PublicCredentialsManager => !isScriptPublicCredentialsManager(credManager);
+
+/**
+ * Gets whether the given address has a transaction history.
+ *
+ * @param address The address to query.
+ * @param chainHistoryProvider The chain history provider where to fetch the history from.
+ */
+const addressHasTx = async (
+  address: Cardano.PaymentAddress,
+  chainHistoryProvider: ChainHistoryProvider
+): Promise<boolean> => {
+  const txs = await chainHistoryProvider.transactionsByAddresses({
+    addresses: [address],
+    pagination: {
+      limit: 1,
+      startAt: 0
+    }
+  });
+
+  return txs.totalResultCount > 0;
+};
 
 export interface BaseWalletDependencies {
   readonly witnesser: Witnesser;
@@ -819,6 +841,41 @@ export class BaseWallet implements ObservableWallet {
     }
 
     return firstValueFrom(this.addresses$);
+  }
+
+  async getNextUnusedAddress(): Promise<WalletAddress[]> {
+    const knownAddresses = await firstValueFrom(this.addresses$);
+
+    if (knownAddresses.length === 0) {
+      throw new Error('No known address found for this wallet');
+    }
+
+    if (isBip32PublicCredentialsManager(this.#publicCredentialsManager)) {
+      knownAddresses.sort((a, b) => b.index - a.index);
+      const latestAddress = knownAddresses[0];
+
+      let isEmpty = !(await addressHasTx(latestAddress.address, this.chainHistoryProvider));
+
+      if (isEmpty) return [latestAddress];
+
+      const newAddress = await this.#publicCredentialsManager.bip32Account.deriveAddress(
+        { index: latestAddress.index + 1, type: AddressType.External },
+        0
+      );
+
+      await firstValueFrom(this.#addressTracker.addAddresses([newAddress]));
+
+      // Sanity check, make sure the newly generated address is also empty.
+      isEmpty = !(await addressHasTx(newAddress.address, this.chainHistoryProvider));
+
+      if (isEmpty) return [newAddress];
+
+      return await this.getNextUnusedAddress();
+    }
+
+    // Script wallet.
+    const isEmpty = !(await addressHasTx(knownAddresses[0].address, this.chainHistoryProvider));
+    return isEmpty ? [knownAddresses[0]] : [];
   }
 
   /** Update the witness of a transaction with witness provided by this wallet */

--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -388,7 +388,10 @@ const baseCip30WalletApi = (
   },
   getUnusedAddresses: async (): Promise<Cbor[]> => {
     logger.debug('getting unused addresses');
-    return Promise.resolve([]);
+    const wallet = await firstValueFrom(wallet$);
+    const addresses = await wallet.getNextUnusedAddress();
+
+    return addresses.map((groupAddresses) => cardanoAddressToCbor(groupAddresses.address));
   },
   getUsedAddresses: async (): Promise<Cbor[]> => {
     logger.debug('getting used addresses');

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -130,6 +130,14 @@ export interface ObservableWallet {
    */
   discoverAddresses(): Promise<WalletAddress[]>;
 
+  /**
+   * Get the next unused address for the wallet.
+   *
+   * @returns Promise that resolves with the next unused addresses. Return an empty array if there
+   * are no available unused addresses (I.E Single address wallets such as script wallets which already used up their only address).
+   */
+  getNextUnusedAddress(): Promise<WalletAddress[]>;
+
   shutdown(): void;
 }
 

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -460,8 +460,9 @@ describe('cip30', () => {
       });
 
       test('api.getUnusedAddresses', async () => {
-        const cipUsedAddressess = await api.getUnusedAddresses(context);
-        expect(cipUsedAddressess).toEqual([]);
+        const addresses = (await firstValueFrom(wallet.addresses$)).map((grouped) => grouped.address);
+        const cipUnusedAddressess = await api.getUnusedAddresses(context);
+        expect(cipUnusedAddressess).toEqual([Cardano.Address.fromString(addresses[0])!.toBytes()]);
       });
 
       test('api.getChangeAddress', async () => {

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -128,6 +128,7 @@ export const observableWalletProperties: RemoteApiProperties<ObservableWallet> =
   finalizeTx: RemoteApiPropertyType.MethodReturningPromise,
   genesisParameters$: RemoteApiPropertyType.HotObservable,
   getName: RemoteApiPropertyType.MethodReturningPromise,
+  getNextUnusedAddress: RemoteApiPropertyType.MethodReturningPromise,
   governance: {
     getPubDRepKey: RemoteApiPropertyType.MethodReturningPromise,
     isRegisteredAsDRep$: RemoteApiPropertyType.HotObservable


### PR DESCRIPTION
# Context

Our CIP-30 `getUnusedAddresses` implementation currently always returns an empty array. Particular DApps require wallets to use a freshly created address, as such we must enable this feature in our CIP-30 implementation.

# Proposed Solution

BaseWallet now implements a new `getNextUnusedAddress` method, which tries to find and track the next unused wallet, it does this by first listing all known addresses, picking the address with the highest derivation index and checking whether this is an empty address or not, if it is an unused address, it returns this address, otherwise, it generates a new unused address, adds it to the tracked addresses and returns it. This guarantees that we are always tracking our next unused address if it is ever requested.

# Important Changes Introduced

- BaseWallet implementes a new  `getNextUnusedAddress` method that returns the next empty address.
- CIP-30 `getUnusedAddresses` now return an array with the next unused address.
