### PR TITLE
test(e2e): fix flaky conway era e2e tests

### DIFF
--- a/packages/cardano-services/test/util/TypeormService.test.ts
+++ b/packages/cardano-services/test/util/TypeormService.test.ts
@@ -63,6 +63,10 @@ describe('TypeormService', () => {
       await expect(queryFailureReady).rejects.toThrowError();
       const querySuccessReady = service.withQueryRunner(async () => 'ok');
       connectionConfig$.next(goodConnectionConfig);
+
+      // Allow the service to reconnect to the datasource with the new configuration
+      await new Promise((resolve) => setTimeout(resolve, 1));
+
       await expect(querySuccessReady).resolves.toBe('ok');
     });
   });

--- a/packages/core/src/CardanoNode/types/CardanoNodeErrors.ts
+++ b/packages/core/src/CardanoNode/types/CardanoNodeErrors.ts
@@ -1,5 +1,6 @@
 import { CustomError } from 'ts-custom-error';
 import type * as Cardano from '../../Cardano';
+import type * as Crypto from '@cardano-sdk/crypto';
 
 export enum GeneralCardanoNodeErrorCode {
   ServerNotReady = 503,
@@ -128,4 +129,12 @@ export type IncompleteWithdrawalsData = {
 
 export type UnknownOutputReferencesData = {
   unknownOutputReferences: Cardano.TxIn[];
+};
+
+export type CredentialAlreadyRegisteredData = {
+  hash: Crypto.Hash28ByteBase16;
+};
+
+export type DRepAlreadyRegisteredData = {
+  hash: Crypto.Hash28ByteBase16;
 };

--- a/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
+++ b/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
@@ -2,6 +2,8 @@
 import {
   ChainSyncError,
   ChainSyncErrorCode,
+  CredentialAlreadyRegisteredData,
+  DRepAlreadyRegisteredData,
   GeneralCardanoNodeError,
   GeneralCardanoNodeErrorCode,
   IncompleteWithdrawalsData,
@@ -124,3 +126,11 @@ export const isUnknownOutputReferences = (
   error: unknown
 ): error is TxSubmissionError<UnknownOutputReferencesData | null> =>
   error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.UnknownOutputReferences;
+
+export const isCredentialAlreadyRegistered = (
+  error: unknown
+): error is TxSubmissionError<CredentialAlreadyRegisteredData | null> =>
+  error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.CredentialAlreadyRegistered;
+
+export const isDrepAlreadyRegistered = (error: unknown): error is TxSubmissionError<DRepAlreadyRegisteredData | null> =>
+  error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.DRepAlreadyRegistered;

--- a/packages/core/test/CardanoNode/util/cardanoNodeErrors.test.ts
+++ b/packages/core/test/CardanoNode/util/cardanoNodeErrors.test.ts
@@ -78,6 +78,16 @@ describe('util/cardanoNodeErrors', () => {
           new TxSubmissionError(TxSubmissionErrorCode.OutsideOfValidityInterval, null, '')
         )
       ).toBe(true);
+      expect(
+        CardanoNodeUtil.isCredentialAlreadyRegistered(
+          new TxSubmissionError(TxSubmissionErrorCode.CredentialAlreadyRegistered, null, '')
+        )
+      ).toBe(true);
+      expect(
+        CardanoNodeUtil.isDrepAlreadyRegistered(
+          new TxSubmissionError(TxSubmissionErrorCode.DRepAlreadyRegistered, null, '')
+        )
+      ).toBe(true);
     });
     it('returns false if error type or code does not match', () => {
       expect(CardanoNodeUtil.isValueNotConservedError(generalError)).toBe(false);
@@ -95,6 +105,16 @@ describe('util/cardanoNodeErrors', () => {
       ).toBe(false);
       expect(
         CardanoNodeUtil.isOutsideOfValidityIntervalError(
+          new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
+        )
+      ).toBe(false);
+      expect(
+        CardanoNodeUtil.isCredentialAlreadyRegistered(
+          new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
+        )
+      ).toBe(false);
+      expect(
+        CardanoNodeUtil.isDrepAlreadyRegistered(
           new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
         )
       ).toBe(false);

--- a/packages/e2e/test/wallet_epoch_3/PersonalWallet/conwayTransactions.test.ts
+++ b/packages/e2e/test/wallet_epoch_3/PersonalWallet/conwayTransactions.test.ts
@@ -135,7 +135,7 @@ export const paramsUpdate: Cardano.ProtocolParametersUpdateConway = {
   treasuryExpansion: '0.25'
 };
 
-describe.skip('PersonalWallet/conwayTransactions', () => {
+describe('PersonalWallet/conwayTransactions', () => {
   let dRepWallet: BaseWallet;
   let wallet: BaseWallet;
 

--- a/packages/wallet/src/Wallets/BaseWallet.ts
+++ b/packages/wallet/src/Wallets/BaseWallet.ts
@@ -685,7 +685,9 @@ export class BaseWallet implements ObservableWallet {
           // TODO: check if IncompleteWithdrawals available withdrawal amount === wallet's reward acc balance?
           // Not sure what the 'Withdrawals' in error data is exactly: value being withdrawed, or reward acc balance
           CardanoNodeUtil.isIncompleteWithdrawalsError(error.innerError) ||
-          CardanoNodeUtil.isUnknownOutputReferences(error.innerError))
+          CardanoNodeUtil.isUnknownOutputReferences(error.innerError) ||
+          CardanoNodeUtil.isCredentialAlreadyRegistered(error.innerError) ||
+          CardanoNodeUtil.isDrepAlreadyRegistered(error.innerError))
       ) {
         this.#logger.debug(
           `Transaction ${outgoingTx.id} failed with ${error.innerError}, but it appears to be already submitted...`


### PR DESCRIPTION
# Context

The latest version of the node changed priorities on the types of errors it reports, we were retrying some transactions that we weren't suppose to. We are now handling properly the new types of errors.

# Proposed Solution

- Added to our retry exception list of errors `CredentialAlreadyRegisterd` and `DrepAlreadyRegistered`
- Added a timeout in the TypeormSerivce tests that tests re-connection to allow the service to reconnect to the datasource.

