### PR TITLE
feat(web-extension)!: emit wallet and id from activeWallet$

### DIFF
--- a/packages/e2e/test/web-extension/extension/background/cip30.ts
+++ b/packages/e2e/test/web-extension/extension/background/cip30.ts
@@ -2,7 +2,7 @@ import { cip30 } from '@cardano-sdk/web-extension';
 import { runtime } from 'webextension-polyfill';
 import { cip30 as walletCip30 } from '@cardano-sdk/wallet';
 
-import { NEVER } from 'rxjs';
+import { NEVER, map } from 'rxjs';
 import { authenticator } from './authenticator';
 import { logger } from '../util';
 import { wallet$ } from './walletManager';
@@ -23,5 +23,9 @@ const confirmationCallback: walletCip30.CallbackConfirmation = {
   submitTx: async () => true
 };
 
-const walletApi = walletCip30.createWalletApi(wallet$, confirmationCallback, { logger });
+const walletApi = walletCip30.createWalletApi(
+  wallet$.pipe(map((activeWallet) => activeWallet?.observableWallet || null)),
+  confirmationCallback,
+  { logger }
+);
 cip30.initializeBackgroundScript({ walletName }, { authenticator, logger, runtime, walletApi });

--- a/packages/e2e/test/web-extension/extension/background/supplyDistributionTracker.ts
+++ b/packages/e2e/test/web-extension/extension/background/supplyDistributionTracker.ts
@@ -8,7 +8,7 @@ import { walletName } from '../const';
 
 export const supplyDistributionTrackerReady = (async () =>
   createSupplyDistributionTracker(
-    { trigger$: wallet$.pipe(switchMap((wallet) => wallet.currentEpoch$)) },
+    { trigger$: wallet$.pipe(switchMap((wallet) => wallet.observableWallet.currentEpoch$)) },
     {
       logger,
       networkInfoProvider: await networkInfoProviderFactory.create(

--- a/packages/e2e/test/web-extension/extension/background/walletManager.ts
+++ b/packages/e2e/test/web-extension/extension/background/walletManager.ts
@@ -20,7 +20,7 @@ import { InvalidArgumentError, isNotNil } from '@cardano-sdk/util';
 import { Metadata, env, logger } from '../util';
 import { storage as WebExtensionStorage, runtime } from 'webextension-polyfill';
 import { Witnesser } from '@cardano-sdk/key-management';
-import { filter, from, merge, of } from 'rxjs';
+import { filter, from, map, merge, of } from 'rxjs';
 import { getWallet } from '../../../../src';
 import { storage } from '@cardano-sdk/wallet';
 import { toEmpty } from '@cardano-sdk/util-rxjs';
@@ -129,7 +129,7 @@ exposeApi(
 
 exposeApi(
   {
-    api$: walletManager.activeWallet$.asObservable(),
+    api$: walletManager.activeWallet$.pipe(map((activeWallet) => activeWallet?.observableWallet || null)),
     baseChannel: walletChannel(walletName),
     properties: observableWalletProperties
   },

--- a/packages/web-extension/test/walletManager/walletManager.test.ts
+++ b/packages/web-extension/test/walletManager/walletManager.test.ts
@@ -231,7 +231,10 @@ describe('WalletManager', () => {
 
     it('sets active wallet to wallet created by factory', async () => {
       const activeWallet = await firstValueFrom(walletManager.activeWallet$);
-      expect(activeWallet).toEqual(mockWallet);
+      expect(activeWallet).toEqual({
+        observableWallet: mockWallet,
+        props: expect.objectContaining({ walletId: expect.stringContaining('') })
+      });
     });
 
     it('does not activate same wallet twice', async () => {


### PR DESCRIPTION
Using Lace, activeWallet and activeWalletId observables emit independently. In order to synchronise you need to know which emits first.

Emitting both from the same observable eliminates potential race conditions

LW-11406