### PR TITLE
fix(wallet): remove redundant sort on getChangeAddres

### DIFF
--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -23,7 +23,7 @@ import { InputSelectionError, InputSelectionFailure } from '@cardano-sdk/input-s
 import { Logger } from 'ts-log';
 import { MessageSender } from '@cardano-sdk/key-management';
 import { Observable, firstValueFrom, from, map, mergeMap, race, throwError } from 'rxjs';
-import { ObservableWallet, isKeyHashAddress, isScriptAddress } from './types';
+import { ObservableWallet } from './types';
 import { requiresForeignSignatures } from './services';
 import uniq from 'lodash/uniq.js';
 
@@ -279,19 +279,6 @@ const baseCip30WalletApi = (
     try {
       const wallet = await firstValueFrom(wallet$);
       const addresses = await firstValueFrom(wallet.addresses$);
-
-      const isScriptWallet = addresses.some(isScriptAddress);
-
-      if (!isScriptWallet) {
-        addresses.sort((a, b) => {
-          if (isKeyHashAddress(a) && isKeyHashAddress(b)) {
-            return a.index - b.index;
-          }
-
-          return 0; // Cant happen, but in any case do not sort.
-        });
-      }
-
       const address = addresses[0].address;
 
       if (!address) {

--- a/packages/wallet/test/integration/cip30mapping.test.ts
+++ b/packages/wallet/test/integration/cip30mapping.test.ts
@@ -504,19 +504,19 @@ describe('cip30', () => {
         const addresses = [
           {
             accountIndex: 0,
-            address: address_1_0,
-            index: 1,
+            address: address_0_0,
+            index: 0,
             networkId: Cardano.NetworkId.Testnet,
-            rewardAccount: rewardAccount_1,
+            rewardAccount: rewardAccount_0,
             stakeKeyDerivationPath: { index: 0, role: KeyRole.Stake },
             type: AddressType.External
           },
           {
             accountIndex: 0,
-            address: address_0_0,
-            index: 0,
+            address: address_1_0,
+            index: 1,
             networkId: Cardano.NetworkId.Testnet,
-            rewardAccount: rewardAccount_0,
+            rewardAccount: rewardAccount_1,
             stakeKeyDerivationPath: { index: 0, role: KeyRole.Stake },
             type: AddressType.External
           }
@@ -524,7 +524,7 @@ describe('cip30', () => {
 
         const newApi = cip30.createWalletApi(
           of({
-            addresses$: of(addresses),
+            addresses$: of(addresses), // these are guaranteed to be sorted
             getNextUnusedAddress: () => [addresses[1]]
           } as unknown as ObservableWallet),
           confirmationCallback,


### PR DESCRIPTION
# Context

Now that addresses in address$ observable are guaranteed to be sorted, we no longer need to sort it here.

