### PR TITLE
refactor!: hoist bufferChainSyncEvent to projection package

### DIFF
--- a/packages/cardano-services/src/Projection/createTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/createTypeormProjection.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable prefer-spread */
-import { Bootstrap, ProjectionEvent, logProjectionProgress, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ObservableCardanoNode } from '@cardano-sdk/core';
+import {
+  Bootstrap,
+  ObservableCardanoNode,
+  ProjectionEvent,
+  logProjectionProgress,
+  requestNext
+} from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
 import { Observable, concat, defer, groupBy, mergeMap, take, takeWhile } from 'rxjs';
 import {

--- a/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
+++ b/packages/cardano-services/src/Projection/prepareTypeormProjection.ts
@@ -44,8 +44,8 @@ import {
   willStoreStakePools,
   willStoreUtxo
 } from '@cardano-sdk/projection-typeorm';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { Mappers as Mapper, ProjectionEvent } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers as Mapper, ProjectionEvent } from '@cardano-sdk/projection';
 import { ObservableType, passthrough } from '@cardano-sdk/util-rxjs';
 import { POOLS_METRICS_INTERVAL_DEFAULT, POOLS_METRICS_OUTDATED_INTERVAL_DEFAULT } from '../Program/programs/types';
 import { Sorter } from '@hapi/topo';

--- a/packages/cardano-services/src/TxSubmit/NodeTxSubmitProvider.ts
+++ b/packages/cardano-services/src/TxSubmit/NodeTxSubmitProvider.ts
@@ -5,7 +5,6 @@ import {
   HandleOwnerChangeError,
   HandleProvider,
   HealthCheckResponse,
-  ObservableCardanoNode,
   ProviderError,
   ProviderFailure,
   SubmitTxArgs,
@@ -14,6 +13,7 @@ import {
 } from '@cardano-sdk/core';
 import { InMemoryCache } from '../InMemoryCache';
 import { Logger } from 'ts-log';
+import { ObservableCardanoNode } from '@cardano-sdk/projection';
 import { WithLogger } from '@cardano-sdk/util';
 
 type ObservableTxSubmitter = Pick<ObservableCardanoNode, 'healthCheck$' | 'submitTx'>;

--- a/packages/cardano-services/test/Projection/createTypeormProjection.test.ts
+++ b/packages/cardano-services/test/Projection/createTypeormProjection.test.ts
@@ -6,8 +6,9 @@ import {
   TokensEntity,
   createDataSource
 } from '@cardano-sdk/projection-typeorm';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { ProjectionName, createTypeormProjection, prepareTypeormProjection } from '../../src';
 import { lastValueFrom } from 'rxjs';
 import { projectorConnectionConfig, projectorConnectionConfig$ } from '../util';

--- a/packages/core/src/CardanoNode/types/CardanoNode.ts
+++ b/packages/core/src/CardanoNode/types/CardanoNode.ts
@@ -1,5 +1,5 @@
 import type { HealthCheckResponse } from '../../Provider';
-import type { Lovelace, PoolId, VrfVkHex } from '../../Cardano';
+import type { Lovelace, PoolId, Tip, VrfVkHex } from '../../Cardano';
 import type { Milliseconds } from '../../util';
 
 export interface EraSummary {
@@ -48,3 +48,13 @@ export interface CardanoNode {
    */
   healthCheck(): Promise<HealthCheckResponse>;
 }
+
+// Similar to Ogmios.Point, but using Cardano.BlockId opaque string for hash
+export type Point = Pick<Tip, 'hash' | 'slot'>;
+export type Origin = 'origin';
+export type TipOrOrigin = Tip | Origin;
+export type PointOrOrigin = Point | Origin;
+export type Intersection = {
+  point: PointOrOrigin;
+  tip: TipOrOrigin;
+};

--- a/packages/core/src/CardanoNode/types/index.ts
+++ b/packages/core/src/CardanoNode/types/index.ts
@@ -1,3 +1,2 @@
 export * from './CardanoNode';
 export * from './CardanoNodeErrors';
-export * from './ObservableCardanoNode';

--- a/packages/e2e/test/projection/offline-fork.test.ts
+++ b/packages/e2e/test/projection/offline-fork.test.ts
@@ -2,8 +2,12 @@ import * as Postgres from '@cardano-sdk/projection-typeorm';
 import { BlockDataEntity, BlockEntity, StakeKeyEntity } from '@cardano-sdk/projection-typeorm';
 import {
   Bootstrap,
+  ChainSyncEvent,
+  ChainSyncEventType,
+  ChainSyncRollForward,
   InMemory,
   Mappers,
+  ObservableCardanoNode,
   ProjectionEvent,
   ProjectionOperator,
   StabilityWindowBuffer,
@@ -11,15 +15,7 @@ import {
   requestNext,
   withStaticContext
 } from '@cardano-sdk/projection';
-import {
-  Cardano,
-  ChainSyncEvent,
-  ChainSyncEventType,
-  ChainSyncRollForward,
-  ObservableCardanoNode,
-  Point,
-  TipOrOrigin
-} from '@cardano-sdk/core';
+import { Cardano, Point, TipOrOrigin } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { ConnectionConfig } from '@cardano-ogmios/client';
 import { Observable, filter, firstValueFrom, lastValueFrom, map, of, take, takeWhile, throwError, toArray } from 'rxjs';

--- a/packages/e2e/test/projection/single-tenant-utxo.test.ts
+++ b/packages/e2e/test/projection/single-tenant-utxo.test.ts
@@ -1,6 +1,6 @@
 import * as Postgres from '@cardano-sdk/projection-typeorm';
-import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ObservableCardanoNode } from '@cardano-sdk/core';
+import { Bootstrap, Mappers, ObservableCardanoNode, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { ConnectionConfig } from '@cardano-ogmios/client';
 import { DataSource, QueryRunner } from 'typeorm';
 import { Observable, filter, firstValueFrom, lastValueFrom, of, scan, takeWhile } from 'rxjs';

--- a/packages/golden-test-generator/package.json
+++ b/packages/golden-test-generator/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@cardano-sdk/core": "workspace:~",
     "@cardano-sdk/ogmios": "workspace:~",
+    "@cardano-sdk/projection": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
     "@cardano-sdk/util-dev": "workspace:~",
     "bunyan": "^1.8.15",

--- a/packages/golden-test-generator/src/ChainSyncEvents/chainSyncEvents.ts
+++ b/packages/golden-test-generator/src/ChainSyncEvents/chainSyncEvents.ts
@@ -1,4 +1,5 @@
-import { Cardano, ChainSyncEventType, Intersection } from '@cardano-sdk/core';
+import { Cardano, Intersection } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { GeneratorMetadata } from '../Content';
 import { Logger } from 'ts-log';
 import { Ogmios, ogmiosToCore } from '@cardano-sdk/ogmios';

--- a/packages/golden-test-generator/src/tsconfig.json
+++ b/packages/golden-test-generator/src/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../../util/src"
+    },
+    {
+      "path": "../../projection/src"
     }
   ]
 }

