### PR TITLE
fix(hardware-ledger): delegate vote drep is a hash not key path

### DIFF
--- a/packages/hardware-ledger/test/transformers/certificates.test.ts
+++ b/packages/hardware-ledger/test/transformers/certificates.test.ts
@@ -701,14 +701,8 @@ describe('certificates', () => {
           {
             params: {
               dRep: {
-                keyPath: [
-                  util.harden(CardanoKeyConst.PURPOSE),
-                  util.harden(CardanoKeyConst.COIN_TYPE),
-                  util.harden(0),
-                  3,
-                  0
-                ],
-                type: Ledger.DRepParamsType.KEY_PATH
+                keyHashHex: '7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8',
+                type: Ledger.DRepParamsType.KEY_HASH
               },
               stakeCredential: {
                 scriptHashHex: '7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8',


### PR DESCRIPTION
# Context
Self drep `Ledger.DRepParamsType.KEY_PATH` was used when mapping VoteDelegation certificate.
That is wrong, we have to pass the drep key hash, otherwise the ledger device will always calculate the DRep as our own, instead of the target one.

# Proposed Solution
VoteDelegation certificate should map drep to `DRepParamsType.KEY_HASH`.

# Important Changes Introduced
