### PR TITLE
LW-11492 Fix attempt for projector health check

### DIFF
--- a/packages/cardano-services/src/Projection/ProjectionHttpService.ts
+++ b/packages/cardano-services/src/Projection/ProjectionHttpService.ts
@@ -86,7 +86,7 @@ export class ProjectionHttpService<T extends BaseProjectionEvent> extends HttpSe
   #dryRun?: boolean;
 
   constructor(
-    { projection$, projectionNames, healthTimeout = Milliseconds(60_000), dryRun }: ProjectionServiceProps<T>,
+    { projection$, projectionNames, healthTimeout = Milliseconds(180_000), dryRun }: ProjectionServiceProps<T>,
     { logger, router = express.Router() }: ProjectionServiceDependencies
   ) {
     super(


### PR DESCRIPTION
# Context

- Projectors often have negative heath check.
- Investigation conclusions:
  1. the default health check timeout is 1 minute;
  2. even if _unusual_ it is _normal_ for networks to take longer than 1 minute to produce a new block.

# Proposed Solution

Increased the default health check timeout to 3 minutes;