--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -58,6 +58,7 @@
     "@cardano-ogmios/schema": "6.5.0",
     "@cardano-sdk/core": "workspace:~",
     "@cardano-sdk/crypto": "workspace:~",
+    "@cardano-sdk/projection": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
     "backoff-rxjs": "^7.0.0",
     "buffer": "5.7.1",

--- a/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/OgmiosObservableCardanoNode.ts
+++ b/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/OgmiosObservableCardanoNode.ts
@@ -8,8 +8,6 @@ import {
   GeneralCardanoNodeErrorCode,
   HealthCheckResponse,
   Milliseconds,
-  ObservableCardanoNode,
-  ObservableChainSync,
   PointOrOrigin,
   StakeDistribution,
   StateQueryErrorCode
@@ -49,6 +47,7 @@ import {
   withCoreCardanoNodeError
 } from '../queries';
 import isEqual from 'lodash/isEqual.js';
+import type { ObservableCardanoNode, ObservableChainSync } from '@cardano-sdk/projection';
 import type { Serialization } from '@cardano-sdk/core';
 
 const ogmiosToCoreIntersection = (intersection: ChainSynchronization.Intersection) => ({

--- a/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/createObservableChainSyncClient.ts
+++ b/packages/ogmios/src/CardanoNode/OgmiosObservableCardanoNode/createObservableChainSyncClient.ts
@@ -1,12 +1,6 @@
-import {
-  ChainSyncEvent,
-  ChainSyncEventType,
-  GeneralCardanoNodeError,
-  GeneralCardanoNodeErrorCode,
-  PointOrOrigin,
-  RequestNext
-} from '@cardano-sdk/core';
+import { ChainSyncEvent, ChainSyncEventType, RequestNext } from '@cardano-sdk/projection';
 import { ChainSynchronization, InteractionContext, Schema, safeJSON } from '@cardano-ogmios/client';
+import { GeneralCardanoNodeError, GeneralCardanoNodeErrorCode, PointOrOrigin } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
 import { Observable, Subscriber, from, switchMap } from 'rxjs';
 import { WithLogger, toSerializableObject } from '@cardano-sdk/util';

--- a/packages/ogmios/src/tsconfig.json
+++ b/packages/ogmios/src/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../../util-rxjs/src"
     },
     {
+      "path": "../../projection/src"
+    },
+    {
       "path": "../../crypto/src"
     }
   ]

--- a/packages/projection-typeorm/src/TypeormStabilityWindowBuffer.ts
+++ b/packages/projection-typeorm/src/TypeormStabilityWindowBuffer.ts
@@ -1,10 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BlockDataEntity } from './entity';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import {
+  ChainSyncEventType,
+  ProjectionEvent,
+  RollForwardEvent,
+  StabilityWindowBuffer,
+  WithNetworkInfo
+} from '@cardano-sdk/projection';
 import { LessThan, QueryRunner } from 'typeorm';
 import { Logger } from 'ts-log';
 import { Observable, catchError, concatMap, from, map, of, switchMap, take } from 'rxjs';
-import { ProjectionEvent, RollForwardEvent, StabilityWindowBuffer, WithNetworkInfo } from '@cardano-sdk/projection';
 import { ReconnectionConfig } from '@cardano-sdk/util-rxjs';
 import { RetryBackoffConfig, retryBackoff } from 'backoff-rxjs';
 import { TypeormConnection } from './createDataSource';

--- a/packages/projection-typeorm/src/createTypeormTipTracker.ts
+++ b/packages/projection-typeorm/src/createTypeormTipTracker.ts
@@ -1,9 +1,9 @@
-import { BaseProjectionEvent } from '@cardano-sdk/projection';
+import { BaseProjectionEvent, ChainSyncEventType } from '@cardano-sdk/projection';
 import { BlockEntity } from './entity';
-import { ChainSyncEventType, TipOrOrigin } from '@cardano-sdk/core';
 import { Observable, ReplaySubject, from, map, of, switchMap, take, tap } from 'rxjs';
 import { ReconnectionConfig } from '@cardano-sdk/util-rxjs';
 import { RetryBackoffConfig, retryBackoff } from 'backoff-rxjs';
+import { TipOrOrigin } from '@cardano-sdk/core';
 import { TypeormConnection } from './createDataSource';
 import { isRecoverableTypeormError } from './isRecoverableTypeormError';
 

--- a/packages/projection-typeorm/src/operators/storeAddresses.ts
+++ b/packages/projection-typeorm/src/operators/storeAddresses.ts
@@ -1,7 +1,7 @@
 import { AddressEntity } from '../entity/Address.entity';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers } from '@cardano-sdk/projection';
 import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
-import { Mappers } from '@cardano-sdk/projection';
 import { QueryRunner } from 'typeorm';
 import { StakeKeyRegistrationEntity } from '../entity';
 import { certificatePointerToId, typeormOperator } from './util';

--- a/packages/projection-typeorm/src/operators/storeAssets.ts
+++ b/packages/projection-typeorm/src/operators/storeAssets.ts
@@ -1,6 +1,6 @@
 import { AssetEntity } from '../entity';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { Mappers } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers } from '@cardano-sdk/projection';
 import { QueryRunner } from 'typeorm';
 import { typeormOperator } from './util';
 

--- a/packages/projection-typeorm/src/operators/storeBlock.ts
+++ b/packages/projection-typeorm/src/operators/storeBlock.ts
@@ -1,5 +1,5 @@
 import { BlockEntity } from '../entity';
-import { ChainSyncEventType } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { typeormOperator } from './util';
 
 export const storeBlock = typeormOperator(async (evt) => {

--- a/packages/projection-typeorm/src/operators/storeGovernanceAction.ts
+++ b/packages/projection-typeorm/src/operators/storeGovernanceAction.ts
@@ -1,6 +1,6 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers, ProjectionEvent } from '@cardano-sdk/projection';
 import { GovernanceActionEntity } from '../entity';
-import { Mappers, ProjectionEvent } from '@cardano-sdk/projection';
 import { typeormOperator } from './util';
 
 export const willStoreGovernanceAction = (evt: ProjectionEvent<Mappers.WithGovernanceActions>) =>

--- a/packages/projection-typeorm/src/operators/storeHandleMetadata.ts
+++ b/packages/projection-typeorm/src/operators/storeHandleMetadata.ts
@@ -1,6 +1,5 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers } from '@cardano-sdk/projection';
 import { HandleMetadataEntity } from '../entity';
