### PR TITLE
feat(cardano-services): implement provider selection based on env variables and config

### DIFF
--- a/packages/cardano-services/src/Program/options/index.ts
+++ b/packages/cardano-services/src/Program/options/index.ts
@@ -1,3 +1,4 @@
+export * from './providers';
 export * from './common';
 export * from './ogmios';
 export * from './policyIds';

--- a/packages/cardano-services/src/Program/options/providers.ts
+++ b/packages/cardano-services/src/Program/options/providers.ts
@@ -1,0 +1,79 @@
+import { newOption } from './util';
+
+export enum ProviderImplementation {
+  TYPEORM = 'typeorm',
+  BLOCKFROST = 'blockfrost',
+  DBSYNC = 'dbsync',
+  // Below ones are specific to TxSubmitProvider
+  SUBMIT_NODE = 'submit-node',
+  SUBMIT_API = 'submit-api'
+}
+
+export type ProviderImplementations = {
+  assetProvider?: ProviderImplementation;
+  rewardsProvider?: ProviderImplementation;
+  networkInfoProvider?: ProviderImplementation;
+  utxoProvider?: ProviderImplementation;
+  txSubmitProvider?: ProviderImplementation;
+  chainHistoryProvider?: ProviderImplementation;
+  stakePoolProvider?: ProviderImplementation;
+};
+export const ProviderImplementationDescription = 'Select one of the available provider implementations';
+const argParser = (impl: string) => ProviderImplementation[impl.toUpperCase() as keyof typeof ProviderImplementation];
+export const providerSelectionOptions = [
+  newOption(
+    '--asset-provider <implementation>',
+    ProviderImplementationDescription,
+    'ASSET_PROVIDER',
+    argParser,
+    ProviderImplementation.DBSYNC
+  )
+    .conflicts('useTypeormAssetProvider')
+    .choices([ProviderImplementation.BLOCKFROST, ProviderImplementation.DBSYNC, ProviderImplementation.TYPEORM]),
+  newOption(
+    '--stake-pool-provider <implementation>',
+    ProviderImplementationDescription,
+    'STAKE_POOL_PROVIDER',
+    argParser,
+    ProviderImplementation.DBSYNC
+  )
+    .conflicts('useTypeormStakePoolProvider')
+    .choices([ProviderImplementation.DBSYNC, ProviderImplementation.TYPEORM]),
+  newOption(
+    '--utxo-provider <implementation>',
+    ProviderImplementationDescription,
+    'UTXO_PROVIDER',
+    argParser,
+    ProviderImplementation.DBSYNC
+  ).choices([ProviderImplementation.BLOCKFROST, ProviderImplementation.DBSYNC]),
+  newOption(
+    '--chain-history-provider <implementation>',
+    ProviderImplementationDescription,
+    'CHAIN_HISTORY_PROVIDER',
+    argParser,
+    ProviderImplementation.DBSYNC
+  ).choices([ProviderImplementation.BLOCKFROST, ProviderImplementation.DBSYNC]),
+  newOption(
+    '--rewards-provider <implementation>',
+    ProviderImplementationDescription,
+    'REWARDS_PROVIDER',
+    argParser,
+    ProviderImplementation.DBSYNC
+  ).choices([ProviderImplementation.BLOCKFROST, ProviderImplementation.DBSYNC]),
+  newOption(
+    '--network-info-provider <implementation>',
+    ProviderImplementationDescription,
+    'NETWORK_INFO_PROVIDER',
+    argParser,
+    ProviderImplementation.DBSYNC
+  ).choices([ProviderImplementation.BLOCKFROST, ProviderImplementation.DBSYNC]),
+  newOption(
+    '--tx-submit-provider <implementation>',
+    ProviderImplementationDescription,
+    'TX_SUBMIT_PROVIDER',
+    argParser,
+    ProviderImplementation.SUBMIT_NODE
+  )
+    .conflicts('useSubmitApi')
+    .choices([ProviderImplementation.BLOCKFROST, ProviderImplementation.SUBMIT_API, ProviderImplementation.SUBMIT_NODE])
+];

