### PR TITLE
build: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    commit-message:
+      prefix: build
+    groups:
+      security-updates:
+        applies-to: security-updates
+        update-types:
+          - "patch"
+          - "minor"
+      non-breaking-version-updates:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
+      breaking-updates:
+        update-types:
+          - "major"


### PR DESCRIPTION
# Context

- Dependabot is great but it would be better to batch and group by update types for easier handling.
- It's also currently using a non-standard commit type.
- Enabling the **Grouped security updates** option bundles everything together, which is not ideal since it then requires accepting major breaking changes alongside critical security patches :-1: 

![image](https://github.com/user-attachments/assets/27547071-4663-48e6-9bd3-0c46b5595996)


# Proposed Solution
Group updates into non-breaking security, non-breaking version, and breaking, on a weekly batch cycle @ 6AM UTC Monday morning. Also set prefix to conform with Conventional Commits, Angular types.

# Important Changes Introduced
There will be a slight delay on being alerted to critical issues, however I can't see a way to isolate critical updates to use an instantaneous strategy, plus there is a way to be alerted via email.

