### PR TITLE
test(e2e): fix wrong method name for stake pool stats

### DIFF
--- a/packages/e2e/test/k6/scenarios/wallets.test.js
+++ b/packages/e2e/test/k6/scenarios/wallets.test.js
@@ -245,7 +245,7 @@ const syncWallet = ({ wallet, poolAddress }) => {
   if (RUN_MODE === RunMode.Restore) {
     sdkCom.stakePoolSearch(poolAddress);
   }
-  sdkCom.stats();
+  sdkCom.stakePoolStats();
 
   // Consider the wallet synced by tracking its first address
   syncedWallets.add(addresses[0]);


### PR DESCRIPTION
# Context

Wrong method name causes test to not run this query:
```
TypeError: Object has no member 'stats'
	at syncWallet (file:///github/workspace/packages/e2e/test/k6/scenarios/wallets.test.js:248:15(92))
	at default (file:///github/workspace/packages/e2e/test/k6/scenarios/wallets.test.js:273:74(47))
```

# Proposed Solution

# Important Changes Introduced