--- a/packages/cardano-services/src/Program/programs/types.ts
+++ b/packages/cardano-services/src/Program/programs/types.ts
@@ -1,10 +1,11 @@
 import {
   CommonProgramOptions,
+  HandlePolicyIdsProgramOptions,
   OgmiosProgramOptions,
   PosgresProgramOptions,
+  ProviderImplementations,
   StakePoolMetadataProgramOptions
 } from '../options';
-import { HandlePolicyIdsProgramOptions } from '../options/policyIds';
 import { Milliseconds, Seconds } from '@cardano-sdk/core';
 import { TypeOrmStakePoolProviderProps } from '../../StakePool';
 import { defaultJobOptions } from '@cardano-sdk/projection-typeorm';
@@ -73,7 +74,8 @@ export type ProviderServerArgs = CommonProgramOptions &
   OgmiosProgramOptions &
   HandlePolicyIdsProgramOptions &
   StakePoolMetadataProgramOptions &
-  TypeOrmStakePoolProviderProps & {
+  TypeOrmStakePoolProviderProps &
+  ProviderImplementations & {
     allowedOrigins?: string[];
     assetCacheTTL?: Seconds;
     disableStakePoolMetricApy?: boolean;

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -44,6 +44,7 @@ import {
   loadProviderServer,
   loadWsServer,
   newOption,
+  providerSelectionOptions,
   stringOptionToBoolean,
   withCommonOptions,
   withHandlePolicyIdsOptions,
@@ -377,7 +378,8 @@ addOptions(withOgmiosOptions(withHandlePolicyIdsOptions(providerServerWithCommon
     ProviderServerOptionDescriptions.UseWebSocketApi,
     'USE_WEB_SOCKET_API',
     (val) => stringOptionToBoolean(val, Programs.ProviderServer, ProviderServerOptionDescriptions.UseWebSocketApi)
-  )
+  ),
+  ...providerSelectionOptions
 ]).action(async (serviceNames: ServiceNames[], args: ProviderServerArgs) =>
   runServer('Provider server', { args, serviceNames }, () =>
     loadProviderServer({

--- a/packages/cardano-services/test/cli.test.ts
+++ b/packages/cardano-services/test/cli.test.ts
@@ -1112,5 +1112,147 @@ describe('CLI', () => {
           notDump
         }));
     });
+
+    describe('provider implementation selection', () => {
+      testCli('check defaults', 'provider', {
+        expectedArgs: {
+          args: {
+            assetProvider: 'dbsync',
+            chainHistoryProvider: 'dbsync',
+            networkInfoProvider: 'dbsync',
+            rewardsProvider: 'dbsync',
+            stakePoolProvider: 'dbsync',
+            txSubmitProvider: 'submit-node',
+            utxoProvider: 'dbsync'
+          }
+        }
+      });
+      describe('--asset-provider', () => {
+        testCli('set successful', 'provider', {
+          args: ['--asset-provider', 'blockfrost'],
+          env: { ASSET_PROVIDER: 'blockfrost' },
+          expectedArgs: {
+            args: {
+              assetProvider: 'blockfrost'
+            }
+          }
+        });
+        testCli('set unsuccessful', 'provider', {
+          args: ['--asset-provider', 'not-valid'],
+          env: { ASSET_PROVIDER: 'not-valid' },
+          expectedError: 'is invalid'
+        });
+        testCli('conflicts', 'provider', {
+          args: ['--asset-provider', 'blockfrost', '--use-typeorm-asset-provider', 'true'],
+          env: { ASSET_PROVIDER: 'blockfrost', USE_TYPEORM_ASSET_PROVIDER: 'true' },
+          expectedError: 'cannot be used with'
+        });
+      });
+      describe('--stake-pool-provider', () => {
+        testCli('set successful', 'provider', {
+          args: ['--stake-pool-provider', 'typeorm'],
+          env: { STAKE_POOL_PROVIDER: 'typeorm' },
+          expectedArgs: {
+            args: {
+              stakePoolProvider: 'typeorm'
+            }
+          }
+        });
+        testCli('set unsuccessful', 'provider', {
+          args: ['--stake-pool-provider', 'not-valid'],
+          env: { STAKE_POOL_PROVIDER: 'not-valid' },
+          expectedError: 'is invalid'
+        });
+        testCli('conflicts', 'provider', {
+          args: ['--stake-pool-provider', 'dbsync', '--use-typeorm-stake-pool-provider', 'true'],
+          env: { STAKE_POOL_PROVIDER: 'typeorm', USE_TYPEORM_STAKE_POOL_PROVIDER: 'true' },
+          expectedError: 'cannot be used with'
+        });
+      });
+
+      describe('--utxo-provider', () => {
+        testCli('set successful', 'provider', {
+          args: ['--utxo-provider', 'blockfrost'],
+          env: { UTXO_PROVIDER: 'blockfrost' },
+          expectedArgs: {
+            args: {
+              utxoProvider: 'blockfrost'
+            }
+          }
+        });
+        testCli('set unsuccessful', 'provider', {
+          args: ['--utxo-provider', 'not-valid'],
+          env: { UTXO_PROVIDER: 'not-valid' },
+          expectedError: 'is invalid'
+        });
+      });
+
+      describe('--chain-history-provider', () => {
+        testCli('set successful', 'provider', {
+          args: ['--chain-history-provider', 'blockfrost'],
+          env: { CHAIN_HISTORY_PROVIDER: 'blockfrost' },
+          expectedArgs: {
+            args: {
+              chainHistoryProvider: 'blockfrost'
+            }
+          }
+        });
+        testCli('set unsuccessful', 'provider', {
+          args: ['--chain-history-provider', 'not-valid'],
+          env: { CHAIN_HISTORY_PROVIDER: 'not-valid' },
+          expectedError: 'is invalid'
+        });
+      });
+
+      describe('--rewards-provider', () => {
+        testCli('set successful', 'provider', {
+          args: ['--rewards-provider', 'blockfrost'],
+          env: { REWARDS_PROVIDER: 'blockfrost' },
+          expectedArgs: {
+            args: {
+              rewardsProvider: 'blockfrost'
+            }
+          }
+        });
+        testCli('set unsuccessful', 'provider', {
+          args: ['--rewards-provider', 'not-valid'],
+          env: { REWARDS_PROVIDER: 'not-valid' },
+          expectedError: 'is invalid'
+        });
+      });
+
+      describe('--network-info-provider', () => {
+        testCli('set successful', 'provider', {
+          args: ['--network-info-provider', 'blockfrost'],
+          env: { NETWORK_INFO_PROVIDER: 'blockfrost' },
+          expectedArgs: {
+            args: {
+              networkInfoProvider: 'blockfrost'
+            }
+          }
+        });
+        testCli('set unsuccessful', 'provider', {
+          args: ['--network-info-provider', 'not-valid'],
+          env: { NETWORK_INFO_PROVIDER: 'not-valid' },
+          expectedError: 'is invalid'
+        });
+      });
+      describe('--tx-submit-provider', () => {
+        testCli('set successful', 'provider', {
+          args: ['--tx-submit-provider', 'blockfrost'],
+          env: { TX_SUBMIT_PROVIDER: 'blockfrost' },
+          expectedArgs: {
+            args: {
+              txSubmitProvider: 'blockfrost'
+            }
+          }
+        });
+        testCli('set unsuccessful', 'provider', {
+          args: ['--tx-submit-provider', 'not-valid'],
+          env: { TX_SUBMIT_PROVIDER: 'not-valid' },
+          expectedError: 'is invalid'
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
For most providers, we have multiple implementations.
This feature allows us to pick which implementation we run inside the related HttpService.

# Context

This PR is based on `blockfrost` branch and can be merged directly into the `master` once the `blockfrost` branch is merged.

# Proposed Solution
It's backward compatible by respecting or throwing errors in case of conflict with the old env vars or configs.
For example,

- if `USE_SUBMIT_API` is set to any value, setting the `TX_SUBMIT_PROVIDER` value will throw an error.


# Important Changes Introduced
