### PR TITLE
feat(cardano-services): improve health check response times by aggregating and caching

### DIFF
--- a/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
+++ b/packages/cardano-services/src/Asset/TypeormAssetProvider/TypeormAssetProvider.ts
@@ -28,12 +28,12 @@ export class TypeormAssetProvider extends TypeormProvider implements AssetProvid
   #paginationPageSizeLimit: number;
 
   constructor({ paginationPageSizeLimit }: TypeormAssetProviderProps, dependencies: TypeormAssetProviderDependencies) {
-    const { connectionConfig$, entities, logger } = dependencies;
-    super('TypeormAssetProvider', { connectionConfig$, entities, logger });
+    const { connectionConfig$, entities, logger, healthCheckCache } = dependencies;
+    super('TypeormAssetProvider', { connectionConfig$, entities, healthCheckCache, logger });
 
     this.#dependencies = dependencies;
     this.#paginationPageSizeLimit = paginationPageSizeLimit;
-    this.#nftMetadataService = new TypeOrmNftMetadataService({ connectionConfig$, entities, logger });
+    this.#nftMetadataService = new TypeOrmNftMetadataService({ connectionConfig$, entities, healthCheckCache, logger });
   }
 
   async getAsset({ assetId, extraData }: GetAssetArgs): Promise<Asset.AssetInfo> {

--- a/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
+++ b/packages/cardano-services/src/InMemoryCache/InMemoryCache.ts
@@ -5,8 +5,8 @@ export type Key = string | number;
 export type AsyncAction<T> = () => Promise<T>;
 
 export class InMemoryCache {
-  #cache: NodeCache;
-  #ttlDefault: number;
+  protected cache: NodeCache;
+  protected ttlDefault: number;
 
   /**
    *
@@ -14,8 +14,8 @@ export class InMemoryCache {
    * @param cache The cache engine. It must extend NodeCache
    */
   constructor(ttl: Seconds | 0, cache: NodeCache = new NodeCache()) {
-    this.#ttlDefault = ttl;
-    this.#cache = cache;
+    this.ttlDefault = ttl;
+    this.cache = cache;
   }
 
   /**
@@ -26,8 +26,8 @@ export class InMemoryCache {
    * @param ttl The time to live in seconds
    * @returns The value stored with the key
    */
-  public async get<T>(key: Key, asyncAction: AsyncAction<T>, ttl = this.#ttlDefault): Promise<T> {
-    const cachedValue: T | undefined = this.#cache.get(key);
+  public async get<T>(key: Key, asyncAction: AsyncAction<T>, ttl = this.ttlDefault): Promise<T> {
+    const cachedValue: T | undefined = this.cache.get(key);
     if (cachedValue) {
       return cachedValue;
     }
@@ -35,7 +35,7 @@ export class InMemoryCache {
     const resultPromise = asyncAction();
     this.set(
       key,
-      resultPromise.catch(() => this.#cache.del(key)),
+      resultPromise.catch(() => this.cache.del(key)),
       ttl
     );
     return resultPromise;
@@ -48,7 +48,7 @@ export class InMemoryCache {
    * @returns The value stored in the key
    */
   public getVal<T>(key: Key) {
-    return this.#cache.get<T>(key);
+    return this.cache.get<T>(key);
   }
 
   /**
@@ -59,8 +59,8 @@ export class InMemoryCache {
    * @param ttl The time to live in seconds
    * @returns The success state of the operation
    */
-  public set<T>(key: Key, value: T, ttl = this.#ttlDefault) {
-    return this.#cache.set<T>(key, value, ttl);
+  public set<T>(key: Key, value: T, ttl = this.ttlDefault) {
+    return this.cache.set<T>(key, value, ttl);
   }
 
   /**
@@ -69,7 +69,7 @@ export class InMemoryCache {
    * @param keys cache key to delete or a array of cache keys
    */
   public invalidate(keys: Key | Key[]) {
-    this.#cache.del(keys);
+    this.cache.del(keys);
   }
 
   /**
@@ -78,16 +78,16 @@ export class InMemoryCache {
    * @returns An array of all keys
    */
   public keys() {
-    return this.#cache.keys();
+    return this.cache.keys();
   }
 
   /** Clear the interval timeout which is set on check period option. Default: 600 */
   public shutdown() {
-    this.#cache.close();
+    this.cache.close();
   }
 
   /** Clear the whole data and reset the stats */
   public clear() {
-    this.#cache.flushAll();
+    this.cache.flushAll();
   }
 }

--- a/packages/cardano-services/src/InMemoryCache/WarmCache.ts
+++ b/packages/cardano-services/src/InMemoryCache/WarmCache.ts
@@ -1,0 +1,98 @@
+import { AsyncAction, InMemoryCache, Key } from './InMemoryCache';
+import { Seconds } from '@cardano-sdk/core';
+import NodeCache from 'node-cache';
+
+interface WarmCacheItem<T> {
+  asyncAction: AsyncAction<T>;
+  value: T;
+  ttl: number;
+  updateTime: number;
+}
+
+export class WarmCache extends InMemoryCache {
+  constructor(ttl: Seconds, expireCheckPeriod: Seconds) {
+    const cache = new NodeCache({
+      checkperiod: expireCheckPeriod,
+      deleteOnExpire: true,
+      stdTTL: ttl,
+      useClones: false
+    });
+    super(ttl, cache);
+
+    this.cache.on('expired', (key, value) => {
+      this.#warm(key, value, this.cache);
+    });
+  }
+
+  public mockCache(cache: NodeCache) {
+    this.cache = cache;
+  }
+  public async get<T>(key: Key, asyncAction: AsyncAction<T>, ttl = this.ttlDefault): Promise<T> {
+    const cachedValue: WarmCacheItem<T> | undefined = this.cache.get(key);
+
+    if (cachedValue && cachedValue.value) {
+      return cachedValue.value;
+    }
+
+    const updateTime = Date.now();
+    const promise = this.#setWarmCacheItem<T>(key, asyncAction, ttl, this.cache, updateTime);
+
+    this.cache.set(
+      key,
+      {
+        asyncAction,
+        ttl,
+        updateTime,
+        value: promise
+        // value: _resolved ? Promise.resolve(value) : Promise.reject(value)
+      } as WarmCacheItem<T>,
+      ttl
+    );
+
+    return promise;
+  }
+
+  #warm<T>(key: string, item: WarmCacheItem<T> | undefined, cacheNode: NodeCache) {
+    if (item && item.asyncAction) {
+      this.#setWarmCacheItem(key, item.asyncAction, item.ttl, cacheNode, Date.now()).catch(
+        () => 'rejected in the background'
+      );
+    }
+  }
+
+  async #setWarmCacheItem<T>(
+    key: Key,
+    asyncAction: AsyncAction<T>,
+    ttl: number,
+    cacheNode: NodeCache,
+    updateTime: number
+  ) {
+    const handleValue = (value: T, _resolved = true) => {
+      const item = this.cache.get(key) as WarmCacheItem<T>;
+      if (item && item.updateTime > updateTime) {
+        return item.value;
+      }
+      const promise = _resolved ? Promise.resolve(value) : Promise.reject(value);
+
+      cacheNode.set(
+        key,
+        {
+          asyncAction,
+          ttl,
+          updateTime,
+          value: promise
+          // value: _resolved ? Promise.resolve(value) : Promise.reject(value)
+        } as WarmCacheItem<T>,
+        ttl
+      );
+      return promise;
+    };
+
+    try {
+      const value = await asyncAction();
+      return handleValue(value, true);
+    } catch (error) {
+      return handleValue(error as T, false);
+    }
+  }
+}

--- a/packages/cardano-services/src/util/TypeormProvider/TypeormProvider.ts
+++ b/packages/cardano-services/src/util/TypeormProvider/TypeormProvider.ts
@@ -1,13 +1,17 @@
 import { HealthCheckResponse, Milliseconds, Provider } from '@cardano-sdk/core';
+import { InMemoryCache } from '../../InMemoryCache';
 import { TypeormService, TypeormServiceDependencies } from '../TypeormService';
 import { skip } from 'rxjs';
 
-export type TypeormProviderDependencies = Omit<TypeormServiceDependencies, 'connectionTimeout'>;
+export type TypeormProviderDependencies = Omit<TypeormServiceDependencies, 'connectionTimeout'> & {
+  healthCheckCache: InMemoryCache;
+};
 
 const unhealthy = { ok: false, reason: 'Provider error' };
 
 export abstract class TypeormProvider extends TypeormService implements Provider {
   health: HealthCheckResponse = { ok: false, reason: 'not started' };
+  healthCheckCache: InMemoryCache;
 
   constructor(name: string, dependencies: TypeormProviderDependencies) {
     super(name, { ...dependencies, connectionTimeout: Milliseconds(1000) });
@@ -15,12 +19,16 @@ export abstract class TypeormProvider extends TypeormService implements Provider
     this.dataSource$.pipe(skip(1)).subscribe((dataSource) => {
       this.health = dataSource ? { ok: true } : unhealthy;
     });
+
+    this.healthCheckCache = dependencies.healthCheckCache;
   }
 
   async healthCheck(): Promise<HealthCheckResponse> {
     if (this.state === 'running')
       try {
-        await this.withDataSource((dataSource) => dataSource.query('SELECT 1'));
+        await this.healthCheckCache.get(`typeorm_db_${this.name}`, () =>
+          this.withDataSource((dataSource) => dataSource.query('SELECT 1'))
+        );
       } catch {
         return unhealthy;
       }

--- a/packages/cardano-services/test/Asset/TypeOrmNftMetadataService.test.ts
+++ b/packages/cardano-services/test/Asset/TypeOrmNftMetadataService.test.ts
@@ -1,5 +1,5 @@
 import { Cardano, util } from '@cardano-sdk/core';
-import { TypeOrmNftMetadataService, createDnsResolver, getConnectionConfig, getEntities } from '../../src';
+import { NoCache, TypeOrmNftMetadataService, createDnsResolver, getConnectionConfig, getEntities } from '../../src';
 import { logger, mockProviders } from '@cardano-sdk/util-dev';
 
 describe('TypeOrmNftMetadataService', () => {
@@ -11,7 +11,7 @@ describe('TypeOrmNftMetadataService', () => {
     const connectionConfig$ = getConnectionConfig(dnsResolver, 'test', 'Asset', {
       postgresConnectionStringAsset: process.env.POSTGRES_CONNECTION_STRING_ASSET!
     });
-    service = new TypeOrmNftMetadataService({ connectionConfig$, entities, logger });
+    service = new TypeOrmNftMetadataService({ connectionConfig$, entities, healthCheckCache: new NoCache(), logger });
     await service.initialize();
     await service.start();
   });

--- a/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetFixtureBuilder.ts
+++ b/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetFixtureBuilder.ts
@@ -2,6 +2,7 @@ import { Asset, Cardano } from '@cardano-sdk/core';
 import { AssetEntity, NftMetadataEntity } from '@cardano-sdk/projection-typeorm';
 import { IsNull, Not } from 'typeorm';
 import { Logger } from 'ts-log';
+import { NoCache } from '../../../src';
 import { TypeormProvider, TypeormProviderDependencies } from '../../../src/util';
 
 export enum TypeormAssetWith {
@@ -12,7 +13,7 @@ export class TypeormAssetFixtureBuilder extends TypeormProvider {
   #logger: Logger;
 
   constructor({ connectionConfig$, entities, logger }: TypeormProviderDependencies) {
-    super('TypeormAssetFixtureBuilder', { connectionConfig$, entities, logger });
+    super('TypeormAssetFixtureBuilder', { connectionConfig$, entities, healthCheckCache: new NoCache(), logger });
     this.#logger = logger;
   }
 

--- a/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetProvider.test.ts
+++ b/packages/cardano-services/test/Asset/TypeormAssetProvider/TypeormAssetProvider.test.ts
@@ -1,6 +1,6 @@
 import { Cardano, ProviderError, ProviderFailure } from '@cardano-sdk/core';
-import { Observable } from 'rxjs';
 import {
+  NoCache,
   PAGINATION_PAGE_SIZE_LIMIT_ASSETS,
   TokenMetadataService,
   TypeormAssetProvider,
@@ -8,6 +8,7 @@ import {
   getConnectionConfig,
   getEntities
 } from '../../../src';
+import { Observable } from 'rxjs';
 import { PgConnectionConfig } from '@cardano-sdk/projection-typeorm';
 import { TypeormAssetFixtureBuilder, TypeormAssetWith } from './TypeormAssetFixtureBuilder';
 import { logger } from '@cardano-sdk/util-dev';
@@ -43,9 +44,14 @@ describe('TypeormAssetProvider', () => {
       {
         paginationPageSizeLimit: PAGINATION_PAGE_SIZE_LIMIT_ASSETS
       },
-      { connectionConfig$, entities, logger, tokenMetadataService }
+      { connectionConfig$, entities, healthCheckCache: new NoCache(), logger, tokenMetadataService }
     );
-    fixtureBuilder = new TypeormAssetFixtureBuilder({ connectionConfig$, entities, logger });
+    fixtureBuilder = new TypeormAssetFixtureBuilder({
+      connectionConfig$,
+      entities,
+      healthCheckCache: new NoCache(),
+      logger
+    });
 
     await provider.initialize();
     await provider.start();

--- a/packages/cardano-services/test/Handle/TypeOrmHandleProvider.test.ts
+++ b/packages/cardano-services/test/Handle/TypeOrmHandleProvider.test.ts
@@ -1,5 +1,5 @@
 import { HandleFixtures, createHandleFixtures } from './fixtures';
-import { TypeOrmHandleProvider, createDnsResolver, getConnectionConfig, getEntities } from '../../src';
+import { NoCache, TypeOrmHandleProvider, createDnsResolver, getConnectionConfig, getEntities } from '../../src';
 import { logger } from '@cardano-sdk/util-dev';
 
 describe('TypeOrmHandleProvider', () => {
@@ -14,7 +14,7 @@ describe('TypeOrmHandleProvider', () => {
     });
 
     fixtures = await createHandleFixtures(connectionConfig$);
-    provider = new TypeOrmHandleProvider({ connectionConfig$, entities, logger });
+    provider = new TypeOrmHandleProvider({ connectionConfig$, entities, healthCheckCache: new NoCache(), logger });
 
     await provider.initialize();
     await provider.start();

--- a/packages/cardano-services/test/InMemoryCache/InMemoryCache.test.ts
+++ b/packages/cardano-services/test/InMemoryCache/InMemoryCache.test.ts
@@ -1,49 +1,28 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  CURRENT_EPOCH_KEY,
+  TOTAL_STAKE_KEY,
+  cacheMiss,
+  createNodeCacheMocked,
+  currentEpoch,
+  sharedInMemoryCacheTests,
+  totalStakeCachedValue
+} from './SharedTests';
 import { DB_CACHE_TTL_DEFAULT, InMemoryCache } from '../../src/InMemoryCache';
 import NodeCache from 'node-cache';
 
 describe('InMemoryCache', () => {
-  const CURRENT_EPOCH_KEY = 'NetworkInfo_current_epoch';
-  const TOTAL_STAKE_KEY = 'NetworkInfo_total_stake';
-  const totalStakeCachedValue = 4_500_000_001;
-  const currentEpoch = 250;
   const cachedValues: any = {
     [CURRENT_EPOCH_KEY]: currentEpoch,
     [TOTAL_STAKE_KEY]: totalStakeCachedValue
   };
-  const cacheMiss = undefined;
+  const nodeCacheMocked: jest.MockedClass<any> = createNodeCacheMocked(cachedValues);
+  const cache = new InMemoryCache(DB_CACHE_TTL_DEFAULT, nodeCacheMocked);
+  sharedInMemoryCacheTests(nodeCacheMocked, cachedValues, cache, 'InMemoryCache');
 
   describe('with mocked node-cache', () => {
-    const nodeCacheMocked: jest.MockedClass<any> = {
-      close: jest.fn(),
-      del: jest.fn(() => true),
-      flushAll: jest.fn(),
-      get: jest.fn((key) => cachedValues[key]),
-      getVal: jest.fn((key) => cachedValues[key]),
-      keys: jest.fn(() => [CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]),
-      set: jest.fn(() => true)
-    };
-    const cache = new InMemoryCache(DB_CACHE_TTL_DEFAULT, nodeCacheMocked);
-
     afterEach(async () => {
       jest.clearAllMocks();
-    });
-
-    it('get with cache hit', async () => {
-      const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve());
-      expect(response).toEqual(totalStakeCachedValue);
-      expect(nodeCacheMocked.get).toBeCalled();
-      expect(nodeCacheMocked.set).not.toBeCalled();
-    });
-
-    it('get with cache miss', async () => {
-      const dbQueryTotalStakeResponse = '445566778899';
-      (nodeCacheMocked as jest.MockedClass<any>).get.mockImplementationOnce(() => cacheMiss);
-
-      const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve(dbQueryTotalStakeResponse));
-      expect(response).toEqual(dbQueryTotalStakeResponse);
-      expect(nodeCacheMocked.get).toBeCalled();
-      expect(nodeCacheMocked.set).toBeCalled();
     });
 
     it('get with cache miss but db query fails the cache is properly cleared', async () => {
@@ -54,34 +33,7 @@ describe('InMemoryCache', () => {
       expect(nodeCacheMocked.set).toBeCalled();
       expect(nodeCacheMocked.del).toHaveBeenCalledWith(TOTAL_STAKE_KEY);
     });
-
-    it('set', async () => {
-      expect(cache.set(CURRENT_EPOCH_KEY, currentEpoch, 120)).toEqual(true);
-      expect(nodeCacheMocked.set).toBeCalled();
-    });
-
-    it('getVal', async () => {
-      expect(cache.getVal(TOTAL_STAKE_KEY)).toEqual(totalStakeCachedValue);
-      expect(nodeCacheMocked.get).toBeCalled();
-    });
-
-    it('keys', async () => {
-      const keys = cache.keys();
-      expect(keys).toEqual([CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]);
-      expect(nodeCacheMocked.keys).toBeCalled();
-    });
-
-    it('shutdown', async () => {
-      cache.shutdown();
-      expect(nodeCacheMocked.close).toBeCalled();
-    });
-
-    it('clear', async () => {
-      cache.clear();
-      expect(nodeCacheMocked.flushAll).toBeCalled();
-    });
   });
-
   describe('with real node-cache', () => {
     it('get called multiple times does not query twice and returns the same result', async () => {
       const realCache = new InMemoryCache(DB_CACHE_TTL_DEFAULT, new NodeCache());

--- a/packages/cardano-services/test/InMemoryCache/SharedTests.ts
+++ b/packages/cardano-services/test/InMemoryCache/SharedTests.ts
@@ -1,0 +1,73 @@
+import { InMemoryCache } from '../../src';
+
+export const CURRENT_EPOCH_KEY = 'NetworkInfo_current_epoch';
+export const TOTAL_STAKE_KEY = 'NetworkInfo_total_stake';
+export const totalStakeCachedValue = 4_500_000_001;
+export const currentEpoch = 250;
+export const cacheMiss = undefined;
+
+export const createNodeCacheMocked = (cachedValues: { [key: string]: unknown }) => ({
+  close: jest.fn(),
+  del: jest.fn(() => true),
+  flushAll: jest.fn(),
+  get: jest.fn((key) => cachedValues[key]),
+  getVal: jest.fn((key) => cachedValues[key]),
+  keys: jest.fn(() => [CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]),
+  set: jest.fn(() => true)
+});
+export const sharedInMemoryCacheTests = (
+  /* eslint-disable-next-line  @typescript-eslint/no-explicit-any */
+  nodeCacheMocked: jest.MockedClass<any>,
+  cachedValues: { [key: string]: unknown },
+  cache: InMemoryCache,
+  implName: string
+) => {
+  describe(`shared tests for ${implName}, with mocked node-cache`, () => {
+    afterEach(async () => {
+      jest.clearAllMocks();
+    });
+
+    it('get with cache hit', async () => {
+      const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve());
+      expect(response).toEqual(totalStakeCachedValue);
+      expect(nodeCacheMocked.get).toBeCalled();
+      expect(nodeCacheMocked.set).not.toBeCalled();
+    });
+
+    it('get with cache miss', async () => {
+      const dbQueryTotalStakeResponse = '445566778899';
+      nodeCacheMocked.get.mockImplementationOnce(() => cacheMiss);
+
+      const response = await cache.get(TOTAL_STAKE_KEY, () => Promise.resolve(dbQueryTotalStakeResponse));
+      expect(response).toEqual(dbQueryTotalStakeResponse);
+      expect(nodeCacheMocked.get).toBeCalled();
+      expect(nodeCacheMocked.set).toBeCalled();
+    });
+
+    it('set', async () => {
+      expect(cache.set(CURRENT_EPOCH_KEY, currentEpoch, 120)).toEqual(true);
+      expect(nodeCacheMocked.set).toBeCalled();
+    });
+
+    it('getVal', async () => {
+      expect(cache.getVal(TOTAL_STAKE_KEY)).toEqual(cachedValues[TOTAL_STAKE_KEY]);
+      expect(nodeCacheMocked.get).toBeCalled();
+    });
+
+    it('keys', async () => {
+      const keys = cache.keys();
+      expect(keys).toEqual([CURRENT_EPOCH_KEY, TOTAL_STAKE_KEY]);
+      expect(nodeCacheMocked.keys).toBeCalled();
+    });
+
+    it('shutdown', async () => {
+      cache.shutdown();
+      expect(nodeCacheMocked.close).toBeCalled();
+    });
+
+    it('clear', async () => {
+      cache.clear();
+      expect(nodeCacheMocked.flushAll).toBeCalled();
+    });
+  });
+};

--- a/packages/cardano-services/test/InMemoryCache/WarmCache.test.ts
+++ b/packages/cardano-services/test/InMemoryCache/WarmCache.test.ts
@@ -1,0 +1,227 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  CURRENT_EPOCH_KEY,
+  TOTAL_STAKE_KEY,
+  cacheMiss,
+  createNodeCacheMocked,
+  currentEpoch,
+  sharedInMemoryCacheTests,
+  totalStakeCachedValue
+} from './SharedTests';
+import { DB_CACHE_TTL_DEFAULT } from '../../src/InMemoryCache';
+import { Seconds } from '@cardano-sdk/core';
+import { WarmCache } from '../../src/InMemoryCache/WarmCache';
+
+describe('WarmCache', () => {
+  const cachedValues = {
+    [CURRENT_EPOCH_KEY]: {
+      asyncAction: () => Promise.resolve(currentEpoch),
+      value: currentEpoch
+    },
+    [TOTAL_STAKE_KEY]: {
+      asyncAction: () => Promise.resolve(totalStakeCachedValue),
+      value: totalStakeCachedValue
+    }
+  };
+
+  describe('with mocked node-cache', () => {
+    const nodeCacheMocked: jest.MockedClass<any> = createNodeCacheMocked(cachedValues);
+
+    const cache = new WarmCache(DB_CACHE_TTL_DEFAULT, Seconds(1));
+    cache.mockCache(nodeCacheMocked);
+
+    sharedInMemoryCacheTests(nodeCacheMocked, cachedValues, cache, 'WarmCache');
+
+    afterEach(async () => {
+      jest.clearAllMocks();
+    });
+
+    it('get with cache miss but db query fails the cache is properly handled', async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(1_725_528_828_051);
+      (nodeCacheMocked as jest.MockedClass<any>).get.mockImplementationOnce(() => cacheMiss);
+      const promise = Promise.reject('db');
+      const asyncAction = jest.fn(() => promise);
+      await expect(cache.get(TOTAL_STAKE_KEY, asyncAction)).rejects.toEqual('db');
+
+      await Promise.resolve();
+      expect(asyncAction).toBeCalledTimes(1);
+      expect(nodeCacheMocked.set).toBeCalledTimes(2);
+      expect(nodeCacheMocked.set).toHaveBeenCalledWith(
+        TOTAL_STAKE_KEY,
+        { asyncAction, ttl: 7200, updateTime: 1_725_528_828_051, value: promise },
+        7200
+      );
+    });
+  });
+
+  describe('with real node-cache', () => {
+    jest.useFakeTimers();
+
+    const WARM = 'warm';
+    const WARMER = 'warmer';
+    const HOT = 'hot';
+    const COLD = 'cold';
+
+    it('get called multiple times does not query twice and returns the same result', async () => {
+      const realCache = new WarmCache(DB_CACHE_TTL_DEFAULT, Seconds(10));
+
+      let resolveQuery: Function;
+      const queryResult = new Promise((resolve) => (resolveQuery = resolve));
+      const dbSyncQuery = jest.fn(() => queryResult);
+
+      await Promise.resolve();
+      const result1 = realCache.get(TOTAL_STAKE_KEY, dbSyncQuery);
+      await Promise.resolve();
+      const result2 = realCache.get(TOTAL_STAKE_KEY, dbSyncQuery);
+
+      resolveQuery!('db');
+      expect(await result1).toEqual(await result2);
+
+      expect(dbSyncQuery).toBeCalledTimes(1);
+    });
+
+    it('get warmer in the background', async () => {
+      const mockedFunc = jest
+        .fn()
+        .mockImplementation(() => Promise.reject('default'))
+        .mockImplementationOnce(() => Promise.resolve(COLD))
+        .mockImplementationOnce(() => Promise.resolve(WARM))
+        .mockImplementationOnce(() => Promise.resolve(WARMER))
+        .mockImplementationOnce(() => Promise.resolve(HOT));
+
+      const realCache = new WarmCache(Seconds(5), Seconds(0.1));
+
+      // first round - no warming
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(COLD);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(COLD);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      // second round - first warming
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARM);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARM);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      // third round - second warming
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARMER);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARMER);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      // fourth round - third warming
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(HOT);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(HOT);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      realCache.shutdown();
+    });
+
+    it('warming handles rejects in the background', async () => {
+      const mockedFunc = jest
+        .fn()
+        .mockImplementation(() => Promise.resolve('default'))
+        .mockImplementationOnce(() => Promise.reject(COLD))
+        .mockImplementationOnce(() => Promise.resolve(WARM))
+        .mockImplementationOnce(() => Promise.reject(COLD))
+        .mockImplementationOnce(() => Promise.resolve(WARMER))
+        .mockImplementationOnce(() => Promise.resolve(HOT));
+
+      const realCache = new WarmCache(Seconds(5), Seconds(0.1));
+
+      // first round - no warming
+      await expect(realCache.get('key1', mockedFunc)).rejects.toBe(COLD);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      // first round - warming of rejected
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARM);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      // second round - first warming but rejected in the background
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1); // a new call in the background
+      await expect(realCache.get('key1', mockedFunc)).rejects.toBe(COLD);
+
+      // third round - second warming, rejected get warmed in the background
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1); // new call in the background
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARMER);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARMER);
+      expect(mockedFunc).toBeCalledTimes(1); // no new call
+
+      // fourth round - third warming
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1); // a new call in the background
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(HOT);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(HOT);
+      expect(mockedFunc).toBeCalledTimes(1); // no new call
+
+      realCache.shutdown();
+    });
+
+    it('warming handles lagging and race conditions', async () => {
+      const mockedFunc = jest
+        .fn()
+        .mockImplementation(() => Promise.reject('default'))
+        .mockImplementationOnce(() => Promise.resolve(COLD))
+        .mockImplementationOnce(() => Promise.resolve(WARM))
+        .mockImplementationOnce(() => new Promise((_resolve, reject) => setTimeout(() => reject('timeout'), 2000)))
+        .mockImplementationOnce(() => Promise.resolve(WARMER))
+        .mockImplementationOnce(() => Promise.resolve(HOT));
+
+      const realCache = new WarmCache(Seconds(5), Seconds(0.1));
+
+      // first round - no warming
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(COLD);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(COLD);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      // second round - warming
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARM);
+
+      // third round - timeout call finished, but couldn't override a newer call finished
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARMER);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(WARMER);
+      expect(mockedFunc).toBeCalledTimes(2);
+
+      // fourth round
+      mockedFunc.mockClear();
+      jest.advanceTimersByTime(5100);
+      await Promise.resolve();
+      expect(mockedFunc).toBeCalledTimes(1);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(HOT);
+      await expect(realCache.get('key1', mockedFunc)).resolves.toBe(HOT);
+      expect(mockedFunc).toBeCalledTimes(1);
+
+      realCache.shutdown();
+    });
+  });
+});

--- a/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
+++ b/packages/cardano-services/test/StakePool/TypeormStakePoolProvider/TypeormStakePoolProvider.test.ts
@@ -7,6 +7,7 @@ import {
   HttpServer,
   HttpServerConfig,
   InMemoryCache,
+  NoCache,
   StakePoolHttpService,
   TypeormStakePoolProvider,
   UNLIMITED_CACHE_TTL,
@@ -154,7 +155,13 @@ describe('TypeormStakePoolProvider', () => {
         provider = stakePoolHttpProvider(clientConfig);
         stakePoolProvider = new TypeormStakePoolProvider(
           { fuzzyOptions: DEFAULT_FUZZY_SEARCH_OPTIONS, lastRosEpochs: 10, paginationPageSizeLimit: pagination.limit },
-          { cache: new InMemoryCache(UNLIMITED_CACHE_TTL), connectionConfig$, entities, logger }
+          {
+            cache: new InMemoryCache(UNLIMITED_CACHE_TTL),
+            connectionConfig$,
+            entities,
+            healthCheckCache: new NoCache(),
+            logger
+          }
         );
         service = new StakePoolHttpService({ logger, stakePoolProvider });
         httpServer = new HttpServer(config, { logger, runnableDependencies: [], services: [service] });

--- a/packages/cardano-services/test/TxSubmit/NodeTxSubmitProvider.test.ts
+++ b/packages/cardano-services/test/TxSubmit/NodeTxSubmitProvider.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@cardano-sdk/core';
 import { EMPTY, ReplaySubject, of, throwError } from 'rxjs';
 import { HexBlob } from '@cardano-sdk/util';
-import { NodeTxSubmitProvider, NodeTxSubmitProviderProps } from '../../src';
+import { NoCache, NodeTxSubmitProvider, NodeTxSubmitProviderProps } from '../../src';
 import { generateRandomHexString } from '@cardano-sdk/util-dev';
 import { dummyLogger as logger } from 'ts-log';
 
@@ -53,7 +53,7 @@ describe('NodeTxSubmitProvider', () => {
 
   describe('without handle provider', () => {
     beforeEach(async () => {
-      provider = new NodeTxSubmitProvider({ cardanoNode, logger });
+      provider = new NodeTxSubmitProvider({ cardanoNode, healthCheckCache: new NoCache(), logger });
     });
 
     describe('submitTx', () => {
@@ -104,7 +104,7 @@ describe('NodeTxSubmitProvider', () => {
   describe('with handle provider', () => {
     beforeEach(() => {
       handleProvider = { getPolicyIds: jest.fn(), healthCheck: jest.fn(), resolveHandles: jest.fn() };
-      provider = new NodeTxSubmitProvider({ cardanoNode, handleProvider, logger });
+      provider = new NodeTxSubmitProvider({ cardanoNode, handleProvider, healthCheckCache: new NoCache(), logger });
     });
 
     describe('initialized provider', () => {

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -47,7 +47,7 @@ import {
 } from '@cardano-sdk/cardano-services-client';
 import { LedgerKeyAgent } from '@cardano-sdk/hardware-ledger';
 import { Logger } from 'ts-log';
-import { NodeTxSubmitProvider } from '@cardano-sdk/cardano-services';
+import { NoCache, NodeTxSubmitProvider } from '@cardano-sdk/cardano-services';
 import { OgmiosObservableCardanoNode } from '@cardano-sdk/ogmios';
 import { TrezorKeyAgent } from '@cardano-sdk/hardware-trezor';
 import { createStubStakePoolProvider } from '@cardano-sdk/util-dev';
@@ -165,8 +165,10 @@ txSubmitProviderFactory.register(OGMIOS_PROVIDER, async (params: any, logger: Lo
           {
             connectionConfig$: of(connectionConfig)
           },
+
           { logger }
         ),
+        healthCheckCache: new NoCache(),
         logger
       })
     );


### PR DESCRIPTION
This PR aims to improve health check API response times  (to under 1 sec) by pre-fetching and caching the underlying service health.

# Context

Generating on-demand health check responses is taking a long time. 

# Proposed Solution

We want to aggregate and cache underlying health check responses in the background. On-demand health check API responses will be generated from the always-warm cache.

We implemented a WarmCache logic by extending InMemoryCache.

One cache can be shared with multiple providers.

# Important Changes Introduced
Now, various providers will be aggregating health checks independently in the background. 