### PR TITLE
fix: update hashScriptData for conway

### DIFF
--- a/packages/tx-construction/src/computeScriptDataHash.ts
+++ b/packages/tx-construction/src/computeScriptDataHash.ts
@@ -4,7 +4,6 @@ import { Cardano, Serialization } from '@cardano-sdk/core';
 import { Hash32ByteBase16 } from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
 
-const CBOR_EMPTY_LIST = new Uint8Array([0x80]);
 const CBOR_EMPTY_MAP = new Uint8Array([0xa0]);
 
 /**
@@ -49,13 +48,16 @@ const hashScriptData = (
   const writer = new Serialization.CborWriter();
 
   if (datums && datums.length > 0 && (!redemeers || redemeers.length === 0)) {
-    /*
+    /* (Deprecated)
      ; Note that in the case that a transaction includes datums but does not
      ; include any redeemers, the script data format becomes (in hex):
      ; [ 80 | datums | A0 ]
      ; corresponding to a CBOR empty list and an empty map).
     */
-    writer.writeEncodedValue(CBOR_EMPTY_LIST);
+    /* Post Babbage:
+     ; [ A0 | datums | A0 ]
+    */
+    writer.writeEncodedValue(CBOR_EMPTY_MAP);
     writer.writeEncodedValue(getCborEncodedArray(datums));
     writer.writeEncodedValue(CBOR_EMPTY_MAP);
   } else {

--- a/packages/tx-construction/test/computeScriptDataHash.test.ts
+++ b/packages/tx-construction/test/computeScriptDataHash.test.ts
@@ -122,7 +122,7 @@ describe('computeScriptDataHash', () => {
     const hash = computeScriptDataHash(costModels, [Cardano.PlutusLanguageVersion.V2], undefined, datums);
 
     // Assert
-    expect(hash).toEqual('c28fc2f0e5644f00ee5194c83630e9f064aba4a7cf0319bf6f113785120b1744');
+    expect(hash).toEqual('944e124d2dd13f99d5dc416573dc0d2dd54f3bd52280a38ff7bbefd434f68274');
   });
 
   it('can compute script data hash for transactions that uses several datums and redeemers', () => {


### PR DESCRIPTION
# Context

PPViewHashesDontMatch issue when submitting the transaction with AsHash datum
https://github.com/IntersectMBO/cardano-ledger/blob/c183a0b037c943a387f5a450b5354e56eb1aa598/eras/conway/impl/cddl-files/conway.cddl#L340

# Proposed Solution

# Important Changes Introduced
