### PR TITLE
feat(dapp-connector): custom inject key, extensions and api

### DIFF
--- a/packages/dapp-connector/src/injectGlobal.ts
+++ b/packages/dapp-connector/src/injectGlobal.ts
@@ -3,7 +3,13 @@ import { Logger } from 'ts-log';
 
 export type WindowMaybeWithCardano = Window & { cardano?: { [k: string]: Cip30Wallet } };
 
-export const injectGlobal = (window: WindowMaybeWithCardano, wallet: Cip30Wallet, logger: Logger): void => {
+export const injectGlobal = (
+  window: WindowMaybeWithCardano,
+  wallet: Cip30Wallet,
+  logger: Logger,
+  injectKey?: string
+): void => {
+  injectKey = injectKey ?? wallet.name;
   if (!window.cardano) {
     logger.debug(
       {
@@ -22,7 +28,7 @@ export const injectGlobal = (window: WindowMaybeWithCardano, wallet: Cip30Wallet
       'Cardano global scope exists'
     );
   }
-  window.cardano[wallet.name] = window.cardano[wallet.name] || wallet;
+  window.cardano[injectKey] = window.cardano[injectKey] || wallet;
   logger.debug(
     {
       module: 'injectWindow',

--- a/packages/dapp-connector/test/injectGlobal.test.ts
+++ b/packages/dapp-connector/test/injectGlobal.test.ts
@@ -71,5 +71,19 @@ describe('injectGlobal', () => {
       ]);
       expect(window.cardano['another-obj']).toBe(anotherObj);
     });
+
+    it('injects the wallet public API using custom injection name', () => {
+      const wallet = new Cip30Wallet(properties, { api, authenticator: stubAuthenticator(), logger });
+      injectGlobal(window, wallet, logger, 'customKey');
+      expect(window.cardano.customKey.name).toBe(properties.walletName);
+      expect(Object.keys(window.cardano.customKey)).toEqual([
+        'apiVersion',
+        'supportedExtensions',
+        'icon',
+        'name',
+        'enable',
+        'isEnabled'
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Add support for:
- inject api under custom key, instead of wallet name
- configure the supported extensions when constructing the Cip30Wallet object
- deviation from standard cip30 api. Currently overrides getCollateral to return empty array when no collaterals are found