-import { Mappers } from '@cardano-sdk/projection';
 import { WithStoredProducedUtxo } from './storeUtxo';
 import { typeormOperator } from './util';
 

--- a/packages/projection-typeorm/src/operators/storeHandles.ts
+++ b/packages/projection-typeorm/src/operators/storeHandles.ts
@@ -1,7 +1,7 @@
 import { AssetEntity, HandleEntity, HandleMetadataEntity } from '../entity';
-import { Cardano, ChainSyncEventType, Handle } from '@cardano-sdk/core';
+import { Cardano, Handle } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers } from '@cardano-sdk/projection';
 import { In, QueryRunner } from 'typeorm';
-import { Mappers } from '@cardano-sdk/projection';
 import { WithMintedAssetSupplies } from './storeAssets';
 import { typeormOperator } from './util';
 import sortBy from 'lodash/sortBy.js';

--- a/packages/projection-typeorm/src/operators/storeNftMetadata.ts
+++ b/packages/projection-typeorm/src/operators/storeNftMetadata.ts
@@ -1,6 +1,6 @@
-import { Asset, Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Asset, Cardano } from '@cardano-sdk/core';
 import { AssetEntity, NftMetadataEntity, NftMetadataType } from '../entity';
-import { Mappers, ProjectionEvent } from '@cardano-sdk/projection';
+import { ChainSyncEventType, Mappers, ProjectionEvent } from '@cardano-sdk/projection';
 import { Repository } from 'typeorm';
 import { typeormOperator } from './util';
 

--- a/packages/projection-typeorm/src/operators/storePoolMetricsUpdateJob.ts
+++ b/packages/projection-typeorm/src/operators/storePoolMetricsUpdateJob.ts
@@ -1,4 +1,5 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { STAKE_POOL_METRICS_UPDATE } from '../pgBoss';
 import { WithPgBoss } from './withTypeormTransaction';
 import { typeormOperator } from './util';

--- a/packages/projection-typeorm/src/operators/storeStakeKeyRegistrations.ts
+++ b/packages/projection-typeorm/src/operators/storeStakeKeyRegistrations.ts
@@ -1,5 +1,4 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
-import { Mappers } from '@cardano-sdk/projection';
+import { ChainSyncEventType, Mappers } from '@cardano-sdk/projection';
 import { StakeKeyRegistrationEntity } from '../entity';
 import { certificatePointerToId, typeormOperator } from './util';
 

--- a/packages/projection-typeorm/src/operators/storeStakePoolMetadataJob.ts
+++ b/packages/projection-typeorm/src/operators/storeStakePoolMetadataJob.ts
@@ -1,5 +1,4 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
-import { Mappers } from '@cardano-sdk/projection';
+import { ChainSyncEventType, Mappers } from '@cardano-sdk/projection';
 import { STAKE_POOL_METADATA_QUEUE, StakePoolMetadataJob, defaultJobOptions } from '../pgBoss';
 import { WithPgBoss } from './withTypeormTransaction';
 import { certificatePointerToId, typeormOperator } from './util';

--- a/packages/projection-typeorm/src/operators/storeStakePoolRewardsJob.ts
+++ b/packages/projection-typeorm/src/operators/storeStakePoolRewardsJob.ts
@@ -1,4 +1,5 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { STAKE_POOL_REWARDS, defaultJobOptions } from '../pgBoss';
 import { WithPgBoss } from './withTypeormTransaction';
 import { typeormOperator } from './util';

--- a/packages/projection-typeorm/src/operators/storeStakePools.ts
+++ b/packages/projection-typeorm/src/operators/storeStakePools.ts
@@ -1,6 +1,6 @@
-import { Cardano, ChainSyncEventType, EraSummary, epochSlotsCalc } from '@cardano-sdk/core';
+import { Cardano, EraSummary, epochSlotsCalc } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers, ProjectionEvent } from '@cardano-sdk/projection';
 import { In, Not, QueryRunner, Repository } from 'typeorm';
-import { Mappers, ProjectionEvent } from '@cardano-sdk/projection';
 import {
   MaxCertificatePointerIdCertificateIndex as MaxCertificatePointerIdCertIndex,
   MaxCertificatePointerIdTxIndex,

--- a/packages/projection-typeorm/src/operators/storeUtxo.ts
+++ b/packages/projection-typeorm/src/operators/storeUtxo.ts
@@ -1,5 +1,5 @@
-import { Cardano, ChainSyncEventType, Serialization } from '@cardano-sdk/core';
-import { Mappers } from '@cardano-sdk/projection';
+import { Cardano, Serialization } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers } from '@cardano-sdk/projection';
 import { ObjectLiteral } from 'typeorm';
 import { OutputEntity, TokensEntity } from '../entity';
 import { typeormOperator } from './util';

--- a/packages/projection-typeorm/test/TypeormStabilityWindowBuffer.test.ts
+++ b/packages/projection-typeorm/test/TypeormStabilityWindowBuffer.test.ts
@@ -6,9 +6,9 @@ import {
   createObservableConnection,
   willStoreBlockData
 } from '../src';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, ProjectionEvent } from '@cardano-sdk/projection';
 import { DataSource, NoConnectionForRepositoryError, QueryRunner, Repository } from 'typeorm';
-import { ProjectionEvent } from '@cardano-sdk/projection';
 import { connectionConfig$, createBlockEntity, createBlockHeader, initializeDataSource } from './util';
 import { createStubObservable, logger } from '@cardano-sdk/util-dev';
 import { firstValueFrom, of, throwError } from 'rxjs';

--- a/packages/projection-typeorm/test/createTypeormTipTracker.test.ts
+++ b/packages/projection-typeorm/test/createTypeormTipTracker.test.ts
@@ -1,4 +1,4 @@
-import { BaseProjectionEvent } from '@cardano-sdk/projection';
+import { BaseProjectionEvent, ChainSyncEventType } from '@cardano-sdk/projection';
 import {
   BlockEntity,
   TypeormConnection,
@@ -6,7 +6,7 @@ import {
   createObservableConnection,
   createTypeormTipTracker
 } from '../src';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { DataSource, NoConnectionForRepositoryError, QueryRunner, Repository } from 'typeorm';
 import { Observable, firstValueFrom, of, throwError } from 'rxjs';
 import { RetryBackoffConfig } from 'backoff-rxjs';

--- a/packages/projection-typeorm/test/operators/storeAssets.test.ts
+++ b/packages/projection-typeorm/test/operators/storeAssets.test.ts
@@ -12,8 +12,8 @@ import {
   willStoreAssets,
   withTypeormTransaction
 } from '../../src';
-import { Bootstrap, Mappers, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Bootstrap, ChainSyncEventType, Mappers, requestNext } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { Mint } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { QueryRunner } from 'typeorm';

--- a/packages/projection-typeorm/test/operators/storeGovernanceAction.test.ts
+++ b/packages/projection-typeorm/test/operators/storeGovernanceAction.test.ts
@@ -1,7 +1,7 @@
 import { BlockEntity, GovernanceActionEntity } from '../../src';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers, ProjectionEvent } from '@cardano-sdk/projection';
 import { DataSource, QueryRunner } from 'typeorm';
