### PR TITLE
Feat/lw 11589 make auxiliary data and witness available in sign request

### DIFF
--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -465,10 +465,10 @@ const baseCip30WalletApi = (
   },
   signTx: async ({ sender }: SenderContext, tx: Cbor, partialSign?: Boolean): Promise<Cbor> => {
     const scope = new ManagedFreeableScope();
-    logger.debug('signTx');
-    const txDecoded = Serialization.Transaction.fromCbor(Serialization.TxCBOR(tx));
+    logger.debug('signTx', tx);
+    const txCbor = Serialization.TxCBOR(tx);
+    const txDecoded = Serialization.Transaction.fromCbor(txCbor);
     const wallet = await firstValueFrom(wallet$);
-    const hash = txDecoded.getId();
     const coreTx = txDecoded.toCore();
 
     const needsForeignSignature = await requiresForeignSignatures(coreTx, wallet);
@@ -493,9 +493,8 @@ const baseCip30WalletApi = (
           witness: { signatures }
         } = await signOrCancel(
           wallet.finalizeTx({
-            bodyCbor: txDecoded.body().toCbor(),
             signingContext: { sender },
-            tx: { ...coreTx, hash }
+            tx: txCbor
           }),
           confirmationResult,
           () => new TxSignError(TxSignErrorCode.UserDeclined, 'user declined signing tx')

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -49,8 +49,13 @@ export interface SyncStatus extends Shutdown {
   isSettled$: Observable<boolean>;
 }
 
+/**
+ * If tx is the transaction CBOR, the auxiliary data, witness and isValid properties are ignored.
+ * If tx is `Cardano.TxBodyWithHash`, the transaction is reconstructed from along with the other
+ * provided properties.
+ */
 export type FinalizeTxProps = Omit<TxContext, 'signingContext'> & {
-  tx: Cardano.TxBodyWithHash;
+  tx: Cardano.TxBodyWithHash | Serialization.TxCBOR;
   bodyCbor?: HexBlob;
   signingContext?: Partial<SignTransactionContext>;
 };
@@ -77,6 +82,9 @@ export type WalletAddress = GroupedAddress | ScriptAddress;
 export const isScriptAddress = (address: WalletAddress): address is ScriptAddress => 'scripts' in address;
 
 export const isKeyHashAddress = (address: WalletAddress): address is GroupedAddress => !isScriptAddress(address);
+
+export const isTxBodyWithHash = (tx: Serialization.TxCBOR | Cardano.TxBodyWithHash): tx is Cardano.TxBodyWithHash =>
+  typeof tx === 'object' && 'hash' in tx && 'body' in tx;
 
 export interface ObservableWallet {
   readonly balance: BalanceTracker;


### PR DESCRIPTION
# Context

`wallet.finalizeTx` has optional params for `auxiliaryData, witnessSet and isValid`.
`cip30.signTx` did extract this data from the input transaction CBOR, to pass it down to the `finalizeTx` method.
Further more, even if they are included, serializing the transaction body (passed as CBOR) with the `auxiliaryData and witnessSet` (as deserialised core types), might not result in the same CBOR, due to differences in serialization implementation.

# Proposed Solution
cip30.signTx always receives the entire transaction cbor, not just the transaction body.
Extend wallet.finalizeTx() to accept CBOR in the `tx` parameter. When provided, the other optional parameters (witnessSet, auxiliaryData, isValid) are ignored, and the transaction CBOR is passed as is to the witnesser.

# Important Changes Introduced
