### PR TITLE
LW-11264 Add to BaseWallet re-submit exceptions UnknownCredential and DrepNotRegistered errors

### DIFF
--- a/packages/core/src/CardanoNode/types/CardanoNodeErrors.ts
+++ b/packages/core/src/CardanoNode/types/CardanoNodeErrors.ts
@@ -1,3 +1,5 @@
+// cSpell:ignore deserialisation
+
 import { CustomError } from 'ts-custom-error';
 import type * as Cardano from '../../Cardano';
 import type * as Crypto from '@cardano-sdk/crypto';
@@ -136,5 +138,13 @@ export type CredentialAlreadyRegisteredData = {
 };
 
 export type DRepAlreadyRegisteredData = {
+  hash: Crypto.Hash28ByteBase16;
+};
+
+export type UnknownCredentialData = {
+  hash: Crypto.Hash28ByteBase16;
+};
+
+export type DRepNotRegisteredData = {
   hash: Crypto.Hash28ByteBase16;
 };

--- a/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
+++ b/packages/core/src/CardanoNode/util/cardanoNodeErrors.ts
@@ -4,6 +4,7 @@ import {
   ChainSyncErrorCode,
   CredentialAlreadyRegisteredData,
   DRepAlreadyRegisteredData,
+  DRepNotRegisteredData,
   GeneralCardanoNodeError,
   GeneralCardanoNodeErrorCode,
   IncompleteWithdrawalsData,
@@ -12,6 +13,7 @@ import {
   StateQueryErrorCode,
   TxSubmissionError,
   TxSubmissionErrorCode,
+  UnknownCredentialData,
   UnknownOutputReferencesData,
   ValueNotConservedData
 } from '../types';
@@ -134,3 +136,9 @@ export const isCredentialAlreadyRegistered = (
 
 export const isDrepAlreadyRegistered = (error: unknown): error is TxSubmissionError<DRepAlreadyRegisteredData | null> =>
   error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.DRepAlreadyRegistered;
+
+export const isUnknownCredential = (error: unknown): error is TxSubmissionError<UnknownCredentialData | null> =>
+  error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.UnknownCredential;
+
+export const isDrepNotRegistered = (error: unknown): error is TxSubmissionError<DRepNotRegisteredData | null> =>
+  error instanceof TxSubmissionError && error.code === TxSubmissionErrorCode.DRepNotRegistered;

--- a/packages/core/test/CardanoNode/util/cardanoNodeErrors.test.ts
+++ b/packages/core/test/CardanoNode/util/cardanoNodeErrors.test.ts
@@ -61,7 +61,7 @@ describe('util/cardanoNodeErrors', () => {
     });
   });
 
