### PR TITLE
fix: expect disconnects during remote api method call

### DIFF
--- a/packages/e2e/test/web-extension/extension/background/cip30.ts
+++ b/packages/e2e/test/web-extension/extension/background/cip30.ts
@@ -2,6 +2,7 @@ import { cip30 } from '@cardano-sdk/web-extension';
 import { runtime } from 'webextension-polyfill';
 import { cip30 as walletCip30 } from '@cardano-sdk/wallet';
 
+import { NEVER } from 'rxjs';
 import { authenticator } from './authenticator';
 import { logger } from '../util';
 import { wallet$ } from './walletManager';
@@ -12,12 +13,12 @@ const confirmationCallback: walletCip30.CallbackConfirmation = {
   signData: async ({ sender }) => {
     if (!sender) throw new Error('No sender context');
     logger.info('signData request from', sender);
-    return true;
+    return { cancel$: NEVER };
   },
   signTx: async ({ sender }) => {
     if (!sender) throw new Error('No sender context');
     logger.info('signTx request', sender);
-    return true;
+    return { cancel$: NEVER };
   },
   submitTx: async () => true
 };

--- a/packages/web-extension/src/messaging/BackgroundMessenger.ts
+++ b/packages/web-extension/src/messaging/BackgroundMessenger.ts
@@ -53,6 +53,9 @@ export const createBackgroundMessenger = ({ logger, runtime }: MessengerDependen
     message$.next({ data, port });
   };
   const onPortDisconnected = (port: MessengerPort) => {
+    if (runtime.lastError) {
+      logger.warn(`[BackgroundMessenger(${port.name})] Last runtime error`, runtime.lastError);
+    }
     port.onMessage.removeListener(onPortMessage);
     port.onDisconnect.removeListener(onPortDisconnected);
     const { ports$ } = channels.get(port.name)!;

--- a/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
+++ b/packages/web-extension/src/messaging/NonBackgroundMessenger.ts
@@ -73,6 +73,9 @@ export const createNonBackgroundMessenger = (
     message$.next({ data, port });
   };
   const onDisconnect = (port: MessengerPort) => {
+    if (runtime.lastError) {
+      logger.warn(`[NonBackgroundMessenger(${channel})] Last runtime error`, runtime.lastError);
+    }
     disconnect$.next({
       disconnected: port,
       remaining: []

--- a/packages/web-extension/src/messaging/types.ts
+++ b/packages/web-extension/src/messaging/types.ts
@@ -60,6 +60,7 @@ export interface MessengerPort {
 export interface MinimalRuntime {
   connect(connectInfo: Runtime.ConnectConnectInfoType): MessengerPort;
   onConnect: MinimalEvent<(port: MessengerPort) => void>;
+  lastError?: unknown;
 }
 
 export interface MessengerDependencies {


### PR DESCRIPTION
# Context

it happens due to unknown reason, possibly due to the recently introduced BFCache feature in chromium)

also log runtime.lastError when port disconnects

# Proposed Solution

Do not throw if port re-connects within 10s (normally it takes ~1s)

# Important Changes Introduced

BREAKING CHANGE: change return type of createWalletApi callbacks. 
See [changes in lace](https://github.com/input-output-hk/lace/commit/01b8b6e86faa2cf83a3ccc100277fa6f05840793)