-import { Mappers, ProjectionEvent } from '@cardano-sdk/projection';
 import { WithTypeormContext, storeBlock, storeGovernanceAction } from '../../src/operators';
 import { firstValueFrom, of } from 'rxjs';
 import { initializeDataSource } from '../util';

--- a/packages/projection-typeorm/test/operators/storeHandleMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeHandleMetadata.test.ts
@@ -17,8 +17,8 @@ import {
   willStoreHandleMetadata,
   withTypeormTransaction
 } from '../../src';
-import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ObservableCardanoNode } from '@cardano-sdk/core';
+import { Bootstrap, Mappers, ObservableCardanoNode, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { HandleMetadata } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { Observable, firstValueFrom } from 'rxjs';

--- a/packages/projection-typeorm/test/operators/storeHandles/general.test.ts
+++ b/packages/projection-typeorm/test/operators/storeHandles/general.test.ts
@@ -1,5 +1,6 @@
-import { Asset, Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Asset, Cardano } from '@cardano-sdk/core';
 import { AssetEntity, HandleEntity, OutputEntity, willStoreHandles } from '../../../src';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { HandleOwnership } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { ProjectorContext, createProjectorContext } from '../util';
 import { QueryRunner } from 'typeorm';

--- a/packages/projection-typeorm/test/operators/storeHandles/ownership.test.ts
+++ b/packages/projection-typeorm/test/operators/storeHandles/ownership.test.ts
@@ -1,5 +1,5 @@
-import { BaseProjectionEvent } from '@cardano-sdk/projection';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { BaseProjectionEvent, ChainSyncEventType } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData } from '@cardano-sdk/util-dev';
 import { HandleEntity } from '../../../src';
 import { ProjectorContext, createProjectorContext, createStubProjectionSource, filterAssets } from '../util';

--- a/packages/projection-typeorm/test/operators/storeHandles/util.ts
+++ b/packages/projection-typeorm/test/operators/storeHandles/util.ts
@@ -20,8 +20,15 @@ import {
   typeormTransactionCommit,
   withTypeormTransaction
 } from '../../../src';
-import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ChainSyncEventType, ObservableCardanoNode } from '@cardano-sdk/core';
+import {
+  Bootstrap,
+  ChainSyncEventType,
+  Mappers,
+  ObservableCardanoNode,
+  ProjectionEvent,
+  requestNext
+} from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger, mockProviders } from '@cardano-sdk/util-dev';
 import { Observable } from 'rxjs';
 import { ProjectorContext, createProjectorTilFirst, createStubProjectionSource } from '../util';