-  describe('specific error typeguard utils', () => {
+  describe('specific error type-guard utils', () => {
     it('returns true if error type and code matches', () => {
       expect(
         CardanoNodeUtil.isValueNotConservedError(
@@ -87,6 +87,12 @@ describe('util/cardanoNodeErrors', () => {
         CardanoNodeUtil.isDrepAlreadyRegistered(
           new TxSubmissionError(TxSubmissionErrorCode.DRepAlreadyRegistered, null, '')
         )
+      ).toBe(true);
+      expect(
+        CardanoNodeUtil.isUnknownCredential(new TxSubmissionError(TxSubmissionErrorCode.UnknownCredential, null, ''))
+      ).toBe(true);
+      expect(
+        CardanoNodeUtil.isDrepNotRegistered(new TxSubmissionError(TxSubmissionErrorCode.DRepNotRegistered, null, ''))
       ).toBe(true);
     });
     it('returns false if error type or code does not match', () => {
@@ -115,6 +121,16 @@ describe('util/cardanoNodeErrors', () => {
       ).toBe(false);
       expect(
         CardanoNodeUtil.isDrepAlreadyRegistered(
+          new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
+        )
+      ).toBe(false);
+      expect(
+        CardanoNodeUtil.isUnknownCredential(
+          new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
+        )
+      ).toBe(false);
+      expect(
+        CardanoNodeUtil.isDrepNotRegistered(
           new TxSubmissionError(TxSubmissionErrorCode.IncompleteWithdrawals, null, '')
         )
       ).toBe(false);

--- a/packages/ogmios/src/CardanoNode/queries.ts
+++ b/packages/ogmios/src/CardanoNode/queries.ts
@@ -4,6 +4,7 @@ import {
   ChainSyncError,
   CredentialAlreadyRegisteredData,
   DRepAlreadyRegisteredData,
+  DRepNotRegisteredData,
   GeneralCardanoNodeError,
   GeneralCardanoNodeErrorCode,
   IncompleteWithdrawalsData,
@@ -12,6 +13,7 @@ import {
   StateQueryError,
   TxSubmissionError,
   TxSubmissionErrorCode,
+  UnknownCredentialData,
   UnknownOutputReferencesData,
   ValueNotConservedData
 } from '@cardano-sdk/core';
@@ -21,8 +23,10 @@ import { Logger } from 'ts-log';
 import {
   SubmitTransactionFailureCredentialAlreadyRegistered,
   SubmitTransactionFailureDRepAlreadyRegistered,
+  SubmitTransactionFailureDRepNotRegistered,
   SubmitTransactionFailureIncompleteWithdrawals,
   SubmitTransactionFailureOutsideOfValidityInterval,
+  SubmitTransactionFailureUnknownCredential,
   SubmitTransactionFailureUnknownOutputReferences,
   SubmitTransactionFailureValueNotConserved
 } from '@cardano-ogmios/schema';
@@ -76,6 +80,23 @@ const errorDataToCore = (data: unknown, code: number) => {
         return {
           hash: typedData.knownDelegateRepresentative.id as Crypto.Hash28ByteBase16
         } as DRepAlreadyRegisteredData;
+      }
+      return null;
+    }
+    case TxSubmissionErrorCode.UnknownCredential: {
+      const typedData = data as SubmitTransactionFailureUnknownCredential['data'];
+
+      return {
+        hash: typedData.unknownCredential as Crypto.Hash28ByteBase16
+      } as UnknownCredentialData;
+    }
+    case TxSubmissionErrorCode.DRepNotRegistered: {
+      const typedData = data as SubmitTransactionFailureDRepNotRegistered['data'];
+
+      if (typedData.unknownDelegateRepresentative.type === 'registered') {
+        return {
+          hash: typedData.unknownDelegateRepresentative.id as Crypto.Hash28ByteBase16
+        } as DRepNotRegisteredData;
       }
       return null;
     }

--- a/packages/wallet/src/Wallets/BaseWallet.ts
+++ b/packages/wallet/src/Wallets/BaseWallet.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore coeff vkeys
 /* eslint-disable unicorn/no-nested-ternary */
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {
@@ -659,6 +660,7 @@ export class BaseWallet implements ObservableWallet {
     return new GenericTxBuilder(this.getTxBuilderDependencies());
   }
 
+  // eslint-disable-next-line complexity
   async #submitTx(
     outgoingTx: OutgoingTx,
     { mightBeAlreadySubmitted }: SubmitTxOptions = {}
@@ -683,11 +685,13 @@ export class BaseWallet implements ObservableWallet {
           // error.innerError.data is not set by cardano submit api. It is only set when error is coming from Ogmios.
           (!error.innerError?.data || error.innerError.data.produced.coins === 0n)) ||
           // TODO: check if IncompleteWithdrawals available withdrawal amount === wallet's reward acc balance?
-          // Not sure what the 'Withdrawals' in error data is exactly: value being withdrawed, or reward acc balance
+          // Not sure what the 'Withdrawals' in error data is exactly: value being withdrawn, or reward acc balance
           CardanoNodeUtil.isIncompleteWithdrawalsError(error.innerError) ||
           CardanoNodeUtil.isUnknownOutputReferences(error.innerError) ||
           CardanoNodeUtil.isCredentialAlreadyRegistered(error.innerError) ||
-          CardanoNodeUtil.isDrepAlreadyRegistered(error.innerError))
+          CardanoNodeUtil.isDrepAlreadyRegistered(error.innerError) ||
+          CardanoNodeUtil.isUnknownCredential(error.innerError) ||
+          CardanoNodeUtil.isDrepNotRegistered(error.innerError))
       ) {
         this.#logger.debug(
           `Transaction ${outgoingTx.id} failed with ${error.innerError}, but it appears to be already submitted...`


### PR DESCRIPTION
# Context

We still have some flakiness:
https://github.com/input-output-hk/cardano-js-sdk/actions/runs/10387686363/job/28761702839?pr=1421

#1414 follow up

# Proposed Solution

Added retry strategy for missing exceptions