### PR TITLE
LW-11310 Add option to choose target cluster for deployed environments e2e tests

### DIFF
--- a/.github/workflows/test-deploy-e2e.yaml
+++ b/.github/workflows/test-deploy-e2e.yaml
@@ -9,11 +9,32 @@ on:
         required: true
         default: 'dev-preprod'
         options:
-        - live-preprod
-        - live-preview
-        - dev-preprod
-        - dev-preview
-        - staging-preprod
+          - live-preprod
+          - live-preview
+          - dev-preprod
+          - dev-preview
+          - staging-preprod
+      cluster:
+        description: 'Specific cluster to run e2e tests against'
+        type: choice
+        required: true
+        default: 'any'
+        options:
+          - any
+          - eu-central-1
+          - us-east-2
+      level:
+        description: 'Log level'
+        type: choice
+        required: true
+        default: 'fatal'
+        options:
+          - fatal
+          - error
+          - warn
+          - info
+          - debug
+          - trace
 
 env:
   TL_DEPTH: ${{ github.event.pull_request.head.repo.fork && '0' || fromJson(vars.TL_DEPTH) }}
@@ -33,7 +54,7 @@ jobs:
         working-directory: ./packages/e2e/
         run: |
           if [[ "${{ inputs.environment }}" == *"preprod"* ]]; then networkMagic=1; else networkMagic=2; fi
-          ./src/scripts/generate-dotenv.sh ${{ inputs.environment }}
+          ./src/scripts/generate-dotenv.sh ${{ inputs.environment }} ${{ inputs.cluster }}
           echo "KEY_MANAGEMENT_PARAMS='$(jq --argjson networkMagic $networkMagic --arg mnemonic "${{ secrets.MNEMONIC }}" <<< '{"bip32Ed25519": "Sodium", "accountIndex": 0, "chainId":{"networkId": 0, "networkMagic": 0}, "passphrase":"some_passphrase","mnemonic":"mnemonics"}' '.mnemonic=$mnemonic | .chainId.networkMagic=$networkMagic')'" >> .env
 
       - name: 🧰 Setup Node.js
@@ -49,6 +70,7 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
 
-      - name: 🔬 Test - e2e - wallet at epoch 0
+      - name: 🔬 Test - e2e - wallet
         run: |
-          yarn workspace @cardano-sdk/e2e test:wallet
+          TL_DEPTH=0 TL_LEVEL=${{ inputs.level }} yarn workspace @cardano-sdk/e2e test:wallet-real-ada
+        shell: bash

--- a/packages/e2e/src/scripts/generate-dotenv.sh
+++ b/packages/e2e/src/scripts/generate-dotenv.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
+
+set -e
 set -x
 set -o
 
-environment="$1"
+case $2 in
+  any)
+    environment="$1"
+    ;;
+  *)
+    environment="$1.$2"
+    ;;
+esac
 
-url="https://${environment}.lw.iog.io"
+domain="${environment}.lw.iog.io"
+url="https://${domain}/"
 
 # Construct the environment file content
 envFileContent="
@@ -16,19 +26,22 @@ KEY_MANAGEMENT_PROVIDER=inMemory
 
 # Providers setup - required by getWallet
 TEST_CLIENT_ASSET_PROVIDER=http
-TEST_CLIENT_ASSET_PROVIDER_PARAMS='{\"baseUrl\":\"$url:4000/\"}'
+TEST_CLIENT_ASSET_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
+TEST_CLIENT_CHAIN_HISTORY_PROVIDER=http
+TEST_CLIENT_CHAIN_HISTORY_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_HANDLE_PROVIDER=http
-TEST_CLIENT_HANDLE_PROVIDER_PARAMS='{\"baseUrl\":\"$url:4011/\"}'
+TEST_CLIENT_HANDLE_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_NETWORK_INFO_PROVIDER=http
-TEST_CLIENT_NETWORK_INFO_PROVIDER_PARAMS='{\"baseUrl\":\"$url:4000/\"}'
+TEST_CLIENT_NETWORK_INFO_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_REWARDS_PROVIDER=http
-TEST_CLIENT_REWARDS_PROVIDER_PARAMS='{\"baseUrl\":\"$url:4000/\"}'
+TEST_CLIENT_REWARDS_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_TX_SUBMIT_PROVIDER=http
-TEST_CLIENT_TX_SUBMIT_PROVIDER_PARAMS='{\"baseUrl\":\"$url:4000/\"}'
+TEST_CLIENT_TX_SUBMIT_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_UTXO_PROVIDER=http
-TEST_CLIENT_UTXO_PROVIDER_PARAMS='{\"baseUrl\":\"$url:4000/\"}'
+TEST_CLIENT_UTXO_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_STAKE_POOL_PROVIDER=http
-TEST_CLIENT_STAKE_POOL_PROVIDER_PARAMS='{\"baseUrl\":\"$url:4000/\"}'
+TEST_CLIENT_STAKE_POOL_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
+WS_PROVIDER_URL='wss://${domain}/ws'
 "
 
 # Write the environment file content to the specified file

--- a/packages/e2e/src/util/util.ts
+++ b/packages/e2e/src/util/util.ts
@@ -90,6 +90,11 @@ export const normalizeTxBody = (body: Cardano.HydratedTxBody | Cardano.TxBody) =
   return dehydratedTx;
 };
 
+// We do not afford to wait for 3 confirmations on real network as it is a too long wait.
+// In preview it happened more than 4 minutes required to have 3 confirmations,
+// making the test to fail for timeout waiting for the third confirmation.
+const defaultWaitConfirmation = env.NETWORK_SPEED === 'fast' ? 3 : 1;
+
 export const txConfirmed = (
   {
     tip$,
@@ -99,7 +104,7 @@ export const txConfirmed = (
     }
   }: ObservableWallet,
   { id }: Pick<Cardano.Tx, 'id'>,
-  numConfirmations = 3
+  numConfirmations = defaultWaitConfirmation
 ) =>
   firstValueFromTimed(
     merge(


### PR DESCRIPTION
# Context

- Some recently introduced change (fast / slow network distinction, hot reload, etc.) wasn’t reflected on e2e against deployed environments: this broken them.
- Sometimes we need to choose a specific cluster to run the tests against: we need to add this option.

# Proposed Solution

- Fixed the impacted files
- Added the cluster dedicated CI input
- Reduced the amount of confirmation required in slow networks