### PR TITLE
test(e2e): abort k6 wallets test if too many failed requests

### DIFF
--- a/packages/e2e/test/k6/scenarios/wallets.test.js
+++ b/packages/e2e/test/k6/scenarios/wallets.test.js
@@ -161,11 +161,19 @@ export const options = {
     }
   },
   thresholds: {
+    http_req_failed: [
+      {
+        // Stop the test if more than 10% of requests fail to avoid using VUh for nothing
+        abortOnFail: true,
+        // Wait for 2 minutes to get more data. If the error rate is still high, the test will fail
+        delayAbortEval: '2m',
+        threshold: 'rate<0.1'
+      }
+    ],
     // All wallets should have syncd
     // Use https://k6.io/docs/using-k6/thresholds/ to set more thresholds. E.g.:
     // wallet_sync: ['p(95)<5000'], // 95% of wallets should sync in under 5 seconds
     wallet_sync: [{ delayAbortEval: '5s', threshold: 'p(95) < 30000' }],
-
     wallet_sync_count: [`count >= ${MAX_VU}`] // We get a nice graph if we enable thresholds. See this stat on a graph
   }
 };


### PR DESCRIPTION


# Context

wallets K6 test does not fail regardless of how many requests fail.
P95, P99 response times seem to include the failed response times, which are usually fast.

# Proposed Solution
abort k6 wallets test if too many failed requests
- show that test is failing, otherwise failed requests are considered successful with small response time
- To save on K6 VUh
-
# Important Changes Introduced
