### PR TITLE
fix: correctly set handle owner when handle is upgraded to cip68

### DIFF
--- a/packages/projection-typeorm/test/operators/storeHandles/util.ts
+++ b/packages/projection-typeorm/test/operators/storeHandles/util.ts
@@ -21,7 +21,7 @@ import {
   withTypeormTransaction
 } from '../../../src';
 import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano, ChainSyncEventType, ObservableCardanoNode } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger, mockProviders } from '@cardano-sdk/util-dev';
 import { Observable } from 'rxjs';
 import { ProjectorContext, createProjectorTilFirst, createStubProjectionSource } from '../util';
@@ -113,14 +113,15 @@ export const mapAndStore =
     evt$.pipe(applyMappers, storeData(buffer));
 
 export const project$ =
-  ({ buffer, tipTracker }: ProjectorContext) =>
+  ({ buffer, tipTracker }: ProjectorContext, cardanoNode: ObservableCardanoNode = stubEvents.cardanoNode) =>
   () =>
     Bootstrap.fromCardanoNode({
       blocksBufferLength: 10,
       buffer,
-      cardanoNode: stubEvents.cardanoNode,
+      cardanoNode,
       logger,
       projectedTip$: tipTracker.tip$
     }).pipe(mapAndStore({ buffer, tipTracker }), tipTracker.trackProjectedTip(), requestNext());
 
-export const projectTilFirst = (context: ProjectorContext) => createProjectorTilFirst(project$(context));
+export const projectTilFirst = (context: ProjectorContext, cardanoNode?: ObservableCardanoNode) =>
+  createProjectorTilFirst(project$(context, cardanoNode));

--- a/packages/projection/src/operators/Mappers/withHandles.ts
+++ b/packages/projection/src/operators/Mappers/withHandles.ts
@@ -160,8 +160,8 @@ export const withHandles =
         const handleMap = evt.block.body.reduce(
           (handles, { body: { outputs, mint } }) => ({
             ...handles,
-            ...getOutputHandles(outputs, policyIds, evt.cip67, logger),
-            ...getBurnedHandles(mint, policyIds, evt.cip67, logger)
+            ...getBurnedHandles(mint, policyIds, evt.cip67, logger),
+            ...getOutputHandles(outputs, policyIds, evt.cip67, logger)
           }),
           {} as Record<string, HandleOwnership>
         );

