### PR TITLE
fix(cardano-services): correctly load Mapper.withGovernanceActions

### DIFF
--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -99,6 +99,7 @@ const createMapperOperators = (
     withAddresses: Mapper.withAddresses(),
     withCIP67: Mapper.withCIP67(),
     withCertificates: Mapper.withCertificates(),
+    withGovernanceActions: Mapper.withGovernanceActions(),
     withHandleMetadata,
     withHandles,
     withMint: Mapper.withMint(),
@@ -250,6 +251,7 @@ const mapperInterDependencies: Partial<Record<MapperName, MapperName[]>> = {
 const storeMapperDependencies: Partial<Record<StoreName, MapperName[]>> = {
   storeAddresses: ['withAddresses'],
   storeAssets: ['withMint'],
+  storeGovernanceAction: ['withGovernanceActions'],
   storeHandleMetadata: ['withHandleMetadata'],
   storeHandles: ['withHandles'],
   storeNftMetadata: ['withNftMetadata'],


### PR DESCRIPTION
# Context

While supporting @will-break-it on LW-10737 we realized about this issue.

# Proposed Solution

Loaded the mapper.
