### PR TITLE
test(e2e): reduce test flakiness

### DIFF
--- a/packages/e2e/test/wallet_epoch_0/PersonalWallet/metadata.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/PersonalWallet/metadata.test.ts
@@ -1,8 +1,7 @@
 import { BaseWallet, createWalletUtil } from '@cardano-sdk/wallet';
 import { Cardano } from '@cardano-sdk/core';
-import { filter, firstValueFrom, map } from 'rxjs';
-import { getEnv, getWallet, walletReady, walletVariables } from '../../../src';
-import { isNotNil } from '@cardano-sdk/util';
+import { firstValueFrom } from 'rxjs';
+import { getEnv, getWallet, submitAndConfirm, walletReady, walletVariables } from '../../../src';
 import { logger } from '@cardano-sdk/util-dev';
 
 const env = getEnv(walletVariables);
@@ -35,15 +34,8 @@ describe('PersonalWallet/metadata', () => {
       .build()
       .sign();
 
-    const outgoingTx = signedTx;
-    await wallet.submitTx(signedTx);
+    const [, loadedTx] = await submitAndConfirm(wallet, signedTx, 1);
 
-    const loadedTx = await firstValueFrom(
-      wallet.transactions.history$.pipe(
-        map((txs) => txs.find((tx) => tx.id === outgoingTx.id)),
-        filter(isNotNil)
-      )
-    );
     expect(loadedTx.auxiliaryData?.blob).toEqual(metadata);
   });
 });

--- a/packages/e2e/test/wallet_epoch_0/PersonalWallet/mint.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/PersonalWallet/mint.test.ts
@@ -13,8 +13,7 @@ import {
   walletVariables
 } from '../../../src';
 import { createLogger } from '@cardano-sdk/util-dev';
-import { filter, firstValueFrom, map, take } from 'rxjs';
-import { isNotNil } from '@cardano-sdk/util';
+import { filter, firstValueFrom } from 'rxjs';
 
 const env = getEnv(walletVariables);
 const logger = createLogger();
@@ -99,16 +98,7 @@ describe('PersonalWallet/mint', () => {
     };
 
     const signedTx = await wallet.finalizeTx(finalizeProps);
-    await submitAndConfirm(wallet, signedTx);
-
-    // Search chain history to see if the transaction is there.
-    const txFoundInHistory = await firstValueFrom(
-      wallet.transactions.history$.pipe(
-        map((txs) => txs.find((tx) => tx.id === signedTx.id)),
-        filter(isNotNil),
-        take(1)
-      )
-    );
+    const [, txFoundInHistory] = await submitAndConfirm(wallet, signedTx, 1);
 
     expect(txFoundInHistory.id).toEqual(signedTx.id);
 

--- a/packages/e2e/test/wallet_epoch_0/PersonalWallet/txChainHistory.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/PersonalWallet/txChainHistory.test.ts
@@ -1,7 +1,7 @@
 import { BaseWallet } from '@cardano-sdk/wallet';
 import { Cardano, CardanoNodeUtil } from '@cardano-sdk/core';
 import { filter, firstValueFrom, map, take } from 'rxjs';
-import { getEnv, getWallet, normalizeTxBody, walletReady, walletVariables } from '../../../src';
+import { getEnv, getWallet, normalizeTxBody, submitAndConfirm, walletReady, walletVariables } from '../../../src';
 import { isNotNil } from '@cardano-sdk/util';
 import { logger } from '@cardano-sdk/util-dev';
 
@@ -28,7 +28,7 @@ describe('PersonalWallet/txChainHistory', () => {
     const txBuilder = wallet.createTxBuilder();
     const txOutput = await txBuilder.buildOutput().address(receivingAddress).coin(tAdaToSend).build();
     signedTx = (await txBuilder.addOutput(txOutput).build().sign()).tx;
-    await wallet.submitTx(signedTx);
+    await submitAndConfirm(wallet, signedTx, 1);
 
     logger.info(
       `Submitted transaction id: ${signedTx.id}, inputs: ${JSON.stringify(

--- a/packages/e2e/test/wallet_epoch_0/SharedWallet/simpleTx.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/SharedWallet/simpleTx.test.ts
@@ -6,6 +6,7 @@ import {
   getEnv,
   getWallet,
   normalizeTxBody,
+  submitAndConfirm,
   waitForWalletStateSettle,
   walletReady,
   walletVariables
@@ -52,7 +53,7 @@ describe('SharedWallet/simpleTx', () => {
     const txBuilder = faucetWallet.createTxBuilder();
     const txOutput = await txBuilder.buildOutput().address(receivingAddress).coin(initialFunds).build();
     fundingTx = (await txBuilder.addOutput(txOutput).build().sign()).tx;
-    await faucetWallet.submitTx(fundingTx);
+    await submitAndConfirm(faucetWallet, fundingTx, 1);
 
     logger.info(
       `Submitted transaction id: ${fundingTx.id}, inputs: ${JSON.stringify(


### PR DESCRIPTION
# Context

Out e2e test often uses a piec of code like following
```
    await wallet.submitTx(signedTx);

    // Search chain history to see if the transaction is there.
    const txFoundInHistory = await firstValueFrom(
      wallet.transactions.history$.pipe(
        map((txs) => txs.find((tx) => tx.id === signedTx.id)),
        filter(isNotNil),
        take(1)
      )
    );
```
next perform the checks.
The problem is this code is based only on `ChainHistoryProvider` while some checks are performed on `Observable`s sometimes based on other providers (`AssetProvider`, `UtxoProvider`, etc...).
This is a source of flakiness as check result may be dependent on which provider completes earlier.

# Proposed Solution

Substitute given piece of code (where required) with `submitAndConfirm` utility, which internally also waits for the wallet to be settled, i.e. all the providers finished their tasks.
This also slightly reduce code repetition.