### PR TITLE
Fix signed/unsigned bug in Value.fromCBOR

### DIFF
--- a/packages/core/src/Serialization/TransactionBody/Value.ts
+++ b/packages/core/src/Serialization/TransactionBody/Value.ts
@@ -81,7 +81,7 @@ export class Value {
     const reader = new CborReader(cbor);
 
     if (reader.peekState() === CborReaderState.UnsignedInteger) {
-      const coins = reader.readInt();
+      const coins = reader.readUInt();
       return new Value(coins);
     }
 
@@ -93,7 +93,7 @@ export class Value {
         `Expected an array of ${VALUE_ARRAY_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const coins = reader.readInt();
+    const coins = reader.readUInt();
     const multiassets = new Map<Crypto.Hash28ByteBase16, Map<Cardano.AssetName, bigint>>();
 
     reader.readStartMap();
@@ -105,7 +105,7 @@ export class Value {
       reader.readStartMap();
       while (reader.peekState() !== CborReaderState.EndMap) {
         const assetName = Buffer.from(reader.readByteString()).toString('hex') as unknown as Cardano.AssetName;
-        const quantity = reader.readInt();
+        const quantity = reader.readUInt();
 
         multiassets.get(scriptHash)!.set(assetName, quantity);
       }

--- a/packages/core/test/Serialization/TransactionBody/Value.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/Value.test.ts
@@ -1,12 +1,16 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Cardano from '../../../src/Cardano';
+import { CborContentException, Value } from '../../../src/Serialization';
 import { HexBlob } from '@cardano-sdk/util';
-import { Value } from '../../../src/Serialization';
 
 // Test data used in the following tests was generated with the cardano-serialization-lib
 
 const cbor = HexBlob(
   '821a000f4240a2581c00000000000000000000000000000000000000000000000000000000a3443031323218644433343536186344404142420a581c11111111111111111111111111111111111111111111111111111111a3443031323218644433343536186344404142420a'
+);
+
+const cborWithNegativeCoin = HexBlob(
+  '823a000f423fa2581c00000000000000000000000000000000000000000000000000000000a3443031323218644433343536186344404142420a581c11111111111111111111111111111111111111111111111111111111a3443031323218644433343536186344404142420a'
 );
 
 const unsortedCore = {
@@ -90,5 +94,9 @@ describe('Value', () => {
   it('can encode Value with only lovelace to Core', () => {
     const interval = Value.fromCbor(onlyLovelaceCbor);
     expect(interval.toCore()).toEqual(onlyLovelaceCore);
+  });
+
+  it('can throws if Value CBOR contains negative numbers', () => {
+    expect(() => Value.fromCbor(cborWithNegativeCoin)).toThrow(CborContentException);
   });
 });


### PR DESCRIPTION
It looks like the author meant to do:

    if(reader.peek() === UNSIGNED_INT) { reader.readUInt() }

instead of

    if(reader.peek() === UNSIGNED_INT) { reader.readInt() }
