### PR TITLE
test: update deployed envs e2e test to latest sdk version

### DIFF
--- a/.github/workflows/test-deploy-e2e.yaml
+++ b/.github/workflows/test-deploy-e2e.yaml
@@ -4,21 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to run e2e tests against'
+        description: 'Target environment'
         type: choice
         required: true
-        default: 'dev-preprod'
         options:
-          - live-preprod
-          - live-preview
-          - dev-preprod
-          - dev-preview
-          - staging-preprod
-      cluster:
-        description: 'Specific cluster to run e2e tests against'
+          - 'dev'
+          - 'staging'
+          - 'live'
+      network:
+        description: 'Target network'
         type: choice
         required: true
-        default: 'any'
+        options:
+          - 'preview'
+          - 'preprod'
+          - 'sanchonet'
+      cluster:
+        description: 'Target cluster'
+        type: choice
+        required: true
         options:
           - any
           - eu-central-1
@@ -27,7 +31,6 @@ on:
         description: 'Log level'
         type: choice
         required: true
-        default: 'fatal'
         options:
           - fatal
           - error
@@ -35,10 +38,6 @@ on:
           - info
           - debug
           - trace
-
-env:
-  TL_DEPTH: ${{ github.event.pull_request.head.repo.fork && '0' || fromJson(vars.TL_DEPTH) }}
-  TL_LEVEL: ${{ github.event.pull_request.head.repo.fork && 'info' || vars.TL_LEVEL }}
 
 jobs:
   build_and_test:
@@ -52,10 +51,13 @@ jobs:
 
       - name: Generate .env file
         working-directory: ./packages/e2e/
+        env:
+          CLUSTER: ${{ inputs.cluster }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          MNEMONIC: ${{ secrets.MNEMONIC }}
+          NETWORK: ${{ inputs.network }}
         run: |
-          if [[ "${{ inputs.environment }}" == *"preprod"* ]]; then networkMagic=1; else networkMagic=2; fi
-          ./src/scripts/generate-dotenv.sh ${{ inputs.environment }} ${{ inputs.cluster }}
-          echo "KEY_MANAGEMENT_PARAMS='$(jq --argjson networkMagic $networkMagic --arg mnemonic "${{ secrets.MNEMONIC }}" <<< '{"bip32Ed25519": "Sodium", "accountIndex": 0, "chainId":{"networkId": 0, "networkMagic": 0}, "passphrase":"some_passphrase","mnemonic":"mnemonics"}' '.mnemonic=$mnemonic | .chainId.networkMagic=$networkMagic')'" >> .env
+          ./src/scripts/generate-dotenv.sh
 
       - name: 🧰 Setup Node.js
         uses: actions/setup-node@v3
@@ -71,6 +73,9 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=8192'
 
       - name: 🔬 Test - e2e - wallet
+        env:
+          TL_DEPTH: 0
+          TL_LEVEL: ${{ inputs.level }}
         run: |
-          TL_DEPTH=0 TL_LEVEL=${{ inputs.level }} yarn workspace @cardano-sdk/e2e test:wallet-real-ada
+          yarn workspace @cardano-sdk/e2e test:wallet-real-ada
         shell: bash

--- a/packages/e2e/src/scripts/generate-dotenv.sh
+++ b/packages/e2e/src/scripts/generate-dotenv.sh
@@ -1,15 +1,31 @@
 #!/bin/bash
 
 set -e
-set -x
-set -o
 
-case $2 in
+target="${ENVIRONMENT}-${NETWORK}"
+
+case $CLUSTER in
   any)
-    environment="$1"
+    environment="${target}"
     ;;
   *)
-    environment="$1.$2"
+    environment="${target}.${CLUSTER}"
+    ;;
+esac
+
+case $NETWORK in
+  preprod)
+    networkMagic=1
+    ;;
+  preview)
+    networkMagic=2
+    ;;
+  sanchonet)
+    networkMagic=4
+    ;;
+  *)
+    echo "${NETWORK}: Unknown network"
+    exit 1
     ;;
 esac
 
@@ -17,32 +33,47 @@ domain="${environment}.lw.iog.io"
 url="https://${domain}/"
 
 # Construct the environment file content
-envFileContent="
-# Logger
+envFileContent="\
 LOGGER_MIN_SEVERITY=info
 
-# Key management setup - required by getWallet
-KEY_MANAGEMENT_PROVIDER=inMemory
-
-# Providers setup - required by getWallet
 TEST_CLIENT_ASSET_PROVIDER=http
 TEST_CLIENT_ASSET_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
-TEST_CLIENT_CHAIN_HISTORY_PROVIDER=http
+TEST_CLIENT_CHAIN_HISTORY_PROVIDER=ws
 TEST_CLIENT_CHAIN_HISTORY_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_HANDLE_PROVIDER=http
 TEST_CLIENT_HANDLE_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
-TEST_CLIENT_NETWORK_INFO_PROVIDER=http
+TEST_CLIENT_NETWORK_INFO_PROVIDER=ws
 TEST_CLIENT_NETWORK_INFO_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_REWARDS_PROVIDER=http
 TEST_CLIENT_REWARDS_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_TX_SUBMIT_PROVIDER=http
 TEST_CLIENT_TX_SUBMIT_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
-TEST_CLIENT_UTXO_PROVIDER=http
+TEST_CLIENT_UTXO_PROVIDER=ws
 TEST_CLIENT_UTXO_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 TEST_CLIENT_STAKE_POOL_PROVIDER=http
 TEST_CLIENT_STAKE_POOL_PROVIDER_PARAMS='{\"baseUrl\":\"${url}\"}'
 WS_PROVIDER_URL='wss://${domain}/ws'
-"
+
+KEY_MANAGEMENT_PROVIDER=inMemory
+KEY_MANAGEMENT_PARAMS='{
+  \"bip32Ed25519\": \"Sodium\",
+  \"accountIndex\": 0,
+  \"chainId\": {
+    \"networkId\": 0,
+    \"networkMagic\": ${networkMagic}
+  },
+  \"passphrase\": \"some_passphrase\",
+  \"mnemonic\": \"${MNEMONIC}\"
+}'"
 
 # Write the environment file content to the specified file
 echo "$envFileContent" > .env
+
+# Dump inputs and outputs
+echo "
+Target environment: ${ENVIRONMENT}
+Target network:     ${NETWORK}
+Target cluster:     ${CLUSTER}
+
+Result .env:"
+cat .env


### PR DESCRIPTION
# Context

- The e2e tests against the deployed environments need to be updated to check the `ws-server`.
- The github action has some legacy custom behavior.
- The logic to build the `.env` file is split between the github action and the `generate-dotenv.sh` file.

# Proposed Solution

Refactored the github action and the `generate-dotenv.sh` file.

# Important Changes Introduced

The github action now dumps the `.env` file for clarity; github is smart enough to hide the secret mnemonics.

# Test

The tests pass both in [dev-preview](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/11180116614/job/31081165350) and [dev-preprod](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/11180371379/job/31081957121).