### PR TITLE
fix(ogmios): cannot calculate tx fee for byron block without cbor

### DIFF
--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -398,7 +398,9 @@ const mapWitnessDatums = ({ datums }: Required<Pick<Schema.Transaction, 'datums'
   Object.values(datums).map((datum) => Serialization.PlutusData.fromCbor(HexBlob(datum)).toCore());
 
 export const mapByronTxFee = ({ cbor }: Schema.Transaction) => {
-  const txSize = Buffer.from(HexBlob(cbor!), 'hex').length;
+  // Byron transactions don't have a fee field. In the absence of the cbor field, we can't calculate the fee.
+  if (!cbor) return 0n;
+  const txSize = Buffer.from(HexBlob(cbor), 'hex').length;
   return BigInt(BYRON_TX_FEE_COEFFICIENT * txSize + BYRON_TX_FEE_CONSTANT);
 };
 
@@ -423,7 +425,7 @@ const mapCommonTx = (tx: Schema.Transaction): Cardano.OnChainTx => {
       auxiliaryDataHash,
       certificates: tx.certificates?.map(mapCertificate),
       collaterals: tx.collaterals?.map(mapTxIn),
-      fee: tx.fee?.ada.lovelace ?? mapByronTxFee(tx), // You were here. a common tx has fee but byron does not
+      fee: tx.fee?.ada.lovelace ?? mapByronTxFee(tx),
       inputs: tx.inputs.map(mapTxIn),
       mint: mapMint(tx),
       outputs: tx.outputs.map(mapTxOut),

--- a/packages/ogmios/test/ogmiosToCore/block.test.ts
+++ b/packages/ogmios/test/ogmiosToCore/block.test.ts
@@ -9,6 +9,7 @@ import {
   mockBabbageBlockWithNftMetadata,
   mockBlockOgmiosMetadata,
   mockByronBlock,
+  mockByronBlockWithoutTxCbor,
   mockMaryBlock,
   mockShelleyBlock
 } from './testData';
@@ -32,6 +33,11 @@ describe('ogmiosToCore', () => {
   describe('block', () => {
     it('can translate from byron block', () => {
       expect(ogmiosToCore.block(mockByronBlock)).toMatchSnapshot();
+    });
+
+    it('LW-11243 can translate byron block without tx cbor', () => {
+      const block = ogmiosToCore.block(mockByronBlockWithoutTxCbor);
+      expect(block?.body[0].body.fee).toBe(0n);
     });
 
     it('can translate from shelley block', () => {

--- a/packages/ogmios/test/ogmiosToCore/testData.ts
+++ b/packages/ogmios/test/ogmiosToCore/testData.ts
@@ -86,6 +86,58 @@ export const mockByronBlock: Ogmios.Schema.Block = {
   type: 'bft'
 };
 
+export const mockByronBlockWithoutTxCbor: Ogmios.Schema.Block = {
+  ancestor: '43d58aa00099c44787fdb174db22823494814eb2cdf209b044ca20cc5cf62b25',
+  delegate: {
+    verificationKey:
+      '9180d818e69cd997e34663c418a648c076f2e19cd4194e486e159d8580bc6cda81344440c6ad0e5306fd035bef9281da5d8fbd38f59f588f7081016ee61113d2'
+  },
+  era: 'byron',
+  height: 3314,
+  id: 'cf80534e520fa8f4bde1ed2f623553b8a6a9fd616d73bf9d4f7d6d1687685248',
+  issuer: {
+    verificationKey:
+      'd2965c869901231798c5d02d39fca2a79aa47c3e854921b5855c82fd1470891517e1fa771655ec8cad13ecf6e5719adc5392fc057e1703d5f583311e837462f1'
+  },
+  operationalCertificates: [],
+  protocol: {
+    id: 764_824_073,
+    software: { appName: 'cardano-sl', number: 0 },
+    version: { major: 0, minor: 0, patch: 0 }
+  },
+  size: { bytes: 908 },
+  slot: 3313,
+  transactions: [
+    {
+      id: '6497b33b10fa2619c6efbd9f874ecd1c91badb10bf70850732aab45b90524d9e',
+      inputs: [
+        {
+          index: 0,
+          transaction: {
+            id: 'a12a839c25a01fa5d118167db5acdbd9e38172ae8f00e5ac0a4997ef792a2007'
+          }
+        }
+      ],
+      outputs: [
+        {
+          address:
+            'DdzFFzCqrhsszHTvbjTmYje5hehGbadkT6WgWbaqCy5XNxNttsPNF13eAjjBHYT7JaLJz2XVxiucam1EvwBRPSTiCrT4TNCBas4hfzic',
+          value: { ada: { lovelace: 1_000_000n } }
+        }
+      ],
+      signatories: [
+        {
+          key: '8c0bdedfbbab26a1308300512ffb1b220f068ee13f7612afb076c22de3fb7641',
+          signature:
+            '6cc41635a9794234966629ccfa2a5b089a20ae392f0e92154ff97eda30ff7a082a65fc4b362c24cf58c27f30103b1f1345e15479cf4b80cd4134c0f9dca83109'
+        }
+      ],
+      spends: 'inputs'
+    }
+  ],
+  type: 'bft'
+};
+
 export const mockEpochBoundaryBlock: Ogmios.Schema.Block = {
   ancestor: '5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb',
   era: 'byron',


### PR DESCRIPTION
# Context

[LW-11243](https://input-output.atlassian.net/browse/LW-11243)

Byron transaction fee is calculated using the cbor size.
In the absence of cbor from the projected block, the fee cannot be calculated.
The code assumed cbor is present all the time.
This code was merged from the `conway-era` branch.

# Proposed Solution
Use `0` fee if the cbor is not available to use for calculation.

# Important Changes Introduced


[LW-11243]: https://input-output.atlassian.net/browse/LW-11243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