--- a/packages/util-dev/src/chainSync/data/cip68-handle-problem.json
+++ b/packages/util-dev/src/chainSync/data/cip68-handle-problem.json
@@ -1,0 +1,7189 @@
+{
+  "body": [
+    {
+      "block": {
+        "body": [
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1q9kvs5e4tn402xame55uu9lctjt6w3gqagpdyf989yar22kdc7fq3cvy25gfmuhxucru6qxcwjkpapex85hxyzx0fxgqnwv3ns",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "undefined"
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "133270518"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "4806733f9edd41fbef7a213edeb940d9753f59141b89c1bf342ad7692ce35112"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "190882"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "4806733f9edd41fbef7a213edeb940d9753f59141b89c1bf342ad7692ce35112"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q9kvs5e4tn402xame55uu9lctjt6w3gqagpdyf989yar22kdc7fq3cvy25gfmuhxucru6qxcwjkpapex85hxyzx0fxgqnwv3ns",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4999500000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9kvs5e4tn402xame55uu9lctjt6w3gqagpdyf989yar22kdc7fq3cvy25gfmuhxucru6qxcwjkpapex85hxyzx0fxgqnwv3ns",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5000309118"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": [
+                {
+                  "index": 0,
+                  "txId": "e92ac620bf095094d58a19616d1b6debb9b1cf305870264b1a58446c51d7f4b0"
+                }
+              ],
+              "requiredExtraSignatures": [
+                "6cc853355ceaf51bbbcd29ce17f85c97a74500ea02d224a7293a352a"
+              ],
+              "scriptIntegrityHash": "89fbdd18c1a07a6176efc1f7be79aea830daa78a113737acb1ac53e507465ee5",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "1000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 130868788,
+                "invalidHereafter": 130876140
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "7f0fc4cfb53c3b44a8334da77cba6a868ded6ee90a693b1577cd5563b19fe4c2",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87d80",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "4"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 141594,
+                    "steps": 50748072
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0240485f3be1a7c4ae9554b14eeb47919fba9fd223e0a909531abc24cea1f561",
+                    "6ff211cc87b72a23721222ad0239de98d5f8eed42d37b854d3fd7bb0231fda25b58c457f8ab4b5644c0362832b79cf02f5e5dcdbe66cc0b7cc1d90d0e0f6780e"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "190231"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "9e15a057571f3deaf893069f910395e3c0beb01c82b010e2af343b4537b22dc2"
+                },
+                {
+                  "index": 1,
+                  "txId": "22d721c70c1b9db17cbe71b6f9f3536ff7912b1d099a471c29bd0d42cd402812"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qx95eturl5u958sl28vtdqgla70hvfvervakef7ahmryys8hx7ythj8raz3dwnl7w74zvvhznav52fmwey2a4zfvl5ds04tfs0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2408811183"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1v95sf69jcfhnmknvffwmfvlvnccatqwfjcyh0nlfc6gh5scta2yzg",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2115216815"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130872420
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "ff508f867812197d4a621a579a01fa849ebc8e1c3915df1d15d514b6ccc632a1",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "393b3d3cab6be0897cbc87143cc3a24825dc1d8249df4d37969502931cf856ff",
+                    "efa4be264a8d0f591b400bd0c700e81e9718eea52d73b9df128b3eaa6771c46e78d964fa023a0c53b02ed9c4b868984aa48259a882842ed860c802d6481fb004"
+                  ],
+                  [
+                    "6c0180db688a9e477b10a7792e3c4efd749cddbe0e05068b6cb586dee5405697",
+                    "9ee5b0ef92ca733b9c7b999217c2eb6e680850c49e44d912b8138d98ae6765fbc3f32ba0e68c596dab5e0c26fe7418eb8c5c7e285bb11c5cd732d87feba19d09"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "186665"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "48cfae808dab835060b2592ac603af0c3fec718ff80edaf836f04ba605dda3fb"
+                },
+                {
+                  "index": 1,
+                  "txId": "75067f7878a20f70e239e6d6b41bc4911fd3193451cdc2b4bd97c340b3f65e2b"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qyj0gxqlzf6uuk5j8536wkrnh7wfy2xfjwu3hxn43ar79ky6v40rv57srzawalx57xm4g73dzesgeax0249lj7q7crgqawunxu",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "f73a137e0c1e92d1ad5c394918893e8f3cfa9454726c9603b50fb59f637279636174313436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f73a137e0c1e92d1ad5c394918893e8f3cfa9454726c9603b50fb59f63727963617431303530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f73a137e0c1e92d1ad5c394918893e8f3cfa9454726c9603b50fb59f63727963617432313033",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1262830"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q84wgjyvemfx9aky9lk7f9wtynzltfgg3wmsza3c9h47vg4zwzp9vvgsdgynmfnruvlxgn69qkuzcsn25vtzfh30757s807e56",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "203568301"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q84wgjyvemfx9aky9lk7f9wtynzltfgg3wmsza3c9h47vg4zwzp9vvgsdgynmfnruvlxgn69qkuzcsn25vtzfh30757s807e56",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q84wgjyvemfx9aky9lk7f9wtynzltfgg3wmsza3c9h47vg4zwzp9vvgsdgynmfnruvlxgn69qkuzcsn25vtzfh30757s807e56",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "f73a137e0c1e92d1ad5c394918893e8f3cfa9454726c9603b50fb59f637279636174363437",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2434719"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130879606
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": [
+                {
+                  "quantity": {
+                    "__type": "bigint",
+                    "value": "18473"
+                  },
+                  "stakeAddress": "stake1ux38pqjkxygx5zfa5e37x0nyfazstwpvgf42x93ymchl20gx3s94v"
+                }
+              ]
+            },
+            "id": "3bd6514d85e5f66f4843e86ca03c9537b7d7427ed693b48a2453ed709b7160af",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "a868a0a10424bc1bbc67d65fe813eb0ebe1ff9174245c197ddfd8d94448757e7",
+                    "e03f4968202d77de87e03094b1f224e40123bfefce7023056a044fa7985eee3e05132aeee3e5f534e6199ac91a7193c9362afb006da9894de046eaa3a9cc6503"
+                  ],
+                  [
+                    "6005525eb6c813f5f9400d59aea4b43876f0413b9be6b7fa174a3a15d9415b18",
+                    "85afd1d444b5b6402cd533684081b10c380adb6ffa2cd7d775da4d9efad118e3b081228f744385029a51c487cbc6482ec38ea10025b3d09281842e98689dac07"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "171177"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "f08afb6ed0f933b5064194037cf5df17484865b52836f5aa97b835ed373017bf"
+                },
+                {
+                  "index": 0,
+                  "txId": "dc9e0f8214daf9871af5e84f98825d0d127d55f9f08d43b8bf8b93c60281f0f8"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q8sflkq4mlf3xh0j2sgrzqx5xzpgnujxlugt55ckndwkr9kqhrygf7x338vgkngsefc5h404u0kjl3acmf492nxquhuq0ap8sw",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5214549413"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8666dyqryw9vyww0ssfa2dh0ranvp7jeuyq7m7rvn9rsucru0hmt6lm0357nu3a0h9njudcpzkvfuf8xvjpsahdvsqsvwls9y",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "8246033763"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 97456536,
+                "invalidHereafter": 130875874
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "d9f9fb115b6f284ab21fce6dfcd6e8e6b692b0b19c58ce933cde27e27bfbe452",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "5afa2bc14cdeb7d792b6d8ea3a6980684a3090ed4dd786b3a7969a281ac7771e",
+                    "c6dff7c6febd0f645c1b419c20e4a1aa74f35216d739890818cbe6e60bb77aae6b4fb4896f9d9cac196b9a72f727b23f80375a292d5e30d3488f2b2347481304"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "168317"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "ac925ee883fef1d6cca49888eca6f65a4e116756e1f2cb1a3ce9823f8a75737f"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qyfzynajknnzrqhkek2nlucc7d99jt4qfp0jysk5ahkw04qde20m22lsjccfr0yx95057rvlpq6x4slvxyyuz0edqrqs73skys",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "100000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qyqtadsxdjgeczysq625f47xl6vfek30rf2m8d0u5ca7rj7dhvq9nd9qs2m5jv7wmz744xae8e5vjydxhsn8h447vl7st2qnx9",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3697925517"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 216239162
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "2b83f0e876e9083428911ec50f522202adf691f347064c5e6955da12b64645c4",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0a095a6af0569f270a85a067aeb4f735fd9077e032c88396dbf33e2e85a9dfdf",
+                    "31b7e8307913067b319af27900c68bd3529503e81ca6f6d6e876aa69499b8678c72a06f802111a09b0babcdf663bdf1ee2046bfdb1fa55927e23714129aa720c"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: Order Executed"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "5160f88b929bf8a6c57c285b889488f9137c0ef3cfd0bcf408a10020e69146d5",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1q9dhugez3ka82k2kgh7r2lg0j7aztr8uell46kydfwu3vk6n8w2cdu8mn2ha278q6q25a9rc6gmpfeekavuargcd32vsvxhl7e",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "undefined"
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "4816632228"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "cdef2a754b16d618f18532f93a4e83e271167b7310a2e334cc24a94d24174ef2"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "331833"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "317074e8aff7dfd5ad86713a61ea701ed9a130a2de84e7ed362989cedc2a82f7"
+                },
+                {
+                  "index": 2,
+                  "txId": "cdef2a754b16d618f18532f93a4e83e271167b7310a2e334cc24a94d24174ef2"
+                },
+                {
+                  "index": 1,
+                  "txId": "eba7a7104ae8ec1459b78453e128732438a48653d4ad4d9643af18c6e95eba9a"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qyra4yur7udyyxc6ted20ll3xfyjnwdqplf3lpc6thyldchh9eqjmf3ay75jzuug5sq6l0anes5jrqp0yx2gmuj6cgcqp4xr7g",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "7d869e0e6f936c3299a8b8df2b8f13d5233801e11676ff06e78e8dbe4649474854",
+                          {
+                            "__type": "bigint",
+                            "value": "70559317"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1z84q0denmyep98ph3tmzwsmw0j7zau9ljmsqx6a4rvaau66j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq777e2a",
+                  "datum": {
+                    "cbor": "d8799fd8799fd87a9f581c1eae96baf29e27682ea3f815aba361a0c6059d45e4bfbe95bbd2f44affffd8799f4040ffd8799f581c7d869e0e6f936c3299a8b8df2b8f13d5233801e11676ff06e78e8dbe454649474854ff1a00077c5a1b0000000392dd28cb1b00000008793b95da18641864d8799f190682ffd87980ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd87a9f581c1eae96baf29e27682ea3f815aba361a0c6059d45e4bfbe95bbd2f44affffd8799f4040ffd8799f581c7d869e0e6f936c3299a8b8df2b8f13d5233801e11676ff06e78e8dbe454649474854ff1a00077c5a1b0000000392dd28cb1b00000008793b95da18641864d8799f190682ffd87980ff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd87a9f581c1eae96baf29e27682ea3f815aba361a0c6059d45e4bfbe95bbd2f44affff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd87a9f581c1eae96baf29e27682ea3f815aba361a0c6059d45e4bfbe95bbd2f44affff",
+                            "items": [
+                              {
+                                "cbor": "d87a9f581c1eae96baf29e27682ea3f815aba361a0c6059d45e4bfbe95bbd2f44aff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "1"
+                                },
+                                "fields": {
+                                  "cbor": "9f581c1eae96baf29e27682ea3f815aba361a0c6059d45e4bfbe95bbd2f44aff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "1eae96baf29e27682ea3f815aba361a0c6059d45e4bfbe95bbd2f44a"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799f4040ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f4040ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": ""
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799f581c7d869e0e6f936c3299a8b8df2b8f13d5233801e11676ff06e78e8dbe454649474854ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581c7d869e0e6f936c3299a8b8df2b8f13d5233801e11676ff06e78e8dbe454649474854ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "7d869e0e6f936c3299a8b8df2b8f13d5233801e11676ff06e78e8dbe"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "4649474854"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "490586"
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "15348869323"
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "36393686490"
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "100"
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "100"
+                        },
+                        {
+                          "cbor": "d8799f190682ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f190682ff",
+                            "items": [
+                              {
+                                "__type": "bigint",
+                                "value": "1666"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d87980",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "80",
+                            "items": []
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "7d869e0e6f936c3299a8b8df2b8f13d5233801e11676ff06e78e8dbe4649474854",
+                          {
+                            "__type": "bigint",
+                            "value": "36488630287"
+                          }
+                        ],
+                        [
+                          "f5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c4d5350",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c27b4b7e4ec268faa72a1667fb516f4df13411c4909e69b53fb8aa5661fe1c326",
+                          {
+                            "__type": "bigint",
+                            "value": "9223372036854285231"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "15397775818"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9dhugez3ka82k2kgh7r2lg0j7aztr8uell46kydfwu3vk6n8w2cdu8mn2ha278q6q25a9rc6gmpfeekavuargcd32vsvxhl7e",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4822600395"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": [
+                {
+                  "index": 0,
+                  "txId": "0dc17712e37a4e741767db2f90d4ffbf69faf88b9bed4c47864f7bd912924bea"
+                },
+                {
+                  "index": 0,
+                  "txId": "cf4ecddde0d81f9ce8fcc881a85eb1f8ccdaf6807f03fea4cd02da896a621776"
+                },
+                {
+                  "index": 0,
+                  "txId": "2536194d2a976370a932174c10975493ab58fd7c16395d50e62b7c0e1949baea"
+                },
+                {
+                  "index": 0,
+                  "txId": "d46bd227bd2cf93dedd22ae9b6d92d30140cf0d68b756f6608e38d680c61ad17"
+                }
+              ],
+              "requiredExtraSignatures": [
+                "5b7e23228dba75595645fc357d0f97ba258cfccfff5d588d4bb9165b"
+              ],
+              "scriptIntegrityHash": "d2d3f67373f05ce35b137c3a3b456842eb8ad96c54159dad97741b49a04b9726",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "5000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 130868820,
+                "invalidHereafter": 130869000
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": [
+                {
+                  "quantity": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "stakeAddress": "stake17y02a946720zw6pw50upt2arvxsvvpvaghjtl054h0f0gjsfyjz59"
+                }
+              ]
+            },
+            "id": "f00a485d783910015671d0404a6fdebf6e8a6fffe16cdd6156de6311a2362b92",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d8799f009f1a0013d620ff4100d87a809fd87a80ffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9f009f1a0013d620ff4100d87a809fd87a80ffff",
+                      "items": [
+                        {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        {
+                          "cbor": "9f1a0013d620ff",
+                          "items": [
+                            {
+                              "__type": "bigint",
+                              "value": "1300000"
+                            }
+                          ]
+                        },
+                        {
+                          "__type": "Buffer",
+                          "value": "00"
+                        },
+                        {
+                          "cbor": "d87a80",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "1"
+                          },
+                          "fields": {
+                            "cbor": "80",
+                            "items": []
+                          }
+                        },
+                        {
+                          "cbor": "9fd87a80ff",
+                          "items": [
+                            {
+                              "cbor": "d87a80",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "1"
+                              },
+                              "fields": {
+                                "cbor": "80",
+                                "items": []
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 1305233,
+                    "steps": 521000440
+                  },
+                  "index": 0,
+                  "purpose": "withdrawal"
+                },
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 25305,
+                    "steps": 9547609
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 77308,
+                    "steps": 27884316
+                  },
+                  "index": 2,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "c5d63d7dc066df52592135b6d3cb4f3470d06f7bdd4b2d2e32eb59ca3782662f",
+                    "d8407442789fd2f78ade9917b6a4ab6ef74b4a0dd2dd75448dd9875d5a758bb8510683f79f5c6d066a5fe57b234bc7f8744af92a369dfed6cc7527a20246170a"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: Market Order"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "1feb00f18fbe772cc375aa495da0b08d837a719671e68da62f8ed658915d8fd1",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "190405"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "872477161beb1519ba735f8d55cf8fe6485408ecd310507ad7f9fc6e0fe5c11c"
+                },
+                {
+                  "index": 1,
+                  "txId": "91b6e7e904103f4f1ad66d9f1f4cfd98131a58ce456b32cf6ae432b522231399"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1z8p79rpkcdz8x9d6tft0x0dx5mwuzac2sa4gm8cvkw5hcn8kyzdt6vxz4k7phuqavvnawzl685szg4mdfmsfgfa6t66q4gut9g",
+                  "datum": {
+                    "cbor": "d8799fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffffd87980d8799fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffffd87980d8799f581cf5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c58202ffadbb87144e875749122e0bbb9f535eeaa7f5660c6c4a91bcc4121e477f08dffd8799fd87980d8799f1a0007a194ff1a48282cd3d87980ff1a000f4240d87a80ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffffd87980d8799fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffffd87980d8799f581cf5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c58202ffadbb87144e875749122e0bbb9f535eeaa7f5660c6c4a91bcc4121e477f08dffd8799fd87980d8799f1a0007a194ff1a48282cd3d87980ff1a000f4240d87a80ff",
+                      "items": [
+                        {
+                          "cbor": "d8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328eff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328eff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "ad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328e"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328eff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328eff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "ad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328e"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "f6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d87980",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "80",
+                            "items": []
+                          }
+                        },
+                        {
+                          "cbor": "d8799fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328effd8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328eff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581cad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328eff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "ad78e5fedb2cc5ba18c41948a386ac27bb21f398ebb5a2047593328e"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581cf6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "f6209abd30c2adbc1bf01d6327d70bfa3d2024576d4ee09427ba5eb4"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d87980",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "80",
+                            "items": []
+                          }
+                        },
+                        {
+                          "cbor": "d8799f581cf5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c58202ffadbb87144e875749122e0bbb9f535eeaa7f5660c6c4a91bcc4121e477f08dff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581cf5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c58202ffadbb87144e875749122e0bbb9f535eeaa7f5660c6c4a91bcc4121e477f08dff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "f5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "2ffadbb87144e875749122e0bbb9f535eeaa7f5660c6c4a91bcc4121e477f08d"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799fd87980d8799f1a0007a194ff1a48282cd3d87980ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd87980d8799f1a0007a194ff1a48282cd3d87980ff",
+                            "items": [
+                              {
+                                "cbor": "d87980",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "80",
+                                  "items": []
+                                }
+                              },
+                              {
+                                "cbor": "d8799f1a0007a194ff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f1a0007a194ff",
+                                  "items": [
+                                    {
+                                      "__type": "bigint",
+                                      "value": "500116"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "1210592467"
+                              },
+                              {
+                                "cbor": "d87980",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "80",
+                                  "items": []
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "1000000"
+                        },
+                        {
+                          "cbor": "d87a80",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "1"
+                          },
+                          "fields": {
+                            "cbor": "80",
+                            "items": []
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f534e454b",
+                          {
+                            "__type": "bigint",
+                            "value": "500116"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxkh3e07mvkvtwsccsv53gux4snmkg0nnr4mtgsywkfn9rhkyzdt6vxz4k7phuqavvnawzl685szg4mdfmsfgfa6t66q6lepw2",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f534e454b",
+                          {
+                            "__type": "bigint",
+                            "value": "290117"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4624954"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130879620
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "18d996ab06b289b8642bfafbe8439312ed2cc051acc22c9fdec43401fa13fd95",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "32e0a69a41c8aa000fa22d2222281c69d97f889b992cdd39cd2308fc6fff5a1e",
+                    "f77a59cfbe91ae5e95f4eb1f97e826ea668bbc4f066a0ebf269b7f2c57ec42878e3f5f77c2419838d9d3c4ed29daac6f5699abf7d6a41426c3bc6744b6ef2d03"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Dexhunter Trade",
+                            "Partner ETERNL"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "3e2c0d4536bdfce2164ac693186827f89793f640e0cbb3a45b319cc2a2415e75",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "233317"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "d28d61ae4c631a15e724f1af13bf9cecf1311518f1ea037e1955ea1fe2521362"
+                },
+                {
+                  "index": 4,
+                  "txId": "1186dc844ff43c3233f41cdedd095a9ebbe08711a33f6973e9931eaaf9b28fea"
+                },
+                {
+                  "index": 3,
+                  "txId": "1186dc844ff43c3233f41cdedd095a9ebbe08711a33f6973e9931eaaf9b28fea"
+                },
+                {
+                  "index": 2,
+                  "txId": "fd7c163482bc5aff609775a6ca1d7e4dc07b8035fe4b36f205820804874d6979"
+                },
+                {
+                  "index": 1,
+                  "txId": "b4d26a0130cb59ec7f542eddf8fd333fc87f10fee58bcea277701f6a8b31f704"
+                },
+                {
+                  "index": 1,
+                  "txId": "66e0b1f5c17119761cc0ccf1e4f4eacd150f19995a01a8962c96583bee159c41"
+                },
+                {
+                  "index": 1,
+                  "txId": "3976c9acd40a57efa8437150ec828dc7bb5ff7e6f7ce51c824e1c9cc0a0be818"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q9qh3dgetz0zuedd5gfhwsuxrsr98c0dxtlm9yetkv4frg9hq7wgnqtwpwks50cuxx5lcefzhyw76mm8x9pjyzalz9wslpl2du",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1037637"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1zysz2335xlh96e8gnq22vm88lxxtrp9xdt595taml46szp4hq7wgnqtwpwks50cuxx5lcefzhyw76mm8x9pjyzalz9wsgmuze4",
+                  "datum": {
+                    "cbor": "d8799f4100581c1079318e329e734c012e6db068358566899c13c25d8aa96ab2b40515d8799f4040ff1a077359401a0007a1201b0000000d6936665cd8799f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ffd8799f1b0000000d6936665c1a07735940ff00d8799fd8799f581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0ffd8799fd8799fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffffffff581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a09f581c2f9ff04d8914bf64d671a03d34ab7937eb417831ea6b9f7fbcab96f5ffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9f4100581c1079318e329e734c012e6db068358566899c13c25d8aa96ab2b40515d8799f4040ff1a077359401a0007a1201b0000000d6936665cd8799f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ffd8799f1b0000000d6936665c1a07735940ff00d8799fd8799f581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0ffd8799fd8799fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffffffff581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a09f581c2f9ff04d8914bf64d671a03d34ab7937eb417831ea6b9f7fbcab96f5ffff",
+                      "items": [
+                        {
+                          "__type": "Buffer",
+                          "value": "00"
+                        },
+                        {
+                          "__type": "Buffer",
+                          "value": "1079318e329e734c012e6db068358566899c13c25d8aa96ab2b40515"
+                        },
+                        {
+                          "cbor": "d8799f4040ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f4040ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": ""
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "125000000"
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "500000"
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "57599747676"
+                        },
+                        {
+                          "cbor": "d8799f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "7273455247"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799f1b0000000d6936665c1a07735940ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f1b0000000d6936665c1a07735940ff",
+                            "items": [
+                              {
+                                "__type": "bigint",
+                                "value": "57599747676"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "125000000"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        {
+                          "cbor": "d8799fd8799f581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0ffd8799fd8799fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0ffd8799fd8799fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0ff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581c4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0ff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581cb7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115dff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "b7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115d"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "Buffer",
+                          "value": "4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0"
+                        },
+                        {
+                          "cbor": "9f581c2f9ff04d8914bf64d671a03d34ab7937eb417831ea6b9f7fbcab96f5ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": "2f9ff04d8914bf64d671a03d34ab7937eb417831ea6b9f7fbcab96f5"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "127500000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8l7hny7x96fadvq8cukyqkcfca5xmkrvfrrkt7hp76v3qvssm7fz9ajmtd58ksljgkyvqu6gl23hlcfgv7um5v0rn8qtnzlfk",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9qh3dgetz0zuedd5gfhwsuxrsr98c0dxtlm9yetkv4frg9hq7wgnqtwpwks50cuxx5lcefzhyw76mm8x9pjyzalz9wslpl2du",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "11914007"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "4178b519589e2e65ada2137743861c0653e1ed32ffb2932bb32a91a0",
+                "b7079c89816e0bad0a3f1c31a9fc6522b91ded6f673143220bbf115d"
+              ],
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 130868820,
+                "invalidHereafter": 130872420
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "3e35dc7bc2fc5de900644a9f4c8f507a4eff93c2d568256882c2f7a299ddbb56",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [],
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "648f6e0bd1253223414fbd74d9a0c2f8d36d7f72e846e1b549b81536f4f5ba74",
+                    "7963cbea3e83ac5f6b9d583e269c26d2bbee4e2663f24425e97836fea478c239f7460696e7d255e25ae98c0bebef674676859e307fa4aa7504ce0a3556e5df00"
+                  ],
+                  [
+                    "5dd34feb811bd2a5dbf627eebe0ae4cc0f5df79d6c6e5ad74e7ec323114ec8b0",
+                    "ae1a5f814c09a85520ccd3d72dd56613bfa255ae4b56b4cf065a4557199b19e49d983a35561f0cd179d0e3e3244f77b893098bb14db07c52081c4ca401517805"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": [
+                {
+                  "index": 0,
+                  "txId": "66965c50b1ec5dd4280ef452e03df19791a3f55613e7845f7b9e24bf9737c15d"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "331532"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "3e35dc7bc2fc5de900644a9f4c8f507a4eff93c2d568256882c2f7a299ddbb56"
+                },
+                {
+                  "index": 0,
+                  "txId": "86ac60636b57f42f65dbe7fa625d7b820dbcc901559555e0630015d55be424c9"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q9qh3dgetz0zuedd5gfhwsuxrsr98c0dxtlm9yetkv4frg9hq7wgnqtwpwks50cuxx5lcefzhyw76mm8x9pjyzalz9wslpl2du",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb147273455247",
+                          {
+                            "__type": "bigint",
+                            "value": "60428824016"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2168468"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1x94ec3t25egvhqy2n265xfhq882jxhkknurfe9ny4rl9k6dj764lvrxdayh2ux30fl0ktuh27csgmpevdu89jlxppvrst84slu",
+                  "datum": {
+                    "cbor": "d8799fd8799f581cdb73d7b28075e8869bb862857ded32d9b6fe9420d95aa94f5d34f80a4d72734552475f4144415f4e4654ffd8799f4040ffd8799f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ffd8799f581c7238fd473a767544fcdac95737560156ddcca090018a8008480acf594c72734552475f4144415f4c51ff1903de8000ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799f581cdb73d7b28075e8869bb862857ded32d9b6fe9420d95aa94f5d34f80a4d72734552475f4144415f4e4654ffd8799f4040ffd8799f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ffd8799f581c7238fd473a767544fcdac95737560156ddcca090018a8008480acf594c72734552475f4144415f4c51ff1903de8000ff",
+                      "items": [
+                        {
+                          "cbor": "d8799f581cdb73d7b28075e8869bb862857ded32d9b6fe9420d95aa94f5d34f80a4d72734552475f4144415f4e4654ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581cdb73d7b28075e8869bb862857ded32d9b6fe9420d95aa94f5d34f80a4d72734552475f4144415f4e4654ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "db73d7b28075e8869bb862857ded32d9b6fe9420d95aa94f5d34f80a"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "72734552475f4144415f4e4654"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799f4040ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f4040ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": ""
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": ""
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581c04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14457273455247ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb14"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "7273455247"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799f581c7238fd473a767544fcdac95737560156ddcca090018a8008480acf594c72734552475f4144415f4c51ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581c7238fd473a767544fcdac95737560156ddcca090018a8008480acf594c72734552475f4144415f4c51ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "7238fd473a767544fcdac95737560156ddcca090018a8008480acf59"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "72734552475f4144415f4c51"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "990"
+                        },
+                        {
+                          "cbor": "80",
+                          "items": []
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "04b95368393c821f180deee8229fbd941baaf9bd748ebcdbf7adbb147273455247",
+                          {
+                            "__type": "bigint",
+                            "value": "21800926722137"
+                          }
+                        ],
+                        [
+                          "7238fd473a767544fcdac95737560156ddcca090018a8008480acf5972734552475f4144415f4c51",
+                          {
+                            "__type": "bigint",
+                            "value": "9223371141664426919"
+                          }
+                        ],
+                        [
+                          "db73d7b28075e8869bb862857ded32d9b6fe9420d95aa94f5d34f80a72734552475f4144415f4e4654",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "44770328215"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": [
+                {
+                  "index": 0,
+                  "txId": "c8c93656e8bce07fabe2f42d703060b7c71bfa2e48a2956820d1bd81cc936faa"
+                },
+                {
+                  "index": 0,
+                  "txId": "9915e8d13eda409d58526a8196aec116177bfa3e6556fb7056d8100a56be0691"
+                },
+                {
+                  "index": 1,
+                  "txId": "9915e8d13eda409d58526a8196aec116177bfa3e6556fb7056d8100a56be0691"
+                }
+              ],
+              "requiredExtraSignatures": [
+                "2f9ff04d8914bf64d671a03d34ab7937eb417831ea6b9f7fbcab96f5"
+              ],
+              "scriptIntegrityHash": "2da554c0094fa88e01e4ce444139af63dbf6fcf98817c1fd08003bb722a065b7",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": [
+                {
+                  "quantity": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "stakeAddress": "stake17yl5v2ljg5a320y8v7pkqxhjvfvapu8jtvkxv5gweg9k2jce5kh2n"
+                }
+              ]
+            },
+            "id": "cc2fec5ba14d97d4e896c07075955156e03f55fb89c6159adf36f0d040e449d3",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87a80",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 170000,
+                    "steps": 65000000
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d879820201",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9f0201ff",
+                      "items": [
+                        {
+                          "__type": "bigint",
+                          "value": "2"
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 615000,
+                    "steps": 255000000
+                  },
+                  "index": 1,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "80",
+                    "items": []
+                  },
+                  "executionUnits": {
+                    "memory": 760000,
+                    "steps": 285000000
+                  },
+                  "index": 0,
+                  "purpose": "withdrawal"
+                }
+              ],
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "b1d48c9006183e37e06f9082860da16c99298fb828a29befb101388e20e4abb7",
+                    "fd1b87e2dbfaa0460b68643fa6530f49290f52c3bf44666e2695a145866c628a1b169ae38d175ccb55583e49e1d6c2a27efb25c73ba9df902a5c87874cd0ad0b"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "30"
+                    },
+                    "6"
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "50"
+                    },
+                    "d8799f9fd8799fd8799fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be"
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "51"
+                    },
+                    "8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4ab"
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "52"
+                    },
+                    "a03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff1a003e8fa0ffd8799f"
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "53"
+                    },
+                    "d8799fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5f"
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "54"
+                    },
+                    "a3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60d"
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "55"
+                    },
+                    "b2ad9e5e164f41c00f9a4811ffffffff1a0223ca60ffff581c3a9bb72f68a125"
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "56"
+                    },
+                    "c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cff,"
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "ef9ccc17b4757e9d3e57898c16a2230e3c64e958fa48b304663394f2a9b46798",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "211085"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "19c87ebaf0d78ec8cac641d3a3232ef5e46e7c6b8fc867a73fb18554253800ca"
+                },
+                {
+                  "index": 1,
+                  "txId": "acab1032e1aac85363313ef0ad4dd4a381d5851f5c77c95c291be8fcc91581ec"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1x8rjw3pawl0kelu4mj3c8x20fsczf5pl744s9mxz9v8n7efvjel5h55fgjcxgchp830r7h2l5msrlpt8262r3nvr8ekstg4qrx",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "4c854345e2ac215d1c51d2000e23ae2f99a9b78ba2b7b155e6b52dea7ce4d3c8",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "e32ed3ca446eeee9d94932a8072f8ab4b995c45da161a3f8e44adf1e476f6f667973393932",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1305930"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qyafhde0dzsjtse8we52y999r9rmcy9ytnmr702l50hz6tpd47pea7ksj72fru90pvt9a3sdk2keuhskfaquqru6fqgselrwc0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "f73a137e0c1e92d1ad5c394918893e8f3cfa9454726c9603b50fb59f63727963617431393831",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1163700"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qyafhde0dzsjtse8we52y999r9rmcy9ytnmr702l50hz6tpd47pea7ksj72fru90pvt9a3sdk2keuhskfaquqru6fqgselrwc0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "23737183"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": "3bc4de80c713d703796000940122c7c9bcb5723b244bef55aac066dc145adfa9",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130869730
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "50ec75eb7c85152c2ede0fbfb1cafd150e6c7a8cbc7e4a0a6c46f34a04911955",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799f9fd8799fd8799fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff1a003e8fa0ffd8799fd8799fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffffff1a0223ca60ffff581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f9fd8799fd8799fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff1a003e8fa0ffd8799fd8799fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffffff1a0223ca60ffff581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cff",
+                    "items": [
+                      {
+                        "cbor": "9fd8799fd8799fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff1a003e8fa0ffd8799fd8799fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffffff1a0223ca60ffff",
+                        "items": [
+                          {
+                            "cbor": "d8799fd8799fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff1a003e8fa0ff",
+                            "constructor": {
+                              "__type": "bigint",
+                              "value": "0"
+                            },
+                            "fields": {
+                              "cbor": "9fd8799fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff1a003e8fa0ff",
+                              "items": [
+                                {
+                                  "cbor": "d8799fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff",
+                                  "constructor": {
+                                    "__type": "bigint",
+                                    "value": "0"
+                                  },
+                                  "fields": {
+                                    "cbor": "9fd8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ffd8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffffff",
+                                    "items": [
+                                      {
+                                        "cbor": "d8799f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ff",
+                                        "constructor": {
+                                          "__type": "bigint",
+                                          "value": "0"
+                                        },
+                                        "fields": {
+                                          "cbor": "9f581c80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309ff",
+                                          "items": [
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "80ab694d765799d7cb4199dd08f6a8b9be8bc3ecc3cfeeab2f2a8309"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "cbor": "d8799fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffff",
+                                        "constructor": {
+                                          "__type": "bigint",
+                                          "value": "0"
+                                        },
+                                        "fields": {
+                                          "cbor": "9fd8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffffff",
+                                          "items": [
+                                            {
+                                              "cbor": "d8799fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffff",
+                                              "constructor": {
+                                                "__type": "bigint",
+                                                "value": "0"
+                                              },
+                                              "fields": {
+                                                "cbor": "9fd8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ffff",
+                                                "items": [
+                                                  {
+                                                    "cbor": "d8799f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ff",
+                                                    "constructor": {
+                                                      "__type": "bigint",
+                                                      "value": "0"
+                                                    },
+                                                    "fields": {
+                                                      "cbor": "9f581c2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463ff",
+                                                      "items": [
+                                                        {
+                                                          "__type": "Buffer",
+                                                          "value": "2692ba8f78be55e4aba03b60ceb7d7dce2e8d457891bbdd209f2c463"
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "4100000"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "cbor": "d8799fd8799fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffffff1a0223ca60ff",
+                            "constructor": {
+                              "__type": "bigint",
+                              "value": "0"
+                            },
+                            "fields": {
+                              "cbor": "9fd8799fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffffff1a0223ca60ff",
+                              "items": [
+                                {
+                                  "cbor": "d8799fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffffff",
+                                  "constructor": {
+                                    "__type": "bigint",
+                                    "value": "0"
+                                  },
+                                  "fields": {
+                                    "cbor": "9fd8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cffd8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffffff",
+                                    "items": [
+                                      {
+                                        "cbor": "d8799f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cff",
+                                        "constructor": {
+                                          "__type": "bigint",
+                                          "value": "0"
+                                        },
+                                        "fields": {
+                                          "cbor": "9f581c3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2cff",
+                                          "items": [
+                                            {
+                                              "__type": "Buffer",
+                                              "value": "3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2c"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "cbor": "d8799fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffff",
+                                        "constructor": {
+                                          "__type": "bigint",
+                                          "value": "0"
+                                        },
+                                        "fields": {
+                                          "cbor": "9fd8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffffff",
+                                          "items": [
+                                            {
+                                              "cbor": "d8799fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffff",
+                                              "constructor": {
+                                                "__type": "bigint",
+                                                "value": "0"
+                                              },
+                                              "fields": {
+                                                "cbor": "9fd8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ffff",
+                                                "items": [
+                                                  {
+                                                    "cbor": "d8799f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ff",
+                                                    "constructor": {
+                                                      "__type": "bigint",
+                                                      "value": "0"
+                                                    },
+                                                    "fields": {
+                                                      "cbor": "9f581c2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811ff",
+                                                      "items": [
+                                                        {
+                                                          "__type": "Buffer",
+                                                          "value": "2daf839efad0979491f0af0b165ec60db2ad9e5e164f41c00f9a4811"
+                                                        }
+                                                      ]
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "35900000"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "Buffer",
+                        "value": "3a9bb72f68a125c3277668a214a51947bc10a45cf63f3d5fa3ee2d2c"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "479afea3ef9794288f12d76224af915ec4edd107894d4f01c63a1fe476fd8f66",
+                    "0d4ea58d429e996be77726a7543f38fbcac6cd2f7e1e6f96e8baf45e41c0d605708822aeb3572af32c6e1823aa18b3fcf9fe37cc546f235190def82c8c871805"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "173817"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "9a24e9b113d76e89513ce1a48c538a0ba4ffa9d7336a013b1079d3f1bddd772a"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qy6klwkchy2anq63udppu7t0a56klqg78qx4j3st52w6p255zf8yatzltwcknn3769c3rxppyjskwvfx9mpu4knusl7qg73ul5",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "249565559"
+                    }
+                  }
+                },
+                {
+                  "address": "DdzFFzCqrhse2BTsQj8fjCiqZfK14Qkmr25oqqxgmefz8eTCycaYo9v6Vie7bDHYEv1Yn69gx27NU8MoiLWGDJHsEcgSeTmy4jyRRg3T",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "916151408682"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130876039
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "88f3f88df9dc40bbe90d352bd6c15b0eaf37a0bde3ab0348c2cc855091f38a92",
+            "isValid": true,
+            "witness": {
+              "bootstrap": [
+                {
+                  "addressAttributes": "oQFYHlgcMIM0mr9T6vcTuI5QMZ24eBihnoGCgCKfJVcEMQ==",
+                  "chainCode": "83bbc0bcf88dec411d5b85eae7a5afe2031c9d3df037f6406fb6b0e8004cdad9",
+                  "key": "41f4c3eedd2bbb3a28c14e631d9e970d8da26bf2d03de2c6c6f1637f880df90c",
+                  "signature": "ee533930a79889f9cd1e0be4deebd18f08baf5abaea280e70d079c0b9a8422f157dd4c5eaace79f13bc4ef18dadead0e4009a7640d555caea8dfb6e9146b8705"
+                }
+              ],
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": []
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "187369"
+              },
+              "inputs": [
+                {
+                  "index": 6,
+                  "txId": "e06c06e944517eac47892b8b76d76de6665856a1d8f32cecf8e30c116a7390d1"
+                },
+                {
+                  "index": 7,
+                  "txId": "e06c06e944517eac47892b8b76d76de6665856a1d8f32cecf8e30c116a7390d1"
+                },
+                {
+                  "index": 9,
+                  "txId": "e06c06e944517eac47892b8b76d76de6665856a1d8f32cecf8e30c116a7390d1"
+                },
+                {
+                  "index": 10,
+                  "txId": "e06c06e944517eac47892b8b76d76de6665856a1d8f32cecf8e30c116a7390d1"
+                },
+                {
+                  "index": 1,
+                  "txId": "47f146bbf839a56c563cebbd35188d937649f61aefe541429d99aa8753134691"
+                },
+                {
+                  "index": 10,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 11,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 12,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 13,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 14,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 15,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 16,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 17,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 18,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 19,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1597370334"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "3bcdf3b231808ad25ea62de4be31a9fa377c504f32f28bc7bd4b3377b2b900a5",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "f44ce6186d190f8776fd871d753df7ae503972e4793a2360a423d2f96021e601",
+                    "3fd1e9e4b73084832488c8356e68e8996bd0381136eff9ec205eebf30be84fc679c17fd9265f21ab77a51d294ffb0e868d9b8e6ea81038f5e6f2a75f84e0d808"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "168185"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "8383b0a666b99c6ec410ab8a61c27664632669c4f007788992d03061e28e6bfc"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1v9rrrm2xjcldgyhfjtw8s6dn3sy63jy9rapzp9w238rjk6cqwjck4",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "25008272"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9ueycfgkqjf9ssfd5rj7zujnlg2fdnvstqx99wu5xzmu2lyrm0t4pc2wa6syzyal3rapz07k0ja7vrnux4nmy54ltdqthupgm",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "863342368"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 17780333,
+                "invalidHereafter": 130876020
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "7cba5d791e7447e0809f75ddead5a842232b23491f2f9759c590ec8fbf655336",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "75098bdcf84144572acc753681c03b68ab3f5d075c12affebd1620be689ca542",
+                    "2cde5c0a73b86be4c8abba478fad34d0c8b3bd329e57748b9ca37a5bcde2f57f261daea0f234aadf11628bcd14453cdf79749182113570d2f1291e2417cc4b0c"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "700000"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "51df881d5464cf728013c3d238e00a1105c78f40154930586d890d1ea0f193aa"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q8xjuzfx9hrrkzvufkghf48w3jeyqcn4jzst5ajeuc5kwu4a965zkj4mpyzr53ugh7pzdrxvkpl22vfextaflzhk8qxq7m5he9",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "567087533"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1v8px4syex8e07e6c2ucfheh27t2tcxxjm5el22g0cw32m5g77jc7x",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "6399658502"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "3f9f15c4e4193901c797e78ec3e1006282fa26c5c8912ad376227007fdf46ac4",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "c539a0874a16f317e30304bda4030cca7829d999ae847d8d8d5ea1d2b96493f5",
+                    "fffb4950a0b0403bfadd33dd02cf530ab74d744bdc55f95f627dff0a6dfc9daae86fa7ed18e8cd2368ac3313e40c49a90f8d8d432779d3aad804ba6c21a1b405"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: MasterChef"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "dceb615df4c37cb35edc022e11faba4f98e042261a24cb1e2bca0cc3e4dcc457",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "227629"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "23fd49dd2d8a202d88686f62d57bbe6913c12b42593b8007617866c31d421925"
+                },
+                {
+                  "index": 0,
+                  "txId": "c628193e5e83817561bc20c23b95094ed66c7cfbb5fff6bffbf3628a03b8e518"
+                },
+                {
+                  "index": 1,
+                  "txId": "ff7fb70b55235156cf27507f524d9f439aaca49cf29caaa93b5faffff20cb1c8"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "d195ca7db29f0f13a00cac7fca70426ff60bad4e1e87d3757fae84846876414441",
+                    {
+                      "__type": "bigint",
+                      "value": "-8935072"
+                    }
+                  ],
+                  [
+                    "d195ca7db29f0f13a00cac7fca70426ff60bad4e1e87d3757fae848468764d494e",
+                    {
+                      "__type": "bigint",
+                      "value": "-468947756"
+                    }
+                  ]
+                ]
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qypzcge62xkj8jnw6muz5wrtgy5tp2yc80nezqgkaf8g0rcve2vzak376qrfw4yxuklhlzq7j94ftw3lt8ueahrmtzxqhfyckm",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e",
+                          {
+                            "__type": "bigint",
+                            "value": "468947756"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "10085842"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxkmr0m22xeqludcg5rjdmecjxasu9fat0680qehtcsnftaadgykewa9ufvegeuca9yyq03d9v7ea2y2zthgu7hfgjtsddp6gr",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "123410110161"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxkmr0m22xeqludcg5rjdmecjxasu9fat0680qehtcsnftaadgykewa9ufvegeuca9yyq03d9v7ea2y2zthgu7hfgjtsddp6gr",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "078eafce5cd7edafdf63900edef2c1ea759e77f30ca81d6bbdeec92479756d6d69",
+                          {
+                            "__type": "bigint",
+                            "value": "849485"
+                          }
+                        ],
+                        [
+                          "160a880d9fc45380737cb7e57ff859763230aab28b3ef6a84007bfcc4d495241",
+                          {
+                            "__type": "bigint",
+                            "value": "552154628"
+                          }
+                        ],
+                        [
+                          "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e",
+                          {
+                            "__type": "bigint",
+                            "value": "10364824604026"
+                          }
+                        ],
+                        [
+                          "2d92af60ee429bce238d3fd9f2531b45457301d74dad1bcf3f9d1dca564e4d",
+                          {
+                            "__type": "bigint",
+                            "value": "1252212421"
+                          }
+                        ],
+                        [
+                          "30eceec7b587ebe31d6d79a9140d68f7378a359a14b4550a57d646c94c554e41",
+                          {
+                            "__type": "bigint",
+                            "value": "244890"
+                          }
+                        ],
+                        [
+                          "394d8a0021c8825ad9385c1112009994e37b7b53c0c406d389d452db47756d6d79",
+                          {
+                            "__type": "bigint",
+                            "value": "466415747"
+                          }
+                        ],
+                        [
+                          "4623ab311b7d982d8d26fcbe1a9439ca56661aafcdcd8d8a0ef31fd6475245454e53",
+                          {
+                            "__type": "bigint",
+                            "value": "57167281251"
+                          }
+                        ],
+                        [
+                          "48f69a80dcca7bee58431b8b749faca98700ca456056d153fbea4eb24f4d4e49",
+                          {
+                            "__type": "bigint",
+                            "value": "182568236688584"
+                          }
+                        ],
+                        [
+                          "724a31d1421744cac3bb1d547aa692b43517d651c46e60a0cf1f70ec444f444f",
+                          {
+                            "__type": "bigint",
+                            "value": "38900438"
+                          }
+                        ],
+                        [
+                          "83099a945e95a38d3dc3ab562af81671ed094becf493074251d3f45062616279536869747a75",
+                          {
+                            "__type": "bigint",
+                            "value": "2435852711"
+                          }
+                        ],
+                        [
+                          "9a1dfe73344033e70deab8c5c28c00f62b092814fb14581ec3a3d5160014df10434f4445",
+                          {
+                            "__type": "bigint",
+                            "value": "807486221038474"
+                          }
+                        ],
+                        [
+                          "9abf0afd2f236a19f2842d502d0450cbcd9c79f123a9708f96fd9b96454e4353",
+                          {
+                            "__type": "bigint",
+                            "value": "6440343927"
+                          }
+                        ],
+                        [
+                          "9f452e23804df3040b352b478039357b506ad3b50d2ce0d7cbd5f806435456",
+                          {
+                            "__type": "bigint",
+                            "value": "3708"
+                          }
+                        ],
+                        [
+                          "a1ce0414d79b040f986f3bcd187a7563fd26662390dece6b12262b52464c45534820544f4b454e",
+                          {
+                            "__type": "bigint",
+                            "value": "12580571428960871"
+                          }
+                        ],
+                        [
+                          "bf3e19192da77dfadc7c9065944e50ca7e1a439d90833e3ae58b720a44414e5a4f",
+                          {
+                            "__type": "bigint",
+                            "value": "619088893"
+                          }
+                        ],
+                        [
+                          "bfa9354862e34f2dd417c9068a9367b530d1a704a0f5dc41468c402c50524f434b",
+                          {
+                            "__type": "bigint",
+                            "value": "1897305272"
+                          }
+                        ],
+                        [
+                          "ca942cb8bb5d1ef750766ded355f320880539111f10efa2b1a478ff9524147",
+                          {
+                            "__type": "bigint",
+                            "value": "766712"
+                          }
+                        ],
+                        [
+                          "cc8d1b026353022abbfcc2e1e71159f9e308d9c6e905ac1db24c7fb650617269627573",
+                          {
+                            "__type": "bigint",
+                            "value": "1143430688327"
+                          }
+                        ],
+                        [
+                          "ce5b9e0f8a88255b65f2e4d065c6e716e9fa9a8a86dfb86423dd1ac044494e47",
+                          {
+                            "__type": "bigint",
+                            "value": "369315671302"
+                          }
+                        ],
+                        [
+                          "ea02c99c0668891d6b7cdc49e075cbddf9cd5b89404e5a8a8e5d7016534c4f5020436f696e",
+                          {
+                            "__type": "bigint",
+                            "value": "9632864"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4758240"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "4f641455f17911fe2f55ad3ad67fc2e0b2946b59af3352574322e67e"
+              ],
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130879641
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "f7c86705a9a52c539341aca45f37b24256a432edf941357cdcd4d89d5e75c15c",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": [
+                {
+                  "__type": "native",
+                  "keyHash": "4f641455f17911fe2f55ad3ad67fc2e0b2946b59af3352574322e67e",
+                  "kind": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0621257bb5bd1477c0960b2e391c70baa8a642ad258420daa10bab85d1c24bef",
+                    "f02c4cd4461cea992533dcb550f2154736bb540377aca3745403f3e77f6de40212b7f45b51a5bef646e88a58dfd556a5e5fbb70425c42178ee1229a46892690b"
+                  ],
+                  [
+                    "5424fa10ba83c95c33714c420479c19183a7274e7c1d4161d173842c245b340c",
+                    "940dc3d7a25c138da733dc9d337d81884ad6e1319edacda3472c2ee175acb8844527feaa4fc3254775ad04ec2becf394f2677d579580413b69ee3db8c63e7a05"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "721"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a",
+                          {
+                            "__type": "Map",
+                            "value": [
+                              [
+                                "000de14073696c766572666f78",
+                                {
+                                  "__type": "Map",
+                                  "value": [
+                                    [
+                                      "name",
+                                      "$silverfox"
+                                    ],
+                                    [
+                                      "image",
+                                      "ipfs://zb2rhfAbTyjfxScmK5ytimdsDykgpfrCar3AeHNjJHXW4daan"
+                                    ],
+                                    [
+                                      "mediaType",
+                                      "image/jpeg"
+                                    ],
+                                    [
+                                      "og",
+                                      {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      }
+                                    ],
+                                    [
+                                      "og_number",
+                                      {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      }
+                                    ],
+                                    [
+                                      "rarity",
+                                      "basic"
+                                    ],
+                                    [
+                                      "length",
+                                      {
+                                        "__type": "bigint",
+                                        "value": "9"
+                                      }
+                                    ],
+                                    [
+                                      "characters",
+                                      "letters"
+                                    ],
+                                    [
+                                      "numeric_modifiers",
+                                      ""
+                                    ],
+                                    [
+                                      "version",
+                                      {
+                                        "__type": "bigint",
+                                        "value": "1"
+                                      }
+                                    ],
+                                    [
+                                      "handle_type",
+                                      "handle"
+                                    ]
+                                  ]
+                                }
+                              ]
+                            ]
+                          }
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "a9f70856445af0817b8880a71e6f00b90585beb6201e48da6fed6dcaf747cc97",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qx9t73ew53xtgt5tlruq8gr3grwca0urr0z9j2hre0gnlj0xe7yuukw0jrjaa2zvxnvga0zvycthvuf4l28yev95trdqq8q6rn",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "undefined"
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "2202715719"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "26995bea549b78f4b595bd2b65955d1bf9dfd5ebb253d836baf785684cc25af3"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "241445"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "26995bea549b78f4b595bd2b65955d1bf9dfd5ebb253d836baf785684cc25af3"
+                },
+                {
+                  "index": 25,
+                  "txId": "e2eba7dbc3b3d2f9c0a7f0dd6bdcea9802b2465b1fd926bb194d1e259cbad154"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a73696c766572666f78",
+                    {
+                      "__type": "bigint",
+                      "value": "-1"
+                    }
+                  ],
+                  [
+                    "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a000643b073696c766572666f78",
+                    {
+                      "__type": "bigint",
+                      "value": "1"
+                    }
+                  ],
+                  [
+                    "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a000de14073696c766572666f78",
+                    {
+                      "__type": "bigint",
+                      "value": "1"
+                    }
+                  ]
+                ]
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qx9t73ew53xtgt5tlruq8gr3grwca0urr0z9j2hre0gnlj0xe7yuukw0jrjaa2zvxnvga0zvycthvuf4l28yev95trdqq8q6rn",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a000de14073696c766572666f78",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1176630"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w9xdnc9adstrnakxr4rz3z7zp9q39nh6y9hl2qwhtnx75sgz7x0q3",
+                  "datum": {
+                    "cbor": "d8799fab446e616d654a2473696c766572666f7845696d6167655838697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e496d65646961547970654a696d6167652f6a706567426f6700496f675f6e756d6265720046726172697479456261736963466c656e677468094a63686172616374657273476c657474657273516e756d657269635f6d6f64696669657273404776657273696f6e014b68616e646c655f747970654668616e646c6501af4e7374616e646172645f696d6167655838697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e537374616e646172645f696d6167655f6861736858207ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb4a696d6167655f6861736858207ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb46706f7274616c404864657369676e65724047736f6369616c73404676656e646f72404764656661756c7400536c6173745f7570646174655f616464726573735839018abf472ea44cb42e8bf8f803a07140dd8ebf831bc4592ae3cbd13fc9e6cf89ce59cf90e5dea84c34d88ebc4c2617767135fa8e4cb0b458da4c76616c6964617465645f6279581c4da965a049dfd15ed1ee19fba6e2974a0b79fc416dd1796a1f97f5e14b7376675f76657273696f6e45332e302e374c6167726565645f7465726d7340546d6967726174655f7369675f72657175697265640045747269616c00446e73667700ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fab446e616d654a2473696c766572666f7845696d6167655838697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e496d65646961547970654a696d6167652f6a706567426f6700496f675f6e756d6265720046726172697479456261736963466c656e677468094a63686172616374657273476c657474657273516e756d657269635f6d6f64696669657273404776657273696f6e014b68616e646c655f747970654668616e646c6501af4e7374616e646172645f696d6167655838697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e537374616e646172645f696d6167655f6861736858207ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb4a696d6167655f6861736858207ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb46706f7274616c404864657369676e65724047736f6369616c73404676656e646f72404764656661756c7400536c6173745f7570646174655f616464726573735839018abf472ea44cb42e8bf8f803a07140dd8ebf831bc4592ae3cbd13fc9e6cf89ce59cf90e5dea84c34d88ebc4c2617767135fa8e4cb0b458da4c76616c6964617465645f6279581c4da965a049dfd15ed1ee19fba6e2974a0b79fc416dd1796a1f97f5e14b7376675f76657273696f6e45332e302e374c6167726565645f7465726d7340546d6967726174655f7369675f72657175697265640045747269616c00446e73667700ff",
+                      "items": [
+                        {
+                          "cbor": "ab446e616d654a2473696c766572666f7845696d6167655838697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e496d65646961547970654a696d6167652f6a706567426f6700496f675f6e756d6265720046726172697479456261736963466c656e677468094a63686172616374657273476c657474657273516e756d657269635f6d6f64696669657273404776657273696f6e014b68616e646c655f747970654668616e646c65",
+                          "data": {
+                            "__type": "Map",
+                            "value": [
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6e616d65"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "2473696c766572666f78"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "696d616765"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6d6564696154797065"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "696d6167652f6a706567"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6f67"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6f675f6e756d626572"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "726172697479"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6261736963"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6c656e677468"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "9"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "63686172616374657273"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6c657474657273"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6e756d657269635f6d6f64696669657273"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": ""
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "76657273696f6e"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "1"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "68616e646c655f74797065"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "68616e646c65"
+                                }
+                              ]
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        {
+                          "cbor": "af4e7374616e646172645f696d6167655838697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e537374616e646172645f696d6167655f6861736858207ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb4a696d6167655f6861736858207ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb46706f7274616c404864657369676e65724047736f6369616c73404676656e646f72404764656661756c7400536c6173745f7570646174655f616464726573735839018abf472ea44cb42e8bf8f803a07140dd8ebf831bc4592ae3cbd13fc9e6cf89ce59cf90e5dea84c34d88ebc4c2617767135fa8e4cb0b458da4c76616c6964617465645f6279581c4da965a049dfd15ed1ee19fba6e2974a0b79fc416dd1796a1f97f5e14b7376675f76657273696f6e45332e302e374c6167726565645f7465726d7340546d6967726174655f7369675f72657175697265640045747269616c00446e73667700",
+                          "data": {
+                            "__type": "Map",
+                            "value": [
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "7374616e646172645f696d616765"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "697066733a2f2f7a6232726866416254796a667853636d4b357974696d647344796b67706672436172334165484e6a4a485857346461616e"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "7374616e646172645f696d6167655f68617368"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "7ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "696d6167655f68617368"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "7ea194a8af779f8d396370963eb3dd6a9ac506b9a2bf5334f017193e7268bdbb"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "706f7274616c"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": ""
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "64657369676e6572"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": ""
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "736f6369616c73"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": ""
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "76656e646f72"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": ""
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "64656661756c74"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6c6173745f7570646174655f61646472657373"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "018abf472ea44cb42e8bf8f803a07140dd8ebf831bc4592ae3cbd13fc9e6cf89ce59cf90e5dea84c34d88ebc4c2617767135fa8e4cb0b458da"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "76616c6964617465645f6279"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "4da965a049dfd15ed1ee19fba6e2974a0b79fc416dd1796a1f97f5e1"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "7376675f76657273696f6e"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": "332e302e37"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6167726565645f7465726d73"
+                                },
+                                {
+                                  "__type": "Buffer",
+                                  "value": ""
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6d6967726174655f7369675f7265717569726564"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "747269616c"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                }
+                              ],
+                              [
+                                {
+                                  "__type": "Buffer",
+                                  "value": "6e736677"
+                                },
+                                {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                }
+                              ]
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a000643b073696c766572666f78",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3749700"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx9t73ew53xtgt5tlruq8gr3grwca0urr0z9j2hre0gnlj0xe7yuukw0jrjaa2zvxnvga0zvycthvuf4l28yev95trdqq8q6rn",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2199432050"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "4da965a049dfd15ed1ee19fba6e2974a0b79fc416dd1796a1f97f5e1"
+              ],
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "8dee702f5cf6ec26e256ef54c86cb7516eb8893eb6bcbaf0ab8012ee45e4f065",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": [
+                {
+                  "__type": "native",
+                  "keyHash": "4da965a049dfd15ed1ee19fba6e2974a0b79fc416dd1796a1f97f5e1",
+                  "kind": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "b62a7193927f47ef703ba99a06add1ee2d4d94853a16dcd68ad0f5d9baa18530",
+                    "3ce10a2c8069e4c6267f51a7647eb342561d86debf922e36bc43720bdd642dc52fb284cf33b34afbe6bbed9793f842f45970c710e102a3d19adba2060ab7100b"
+                  ],
+                  [
+                    "67217b1438e1bb73c0d42cd1a2560b9bb2de3d22d8902069f6c93d31535b9537",
+                    "f47e288f399f3d0b2c596770d233d7ccc06d8b70a4e1aa6f1c4f4d77acfebc9e98609f2ab410d643b37a50cc309d961d4665e5ba0b19a3028ff2ba5bc510bd0f"
+                  ],
+                  [
+                    "c33c3b301252a6f5fd7d419433aa9a2d8522d7b9634775233629869a1166d15e",
+                    "851c6d58ae769eebb6b2ed46cf39b1f3c5a43fbb3657a8c5f0cdfa737f33fd9ff03e755bf44d81deef890f7619e5f51457a0f1100752f4b548d18f26a36b850e"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "174829"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "e07d7ca7ea1c70233d01115792620d6e58dc1b7892b6c456a840808083fa809a"
+                },
+                {
+                  "index": 0,
+                  "txId": "0cb8c52786b245fc68080fbba28c9684f25d7006a4d2aad715adc66940bf2735"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1vxldnap0el0n8ygkq5hqlkx8ms0fxhe5slv9jh7k6t96d7sghs87c",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "24518078"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9dwzug2qzdsqvpvrn886nqdtwr02n9kxtwqsxce2gacvedg8akgnwf3y4r2uzqf00rw0pvsucql0pqkzag5n450facqeuerev",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "38847193"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 74702698,
+                "invalidHereafter": 130875922
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "fdad536725245059486a94682084c8c9ab05f8e707a578789e785ff1cc713bf7",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "2553749712c75fbc2584a33811307ae19fd59340b341667f068b24c0cdd6adfe",
+                    "5cd1db91c68118d74325b1322494caa24c23cc3b7d555278d9086acd353417dd0b9626284b9d4bf84378490b1f11495f6ac58d1092eb4ec070ab1d7af4013507"
+                  ],
+                  [
+                    "fd4a8d4a960f9aae8c00d3c506f9b2cd321708d252a36d7bdfe1615eac530c6a",
+                    "5cd1db91c68118d74325b1322494caa24c23cc3b7d555278d9086acd353417dd91f58f61a697ba9796bcd1f1aeb4220556d88e279cce8d59ee325da531ed020b"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [
+                {
+                  "__typename": "StakeDelegationCertificate",
+                  "poolId": "pool18ufrgfgmslekdxnk9v9345qvhrr7vfgzkvneqtwm7unnwaht6ww",
+                  "stakeCredential": {
+                    "hash": "d44a25d32a686357aa1fe68321c530ce6f18890315ad7f9da18b17f3",
+                    "type": 0
+                  }
+                }
+              ],
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "177425"
+              },
+              "inputs": [
+                {
+                  "index": 5,
+                  "txId": "110b10364bac1450e2dbf3a29c46915a29f2b3a059ab3ce388632845944f26bb"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qx0hcdmj9r9ac6akpqme7ddgrx4vsqntavtp4z44l3eh0575fgjax2ngvdt658lxsvsu2vxwduvgjqc444lemgvtzlesyy4pe6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "7383359"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx0hcdmj9r9ac6akpqme7ddgrx4vsqntavtp4z44l3eh0575fgjax2ngvdt658lxsvsu2vxwduvgjqc444lemgvtzlesyy4pe6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5000000"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130879624
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": [
+                {
+                  "quantity": {
+                    "__type": "bigint",
+                    "value": "429949"
+                  },
+                  "stakeAddress": "stake1u82y5fwn9f5xx4a2rlngxgw9xr8x7xyfqv266lua5x930ucr849gz"
+                }
+              ]
+            },
+            "id": "9ade3cb6b1aee90314f3f1b9f93196e86c55d1022b3734a210fbce4507bf63bf",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "a02747853bdab036f816b9dc39f1e911d41135c57345203ec835c801160903d1",
+                    "81f79c902b6bf160aa4604b7741c66724fbbfc41b62d2d12b97e03b423b4bd350c5e2d16f4bf573db45451bd8f8c332a8e2fb523ac5733b5619fbc5067f04307"
+                  ],
+                  [
+                    "044516e2ff2d1ae93116bc29c9398ff493d52f4f5f854d578f572cee226656ac",
+                    "738d97dede36e2f92f60cc1ecde27daa7c6c4d6acd72a16f666cc2aa5a030e731baed12d740222f104c90ebe89ef13d281eac45c2dfb75b95d09a0366e2d4e00"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "876277"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "ac40e11f1e40fd32ad5b0d7a388379a73c4053a30e46b1043e6bde4b34104eb8"
+                },
+                {
+                  "index": 0,
+                  "txId": "ce952f386620e8615faada0000bc90bb134e4cd02b9e5e343756a291665209a7"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q9h4f2vhh5vnqgnsejan3psw6mj3a504fxlqm2eh3262qufesdvfs83ulr22vprsv9mwnt0vgkfwxlflxkns32twqzdqjpq2na",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5396815373"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130875968
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "a94fc09e15dc1838f98a290caee992855db5780c8bdf31428e35bb3ac87a0040",
+            "isValid": true,
+            "witness": {
+              "bootstrap": [],
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "f9659dbdbd10960bdf7ca579faf2da86746f4b49e920aca11a167771f4a5961a",
+                    "458df485431a6e9281310d78a1e120cae5a475e208cd7f3f0dc77c37b9cda572cdb75fdfa6f470fd8fdfd56967948f823561485d3dee9149dd10147802896d08"
+                  ],
+                  [
+                    "09c7dfc92f5b90c84b51a437056e598ab38e656ee3fa56636f2fb4879a27890e",
+                    "b6f2e37185ddffe6290cfe6622635711758349bfd9550f58da9dadc81bcaf8be9750395771f28800278764638e3a706b0fa77fc06df1223edbc88e5dd7658a0a"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "168700"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "c60ecdfa538aebd6de54204e4349ac1dead4840a2012945865687ab1f74a8bc8"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1v804tgee0m3ww7z93zh64wr9flqh9psdhnxg6cykfudgulg6f633p",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "107123831300"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130874820
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "5f7fbe8e04f50656ddefcb80e3ab27187860dcd831a064935d6f7aab13ad15e8",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "494af01e16b62a1a463dfa8f8a7f0c9389253570b8d4f8f7b11a1c286aef1a27",
+                    "f507dae2ad3a4e9c32ffee3b746d0ca020b6b7ecfc83de3f8e020b8c105aaac455a9ce26a2eeea32dd7a8632b79130833dd89ebed6eccd9bea319ae393722109"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Liqwid Withdraw: 146.70 Ada (59.19 USD)"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "458f4c753bb7be5269d1f4a88858872604845e778591c8432e11404aa6893e40",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1q80n6vyknpq5rhyfxvc7tkhm085lsmynua5mxwecwmtl9lfaq92dpj0tt8fhvv4sptnzj290vv874adhlm75tqefrm4sqs3jlx",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "Map",
+                    "value": [
+                      [
+                        "a04ce7a52545e5e33c2867e148898d9e667a69602285f6a1298f9d68",
+                        {
+                          "__type": "bigint",
+                          "value": "3000000000"
+                        }
+                      ]
+                    ]
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "10041022"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "34cbf0d80fdf9e55270feb2aa088c7df4eab9c6211b29e6c5514bdc89971564a"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "376973"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "34cbf0d80fdf9e55270feb2aa088c7df4eab9c6211b29e6c5514bdc89971564a"
+                },
+                {
+                  "index": 1,
+                  "txId": "3db72bc114ec4c23a1edd39d5386c0451d27e2e59fd00a75b749aa4328d0a0f5"
+                },
+                {
+                  "index": 1,
+                  "txId": "52f35e5905f978a0495185d15c7ab7b5ae453ef0959f5f0bc3a915f8701b660d"
+                },
+                {
+                  "index": 1,
+                  "txId": "960a2b4dc459a7d7bb253d1b688eeb27bd6fe42752014871d1f8b7ac04354449"
+                },
+                {
+                  "index": 3,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "a04ce7a52545e5e33c2867e148898d9e667a69602285f6a1298f9d68",
+                    {
+                      "__type": "bigint",
+                      "value": "-7000000020"
+                    }
+                  ]
+                ]
+              },
+              "networkId": 1,
+              "outputs": [
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdex68fug3xenv3hmdsdsxz4f9y84fhjqr47p45r4aqw3ahhsl3c92d",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1zyc5zkajzqtyea4cf5d3y5mlq7fd9yfdz4hq78k3mywg8nha57wx42dufy48hug9tjkem42urlcd7v8qaafq94pfufxsz63f4p",
+                  "datum": {
+                    "cbor": "9f9f3a08be6e433b00000001a13b8613000000ff1b000000011efa8c9fff",
+                    "items": [
+                      {
+                        "cbor": "9f3a08be6e433b00000001a13b8613000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "-146697796"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "-7000000020"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "4814703775"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "7807209cec9f79c9f6cf5bea2ab7826e6e46b6a7583a337b7e20fb36",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "6497812136742"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q80n6vyknpq5rhyfxvc7tkhm085lsmynua5mxwecwmtl9lfaq92dpj0tt8fhvv4sptnzj290vv874adhlm75tqefrm4sqs3jlx",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "1c053cf544c33c3708294bb9885713af1e76160980789ed19ed08dc7687445796675",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a04ce7a52545e5e33c2867e148898d9e667a69602285f6a1298f9d68",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f83b91ea1887a958e385c72fdf432358d40488cbaf56710be60702ff454750594d33",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1456832"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q80n6vyknpq5rhyfxvc7tkhm085lsmynua5mxwecwmtl9lfaq92dpj0tt8fhvv4sptnzj290vv874adhlm75tqefrm4sqs3jlx",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "1c053cf544c33c3708294bb9885713af1e76160980789ed19ed08dc7687445796675",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "41223b3ecf502363dc465dce5ad6671b83ac790e229d3f49e68c33538e22200f5ec04a3cc1cc245e07aa16d429332fefdfdddff0284922057227955e",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "41223b3ecf502363dc465dce5ad6671b83ac790e229d3f49e68c3353c6c2f94852995ce2854b9a3df1667d9534cb9f81cee73a50ba11e9fac1f7c823",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "41223b3ecf502363dc465dce5ad6671b83ac790e229d3f49e68c3353ee0abf71d9883b4451da13cd90c331bae7471541156bd84b8ffde97a115ae925",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "61b3802ce748ed1fdaad2d6c744b19f104285f7d318172a5d4f06a4e000de1402b41274a7f911103a3410ab7da645cebd1afb86ac2e91df6e9c58ea4",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a04ce7a52545e5e33c2867e148898d9e667a69602285f6a1298f9d68",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a776f6c666f6664656669",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f83b91ea1887a958e385c72fdf432358d40488cbaf56710be60702ff454750594d33",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "170769267"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": [
+                {
+                  "index": 0,
+                  "txId": "8078e3eef9f6939b716bdf476ab6a49a96943bc6586ac9e3bf72ed28c6c508cd"
+                },
+                {
+                  "index": 1,
+                  "txId": "c2f410c32cc8b03bae257c9618bb9e211cf792725660c638988a3aa6f26ba198"
+                },
+                {
+                  "index": 0,
+                  "txId": "dd69370c5046e4a6fd880681cd81e4e3871544e54f5593dd5d4af625727b1b64"
+                },
+                {
+                  "index": 1,
+                  "txId": "fc08d1ad4c5c700008ab72e8ecb9d4f7e09bd0e6a172f77cd4d5135b823c2e96"
+                }
+              ],
+              "requiredExtraSignatures": [
+                "df3d3096984141dc893331e5dafb79e9f86c93e769b33b3876d7f2fd"
+              ],
+              "scriptIntegrityHash": "d70db717a285d3ce7b1c5b33c400e0b60f7a4e2bba23096201aa858a178dfa5d",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "3000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 130868820,
+                "invalidHereafter": 130869120
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "2eb4c22b862f1d2cab01be2691415960dde5f5d618b09016fed9a44371900148",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 774131,
+                    "steps": 337545126
+                  },
+                  "index": 4,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "__type": "bigint",
+                    "value": "1"
+                  },
+                  "executionUnits": {
+                    "memory": 801619,
+                    "steps": 346431578
+                  },
+                  "index": 0,
+                  "purpose": "mint"
+                }
+              ],
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "8c86967e391a7e15833260818049b360a5ead964b1c56e01c490355a1faeaf44",
+                    "e9372878ef94b80603e63bcc7f82945e45b7728771ee7ccd308e9748cc765d42e7399b2bd3bae359df93995c7e91f51bb6d13f08220b2f0889630808aba9d105"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "180150"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "7c456535dde8da62beb4e511eaa395a50a47c091d061a21a9b9b19dedb45312e"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1v8u0lkeuml46jmw3356f4gye9gs4wzkta8jxfah0flgfmmsxfsqvm",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "159194800"
+                    }
+                  }
+                },
+                {
+                  "address": "DdzFFzCqrhsu2pd1zMGjHo17jLWksqxdcJ7aWmaECyCjTGKSddPjiE9QLxiEzLnGc4MPKQo4viMQiFcBQDd1utYHvgRkbxVEXzxWmmAM",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "36219200000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qy6j48q56pfz862l3ylads8zxx0mlvv7xtwzxprwhfnlyznygjv9cppk3kvj2rmurctlz6h20lnar7d0rrzlwwmjy0aqp5dxs9",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "23490700"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1v804tgee0m3ww7z93zh64wr9flqh9psdhnxg6cykfudgulg6f633p",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "765815650"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130874820
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "b0ee1dcf40f31fead239342e1560d1703e19e64334c2d67f2faf6bad57b23bca",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "b96b6277faa0a6229da01903c501e9daad1d87460b162b3f35416e8eee44f9b5",
+                    "35a238e53bfe8952a933e9d79f6bcfc157875616494499651c18554752feb92800711cc3b571098081e9d6eed78abc51f2fcaf5eb9bdcbf8a06f144204286a01"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "string",
+                          "f91bee598fe75e44c9c96349fb9b38758d1121ecb8263bbae5432c23b89fecaf"
+                        ]
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "string",
+                          "60872024-07-31 09:12"
+                        ]
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "2"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "string",
+                          "EMISOR CLEMENTE MONETA RUIZ"
+                        ]
+                      ]
+                    }
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "3"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": []
+                    }
+                  ],
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "4"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": []
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "7bf8c35748aaf0a586eeaf5e3b5a06c6e9acec365548d3a721704bf9e31de20e",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "182353"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "20be200ba12c689744b0f31baca0ddc992145a2b478a2490cec608ff63c95616"
+                },
+                {
+                  "index": 1,
+                  "txId": "20be200ba12c689744b0f31baca0ddc992145a2b478a2490cec608ff63c95616"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qxzgjtcejm7634pp5u0spsfxysh04xw376z3ppvym9pnhpz58njxy545ldalpghka7sx94479e49pt7w94mc0ehe0kascvrr5y",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qykyp9aj8cuna43649ygd8an7hzfacth5yxv9n4hl2qucnz58njxy545ldalpghka7sx94479e49pt7w94mc0ehe0kas97kkax",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1446033"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130876065
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "bfb85a1c72d5567a7c7e13abb4ac16dc56c54a85325d9f2ce3e451de3f0e979a",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "229f867cccd017cbbd20fae8966fe6e3b4638208697fe839dce089ccc46b7032",
+                    "955ce47cdaafb6a2b37ad178a3aaf4fa0bde7cc9a0ad1b2360b292a7643aacad3230ca2fc4fb28b13f816fd8f7307b6c4088693642b32eb1e05ebf8a421c580f"
+                  ],
+                  [
+                    "32958e99d65f900f7148f40f1c0ba00cffc260de08e2e1c043123a7a267ba0ef",
+                    "759929ff55c482b772bfb0f8707fbbde015078c5aa396f575e36b4add9b694a3e298f2e1c1c048a85ca12d6c18ae52b6a2dff2e0010b7c81bb3c65c1989a070b"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "168500"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "b3ff03be8370251042d3dd245569948b13726aa925503690ba7e8f797f739bac"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1v804tgee0m3ww7z93zh64wr9flqh9psdhnxg6cykfudgulg6f633p",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1799831500"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130874820
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "ec8657f3f325698c2f837ab0c1f9a33fdf3c4f0f12a118404feae83645c7d672",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "73d5775fad1150a2ea142e756c8ac2fd1a8150c6f23e689dab513a85ad50fc19",
+                    "f6f0602e0658384edf9a90184a092fdc4cf4e6370f247a9c7eaac109b940c3539fa46972ae5e3ec9665b2422894f311a57a176ed2d0cb4eecb76f4c113b84502"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "168500"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "dfb6d8692e2fa03c1e7849209b1442b80b48a11d6a6894c0752310cc0fa15ac8"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1v804tgee0m3ww7z93zh64wr9flqh9psdhnxg6cykfudgulg6f633p",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1443831500"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130874820
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "09654212f7227550f07c2a46383f8f09fa48b211d37c324833cc7e7028bede41",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "5422fa9712afa57cc247f40336b01ae861c4dfe4108ca7a16b1b7ebd03902f27",
+                    "64e7fe59ef914194a7ff9f54f2dcd3004dad6d8af8182616a47296ba4da8db941a1e505ef18242d281904fa3d31ebdba41127512ec3eef112e9601945516230d"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "179317"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "2823012453616e8f0d76ed7f4546cb8ac62d010723d722dd5ebc97bc64411321"
+                },
+                {
+                  "index": 1,
+                  "txId": "5a11547ba209f427bff667f32a9b89ddfaddb2de45447914df797ad6592d20d2"
+                },
+                {
+                  "index": 0,
+                  "txId": "e0ba5ca967e165b727dbc053f10046ddb82b3195c4ced988e4cbc5646b9fe3a0"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1vx9pxvq7q7gjlputskayvpa0r6ye3vcq0hpam35fc3v9dvs966w5e",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "81239850000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8geujmenfrw8l0qvazhdt0u4v0gmugk2am94w9vn74l9nhrzr27g03klu862usxqsru794d03gzkk8n86ta34n85z0sqlufcu",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1110978995"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130872388
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "45f1a0f6d738109bedaeb3fcbf524d4162e3f8ac9e0f94bb8cb6f780595b4fbb",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "c8fbae072939fcc322b212514200f5230b808eff6409223af902d541141afdd6",
+                    "38f03c6167ee3c51ea575b5faacf086ea2f7234d9fff4fa01349a1ead2f7655162b625d6b00c5eaf0a7879a251bf8b9c945ff3720f2d7a9cfc2e77324efaf70f"
+                  ],
+                  [
+                    "568a6057f7d034b3f4d27da1b6bdbd0d442a1564cfbdfd31440b0705ec9b2001",
+                    "ae858549305f7c7b4e7bdf2f4f9d036cb3490f94a33538eda21ee9dd7e167685b10903d288d0cc11785a6e1b06190d601af852d286d7bb64a184097704be7706"
+                  ],
+                  [
+                    "82a2f3d97018125fcd8bf43c516358f2735fe040136b3e9630a002a28beb6ed4",
+                    "0a1198514db29ff02b368f9c2db3818a6e1a2bb89c712ffa31d51ab1e3399eb1f012a4a7f4c2b5b4887bb43179c3803b5d971639e03bd61a1105677b2f5e8b05"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "168500"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "1834151150784693e503b81b16c07886b96cc5366bdaf169cc8d64443790ef68"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1v804tgee0m3ww7z93zh64wr9flqh9psdhnxg6cykfudgulg6f633p",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "61912454"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 130874820
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "9c41a4e2ea3cc6d9d91eb826e9323a9bf01d88e3de44686e6aa6c2022a76b2ba",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "d4d91ededce2fde664623b6df7f67d0758494b725428cd5b8403cfcd65df5f28",
+                    "0638979ff3cd7c58c36f386cc0d7b866f2396830fe415fc528dc087af21b3bc14b2ad54b1cdfd0d581471f36893236a03135f777231f7e4de9de1b50c2ca5108"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "9e82df90afcf2754cd1830da070d2f2e41ac39b6a7f327d8968ac07f7c957318"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "339340"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "9e82df90afcf2754cd1830da070d2f2e41ac39b6a7f327d8968ac07f7c957318"
+                },
+                {
+                  "index": 1,
+                  "txId": "9e82df90afcf2754cd1830da070d2f2e41ac39b6a7f327d8968ac07f7c957318"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1wxxx5uc8t8mphyyf7qmse7vx5fm469puha6uru06djfj4vql8unkl",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "00b9b6a0173eb84b1a8e36242dddc41e723d4385a4657961801e5a8411f50b52",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "5b8495ec9f44c040e83c8bb91fdddd22ee6f28e06712f23561645f4d446a65644f7261636c654e4654",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1224040"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8sefdq99nlv0wefzprjvp5h9mw2l3jvhvgy4tl20kszdlcm5kjdmrpmng059yellupyvwgay2v0lz6663swmds7hp0q8dklg8",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1611595474"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "e194b4052cfec7bb2910472606972edcafc64cbb104aafea7da026ff"
+              ],
+              "scriptIntegrityHash": "c7d73ac7184b33c9f8a75664ed4fb1652c3ac7c1ace0bf6a3c912263de148a09",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 130868821,
+                "invalidHereafter": 130869721
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "6644dd918663b3f8c52433a26e576bdebf4080f69b682f7de4ea666be9030bea",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799f5840a7fa96ee07774de53916f4d1e26c122c15b4a3943af1a0493244c041332f81136c2c101be5b1edf78736666196ea842731920947fe0007ab8ce23d12ced86304d8799fd8799f192710190fc1ffd8799fd8799fd87a9f1b0000019109220c40ffd87a80ffd8799fd87a9f1b00000191092fc7e0ffd87a80ffff43555344ff581c5b8495ec9f44c040e83c8bb91fdddd22ee6f28e06712f23561645f4dff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f5840a7fa96ee07774de53916f4d1e26c122c15b4a3943af1a0493244c041332f81136c2c101be5b1edf78736666196ea842731920947fe0007ab8ce23d12ced86304d8799fd8799f192710190fc1ffd8799fd8799fd87a9f1b0000019109220c40ffd87a80ffd8799fd87a9f1b00000191092fc7e0ffd87a80ffff43555344ff581c5b8495ec9f44c040e83c8bb91fdddd22ee6f28e06712f23561645f4dff",
+                    "items": [
+                      {
+                        "__type": "Buffer",
+                        "value": "a7fa96ee07774de53916f4d1e26c122c15b4a3943af1a0493244c041332f81136c2c101be5b1edf78736666196ea842731920947fe0007ab8ce23d12ced86304"
+                      },
+                      {
+                        "cbor": "d8799fd8799f192710190fc1ffd8799fd8799fd87a9f1b0000019109220c40ffd87a80ffd8799fd87a9f1b00000191092fc7e0ffd87a80ffff43555344ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f192710190fc1ffd8799fd8799fd87a9f1b0000019109220c40ffd87a80ffd8799fd87a9f1b00000191092fc7e0ffd87a80ffff43555344ff",
+                          "items": [
+                            {
+                              "cbor": "d8799f192710190fc1ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f192710190fc1ff",
+                                "items": [
+                                  {
+                                    "__type": "bigint",
+                                    "value": "10000"
+                                  },
+                                  {
+                                    "__type": "bigint",
+                                    "value": "4033"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd87a9f1b0000019109220c40ffd87a80ffd8799fd87a9f1b00000191092fc7e0ffd87a80ffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd87a9f1b0000019109220c40ffd87a80ffd8799fd87a9f1b00000191092fc7e0ffd87a80ffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd87a9f1b0000019109220c40ffd87a80ff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd87a9f1b0000019109220c40ffd87a80ff",
+                                      "items": [
+                                        {
+                                          "cbor": "d87a9f1b0000019109220c40ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f1b0000019109220c40ff",
+                                            "items": [
+                                              {
+                                                "__type": "bigint",
+                                                "value": "1722435112000"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d87a80",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "80",
+                                            "items": []
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d8799fd87a9f1b00000191092fc7e0ffd87a80ff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd87a9f1b00000191092fc7e0ffd87a80ff",
+                                      "items": [
+                                        {
+                                          "cbor": "d87a9f1b00000191092fc7e0ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f1b00000191092fc7e0ff",
+                                            "items": [
+                                              {
+                                                "__type": "bigint",
+                                                "value": "1722436012000"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d87a80",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "80",
+                                            "items": []
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "555344"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "Buffer",
+                        "value": "5b8495ec9f44c040e83c8bb91fdddd22ee6f28e06712f23561645f4d"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799f58404acd77075e50adb1a4065b88b2391d0300103e4b57cda07c370816a01d9abe8a8e4e43ccc45fabfb4bc0db2fda005d90a0c47a7949b4017fa86122e5ba229a09d8799fd8799f192710190fc1ffd8799fd8799fd87a9f1b000001910916b9d0ffd87a80ffd8799fd87a9f1b0000019109247570ffd87a80ffff43555344ff581c5b8495ec9f44c040e83c8bb91fdddd22ee6f28e06712f23561645f4dff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f58404acd77075e50adb1a4065b88b2391d0300103e4b57cda07c370816a01d9abe8a8e4e43ccc45fabfb4bc0db2fda005d90a0c47a7949b4017fa86122e5ba229a09d8799fd8799f192710190fc1ffd8799fd8799fd87a9f1b000001910916b9d0ffd87a80ffd8799fd87a9f1b0000019109247570ffd87a80ffff43555344ff581c5b8495ec9f44c040e83c8bb91fdddd22ee6f28e06712f23561645f4dff",
+                    "items": [
+                      {
+                        "__type": "Buffer",
+                        "value": "4acd77075e50adb1a4065b88b2391d0300103e4b57cda07c370816a01d9abe8a8e4e43ccc45fabfb4bc0db2fda005d90a0c47a7949b4017fa86122e5ba229a09"
+                      },
+                      {
+                        "cbor": "d8799fd8799f192710190fc1ffd8799fd8799fd87a9f1b000001910916b9d0ffd87a80ffd8799fd87a9f1b0000019109247570ffd87a80ffff43555344ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f192710190fc1ffd8799fd8799fd87a9f1b000001910916b9d0ffd87a80ffd8799fd87a9f1b0000019109247570ffd87a80ffff43555344ff",
+                          "items": [
+                            {
+                              "cbor": "d8799f192710190fc1ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f192710190fc1ff",
+                                "items": [
+                                  {
+                                    "__type": "bigint",
+                                    "value": "10000"
+                                  },
+                                  {
+                                    "__type": "bigint",
+                                    "value": "4033"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd87a9f1b000001910916b9d0ffd87a80ffd8799fd87a9f1b0000019109247570ffd87a80ffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd87a9f1b000001910916b9d0ffd87a80ffd8799fd87a9f1b0000019109247570ffd87a80ffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd87a9f1b000001910916b9d0ffd87a80ff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd87a9f1b000001910916b9d0ffd87a80ff",
+                                      "items": [
+                                        {
+                                          "cbor": "d87a9f1b000001910916b9d0ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f1b000001910916b9d0ff",
+                                            "items": [
+                                              {
+                                                "__type": "bigint",
+                                                "value": "1722434370000"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d87a80",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "80",
+                                            "items": []
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d8799fd87a9f1b0000019109247570ffd87a80ff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd87a9f1b0000019109247570ffd87a80ff",
+                                      "items": [
+                                        {
+                                          "cbor": "d87a9f1b0000019109247570ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f1b0000019109247570ff",
+                                            "items": [
+                                              {
+                                                "__type": "bigint",
+                                                "value": "1722435270000"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d87a80",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "1"
+                                          },
+                                          "fields": {
+                                            "cbor": "80",
+                                            "items": []
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "555344"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "Buffer",
+                        "value": "5b8495ec9f44c040e83c8bb91fdddd22ee6f28e06712f23561645f4d"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 512942,
+                    "steps": 235693247
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "590877010000332332232323232332232323232323232323232323232323232323232222322325335001101f13263201a335738921035054350001f35005222223235323232323232333333222222123333330010070060050040030023574200a6ae84010d5d08019aba1002357420026ae84d5d10009aba2001357446ae88d5d10009aba2357440026ae88004d55cf1baa0013574200244444464646a603e024444646a6464646002012640026aa06a44a66a0022c4426a6a64664424660020060046ae84004d4c088d5d09aba200122233302800300200135573c6ea80088848cc00400c00888d4004888c8c94cd4c09c014854cd4ccd5cd19baf00800d03a03915335333573466e1c00d200203a0391123001002130024984c009261300149894cd4ccd5cd19b89002480000e00e4584c02c020ccc09c02c08c008c8c94cd4ccd5cd19b8735573a002900101781709aba135573c0022c6ea8004d5d09aba200e500125335333573466e3cdd719299a999ab9a357466ae880040b80b44d5d08008b1bac00901102d02c153353333573466e1d40552002212200223333573466e1d40592000212200123263202e3357380600660580562a66a666ae68cdc419980ea80100c805a400005a05826603400200c20582a66a00c2c4426a603c004444a66a604000642a66a666ae68cdc780080381981909a9815191918009bac0103200135503b2233335573e0024c464a66a666ae68cdd79aba10010050380371357426ae880044c010d5d10019aab9e37546ae840080e8c94cd4ccd5cd19b8735573a002900001a01989aba135573c0022c6ea8008888d4008888d400c88d4010894cd4c94cd4ccd5cd199b95023337146466e28c0ccd400488008cdc519b8b481292201003033350012200133038005004337146a006446a0084466e28cdc5a416c0207066e28c0d4010cdc519b8b481600e0cdc5181a80119b8b482e8040e001802c0f80f454cd4ccd5cd19b8900533704008900001e81f0a99a999ab9a3371e04000c07c07a26a00644a666a004426a00a44a666a004426a00e446a00444a666a004426a00844a666a00442a66a666ae68cdc48060020260258a99a999ab9a337120020120980962666ae68cdc399b8100900c02f04c04b104b104b1616161616161616103d103d103d33503875a0342a66a666ae68cdc79bae008501203d03c13501422235002223500122533553335002213500e2235002225333500221333573466e20cdc0000a4181f82a00c0920942c2c2c2c2666ae68cdc399981a280c81800a240040880862086207820782c2c205826eb8004c0a8dd600318141bac00635573c6ea80184d55ce9baa0014890d446a65644f7261636c654e4654003200135501a222533500110162213535300700222233300d00300200122253353009003215335333573466e3c00402007006c406c4cc0240200144cc02001c0108c94cd4ccd5cd19b8735573a002900100a00989909118010019bae357426aae780044488004dd51aba135573c6ea80048c8c8ccc88848ccc00401000c008d5d08011aba15001357426ae8940044d5d10009aab9e37540024464460046eac004c8004d5406488c8cccd55cf8011240004a66a666ae68cdc79bae35573aa00400c02c02a26600e00a6eacd55cf2801098021aba2003019135742002640026aa02c444646666aae7c0089200025335333573466e3cdd71aab9d50020040140131375a6aae7940084cc014010d5d100180b89aba1001222123330010040030022333500123003001489042d496e66004881042b496e660025335333573466e20005200000d00c1337169001180119b8148000cdc0000a4004266e2d2000300200132001355012225335333573466e2000520800400d00c133716002006266e2ccdc3000a410008600466e0c005208004489002323233335573ea0044c4646464246660020080060046ae84d5d128021919191999aab9f500226232323212333001004003002375c6ae84d5d1280219a8073ad35742a00664646464a66a666ae68cdc380080700b00a8b0a99a999ab9a3371000201c02c02a26601e66e04038008cdc08070008998078010009bad357426ae894008dd69aba15001135573c6ea8004d5d0a80180a89aba25001135573c6ea8004d5d0a8019bae35742a00602026ae8940044d55cf1baa0014800088cc00c0080048848cc00400c008488c8c8cccd5cd19b8735573aa00490001199109198008018011919191999ab9a3370e6aae754009200023322123300100300233500a00935742a00460166ae84d5d1280111931900699ab9c00f01200b135573ca00226ea8004d5d0a8011919191999ab9a3370e6aae754009200023322123300100300233500a00935742a00460166ae84d5d1280111931900699ab9c00f01200b135573ca00226ea8004d5d09aba2500223263200933573801601c00e26aae7940044dd500089119191999ab9a3370ea00290021091100091999ab9a3370ea00490011190911180180218031aba135573ca00846666ae68cdc3a801a400042444004464c6401466ae7003003c02001c0184d55cea80089baa0012323333573466e1d40052002200623333573466e1d40092000200623263200633573801001600800626aae74dd5000a4c2440042440029210350543100320013550052233335573e0024a00e466a00c6ae84008c00cd5d1001002190009aa802111999aab9f0012500623350053574200460066ae8800800c480044488008488488cc00401000c448c8c00400488cc00cc008008004cd4488cd4488ccccc008cc011220120a8354ba0b4830ebf0614b3425fb14e5d1ed858a2d87812d56307fdc59e23601000480012212051f4ed3fc62618d6cc2a29f50efb6c8fbf4a6e65a02d90b9eae4a1196bafcb550048811ce194b4052cfec7bb2910472606972edcafc64cbb104aafea7da026ff0048303b9b52210355534400222221233333001006005004003002200122123300100300220011",
+                  "version": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "51f4ed3fc62618d6cc2a29f50efb6c8fbf4a6e65a02d90b9eae4a1196bafcb55",
+                    "50c6174c2f822f3543fa6871be207fcfb1e32ce7ac03f93d01ea2ece5707c748792a04ec95b6afb25f508a060e1b78910980b17bd6991c00908d01c666d2a40a"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "700000"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "37ca599c072f5c63e3daa1d7a6607d3caaf81cf48f59d80b03c9076aad14b430"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1v8px4syex8e07e6c2ucfheh27t2tcxxjm5el22g0cw32m5g77jc7x",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": []
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "336300000"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "1c9f43a53e936789d9bec2d85da90666bd6e763915c643147254c2c4fd7e00bf",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "d13de2e52d43bb48ab5c657ce98958cdca04d7a7094ade4fd26897e82707706a",
+                    "2feb900ec4c9092102ad56f71c4917af025f232316c0f0ca05aea581773ef653d5586b6e9e252402b7ffa2187f636e95aa98119eea06e1eb72a0bed6f89b6501"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          }
+        ],
+        "fees": {
+          "__type": "bigint",
+          "value": "7764753"
+        },
+        "header": {
+          "blockNo": 10644079,
+          "hash": "dfeaffbf0c6f5ee153f8de263d8f421dad979fa6718ee4c14b2a7199513ebe46",
+          "slot": 130868885
+        },
+        "issuerVk": "61faf606b31e58a5ad2c229bdb5528a0753d6576d60ee26cdd9c0aaa6c327c80",
+        "previousBlock": "1994bacfe7bb5099f3af410707544f2762365187354fea3d44904778a7eaf413",
+        "size": 21241,
+        "totalOutput": {
+          "__type": "bigint",
+          "value": "7884005951129"
+        },
+        "txCount": 29,
+        "vrf": "vrf_vk1nseua3kx59hyqsphk67w2eure44hlcm03vq84etmm7x5hppn60wssxpgf0"
+      },
+      "eventType": 0,
+      "tip": {
+        "blockNo": 10644079,
+        "hash": "dfeaffbf0c6f5ee153f8de263d8f421dad979fa6718ee4c14b2a7199513ebe46",
+        "slot": 130868885
+      }
+    }
+  ],
+  "metadata": {
+    "cardano": {
+      "compactGenesis": {
+        "era": "shelley",
+        "startTime": "2017-09-23T21:44:51Z",
+        "networkMagic": 764824073,
+        "network": "mainnet",
+        "activeSlotsCoefficient": 0.05,
+        "securityParameter": 2160,
+        "epochLength": 432000,
+        "slotsPerKesPeriod": 129600,
+        "maxKesEvolutions": 62,
+        "slotLength": 1,
+        "updateQuorum": 5,
+        "maxLovelaceSupply": {
+          "__type": "bigint",
+          "value": "45000000000000000"
+        },
+        "initialDelegates": [
+          {
+            "issuer": {
+              "id": "162f94554ac8c225383a2248c245659eda870eaa82d0ef25fc7dcd82"
+            },
+            "delegate": {
+              "id": "4485708022839a7b9b8b639a939c85ec0ed6999b5b6dc651b03c43f6",
+              "vrfVerificationKeyHash": "aba81e764b71006c515986bf7b37a72fbb5554f78e6775f08e384dbd572a4b32"
+            }
+          },
+          {
+            "issuer": {
+              "id": "2075a095b3c844a29c24317a94a643ab8e22d54a3a3a72a420260af6"
+            },
+            "delegate": {
+              "id": "6535db26347283990a252313a7903a45e3526ec25ddba381c071b25b",
+              "vrfVerificationKeyHash": "fcaca997b8105bd860876348fc2c6e68b13607f9bbd23515cd2193b555d267af"
+            }
+          },
+          {
+            "issuer": {
+              "id": "268cfc0b89e910ead22e0ade91493d8212f53f3e2164b2e4bef0819b"
+            },
+            "delegate": {
+              "id": "1d4f2e1fda43070d71bb22a5522f86943c7c18aeb4fa47a362c27e23",
+              "vrfVerificationKeyHash": "63ef48bc5355f3e7973100c371d6a095251c80ceb40559f4750aa7014a6fb6db"
+            }
+          },
+          {
+            "issuer": {
+              "id": "60baee25cbc90047e83fd01e1e57dc0b06d3d0cb150d0ab40bbfead1"
+            },
+            "delegate": {
+              "id": "7f72a1826ae3b279782ab2bc582d0d2958de65bd86b2c4f82d8ba956",
+              "vrfVerificationKeyHash": "c0546d9aa5740afd569d3c2d9c412595cd60822bb6d9a4e8ce6c43d12bd0f674"
+            }
+          },
+          {
+            "issuer": {
+              "id": "ad5463153dc3d24b9ff133e46136028bdc1edbb897f5a7cf1b37950c"
+            },
+            "delegate": {
+              "id": "d9e5c76ad5ee778960804094a389f0b546b5c2b140a62f8ec43ea54d",
+              "vrfVerificationKeyHash": "64fa87e8b29a5b7bfbd6795677e3e878c505bc4a3649485d366b50abadec92d7"
+            }
+          },
+          {
+            "issuer": {
+              "id": "b9547b8a57656539a8d9bc42c008e38d9c8bd9c8adbb1e73ad529497"
+            },
+            "delegate": {
+              "id": "855d6fc1e54274e331e34478eeac8d060b0b90c1f9e8a2b01167c048",
+              "vrfVerificationKeyHash": "66d5167a1f426bd1adcc8bbf4b88c280d38c148d135cb41e3f5a39f948ad7fcc"
+            }
+          },
+          {
+            "issuer": {
+              "id": "f7b341c14cd58fca4195a9b278cce1ef402dc0e06deb77e543cd1757"
+            },
+            "delegate": {
+              "id": "69ae12f9e45c0c9122356c8e624b1fbbed6c22a2e3b4358cf0cb5011",
+              "vrfVerificationKeyHash": "6394a632af51a32768a6f12dac3485d9c0712d0b54e3f389f355385762a478f2"
+            }
+          }
+        ],
+        "initialFunds": {},
+        "initialStakePools": {
+          "stakePools": {},
+          "delegators": {}
+        },
+        "networkId": 1,
+        "systemStart": {
+          "__type": "Date",
+          "value": 1506203091000
+        }
+      },
+      "intersection": {
+        "point": {
+          "hash": "1994bacfe7bb5099f3af410707544f2762365187354fea3d44904778a7eaf413",
+          "slot": 130868820
+        },
+        "tip": {
+          "blockNo": 10737602,
+          "hash": "52ed826103d1fc01a3595e9143b3ca8e85636573af89f037624f0ce3fc501387",
+          "slot": 132774077
+        }
+      }
+    },
+    "options": {
+      "blockHeights": "10644079"
+    },
+    "software": {
+      "commit": {
+        "hash": "7d78ad460a93309ec5bb32f8fbf647a868f42d95",
+        "tags": [
+          "@cardano-sdk/cardano-services-client@0.20.7",
+          "@cardano-sdk/cardano-services@0.29.10",
+          "@cardano-sdk/core@0.39.3",
+          "@cardano-sdk/dapp-connector@0.12.36",
+          "@cardano-sdk/e2e@0.42.0",
+          "@cardano-sdk/golden-test-generator@0.7.75",
+          "@cardano-sdk/governance@0.10.23",
+          "@cardano-sdk/hardware-ledger@0.12.2",
+          "@cardano-sdk/hardware-trezor@0.6.2",
+          "@cardano-sdk/input-selection@0.13.18",
+          "@cardano-sdk/key-management@0.24.2",
+          "@cardano-sdk/ogmios@0.17.7",
+          "@cardano-sdk/projection-typeorm@0.8.37",
+          "@cardano-sdk/projection@0.11.35",
+          "@cardano-sdk/tx-construction@0.21.3",
+          "@cardano-sdk/util-dev@0.22.9",
+          "@cardano-sdk/util-rxjs@0.7.31",
+          "@cardano-sdk/wallet@0.44.1",
+          "@cardano-sdk/web-extension@0.34.0"
+        ]
+      },
+      "name": "@cardano-sdk/golden-test-generator",
+      "version": "0.7.75"
+    }
+  }
+}

--- a/packages/util-dev/src/chainSync/index.ts
+++ b/packages/util-dev/src/chainSync/index.ts
@@ -106,7 +106,8 @@ export enum ChainSyncDataSet {
   WithStakeKeyDeregistration = 'with-stake-key-deregistration.json',
   WithMint = 'with-mint.json',
   WithHandle = 'with-handle.json',
-  WithInlineDatum = 'with-inline-datum.json'
+  WithInlineDatum = 'with-inline-datum.json',
+  Cip68HandleProblem = 'cip68-handle-problem.json'
 }
 
 export const chainSyncData = memoize((dataSet: ChainSyncDataSet) => {


### PR DESCRIPTION
# Context

Found some suspicious logs in mainnet handle provider:
```
[TypeOrmHandleProvider] silverfox has no associated address, which could be the result of a double mint.
```

It [is a valid handle](https://cexplorer.io/asset/asset1lafyy7j4kaa09wrsg34jgz3r3d60ryr3daqth2/tx#data) that was minted just once by upgrading a cip25 handle into cip68.

The bug is caused by [withHandles mapper](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/projection/src/operators/Mappers/withHandles.ts#L163-L164) overwriting handles found in outputs with the ones found in mint (burned), therefore setting address to `null`. 

# Proposed Solution

- [x] create a new chain-sync dataset with problematic block and add an integration test in `projection-typeorm`
- [ ] fix the bug

# Important Changes Introduced