--- a/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
@@ -1,4 +1,4 @@
-import { Asset, Cardano, ChainSyncEventType, ChainSyncRollForward } from '@cardano-sdk/core';
+import { Asset, Cardano } from '@cardano-sdk/core';
 import {
   AssetEntity,
   BlockDataEntity,
@@ -18,7 +18,14 @@ import {
   willStoreNftMetadata,
   withTypeormTransaction
 } from '../../src';
-import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import {
+  Bootstrap,
+  ChainSyncEventType,
+  ChainSyncRollForward,
+  Mappers,
+  ProjectionEvent,
+  requestNext
+} from '@cardano-sdk/projection';
 import { CIP67Asset, ProjectedNftMetadata } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { ChainSyncDataSet, chainSyncData, generateRandomHexString, logger } from '@cardano-sdk/util-dev';
 import { Observable, firstValueFrom, lastValueFrom, toArray } from 'rxjs';

--- a/packages/projection-typeorm/test/operators/storePoolMetricsUpdateJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storePoolMetricsUpdateJob.test.ts
@@ -1,4 +1,4 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { OperatorFunction, of } from 'rxjs';
 import { STAKE_POOL_METRICS_UPDATE, createStorePoolMetricsUpdateJob } from '../../src';
 

--- a/packages/projection-typeorm/test/operators/storeStakePoolMetadataJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePoolMetadataJob.test.ts
@@ -11,9 +11,8 @@ import {
   willStoreStakePoolMetadataJob,
   withTypeormTransaction
 } from '../../src';
-import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { Bootstrap, ChainSyncEventType, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
-import { ChainSyncEventType } from '@cardano-sdk/core';
 import { Observable, filter, of } from 'rxjs';
 import { PoolUpdate } from '@cardano-sdk/projection/dist/cjs/operators/Mappers';
 import { QueryRunner } from 'typeorm';

--- a/packages/projection-typeorm/test/operators/storeStakePoolRewardsJob.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePoolRewardsJob.test.ts
@@ -1,4 +1,5 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '@cardano-sdk/projection';
 import { OperatorFunction, of } from 'rxjs';
 import { STAKE_POOL_REWARDS, storeStakePoolRewardsJob, willStoreStakePoolRewardsJob } from '../../src';
 

--- a/packages/projection-typeorm/test/operators/storeStakePools.test.ts
+++ b/packages/projection-typeorm/test/operators/storeStakePools.test.ts
@@ -15,8 +15,8 @@ import {
   willStoreStakePools,
   withTypeormTransaction
 } from '../../src';
-import { Bootstrap, Mappers, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ChainSyncEventType, ObservableCardanoNode } from '@cardano-sdk/core';
+import { Bootstrap, ChainSyncEventType, Mappers, ObservableCardanoNode, requestNext } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { connectionConfig$, initializeDataSource } from '../util';

--- a/packages/projection-typeorm/test/operators/storeUtxo.test.ts
+++ b/packages/projection-typeorm/test/operators/storeUtxo.test.ts
@@ -15,8 +15,8 @@ import {
   willStoreUtxo,
   withTypeormTransaction
 } from '../../src';
-import { Bootstrap, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Bootstrap, ChainSyncEventType, Mappers, ProjectionEvent, requestNext } from '@cardano-sdk/projection';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { IsNull, Not, QueryRunner } from 'typeorm';
 import { Observable } from 'rxjs';

--- a/packages/projection-typeorm/test/operators/util.ts
+++ b/packages/projection-typeorm/test/operators/util.ts
@@ -1,13 +1,14 @@
 import {
   BaseProjectionEvent,
   BootstrapExtraProps,
+  ChainSyncEventType,
   ProjectionEvent,
   RollBackwardEvent,
   WithBlock,
   WithNetworkInfo
 } from '@cardano-sdk/projection';
 import { BigIntMath } from '@cardano-sdk/util';
-import { Cardano, ChainSyncEventType, Point } from '@cardano-sdk/core';
+import { Cardano, Point } from '@cardano-sdk/core';
 import { Observable, lastValueFrom, map, takeWhile } from 'rxjs';
 import { RetryBackoffConfig } from 'backoff-rxjs';
 import {

--- a/packages/projection/package.json
+++ b/packages/projection/package.json
@@ -2,11 +2,9 @@
   "name": "@cardano-sdk/projection",
   "version": "0.11.36",
   "description": "Chain Sync event projection",
-  "engines": {
-    "node": ">=16.20.2"
-  },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "repository": "https://github.com/input-output-hk/cardano-js-sdk",
+  "license": "Apache-2.0",
+  "sideEffects": false,
   "exports": {
     ".": {
       "development": "./src/index.ts",
@@ -14,12 +12,14 @@
       "require": "./dist/cjs/index.js"
     }
   },
-  "repository": "https://github.com/input-output-hk/cardano-js-sdk",
-  "publishConfig": {
-    "access": "public"
-  },
-  "sideEffects": false,
-  "license": "Apache-2.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "files": [
+    "dist/*",
+    "!dist/tsconfig.tsbuildinfo",
+    "LICENSE",
+    "NOTICE"
+  ],
   "scripts": {
     "build": "yarn build:cjs && tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020 && tsc-alias -p src/tsconfig.json --outDir ./dist/esm && cp ../../build/esm-package.json ./dist/esm/package.json",
     "build:cjs": "tsc --build src && cp ../../build/cjs-package.json ./dist/cjs/package.json",
@@ -40,6 +40,7 @@
   "dependencies": {
     "@cardano-sdk/core": "workspace:~",
     "@cardano-sdk/crypto": "workspace:~",
+    "@cardano-sdk/ogmios": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
     "@cardano-sdk/util-rxjs": "workspace:~",
     "lodash": "^4.17.21",
@@ -49,7 +50,6 @@
     "tsc-alias": "^1.8.10"
   },
   "devDependencies": {
-    "@cardano-sdk/ogmios": "workspace:~",
     "@cardano-sdk/util-dev": "workspace:~",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",
@@ -58,10 +58,10 @@
     "ts-jest": "^28.0.7",
     "typescript": "^4.7.4"
   },
-  "files": [
-    "dist/*",
-    "!dist/tsconfig.tsbuildinfo",
-    "LICENSE",
-    "NOTICE"
-  ]
+  "engines": {
+    "node": ">=16.20.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/projection/src/Bootstrap/fromCardanoNode.ts
+++ b/packages/projection/src/Bootstrap/fromCardanoNode.ts
@@ -1,14 +1,8 @@
 /* eslint-disable max-len */
 /* eslint-disable jsdoc/valid-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  Cardano,
-  ChainSyncEventType,
-  Intersection,
-  ObservableCardanoNode,
-  ObservableChainSync,
-  TipOrOrigin
-} from '@cardano-sdk/core';
+import { Cardano, Intersection, TipOrOrigin } from '@cardano-sdk/core';
+import { ChainSyncEventType, ObservableCardanoNode, ObservableChainSync } from '../ObservableCardanoNode';
 import { Logger } from 'ts-log';
 import { Observable, concat, defer, map, mergeMap, noop, of, switchMap, take, takeWhile, tap } from 'rxjs';
 import { ProjectionEvent, StabilityWindowBuffer, UnifiedExtChainSyncEvent } from '../types';

--- a/packages/projection/src/InMemory/InMemoryStabilityWindowBuffer.ts
+++ b/packages/projection/src/InMemory/InMemoryStabilityWindowBuffer.ts
@@ -1,5 +1,6 @@
 import { BehaviorSubject, Observable, of, tap } from 'rxjs';
-import { Cardano, ChainSyncEventType, TipOrOrigin } from '@cardano-sdk/core';
+import { Cardano, TipOrOrigin } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '../ObservableCardanoNode';
 import { StabilityWindowBuffer, UnifiedExtChainSyncObservable, WithNetworkInfo } from '../types';
 
 export class InMemoryStabilityWindowBuffer implements StabilityWindowBuffer {

--- a/packages/projection/src/InMemory/operators/storeStakePools.ts
+++ b/packages/projection/src/InMemory/operators/storeStakePools.ts
@@ -1,4 +1,5 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '../../ObservableCardanoNode';
 import { Mappers } from '../../operators';
 import { WithInMemoryStore } from '../types';
 import { inMemoryStoreOperator } from './utils';

--- a/packages/projection/src/ObservableCardanoNode.ts
+++ b/packages/projection/src/ObservableCardanoNode.ts
@@ -1,17 +1,15 @@
-import { bufferChainSyncEvent } from '../util/bufferChainSyncEvent';
-import type { Cardano, HealthCheckResponse, Serialization } from '../..';
-import type { EraSummary } from './CardanoNode';
+import {
+  Cardano,
+  EraSummary,
+  HealthCheckResponse,
+  Intersection,
+  PointOrOrigin,
+  Serialization,
+  TipOrOrigin
+} from '@cardano-sdk/core';
+import { bufferChainSyncEvent } from './bufferChainSyncEvent';
+import type { Block, Tip } from '@cardano-sdk/core/dist/cjs/Cardano';
 import type { Observable } from 'rxjs';
-
-// Similar to Ogmios.Point, but using Cardano.BlockId opaque string for hash
-export type Point = Pick<Cardano.Tip, 'hash' | 'slot'>;
-export type Origin = 'origin';
-export type TipOrOrigin = Cardano.Tip | Origin;
-export type PointOrOrigin = Point | Origin;
-export type Intersection = {
-  point: PointOrOrigin;
-  tip: TipOrOrigin;
-};
 
 export enum ChainSyncEventType {
   RollForward,
@@ -25,9 +23,9 @@ export interface WithRequestNext {
 }
 
 export interface ChainSyncRollForward extends WithRequestNext {
-  tip: Cardano.Tip;
+  tip: Tip;
   eventType: ChainSyncEventType.RollForward;
-  block: Cardano.Block;
+  block: Block;
 }
 
 export interface ChainSyncRollBackward extends WithRequestNext {

--- a/packages/projection/src/bufferChainSyncEvent.ts
+++ b/packages/projection/src/bufferChainSyncEvent.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { RequestNext, WithRequestNext } from '../types';
+import { RequestNext, WithRequestNext } from './ObservableCardanoNode';
 
 export const bufferChainSyncEvent =
   <T extends WithRequestNext>(length: number) =>

--- a/packages/projection/src/index.ts
+++ b/packages/projection/src/index.ts
@@ -2,3 +2,5 @@ export * as InMemory from './InMemory';
 export * as Bootstrap from './Bootstrap';
 export * from './operators';
 export * from './types';
+export * from './bufferChainSyncEvent';
+export * from './ObservableCardanoNode';

--- a/packages/projection/src/operators/Mappers/certificates/withStakeKeys.ts
+++ b/packages/projection/src/operators/Mappers/certificates/withStakeKeys.ts
@@ -1,5 +1,6 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '../../../ObservableCardanoNode';
 import { WithCertificates } from './withCertificates';
 import { unifiedProjectorOperator } from '../../utils';
 

--- a/packages/projection/src/operators/logProjectionProgress.ts
+++ b/packages/projection/src/operators/logProjectionProgress.ts
@@ -1,4 +1,5 @@
-import { Cardano, ChainSyncEventType, TipOrOrigin } from '@cardano-sdk/core';
+import { Cardano, TipOrOrigin } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '../ObservableCardanoNode';
 import { Logger } from 'ts-log';
 import { Observable, defer, finalize, tap } from 'rxjs';
 import { UnifiedExtChainSyncEvent } from '../types';

--- a/packages/projection/src/operators/requestNext.ts
+++ b/packages/projection/src/operators/requestNext.ts
@@ -1,5 +1,5 @@
 import { OperatorFunction, map, tap } from 'rxjs';
-import { WithRequestNext } from '@cardano-sdk/core';
+import { WithRequestNext } from '../ObservableCardanoNode';
 import omit from 'lodash/omit.js';
 
 /** Calls event.requestNext() and emits event object without this method */

--- a/packages/projection/src/operators/utils/projectorOperator.ts
+++ b/packages/projection/src/operators/utils/projectorOperator.ts
@@ -1,4 +1,4 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
+import { ChainSyncEventType } from '../../ObservableCardanoNode';
 import { MaybeObservable } from './types';
 import { RollBackwardEvent, RollForwardEvent } from '../../types';
 import { concatMap, isObservable, of } from 'rxjs';

--- a/packages/projection/src/operators/withNetworkInfo.ts
+++ b/packages/projection/src/operators/withNetworkInfo.ts
@@ -1,4 +1,4 @@
-import { ObservableCardanoNode } from '@cardano-sdk/core';
+import { ObservableCardanoNode } from '../ObservableCardanoNode';
 import { WithNetworkInfo } from '../types';
 import { combineLatest, map, take } from 'rxjs';
 import { withStaticContext } from './withStaticContext';

--- a/packages/projection/src/operators/withRolledBackBlock.ts
+++ b/packages/projection/src/operators/withRolledBackBlock.ts
@@ -1,4 +1,5 @@
-import { Cardano, ChainSyncEvent, ChainSyncEventType, TipOrOrigin } from '@cardano-sdk/core';
+import { Cardano, TipOrOrigin } from '@cardano-sdk/core';
+import { ChainSyncEvent, ChainSyncEventType } from '../ObservableCardanoNode';
 import {
   EMPTY,
   Observable,

--- a/packages/projection/src/types.ts
+++ b/packages/projection/src/types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Cardano, ChainSyncRollBackward, ChainSyncRollForward, EraSummary } from '@cardano-sdk/core';
+import { Cardano, EraSummary } from '@cardano-sdk/core';
+import { ChainSyncRollBackward, ChainSyncRollForward } from './ObservableCardanoNode';
 import { Observable } from 'rxjs';
 import { ObservableType } from '@cardano-sdk/util-rxjs';
 

--- a/packages/projection/test/InMemory/InMemoryStabilityWindowBuffer.test.ts
+++ b/packages/projection/test/InMemory/InMemoryStabilityWindowBuffer.test.ts
@@ -1,5 +1,5 @@
-import { Cardano, ChainSyncEventType, Seconds } from '@cardano-sdk/core';
-import { InMemory, UnifiedExtChainSyncEvent, WithNetworkInfo } from '../../src';
+import { Cardano, Seconds } from '@cardano-sdk/core';
+import { ChainSyncEventType, InMemory, UnifiedExtChainSyncEvent, WithNetworkInfo } from '../../src';
 import { firstValueFrom, from } from 'rxjs';
 import { genesisToEraSummary } from '@cardano-sdk/util-dev';
 import { stubBlockId } from '../util';

--- a/packages/projection/test/InMemory/stakeKeys.test.ts
+++ b/packages/projection/test/InMemory/stakeKeys.test.ts
@@ -1,6 +1,5 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { ChainSyncEventType } from '@cardano-sdk/core';
-import { InMemory, Mappers, ProjectionEvent } from '../../src';
+import { ChainSyncEventType, InMemory, Mappers, ProjectionEvent } from '../../src';
 import { firstValueFrom, of } from 'rxjs';
 
 describe('InMemory.storeStakeKeys', () => {

--- a/packages/projection/test/InMemory/storeStakePools.test.ts
+++ b/packages/projection/test/InMemory/storeStakePools.test.ts
@@ -1,5 +1,5 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { InMemory, Mappers, ProjectionEvent } from '../../src';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, InMemory, Mappers, ProjectionEvent } from '../../src';
 import { firstValueFrom, of } from 'rxjs';
 
 describe('InMemory.storeStakePools', () => {

--- a/packages/projection/test/bufferChainSyncEvent.test.ts
+++ b/packages/projection/test/bufferChainSyncEvent.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { BlockId, BlockNo, Slot, Tip } from '../../../src/Cardano';
-import { ChainSyncEvent, ChainSyncEventType, RequestNext } from '../../../src';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEvent, ChainSyncEventType, RequestNext } from '../src';
 import { Observable, Subject, Subscription } from 'rxjs';
-import { bufferChainSyncEvent } from '../../../src/CardanoNode/util/bufferChainSyncEvent';
+import { bufferChainSyncEvent } from '../src/bufferChainSyncEvent';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -20,7 +20,7 @@ class ChainSyncEventTestConsumer {
       complete: () => this.events.push('Consumer completed'),
       error: (error) => this.events.push(`Consumer error: ${error}`),
       next: (value) => {
-        this.current = (value.tip as Tip).blockNo;
+        this.current = (value.tip as Cardano.Tip).blockNo;
         this.events.push(`Got ${this.current}`);
         this.requestNext = value.requestNext;
       }
@@ -106,7 +106,7 @@ class ChainSyncEventTestProducer {
         requestNext: () => {
           this.canProduce = true;
         },
-        tip: { blockNo: BlockNo(count), hash: '' as BlockId, slot: Slot(count) }
+        tip: { blockNo: Cardano.BlockNo(count), hash: '' as Cardano.BlockId, slot: Cardano.Slot(count) }
       });
     }, 1);
   }

--- a/packages/projection/test/integration/InMemory.test.ts
+++ b/packages/projection/test/integration/InMemory.test.ts
@@ -2,6 +2,8 @@ import * as Crypto from '@cardano-sdk/crypto';
 import {
   Bootstrap,
   BootstrapExtraProps,
+  ChainSyncEventType,
+  ChainSyncRollForward,
   InMemory,
   Mappers,
   ProjectionEvent,
@@ -10,7 +12,7 @@ import {
   requestNext,
   withStaticContext
 } from '../../src';
-import { Cardano, ChainSyncEventType, ChainSyncRollForward } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, StubChainSyncData, chainSyncData, logger } from '@cardano-sdk/util-dev';
 import { from, lastValueFrom, of, take, toArray } from 'rxjs';
 

--- a/packages/projection/test/operators/Mappers/certificates/withCertificates.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withCertificates.test.ts
@@ -1,5 +1,5 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { Mappers, RollForwardEvent, UnifiedExtChainSyncEvent } from '../../../../src';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers, RollForwardEvent, UnifiedExtChainSyncEvent } from '../../../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 
 const createEvent = (

--- a/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withStakeKeyRegistrations.test.ts
@@ -1,6 +1,6 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { Mappers, UnifiedExtChainSyncEvent, WithBlock } from '../../../../src';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers, UnifiedExtChainSyncEvent, WithBlock } from '../../../../src';
 import { firstValueFrom, of } from 'rxjs';
 
 type EventData = Mappers.WithCertificates & { eventType: ChainSyncEventType };

--- a/packages/projection/test/operators/Mappers/certificates/withStakeKeys.test.ts
+++ b/packages/projection/test/operators/Mappers/certificates/withStakeKeys.test.ts
@@ -1,6 +1,6 @@
 import * as Crypto from '@cardano-sdk/crypto';
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { Mappers, UnifiedExtChainSyncEvent, WithBlock } from '../../../../src';
+import { Cardano } from '@cardano-sdk/core';
+import { ChainSyncEventType, Mappers, UnifiedExtChainSyncEvent, WithBlock } from '../../../../src';
 import { firstValueFrom, of } from 'rxjs';
 
 type EventData = Mappers.WithCertificates & { eventType: ChainSyncEventType };

--- a/packages/projection/test/operators/Mappers/withNftMetadata.test.ts
+++ b/packages/projection/test/operators/Mappers/withNftMetadata.test.ts
@@ -1,13 +1,13 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { Asset, Cardano, ChainSyncEventType, ChainSyncRollForward, Serialization, util } from '@cardano-sdk/core';
+import { Asset, Cardano, Serialization, util } from '@cardano-sdk/core';
 import {
   ChainSyncDataSet,
   SerializedChainSyncEvent,
   chainSyncData,
   generateRandomHexString
 } from '@cardano-sdk/util-dev';
+import { ChainSyncEventType, ChainSyncRollForward, Mappers, ProjectionEvent } from '../../../src';
 import { HexBlob } from '@cardano-sdk/util';
-import { Mappers, ProjectionEvent } from '../../../src';
 import { Observable, firstValueFrom, map, of } from 'rxjs';
 import { dummyLogger } from 'ts-log';
 

--- a/packages/projection/test/operators/requestNext.test.ts
+++ b/packages/projection/test/operators/requestNext.test.ts
@@ -1,6 +1,5 @@
-import { ChainSyncEventType, ChainSyncRollForward, RequestNext } from '@cardano-sdk/core';
+import { ChainSyncEventType, ChainSyncRollForward, RequestNext, requestNext } from '../../src';
 import { firstValueFrom, of } from 'rxjs';
-import { requestNext } from '../../src';
 
 describe('requestNext', () => {
   it('calls event.requestNext() and emits event object without this method', async () => {

--- a/packages/projection/test/operators/utils/projectorOperator.test.ts
+++ b/packages/projection/test/operators/utils/projectorOperator.test.ts
@@ -1,5 +1,4 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
-import { ExtChainSyncEvent, ProjectorEventHandlers, projectorOperator } from '../../../src';
+import { ChainSyncEventType, ExtChainSyncEvent, ProjectorEventHandlers, projectorOperator } from '../../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 import { of } from 'rxjs';
 

--- a/packages/projection/test/operators/withEpochBoundary.test.ts
+++ b/packages/projection/test/operators/withEpochBoundary.test.ts
@@ -1,5 +1,6 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import {
+  ChainSyncEventType,
   UnifiedExtChainSyncEvent,
   WithEpochBoundary,
   WithEpochNo,

--- a/packages/projection/test/operators/withEpochNo.test.ts
+++ b/packages/projection/test/operators/withEpochNo.test.ts
@@ -1,5 +1,11 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
-import { RollForwardEvent, UnifiedExtChainSyncEvent, WithNetworkInfo, withEpochNo } from '../../src';
+import { Cardano } from '@cardano-sdk/core';
+import {
+  ChainSyncEventType,
+  RollForwardEvent,
+  UnifiedExtChainSyncEvent,
+  WithNetworkInfo,
+  withEpochNo
+} from '../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 import { stubEraSummaries } from '../util';
 

--- a/packages/projection/test/operators/withEventContext.test.ts
+++ b/packages/projection/test/operators/withEventContext.test.ts
@@ -1,5 +1,4 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
-import { ExtChainSyncEvent, withEventContext } from '../../src';
+import { ChainSyncEventType, ExtChainSyncEvent, withEventContext } from '../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 
 describe('withEventContext', () => {

--- a/packages/projection/test/operators/withNetworkInfo.test.ts
+++ b/packages/projection/test/operators/withNetworkInfo.test.ts
@@ -1,6 +1,12 @@
-import { Cardano, ChainSyncEventType } from '@cardano-sdk/core';
+import { Cardano } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, createTestScheduler } from '@cardano-sdk/util-dev';
-import { RollForwardEvent, UnifiedExtChainSyncEvent, WithNetworkInfo, withNetworkInfo } from '../../src';
+import {
+  ChainSyncEventType,
+  RollForwardEvent,
+  UnifiedExtChainSyncEvent,
+  WithNetworkInfo,
+  withNetworkInfo
+} from '../../src';
 
 const { networkInfo, cardanoNode } = chainSyncData(ChainSyncDataSet.WithPoolRetirement);
 

--- a/packages/projection/test/operators/withRolledBackBlock.test.ts
+++ b/packages/projection/test/operators/withRolledBackBlock.test.ts
@@ -1,6 +1,13 @@
-import { Cardano, ChainSyncEventType, ChainSyncRollBackward, TipOrOrigin } from '@cardano-sdk/core';
+import { Cardano, TipOrOrigin } from '@cardano-sdk/core';
 import { ChainSyncDataSet, chainSyncData, createTestScheduler } from '@cardano-sdk/util-dev';
-import { InMemory, UnifiedExtChainSyncEvent, withNetworkInfo, withRolledBackBlock } from '../../src';
+import {
+  ChainSyncEventType,
+  ChainSyncRollBackward,
+  InMemory,
+  UnifiedExtChainSyncEvent,
+  withNetworkInfo,
+  withRolledBackBlock
+} from '../../src';
 import { stubBlockId } from '../util';
 
 const dataWithStakeKeyDeregistration = chainSyncData(ChainSyncDataSet.WithPoolRetirement);

--- a/packages/projection/test/operators/withStaticContext.test.ts
+++ b/packages/projection/test/operators/withStaticContext.test.ts
@@ -1,5 +1,4 @@
-import { ChainSyncEventType } from '@cardano-sdk/core';
-import { ExtChainSyncEvent, withStaticContext } from '../../src';
+import { ChainSyncEventType, ExtChainSyncEvent, withStaticContext } from '../../src';
 import { createTestScheduler } from '@cardano-sdk/util-dev';
 
 describe('withStaticContext', () => {

--- a/packages/util-dev/package.json
+++ b/packages/util-dev/package.json
@@ -2,27 +2,27 @@
   "name": "@cardano-sdk/util-dev",
   "version": "0.22.10",
   "description": "Utilities for tests in other packages",
-  "engines": {
-    "node": ">=16.20.2"
-  },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "repository": "https://github.com/input-output-hk/cardano-js-sdk",
+  "license": "Apache-2.0",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }
   },
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "browser": {
     "./dist/cjs/docker.js": false,
     "./dist/esm/docker.js": false
   },
-  "repository": "https://github.com/input-output-hk/cardano-js-sdk",
-  "publishConfig": {
-    "access": "public"
-  },
-  "sideEffects": false,
-  "license": "Apache-2.0",
+  "files": [
+    "dist/*",
+    "!dist/tsconfig.tsbuildinfo",
+    "LICENSE",
+    "NOTICE"
+  ],
   "scripts": {
     "build": "yarn build:cjs && tsc -p src/tsconfig.json --outDir ./dist/esm --module es2020 && tsc-alias -p src/tsconfig.json --outDir ./dist/esm && cp ./esm-package.json ./dist/esm/package.json && cp -rf src/chainSync/data dist/esm/chainSync/",
     "build:cjs": "tsc --build src && cp ../../build/cjs-package.json ./dist/cjs/package.json && cp -rf src/chainSync/data dist/cjs/chainSync/",
@@ -40,22 +40,11 @@
     "test:debug": "DEBUG=true yarn test",
     "test:e2e": "echo 'test:e2e' command not implemented yet"
   },
-  "devDependencies": {
-    "@types/dockerode": "^3.3.8",
-    "@types/jest": "^26.0.24",
-    "@types/k6": "^0.53.1",
-    "eslint": "^7.32.0",
-    "jest": "^28.1.3",
-    "madge": "^5.0.1",
-    "npm-run-all": "^4.1.5",
-    "ts-jest": "^28.0.7",
-    "tsc-alias": "^1.8.10",
-    "typescript": "^4.7.4"
-  },
   "dependencies": {
     "@cardano-sdk/core": "workspace:~",
     "@cardano-sdk/crypto": "workspace:~",
     "@cardano-sdk/key-management": "workspace:~",
+    "@cardano-sdk/projection": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
     "@types/dockerode": "^3.3.8",
     "axios": "^1.7.4",
@@ -70,10 +59,22 @@
     "rxjs": "^7.4.0",
     "ts-log": "^2.2.4"
   },
-  "files": [
-    "dist/*",
-    "!dist/tsconfig.tsbuildinfo",
-    "LICENSE",
-    "NOTICE"
-  ]
+  "devDependencies": {
+    "@types/dockerode": "^3.3.8",
+    "@types/jest": "^26.0.24",
+    "@types/k6": "^0.53.1",
+    "eslint": "^7.32.0",
+    "jest": "^28.1.3",
+    "madge": "^5.0.1",
+    "npm-run-all": "^4.1.5",
+    "ts-jest": "^28.0.7",
+    "tsc-alias": "^1.8.10",
+    "typescript": "^4.7.4"
+  },
+  "engines": {
+    "node": ">=16.20.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/util-dev/src/chainSync/index.ts
+++ b/packages/util-dev/src/chainSync/index.ts
@@ -2,21 +2,24 @@ import {
   Cardano,
   ChainSyncError,
   ChainSyncErrorCode,
-  ChainSyncEvent,
-  ChainSyncEventType,
-  ChainSyncRollBackward,
-  ChainSyncRollForward,
   GeneralCardanoNodeError,
   GeneralCardanoNodeErrorCode,
   Intersection,
-  ObservableCardanoNode,
   Point,
   PointOrOrigin
 } from '@cardano-sdk/core';
+
+import {
+  ChainSyncEvent,
+  ChainSyncEventType,
+  ChainSyncRollBackward,
+  ChainSyncRollForward
+} from '@cardano-sdk/projection';
 import { Observable, of, throwError } from 'rxjs';
 import { fromSerializableObject } from '@cardano-sdk/util';
 import { genesisToEraSummary } from './genesisToEraSummary';
 import memoize from 'lodash/memoize.js';
+import type { ObservableCardanoNode } from '@cardano-sdk/projection';
 
 export type SerializedChainSyncEvent =
   | Omit<ChainSyncRollForward, 'requestNext'>

--- a/packages/util-dev/src/tsconfig.json
+++ b/packages/util-dev/src/tsconfig.json
@@ -6,6 +6,9 @@
   "references": [
     {
       "path": "../../core/src"
+    },
+    {
+      "path": "../../projection/src"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,6 +3697,7 @@ __metadata:
   dependencies:
     "@cardano-sdk/core": "workspace:~"
     "@cardano-sdk/ogmios": "workspace:~"
+    "@cardano-sdk/projection": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
     "@cardano-sdk/util-dev": "workspace:~"
     "@types/clear": ^0.1.4
@@ -3863,6 +3864,7 @@ __metadata:
     "@cardano-sdk/cardano-services-client": "workspace:~"
     "@cardano-sdk/core": "workspace:~"
     "@cardano-sdk/crypto": "workspace:~"
+    "@cardano-sdk/projection": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
     "@cardano-sdk/util-dev": "workspace:~"
     "@cardano-sdk/util-rxjs": "workspace:~"
@@ -3975,6 +3977,7 @@ __metadata:
     "@cardano-sdk/core": "workspace:~"
     "@cardano-sdk/crypto": "workspace:~"
     "@cardano-sdk/key-management": "workspace:~"
+    "@cardano-sdk/projection": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
     "@types/dockerode": ^3.3.8
     "@types/jest": ^26.0.24


### PR DESCRIPTION
# Context

@cardano-sdk/core requires rxjs but it seems not having it in its dependencies

# Proposed Solution

Hoist bufferChainSyncEvent (the only dependent on rxjs) to projection package

