### PR TITLE
chore: increase cpu/mem for live-mainnet history-provider

### DIFF
--- a/nix/cardano-services/deployments/default.nix
+++ b/nix/cardano-services/deployments/default.nix
@@ -445,6 +445,8 @@ in
             chain-history-provider = {
               enabled = true;
               replicas = 2;
+              resources.limits = mkPodResources "500Mi" "2000m";
+              resources.requests = mkPodResources "150Mi" "1000m";
             };
             # asset-provider = {
             #   enabled = true;
@@ -500,6 +502,8 @@ in
             chain-history-provider = {
               enabled = true;
               replicas = 2;
+              resources.limits = mkPodResources "500Mi" "2000m";
+              resources.requests = mkPodResources "150Mi" "1000m";
             };
             #asset-provider = {
             #  enabled = true;


### PR DESCRIPTION
I see we have been getting cpu throttled with the 1.2 cores so I bumped it up to 2 full cores to see if that helps resolve the issue