### PR TITLE
feat!: replace updateWitness with addSignatures in observable wallet

### DIFF
--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -55,8 +55,8 @@ export type FinalizeTxProps = Omit<TxContext, 'signingContext'> & {
   signingContext?: Partial<SignTransactionContext>;
 };
 
-export type UpdateWitnessProps = {
-  tx: Cardano.Tx;
+export type AddSignaturesProps = {
+  tx: Serialization.TxCBOR;
   sender?: MessageSender;
 };
 
@@ -143,6 +143,9 @@ export interface ObservableWallet {
    * are no available unused addresses (I.E Single address wallets such as script wallets which already used up their only address).
    */
   getNextUnusedAddress(): Promise<WalletAddress[]>;
+
+  /** Updates the transaction witness set with signatures from this wallet. */
+  addSignatures(props: AddSignaturesProps): Promise<Serialization.TxCBOR>;
 
   shutdown(): void;
 }

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -98,6 +98,7 @@ export const txBuilderProperties: RemoteApiProperties<Omit<TxBuilder, 'customize
 };
 
 export const observableWalletProperties: RemoteApiProperties<ObservableWallet> = {
+  addSignatures: RemoteApiPropertyType.MethodReturningPromise,
   addresses$: RemoteApiPropertyType.HotObservable,
   assetInfo$: RemoteApiPropertyType.HotObservable,
   balance: {


### PR DESCRIPTION
# Context

The base wallet currently have a updateWitness method that adds signatures to a given transaction, however, this method does not preserve the original CBOR, we must modify this method to correctly preserve CBOR of the transaction.

# Proposed Solution

Modify updateWitness to take the CBOR of the transaction, add signatures to it, and return the transaction with the new signatures encoded as CBOR.
