### PR TITLE
fix(cardano-services-client): do not call timout id unref in browsers

### DIFF
--- a/packages/cardano-services-client/src/WebSocket.ts
+++ b/packages/cardano-services-client/src/WebSocket.ts
@@ -400,7 +400,8 @@ export class CardanoWsClient extends WsProvider {
       if (this.status === 'stop') this.closeResolver();
       else {
         this.status = 'idle';
-        setTimeout(() => this.connect(), 1000).unref();
+        const timeout = setTimeout(() => this.connect(), 1000);
+        if (typeof timeout.unref === 'function') timeout.unref();
       }
 
       this.emitHealth('closed');
@@ -440,7 +441,7 @@ export class CardanoWsClient extends WsProvider {
         this.logger.error(error, 'Error while refreshing heartbeat', this.clientId);
       }
     }, this.heartbeatInterval);
-    this.heartbeatTimeout.unref();
+    if (typeof this.heartbeatTimeout.unref === 'function') this.heartbeatTimeout.unref();
   }
 
   /** Closes the WebSocket connection. */


### PR DESCRIPTION
# Context

`CardanoWsClient` is calling `timeoutID.unref()`, but it is not supported on browsers.

# Proposed Solution

Check if it is a function before calling it to make it being called only under **Node.js**.