### PR TITLE
fix(ogmios): ignore byron signatures in ogmios mapper

### DIFF
--- a/packages/ogmios/src/ogmiosToCore/tx.ts
+++ b/packages/ogmios/src/ogmiosToCore/tx.ts
@@ -450,7 +450,8 @@ const mapCommonTx = (tx: Schema.Transaction): Cardano.OnChainTx => {
       // ...(tx.scripts && { scripts: [...Object.values(tx.scripts).map(mapScript)] }),
       signatures: new Map(
         tx.signatories
-          .filter((signatory) => !signatory.addressAttributes && !signatory.chainCode)
+          // omitting Byron signatures (length is 128 instead of 64 as in praos transactions)
+          .filter((signatory) => !signatory.addressAttributes && !signatory.chainCode && signatory.key.length === 64)
           .map(({ key, signature }) => [Crypto.Ed25519PublicKeyHex(key), Crypto.Ed25519SignatureHex(signature)])
       )
     }


### PR DESCRIPTION
# Context

Mainnet projection crashes with `InvalidStringError: Invalid string: "expected length '64', got 128"` because it encounters a Byron tx with signatures map that have different length key (128 instead of the expected 64)

Our signatures key validation only supports praos txes

# Proposed Solution

We are not currently using signatures at all. Safe to ignore for the time being.

# Important Changes Introduced
