### PR TITLE
LW-11642 Remove github bot token from checkout step of release github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ jobs:
           # Fetch all history for all tags and branches
           fetch-depth: 0
           ref: master
-          token: ${{ secrets.BOT_GH_TOKEN }}
 
       - name: 🧰 Setup Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
# Context

The `release` github action flow no longer works.

# Proposed Solution

As @mirceahasegan discovered removing the `token` fixes the issue