### PR TITLE
LW-11068 Asset provider OOM fix attempt

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         required: true
         default: false
+      deploy-staging-mainnet:
+        description: Deploy to staging-mainnet
+        type: boolean
+        required: true
+        default: false
       deploy-dev-mainnet:
         description: Deploy to dev-mainnet
         type: boolean
@@ -116,6 +121,9 @@ jobs:
             fi
             if [ "true" == ${{ inputs.deploy-dev-preprod || false }} ] ; then
               echo '{"environment":"dev-preprod", "target":"dev-preprod@us-east-1@v2", "url": "https://dev-preprod.lw.iog.io/"}'
+            fi
+            if [ "true" == ${{ inputs.deploy-staging-mainnet || false }} ] ; then
+              echo '{"environment":"staging-mainnet", "target":"staging-mainnet@eu-west-1@v2", "url": "https://staging-mainnet.lw.iog.io/"}'
             fi
             if [ "true" == ${{ inputs.deploy-staging-preprod || false }} ] ; then
               echo '{"environment":"staging-preprod", "target":"staging-preprod@us-east-1@v2", "url": "https://staging-preprod.lw.iog.io/"}'

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -555,7 +555,7 @@ in
         "staging-mainnet@eu-west-1@v2" = final: {
           name = "${final.namespace}-cardanojs-v2";
           namespace = "staging-mainnet";
-          context = "eks-admin";
+          context = "eks-devs";
           network = "mainnet";
           region = "eu-west-1";
 

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -1,3 +1,5 @@
+# cSpell:ignore builtins cardanojs concat devs healthchecks hostnames kubeconfig pkgs stakepool stakepoolv
+
 {
   pkgs,
   lib ? pkgs.lib,
@@ -14,6 +16,7 @@
     eu-west-1 = readJsonFile ./tf-outputs/lace-dev-eu-west-1.json;
   };
   oci = inputs.self.x86_64-linux.cardano-services.oci-images.cardano-services;
+  # cSpell:disable
   allowedOrigins = [
     # Represents Chrome production version
     "chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk"
@@ -24,6 +27,7 @@
     # Represents Chrome dev preview version
     "chrome-extension://djcdfchkaijggdjokfomholkalbffgil"
   ];
+  # cSpell:enable
 
   allowedOriginsDev =
     allowedOrigins
@@ -158,7 +162,7 @@ in
           ogmiosSrvServiceName = "${final.namespace}-cardano-core.${final.namespace}.svc.cluster.local";
 
           wafARN = tf-outputs.${final.region}.waf_arn;
-          # Healthcheck paramteres for ALB
+          # Healthcheck parameters for ALB
           # For mainnet, default value of timeout of 5 is too short, so have to increase it significantly
           # Interval cannot be less than timeout
           # Note that Kubernetes healthchecks are picked up by balancer controller and reflected in the target group anyway

--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -371,7 +371,7 @@ in
               env.OVERRIDE_FUZZY_OPTIONS = "true";
             };
             handle-provider.enabled = true;
-            #asset-provider.enabled = true;
+            asset-provider.enabled = true;
             chain-history-provider.enabled = true;
           };
 
@@ -580,14 +580,14 @@ in
               replicas = 2;
               env.NODE_ENV = "production";
             };
-            #asset-provider = {
-            #  enabled = true;
-            #  env.NODE_ENV = "production";
-            #};
+            asset-provider = {
+              enabled = true;
+              env.NODE_ENV = "production";
+            };
           };
 
           projectors = {
-            # asset.enabled = true;
+            asset.enabled = true;
             handle.enabled = true;
             stake-pool.enabled = true;
             wallet-api.enabled = true;


### PR DESCRIPTION
# Context

`asset-provider` has memory consumption issues.

# Proposed Solution

Optimized `TypeormAssetProvider.getAssets` method.
- Used `withDataSource` rather than `withQueryRunner`.
- Aggregated the SQL queries to get all `assetInfo`s and `nftMetadata`s with one query (one query for each: two new queries) rather than performing one query for each `assetInfo` or `nftMetadata`.
- Parallelized the functions to get `assetInfo`s, `nftMetadata`s and `tokenMetadata`s.

# Why should that fix?
Before the change, `TypeormAssetProvider.getAssets` was performing several SQL queries on a singe `QueryRunner` _trying to parallelize them_ through `Promise.all`.
A `QueryRunner` represent a PostgreSQL client. Even if [pg](https://www.npmjs.com/package/pg) allows to perform multiple queries before the response for the first one is received, under the wood, PostgreSQL protocol doesn't allow that; by specifications, one PostgreSQL client can perform only one query at time.
The effect of the approach used before the change was to use an high amount of memory to handle the parallelization attempt of the SQL queries as soon as a `TypeormAssetProvider.getAssets` call was received which was gradually decreasing as soon as responses from SQL queries were received.
In my opinion, said behavior multiplied multiple times (once per simultaneous `TypeormAssetProvider.getAssets` call) was the root cause of the problem.

# Important Changes Introduced

- Change `staging-mainnet` context to `eks-devs` as suggested by @gytis-ivaskevicius .
- Enabled SDK deploy on `staging-mainnet` in STD github actions flow.
- Enabled `asset-projector` and `asset-provider` in `staging-mainnet` and `dev-preprod`.
- Add `cSpell` configuration in `nix/cardano-services/deployments/default.nix` to avoid several warning messages from VSCode extension.