### PR TITLE
chore: deploy ops-preview stakepool pgboss

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -826,10 +826,31 @@ in
             backend = {
               enabled = true;
             };
+            stake-pool-provider = {
+              enabled = true;
+              env.OVERRIDE_FUZZY_OPTIONS = "true";
+              env.NODE_ENV = "production";
+            };
+            handle-provider = {
+              enabled = true;
+              env.NODE_ENV = "production";
+            };
             chain-history-provider.enabled = true;
+            #asset-provider = {
+            #  enabled = true;
+            #};
+          };
+
+          projectors = {
+            handle.enabled = true;
+            stake-pool = {
+              enabled = true;
+            };
+            # asset.enabled = true;
           };
 
           values = {
+            pg-boss-worker.enabled = true;
             ws-server.enabled = true;
             cardano-services = {
               ingresOrder = 99;


### PR DESCRIPTION
This upgrade is intended to help us confirm that the order of operations issue with pg-boss/stakepool deploy has been resolved. Intent is to deploy these services and confirm that there is no errors if they all start without issues if they come up at the same time.