### PR TITLE
Bug: support overflowing pointer address slots with constraints

### DIFF
--- a/packages/core/test/Cardano/util/addressesShareAnyKey.test.ts
+++ b/packages/core/test/Cardano/util/addressesShareAnyKey.test.ts
@@ -14,7 +14,7 @@ describe('addressesShareAnyKey', () => {
   const stakeKeyHash2 = Hash28ByteBase16('8293d319ef5b3ac72366dd28006bd315b715f7e7cfcbd3004129b80f');
   const stakeKeyPointer: Cardano.Pointer = {
     certIndex: Cardano.CertIndex(1),
-    slot: Cardano.Slot(123),
+    slot: 123n,
     txIndex: Cardano.TxIndex(2)
   };
 

--- a/packages/core/test/Serialization/TransactionBody/TransactionOutput.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/TransactionOutput.test.ts
@@ -32,6 +32,10 @@ const babbageNoOptionalFieldScriptCbor = HexBlob(
   '82583900537ba48a023f0a3c65e54977ffc2d78c143fb418ef6db058e006d78a7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8821a000f4240a2581c00000000000000000000000000000000000000000000000000000000a3443031323218644433343536186344404142420a581c11111111111111111111111111111111111111111111111111111111a3443031323218644433343536186344404142420a'
 );
 
+const maryOutputPointerCbor = HexBlob(
+  '825826412813b99a80cfb4024374bd0f502959485aa56e0648564ff805f2e51bbcd9819561bddc66141a02faf080'
+);
+
 const canonicallySortedAssets = new Map([
   ['0000000000000000000000000000000000000000000000000000000030313232' as unknown as Cardano.AssetId, 100n],
   ['0000000000000000000000000000000000000000000000000000000033343536' as unknown as Cardano.AssetId, 99n],
@@ -131,6 +135,18 @@ describe('TransactionOutput', () => {
       it('can encode TransactionOutput to Core', () => {
         const output = TransactionOutput.fromCbor(legacyOutputCbor);
         expect(output.toCore()).toEqual(outputWithHashDataCore);
+      });
+
+      it('can decode PointerAddress Output to Core', () => {
+        const output = TransactionOutput.fromCbor(maryOutputPointerCbor);
+        const address = output.address();
+        const hash = address.asPointer()?.getPaymentCredential().hash;
+        expect(hash).toEqual('2813b99a80cfb4024374bd0f502959485aa56e0648564ff805f2e51b');
+        const pointer = address.asPointer()?.getStakePointer();
+        expect(pointer?.slot).toEqual(16_292_793_057n);
+        expect(pointer?.certIndex).toEqual(20);
+        expect(pointer?.txIndex).toEqual(1_011_302);
+        expect(address.toBech32()).toEqual('addr1gy5p8wv6sr8mgqjrwj7s75pft9y94ftwqey9vnlcqhew2xaumxqe2cdam3npgv60hqa');
       });
     });
 

--- a/packages/projection-typeorm/src/operators/storeStakePools.ts
+++ b/packages/projection-typeorm/src/operators/storeStakePools.ts
@@ -95,7 +95,7 @@ const undoUpdateLatestRetirementAndRetiringStatus = async ({
   const { firstSlot } = epochSlotsCalc(epochNo, eraSummaries);
   const epochStartId = certificatePointerToId({
     certIndex: Cardano.CertIndex(0),
-    slot: firstSlot,
+    slot: BigInt(firstSlot),
     txIndex: Cardano.TxIndex(0)
   });
   return Promise.all(
@@ -152,12 +152,12 @@ const computeCertificateIdRange = (epochNo: Cardano.EpochNo, eraSummaries: EraSu
   const { firstSlot, lastSlot } = epochSlotsCalc(epochNo, eraSummaries);
   const minId = certificatePointerToId({
     certIndex: Cardano.CertIndex(0),
-    slot: firstSlot,
+    slot: BigInt(firstSlot),
     txIndex: Cardano.TxIndex(0)
   });
   const maxId = certificatePointerToId({
     certIndex: MaxCertificatePointerIdCertIndex,
-    slot: lastSlot,
+    slot: BigInt(lastSlot),
     txIndex: MaxCertificatePointerIdTxIndex
   });
   return { maxId, minId };

--- a/packages/projection/src/operators/Mappers/certificates/withCertificates.ts
+++ b/packages/projection/src/operators/Mappers/certificates/withCertificates.ts
@@ -24,7 +24,7 @@ const blockCertificates = ({
         certificate,
         pointer: {
           certIndex: Cardano.CertIndex(certIndex),
-          slot: Cardano.Slot(slot),
+          slot: BigInt(slot),
           txIndex: Cardano.TxIndex(txIndex)
         }
       }))

--- a/packages/projection/test/InMemory/storeStakePools.test.ts
+++ b/packages/projection/test/InMemory/storeStakePools.test.ts
@@ -31,14 +31,14 @@ describe('InMemory.storeStakePools', () => {
         poolParameters: {
           id: Cardano.PoolId('pool1n3s8unkvmre59uzt4ned0903f9q2p8dhscw5v9eeyc0sw0m439t')
         } as Cardano.PoolParameters,
-        source: { slot: Cardano.Slot(1) } as Mappers.WithCertificateSource['source']
+        source: { slot: 1n } as Mappers.WithCertificateSource['source']
       }
     ];
     const poolRetirementAtSlot2 = [
       {
         epoch: Cardano.EpochNo(123),
         poolId: Cardano.PoolId('pool1n3s8unkvmre59uzt4ned0903f9q2p8dhscw5v9eeyc0sw0m439t'),
-        source: { slot: Cardano.Slot(2) } as Mappers.WithCertificateSource['source']
+        source: { slot: 2n } as Mappers.WithCertificateSource['source']
       }
     ];
     const storedStakePool = () =>

--- a/packages/projection/test/operators/Mappers/certificates/withCertificates.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withCertificates.test.ts
@@ -47,7 +47,7 @@ describe('withCertificates', () => {
               certificate: certificates[0][0],
               pointer: {
                 certIndex: 0,
-                slot: 1,
+                slot: 1n,
                 txIndex: 0
               }
             },
@@ -55,7 +55,7 @@ describe('withCertificates', () => {
               certificate: certificates[1][0],
               pointer: {
                 certIndex: 0,
-                slot: 1,
+                slot: 1n,
                 txIndex: 1
               }
             },
@@ -63,7 +63,7 @@ describe('withCertificates', () => {
               certificate: certificates[1][1],
               pointer: {
                 certIndex: 1,
-                slot: 1,
+                slot: 1n,
                 txIndex: 1
               }
             }

--- a/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
@@ -9,7 +9,7 @@ describe('withStakeKeyRegistrations', () => {
   it.each(Cardano.StakeRegistrationCertificateTypes)('collects %s registration certificates', async (regCertType) => {
     const pointer: Cardano.Pointer = {
       certIndex: Cardano.CertIndex(1),
-      slot: Cardano.Slot(123),
+      slot: 123n,
       txIndex: Cardano.TxIndex(2)
     };
     const data: EventData = {

--- a/packages/util-dev/src/Cip19TestVectors.ts
+++ b/packages/util-dev/src/Cip19TestVectors.ts
@@ -24,7 +24,7 @@ export const SCRIPT_CREDENTIAL: Cardano.Credential = {
 
 export const POINTER: Cardano.Pointer = {
   certIndex: Cardano.CertIndex(3),
-  slot: Cardano.Slot(2_498_243),
+  slot: 2_498_243n,
   txIndex: Cardano.TxIndex(27)
 };
 


### PR DESCRIPTION
# Context

There are invalid output addresses on mainnet, referencing stake credentials by invalid stake pointer address. These references consist in part of a absolute slot number, which is a location on the blockchain of the stake key registration certificate for that key. The issue arose during indexing when we've found large slot numbers that overflow the JS `Number.MAX_SAFE_INTEGER`.

The mainnet transaction hash, whose first transaction output that caused this issue is: `9a47e091709e4fe1a8ba1291bc8cfd0c0ed0bb9220688b3ccfad5f2d961e8d8e`

# Proposed Solution

We change the variable length encoding/ decoding for pointer addresses to use `bigint` for `Cardano.Pointer.slot` type to support correct serialization for pointer addresses.

# Important Changes Introduced

We have exclusively changed the `Cardano.Pointer.slot` type to `bigint` and not the `Core/Cardano/PartialBlockHeader.slot`.
