### PR TITLE
LW-11501 Bump cardano-node to v9.1.1 and db-sync to v13.5.0.1

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -123,7 +123,7 @@ services:
     depends_on:
       ogmios:
         condition: service_healthy
-    image: ghcr.io/intersectmbo/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.3.0.0}
+    image: ghcr.io/intersectmbo/cardano-db-sync:${CARDANO_DB_SYNC_VERSION:-13.5.0.1}
     restart: on-failure
     stop_signal: SIGINT
     volumes:
@@ -134,7 +134,7 @@ services:
     <<:
       - *logging
       - *with-postgres
-    image: ghcr.io/intersectmbo/cardano-smash-server:${CARDANO_DB_SYNC_VERSION:-13.3.0.0}
+    image: ghcr.io/intersectmbo/cardano-smash-server:${CARDANO_DB_SYNC_VERSION:-13.5.0.1}
     command: ['--config', '/config/cardano-db-sync/config.json']
     environment:
       POSTGRES_HOST: postgres
@@ -155,7 +155,7 @@ services:
 
   cardano-node:
     <<: *logging
-    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-9.1.0}
+    image: ghcr.io/intersectmbo/cardano-node:${CARDANO_NODE_VERSION:-9.1.1}
     command:
       [
         'run',
@@ -201,7 +201,7 @@ services:
 
   cardano-submit-api:
     command: --config /config/cardano-submit-api/config.json --listen-address 0.0.0.0 --socket-path /ipc/node.socket $SUBMIT_API_ARGS
-    image: ghcr.io/intersectmbo/cardano-submit-api:${CARDANO_NODE_VERSION:-9.1.0}
+    image: ghcr.io/intersectmbo/cardano-submit-api:${CARDANO_NODE_VERSION:-9.1.1}
     ports:
       - 8090:8090
     restart: on-failure

--- a/packages/e2e/local-network/Dockerfile
+++ b/packages/e2e/local-network/Dockerfile
@@ -5,16 +5,16 @@ FROM ubuntu:${UBUNTU_VERSION} as builder
 ENV DEBIAN_FRONTEND=nonintercative
 
 WORKDIR /build
-ARG CARDANO_NODE_BUILD_URL=https://github.com/IntersectMBO/cardano-node/releases/download/9.1.0/cardano-node-9.1.0-linux.tar.gz
+ARG CARDANO_NODE_BUILD_URL=https://github.com/IntersectMBO/cardano-node/releases/download/9.1.1/cardano-node-9.1.1-linux.tar.gz
 ARG CARDANO_NODE_BUILD_URL_ARM64=https://github.com/input-output-hk/ogmios-tracker/releases/download/0.1.0/cardano-node-9.1.0-aarch64-linux.tar.gz
 
 RUN set -x && \
   apt-get update -y && \
   apt-get install -y wget tar curl unzip && \
   if [ "$(uname -m)" = "aarch64" ] ; then \
-    curl -fsSL "$CARDANO_NODE_BUILD_URL_ARM64" >cardano-node.tar.gz ;\
-    else \
-    curl -fsSL "$CARDANO_NODE_BUILD_URL" >cardano-node.tar.gz ;\
+    curl -fsSL "$CARDANO_NODE_BUILD_URL_ARM64" >cardano-node.tar.gz ; \
+  else \
+    curl -fsSL "$CARDANO_NODE_BUILD_URL" >cardano-node.tar.gz ; \
   fi && \
   mkdir -p cardano-node && \
   tar -xzf cardano-node.tar.gz -C cardano-node
@@ -34,9 +34,9 @@ COPY --from=builder /build/cardano-node /opt/cardano-node
 ARG TINI_VERSION=v0.19.0
 RUN mkdir -p ./bin && ln -s /opt/cardano-node/bin/* ./bin/ &&\
   if [ "$(uname -m)" = "aarch64" ] ; then \
-  TINI_VARIANT=static-arm64 ;\
+    TINI_VARIANT=static-arm64 ;\
   else \
-  TINI_VARIANT=static-amd64 ;\
+    TINI_VARIANT=static-amd64 ;\
   fi &&\
   curl -fsSL >/tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TINI_VARIANT} &&\
   chmod +x /tini

--- a/packages/e2e/local-network/scripts/install.sh
+++ b/packages/e2e/local-network/scripts/install.sh
@@ -16,7 +16,7 @@ clean() {
 }
 trap clean EXIT
 
-VERSION="9.1.0"
+VERSION="9.1.1"
 
 rm -rf bin
 mkdir -p bin


### PR DESCRIPTION
# Context

External dependencies versions in SDK are behind the ones used in deployed environments.

# Proposed Solution

- Bump `cardano-node` to `v9.1.1`
- Bump `db-sync` to `v13.5.0.1`