### PR TITLE
fix: project cip68 metadata when datum resides in tx witness

### DIFF
--- a/packages/core/src/Asset/NftMetadata/types.ts
+++ b/packages/core/src/Asset/NftMetadata/types.ts
@@ -3,6 +3,12 @@ import * as CidValidator from '@biglup/is-cid';
 import { InvalidStringError, OpaqueString } from '@cardano-sdk/util';
 import type { Metadatum } from '../../Cardano';
 
+const looksLikeIpfsUrlWithoutProtocol = (uri: string) => {
+  const [cid] = uri.split('/');
+  if (!cid) return false;
+  return CidValidator.isValid(cid);
+};
+
 export type Uri = OpaqueString<'Uri'>;
 
 export const Uri = (uri: string) => {
@@ -12,7 +18,7 @@ export const Uri = (uri: string) => {
   if (uri.startsWith('data:')) {
     return uri as unknown as Uri;
   }
-  if (CidValidator.isValid(uri)) {
+  if (looksLikeIpfsUrlWithoutProtocol(uri)) {
     return `ipfs://${uri}` as unknown as Uri;
   }
   throw new InvalidStringError(

--- a/packages/core/test/Asset/NftMetadata/fromMetadatum.test.ts
+++ b/packages/core/test/Asset/NftMetadata/fromMetadatum.test.ts
@@ -12,6 +12,7 @@ describe('NftMetadata.fromMetadatum', () => {
   const assetNameString = Buffer.from(assetNameStringUtf8).toString('hex');
   const policyIdString = 'b0d07d45fe9514f80213f4020e5a61241458be626841cde717cb38a7';
   const assetImageIPFS = 'ipfs://QmWS6DgF8Ma8oooBn7CtD3ChHyzzMw5NXWfnDbVFTip8af';
+  const assetImageIPFSNoProtocol = 'QmbhD98wpxQ8dqQkjv5Z3U59g3UqVQWV7szZWuD5CZy6iV/1.jpg';
   const assetImageHTTPS = 'https://tokens.cardano.org';
   const ipfsUrl = 'ipfs://image';
 
@@ -256,6 +257,12 @@ describe('NftMetadata.fromMetadatum', () => {
     );
     const result = Asset.NftMetadata.fromMetadatum(validAsset, metadatum, logger);
     expect(result?.image).toEqual('ipfs://bafybeihtdkq3ntfcewytdaimnrslpxsatsg47e3bqlsgi3jkax65pypymi');
+  });
+
+  it('supports image without protocol for ipfs uri', () => {
+    const metadatum = createMetadatumWithFiles([], assetImageIPFSNoProtocol, assetNameStringUtf8);
+    const result = Asset.NftMetadata.fromMetadatum(validAsset, metadatum, logger);
+    expect(result?.image).toEqual(`ipfs://${assetImageIPFSNoProtocol}`);
   });
 
   it('supports image with ipfs protocol as array', () => {

--- a/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
+++ b/packages/projection-typeorm/test/operators/storeNftMetadata.test.ts
@@ -494,6 +494,25 @@ describe('storeNftMetadata', () => {
     const metadata = await nftMetadataRepo.findOneBy({ userTokenAssetId });
     expect(metadata).toBeTruthy();
   });
+
+  it('stores metadata from witness datum', async () => {
+    const USER_TOKEN_ASSET_ID = Cardano.AssetId(
+      'ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000de140534832303037'
+    );
+    const REFERENCE_TOKEN_ASSET_ID = Cardano.AssetId(
+      'ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000643b0534832303037'
+    );
+    const eventsWithCip68Handle = filterAssets(chainSyncData(ChainSyncDataSet.Cip68WitnessDatumProblem), [
+      REFERENCE_TOKEN_ASSET_ID,
+      USER_TOKEN_ASSET_ID
+    ]);
+    const evt = await firstValueFrom(project$(eventsWithCip68Handle));
+    const nftMetadata = evt.nftMetadata.find(({ userTokenAssetId }) => userTokenAssetId === USER_TOKEN_ASSET_ID);
+    expect(nftMetadata).toBeTruthy();
+
+    const storedMetadata = await nftMetadataRepo.findOneBy({ userTokenAssetId: USER_TOKEN_ASSET_ID });
+    expect(typeof storedMetadata?.image).toBe('string');
+  });
 });
 
 describe('willStoreNftMetadata', () => {

--- a/packages/projection/src/operators/Mappers/withUtxo.ts
+++ b/packages/projection/src/operators/Mappers/withUtxo.ts
@@ -1,9 +1,10 @@
-import { Cardano } from '@cardano-sdk/core';
+import { Cardano, Serialization } from '@cardano-sdk/core';
 import { FilterByPolicyIds } from './types';
 import { ProjectionOperator } from '../../types';
 import { map } from 'rxjs';
 import { unifiedProjectorOperator } from '../utils';
 
+/** Output datum is hydrated with the datum from witness if present */
 export type ProducedUtxo = [Cardano.TxIn, Cardano.TxOut];
 
 export interface WithUtxo {
@@ -14,15 +15,27 @@ export interface WithUtxo {
   };
 }
 
+const attemptHydrateDatum = (txOut: Cardano.TxOut, witness: Cardano.Witness): Cardano.TxOut => {
+  if (!txOut.datumHash) return txOut;
+  const witnessDatum = witness.datums?.find(
+    (datum) => Serialization.PlutusData.fromCore(datum).hash() === txOut.datumHash
+  );
+  if (!witnessDatum) return txOut;
+  return {
+    ...txOut,
+    datum: witnessDatum
+  };
+};
+
 export const withUtxo = unifiedProjectorOperator<{}, WithUtxo>((evt) => {
-  const produced = evt.block.body.flatMap(({ body: { outputs, collateralReturn }, inputSource, id }) =>
+  const produced = evt.block.body.flatMap(({ body: { outputs, collateralReturn }, inputSource, id, witness }) =>
     (inputSource === Cardano.InputSource.inputs ? outputs : collateralReturn ? [collateralReturn] : []).map(
       (txOut, outputIndex): [Cardano.TxIn, Cardano.TxOut] => [
         {
           index: outputIndex,
           txId: id
         },
-        txOut
+        attemptHydrateDatum(txOut, witness)
       ]
     )
   );

--- a/packages/projection/test/operators/Mappers/withUtxo.test.ts
+++ b/packages/projection/test/operators/Mappers/withUtxo.test.ts
@@ -43,7 +43,8 @@ export const validTxSource$ = of({
             }
           ]
         },
-        inputSource: Cardano.InputSource.inputs
+        inputSource: Cardano.InputSource.inputs,
+        witness: {}
       },
       {
         body: {
@@ -71,7 +72,8 @@ export const validTxSource$ = of({
             }
           ]
         },
-        inputSource: Cardano.InputSource.inputs
+        inputSource: Cardano.InputSource.inputs,
+        witness: {}
       },
       {
         body: {
@@ -108,7 +110,8 @@ export const validTxSource$ = of({
             }
           ]
         },
-        inputSource: Cardano.InputSource.inputs
+        inputSource: Cardano.InputSource.inputs,
+        witness: {}
       }
     ]
   }
@@ -151,7 +154,8 @@ describe('withUtxo', () => {
               }
             ]
           },
-          inputSource: Cardano.InputSource.collaterals
+          inputSource: Cardano.InputSource.collaterals,
+          witness: {}
         },
         {
           body: {
@@ -200,7 +204,8 @@ describe('withUtxo', () => {
               }
             ]
           },
-          inputSource: Cardano.InputSource.collaterals
+          inputSource: Cardano.InputSource.collaterals,
+          witness: {}
         }
       ]
     }
@@ -212,6 +217,167 @@ describe('withUtxo', () => {
     } = await firstValueFrom(validTxSource$.pipe(withUtxo()));
     expect(consumed).toHaveLength(4);
     expect(produced).toHaveLength(5);
+  });
+
+  it('hydrates produced output datum from witness', async () => {
+    const {
+      utxo: { produced }
+    } = await firstValueFrom(
+      of({
+        block: {
+          body: [
+            {
+              body: {
+                inputs: [
+                  {
+                    index: 1,
+                    txId: '434342da3f66f94d929d8c7a49484e1c212c74c6213d7b938119f6e0dcb9454c'
+                  }
+                ],
+                outputs: [
+                  {
+                    address: Cardano.PaymentAddress('addr_test1wzlv9cslk9tcj0wpm9p5t6kajyt37ap5sc9rzkaxa9p67ys2ygypv'),
+                    datumHash: '51f55225cb45388c05903db1e5095382ceafa2d17ff13ffbecf31b037c7c4dc1' as Cardano.DatumHash,
+                    value: { coins: 1_724_100n }
+                  }
+                ]
+              },
+              inputSource: Cardano.InputSource.inputs,
+              witness: {
+                datums: [
+                  {
+                    cbor: 'd8799f4108d8799fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a4f2442c1d8799f1b000000108fdb12acffffff',
+                    constructor: 0n,
+                    fields: {
+                      cbor: '9f4108d8799fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a4f2442c1d8799f1b000000108fdb12acffffff',
+                      items: [
+                        new Uint8Array([8]),
+                        {
+                          cbor: 'd8799fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff',
+                          constructor: 0n,
+                          fields: {
+                            cbor: '9fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff',
+                            items: [
+                              {
+                                cbor: 'd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ff',
+                                constructor: 0n,
+                                fields: {
+                                  cbor: '9fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ff',
+                                  items: [
+                                    {
+                                      cbor: 'd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff',
+                                      constructor: 0n,
+                                      fields: {
+                                        cbor: '9fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff',
+                                        items: [
+                                          {
+                                            cbor: 'd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff',
+                                            constructor: 0n,
+                                            fields: {
+                                              cbor: '9f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff',
+                                              items: [
+                                                new Uint8Array([
+                                                  82, 71, 221, 59, 223, 45, 47, 131, 138, 47, 12, 145, 179, 143, 18,
+                                                  117, 35, 119, 45, 36, 57, 57, 147, 225, 15, 187, 210, 53
+                                                ])
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            cbor: 'd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff',
+                                            constructor: 0n,
+                                            fields: {
+                                              cbor: '9fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff',
+                                              items: [
+                                                {
+                                                  cbor: 'd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff',
+                                                  constructor: 0n,
+                                                  fields: {
+                                                    cbor: '9fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff',
+                                                    items: [
+                                                      {
+                                                        cbor: 'd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff',
+                                                        constructor: 0n,
+                                                        fields: {
+                                                          cbor: '9f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff',
+                                                          items: [
+                                                            new Uint8Array([
+                                                              154, 69, 160, 29, 133, 196, 129, 130, 115, 37, 236, 160,
+                                                              83, 121, 87, 191, 4, 128, 236, 55, 233, 173, 167, 49, 176,
+                                                              100, 0, 208
+                                                            ])
+                                                          ]
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      cbor: 'd87a80',
+                                      constructor: 1n,
+                                      fields: {
+                                        cbor: '80',
+                                        items: []
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                cbor: 'd87a80',
+                                constructor: 1n,
+                                fields: {
+                                  cbor: '80',
+                                  items: []
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        2_500_000n,
+                        {
+                          cbor: 'd8799fd879801a4f2442c1d8799f1b000000108fdb12acffff',
+                          constructor: 0n,
+                          fields: {
+                            cbor: '9fd879801a4f2442c1d8799f1b000000108fdb12acffff',
+                            items: [
+                              {
+                                cbor: 'd87980',
+                                constructor: 0n,
+                                fields: {
+                                  cbor: '80',
+                                  items: []
+                                }
+                              },
+                              1_327_776_449n,
+                              {
+                                cbor: 'd8799f1b000000108fdb12acff',
+                                constructor: 0n,
+                                fields: {
+                                  cbor: '9f1b000000108fdb12acff',
+                                  items: [71_132_975_788n]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      } as ProjectionEvent).pipe(withUtxo())
+    );
+    expect(produced[0][1].datum).toBeTruthy();
   });
 
   it('when inputSource is collateral: maps consumed/produced utxo from collateral/collateralReturn', async () => {

--- a/packages/util-dev/src/chainSync/data/cip68-witness-datum-problem.json
+++ b/packages/util-dev/src/chainSync/data/cip68-witness-datum-problem.json
@@ -1,0 +1,13552 @@
+{
+  "body": [
+    {
+      "block": {
+        "body": [
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qxpgxpf5v75a7s8nqywcamtxr6lkaptry2xdh0cvrrg06rllj9cdhxsr2ufc0mmurmx8kulm0gsru9k20jkwzgxfn3ds09meca",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "undefined"
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "8592785"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "536db89f33ac434ede9bce7f50513266a620c5440faf37ec4c0ac357bc1a764a"
+                },
+                {
+                  "index": 5,
+                  "txId": "84b6483fdc95ae3dc84e19fedcbefd3e19acc94f7c5b134715bb660ed6be6d76"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "482759"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607"
+                },
+                {
+                  "index": 2,
+                  "txId": "ecce3b729b0e8c6e3892f4680c75fe9b4fd79d27eb2d045c959abe38f3b0ee28"
+                },
+                {
+                  "index": 2,
+                  "txId": "1b0efc69e53409da237d991f4e12a67b89c47568ae7332d00ea3262ef80b7f6b"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1zy6r74xk4haj26c7jpq6w25t2xt8qzr9wr2kz805n8re02hlj9cdhxsr2ufc0mmurmx8kulm0gsru9k20jkwzgxfn3ds2944u6",
+                  "datum": {
+                    "cbor": "d87a9fd8799fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffffd8799fd8799f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fffd8799fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b00000004e3b292001a1131960c1a00943ed41b0000018de65c5010d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffffd8799fd8799f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fffd8799fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b00000004e3b292001a1131960c1a00943ed41b0000018de65c5010d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffffff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffffd8799fd8799f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fffd8799fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b00000004e3b292001a1131960c1a00943ed41b0000018de65c5010d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffffd8799fd8799f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fffd8799fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b00000004e3b292001a1131960c1a00943ed41b0000018de65c5010d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffff",
+                            "items": [
+                              {
+                                "cbor": "d8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ff",
+                                        "items": [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "b886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "cbor": "d8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffff",
+                                              "items": [
+                                                {
+                                                  "cbor": "d8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ff",
+                                                  "constructor": {
+                                                    "__type": "bigint",
+                                                    "value": "0"
+                                                  },
+                                                  "fields": {
+                                                    "cbor": "9f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ff",
+                                                    "items": [
+                                                      {
+                                                        "__type": "Buffer",
+                                                        "value": "539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fffd8799fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fffd8799fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f581c8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0fff",
+                                        "items": [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0f"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "cbor": "d8799fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9fd8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bffff",
+                                              "items": [
+                                                {
+                                                  "cbor": "d8799f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bff",
+                                                  "constructor": {
+                                                    "__type": "bigint",
+                                                    "value": "0"
+                                                  },
+                                                  "fields": {
+                                                    "cbor": "9f581cff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5bff",
+                                                    "items": [
+                                                      {
+                                                        "__type": "Buffer",
+                                                        "value": "ff9170db9a03571387ef7c1ecc7b73fb7a203e16ca7cace120c99c5b"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a44"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "41584f"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "21000000000"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "288462348"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "9715412"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "1708966826000"
+                              },
+                              {
+                                "cbor": "d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff",
+                                        "items": [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "__type": "bigint",
+                                      "value": "2"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a4441584f",
+                          {
+                            "__type": "bigint",
+                            "value": "21000000000"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2387740"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxgeuhzp8ghr6adfhrvh05xfsxrs8g9j8kddslpfe7qqmexhznx6h86pnskrmz6pf2fk5qhmaty0ujxussd6xns728pqezqka9",
+                  "datum": {
+                    "cbor": "d8799fd8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ff",
+                            "items": [
+                              {
+                                "cbor": "d8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "2"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1214426"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1zy6r74xk4haj26c7jpq6w25t2xt8qzr9wr2kz805n8re02jnnvddk9vl6g3k4y20jz98mf3xrzg48ljkqdd4kfx4zccsyd06l5",
+                  "datum": {
+                    "cbor": "d8799fd8799fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b0000000ba43b74001a28eff6cf1a0160f7171a240c8400d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b0000000ba43b74001a28eff6cf1a0160f7171a240c8400d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffffff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b0000000ba43b74001a28eff6cf1a0160f7171a240c8400d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff581c420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a444341584f1b0000000ba43b74001a28eff6cf1a0160f7171a240c8400d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ffff",
+                            "items": [
+                              {
+                                "cbor": "d8799fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ffd8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f581cb886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6ff",
+                                        "items": [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "b886bc4cdc0714e7649ee1684ab614c7a8dc5caf2341b455b8e693b6"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "cbor": "d8799fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9fd8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ffff",
+                                              "items": [
+                                                {
+                                                  "cbor": "d8799f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ff",
+                                                  "constructor": {
+                                                    "__type": "bigint",
+                                                    "value": "0"
+                                                  },
+                                                  "fields": {
+                                                    "cbor": "9f581c539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631ff",
+                                                    "items": [
+                                                      {
+                                                        "__type": "Buffer",
+                                                        "value": "539b1adb159fd2236a914f908a7da626189153fe56035b5b24d51631"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a44"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "41584f"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "50000000000"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "686814927"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "23131927"
+                              },
+                              {
+                                "__type": "bigint",
+                                "value": "604800000"
+                              },
+                              {
+                                "cbor": "d8799fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff02ff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f5820bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607ff",
+                                        "items": [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "bcc42ec296a5d94130a900588abcee03d03dd67a5e1b8441999b64cda954f607"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "__type": "bigint",
+                                      "value": "2"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "686814927"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxpgxpf5v75a7s8nqywcamtxr6lkaptry2xdh0cvrrg06rllj9cdhxsr2ufc0mmurmx8kulm0gsru9k20jkwzgxfn3ds09meca",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "221b1b9ebccab1512262347491557279ac0afac63b4fbd10fc596c8a437562656e7369734d757368726f6f6d",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "33568ad11f93b3e79ae8dee5ad928ded72adcea719e92108caf1521b57696c6454616e677a2031353137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "33568ad11f93b3e79ae8dee5ad928ded72adcea719e92108caf1521b57696c6454616e677a2031373532",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "33568ad11f93b3e79ae8dee5ad928ded72adcea719e92108caf1521b57696c6454616e677a2031373833",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "33568ad11f93b3e79ae8dee5ad928ded72adcea719e92108caf1521b57696c6454616e677a2032303632",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "33568ad11f93b3e79ae8dee5ad928ded72adcea719e92108caf1521b57696c6454616e677a2034323636",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "3f75c1332868430e28e156f6309836de8df19b620ab604c1667418365468654d616e6472696c6c7a31373231",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a4441584f",
+                          {
+                            "__type": "bigint",
+                            "value": "1134201639"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747930303831",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747930363933",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747930383530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747930393731",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747931313236",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747931363936",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747931393836",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747932313536",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf50616e6461536f636965747932373235",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "58b9f55e6ea9828dea7a8d9f49420171c6360f99b5e6e86de5fdb6444170654e6174696f6e39353739",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657330313639",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657330313730",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657330353339",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657330373437",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657330373630",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657331313231",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657331343436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657331393833",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657332363531",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657332373739",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657332383031",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657333303238",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657333303432",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5bdb77464535a14b9af8a78e5115955739905d27c1f46621c105fcfa4a756e6b69657333343533",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "77999d5a1e09f9bdc16393cab713f26345dc0827a9e5134cf0f9da374d756c67614b6f6e67323433",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "77999d5a1e09f9bdc16393cab713f26345dc0827a9e5134cf0f9da374d756c67614b6f6e67343038",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "77999d5a1e09f9bdc16393cab713f26345dc0827a9e5134cf0f9da374d756c67614b6f6e67343237",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "77999d5a1e09f9bdc16393cab713f26345dc0827a9e5134cf0f9da374d756c67614b6f6e67393333",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "787a6798527b21ad0e0f62c021b4ce036513a2d3342b5cb519d2ca19000de140506c61747970757320437962657250756e6b732023383031",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba456173746572456767323232",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676731333633",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676731373130",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676732303234",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676732363732",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676733323333",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676735363631",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676739363032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676739363839",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7ed1f9dea9f9ee11f8f7e1fa33b793ca4d8dd0a19a02041744f5acba45617374657245676739393933",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "8021c0ab3285cc3cfff2b7e61e96ece565fb37279b67666741587b5447686f7374636861696e3033363438",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "80c7314177f9f0089d16f412c20f2ada0934c179ad6dc04e27722cf44c4951474f4c44",
+                          {
+                            "__type": "bigint",
+                            "value": "960"
+                          }
+                        ],
+                        [
+                          "80e3ccc66f4dfeff6bc7d906eb166a984a1fc6d314e33721ad6add144261644b657930323633",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "8499c047c0932ba91508fbcd26da722598f6749a1b050627ff0c708753414655",
+                          {
+                            "__type": "bigint",
+                            "value": "15313854"
+                          }
+                        ],
+                        [
+                          "87afd2f2d26c5c3fde1b52a4caf6b462a955edd623a828e91cfc9122416e6369656e74447261676f6e343831",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "93a06006358177f5e619e48d5c421328fc9640699394836e6292fe6e556e626f7468657265644c7963616e33373239",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "93a06006358177f5e619e48d5c421328fc9640699394836e6292fe6e556e626f7468657265644c7963616e34303232",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "93a06006358177f5e619e48d5c421328fc9640699394836e6292fe6e556e626f7468657265644c7963616e34373337",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656430333932",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656430343637",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656430353533",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656430373134",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656430393330",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656431393934",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656432303934",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656432383633",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656434353337",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656434353735",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656434383531",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9547b7d827ffd46cec3b4cfb5c6321bdf91564a5cb9205339bac4e7554656435343733",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "95a427e384527065f2f8946f5e86320d0117839a5e98ea2c0b55fb0048554e54",
+                          {
+                            "__type": "bigint",
+                            "value": "72685706"
+                          }
+                        ],
+                        [
+                          "961f2cac0bb1967d74691af179350c1e1062c7298d1f7be1e4696e312444455250",
+                          {
+                            "__type": "bigint",
+                            "value": "276"
+                          }
+                        ],
+                        [
+                          "971432ff33cd0581be12b320f22774d846425809499d450858a41a3949444f5061737344414f426f6f7374657230303430",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "971432ff33cd0581be12b320f22774d846425809499d450858a41a3949444f5061737344414f426f6f7374657231323435",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "99b750541529ba5cc684f9e1d43911c68913128d45a7004d9344343b000de140435357415020416c6c696573203030342d422023323830",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a2e719d70b9d71636aa825e71c11ca508ecf98eec87182b0e526d7c5000de1404f5554504f53543031353330",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202334323636",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202334333039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202334353034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202334353939",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202334373539",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202334393133",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202334393432",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202335323332",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202335323437",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202335373235",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202335383038",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202335383237",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202335383832",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "b98ae818ee0693e61a8e51db1358240eaa441dba60a8c3766e3f5115000de1404b57494320506c617961626c65202335393634",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657930313432",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657930313638",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657930323235",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657930343233",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657930373835",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657930383531",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657932353239",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657932353738",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657932363436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657932393334",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657933333237",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657933353538",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657933383239",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657933383337",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657933383735",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934303436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934343032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934353536",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934353835",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934363336",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934363735",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934373032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934383938",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657934393038",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657935313632",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c204b7595ab87f70a4a4d3a6c40833e8942b990bacf492090fe8b4d35468654a526e657935323839",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c72d0438330ed1346f4437fcc1c263ea38e933c1124c8d0f2abc63124b57494331373739",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3030343737",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3032383336",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3032383638",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3034363434",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3035393137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3036353939",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3037353637",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3038313532",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3038323436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3038343835",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3038363935",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d34743543ccbda22bb948400a4a919b7b54e82123030702e38cc62b6414c4c45594b41545a3039383939",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d4162cfa26718e8a4357226ffbfc3df6a210b2a4d5727ecbfd1e8eac46554442554430373336",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d4162cfa26718e8a4357226ffbfc3df6a210b2a4d5727ecbfd1e8eac46554442554434313839",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d64a52a708f88252f4fb3b16014c81e605b4b5d0aa3480c02fcc2e2f484f415244",
+                          {
+                            "__type": "bigint",
+                            "value": "22473531289"
+                          }
+                        ],
+                        [
+                          "e09e4f4217669b7f735b7a3724e835d8d6344db128eb03d6ea72885e435432343831",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e4043e606e71239c4611ace8e343f52a5cdd420e7c80700b8b67ef15564950426f78313239",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e4043e606e71239c4611ace8e343f52a5cdd420e7c80700b8b67ef15564950426f78353433",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e97dcfac11d934ae52e16aea123400b2d1a8909df3b099ae14d9b0de4261627920416c69656e3a20476f716f",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e97dcfac11d934ae52e16aea123400b2d1a8909df3b099ae14d9b0de4261627920416c69656e3a2058656e65",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e97dcfac11d934ae52e16aea123400b2d1a8909df3b099ae14d9b0de4261627920416c69656e3a204d65726962",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e97dcfac11d934ae52e16aea123400b2d1a8909df3b099ae14d9b0de4261627920416c69656e3a20437572616875",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e97dcfac11d934ae52e16aea123400b2d1a8909df3b099ae14d9b0de4261627920416c69656e3a204a7978656765",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "eba255af1c4234ea258d3d0ef1ae3bc715432de4b3e6ba481214a4ca4a4152486561647332323436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "ee6da4b71e0913cbebec02edc23653f9b970af69324fdddfed1285d953706163654170653032313539",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "ee6da4b71e0913cbebec02edc23653f9b970af69324fdddfed1285d953706163654170653033373433",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a677261666661726f",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f51ad2225a88c7d1f03f4e3a308cb920296f6440dc4c1d6e60e989be427573696e6573732054696765722023323437",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f51ad2225a88c7d1f03f4e3a308cb920296f6440dc4c1d6e60e989be427573696e657373205469676572202332343736",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "f51ad2225a88c7d1f03f4e3a308cb920296f6440dc4c1d6e60e989be427573696e657373205469676572202332393431",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "fc11a9ef431f81b837736be5f53e4da29b9469c983d07f321262ce614652454e",
+                          {
+                            "__type": "bigint",
+                            "value": "992"
+                          }
+                        ],
+                        [
+                          "fca746f58adf9f3da13b7227e5e2c6052f376447473f4d49f8004195000de140436974697a656e202332383030",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "fd0544d336d9048108cd90eac9d6db315d0eb3a41547ac837558354550616e646153686f67756e30313039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "fd8e4605a691a1505c595c0b8df686e0d3f5c0a5b176c5bb05308dd5456767736572616374333730",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "fd8e4605a691a1505c595c0b8df686e0d3f5c0a5b176c5bb05308dd5456767736572616374343934",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "fd8e4605a691a1505c595c0b8df686e0d3f5c0a5b176c5bb05308dd5456767736572616374353038",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "344137342"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": [
+                {
+                  "index": 0,
+                  "txId": "e92ac620bf095094d58a19616d1b6debb9b1cf305870264b1a58446c51d7f4b0"
+                }
+              ],
+              "requiredExtraSignatures": [
+                "8283053467a9df40f3011d8eed661ebf6e8563228cdbbf0c18d0fd0f",
+                "19524fed350e6a9e928c231f51f737388eaf3f8d547732f68e02bab1"
+              ],
+              "scriptIntegrityHash": "58795a708e69cdc6d7179b5efc7f48c0145bb6bcc40b1e45b291711ec4e37ec0",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "4000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795735,
+                "invalidHereafter": 116799455
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "daf9652cee580dfc7115ce1749bd2c903d074a3b183339c0e3ff04ccb7f9d8ec",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 1134968,
+                    "steps": 425996370
+                  },
+                  "index": 1,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "a29a65cb9421a0e45b99d9d2fde0c76a143ba020927453744f48551bd030d54e",
+                    "7e727b73a386ad6185e38199a93020065f1a745acea9a5d1883e8b59214c6d330ea0168afdbfc5c1d45d38dea15ee258de0de2696d3887f281bb0e9bc4d5cb01"
+                  ],
+                  [
+                    "37fb59abf680ba541f1664ce98cd20d5b730875fef834b4403fc483727db96d9",
+                    "b75fd417ea935c13774d4c43af12fed45ea89cc335a3a694e279022c319a145d61d890b143649219fecf916cf2b8aa4a4a1ab43117489a3eafc410f142003300"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "169197"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "9d81f9ef2665dc376983a0b6f8c9718f519fb3c54a93c0226a8435d38051539d"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qxw0ylp3k9kjahqg0u4uvkw7he3ada20zs22xg7u625qq24aqujvd32rnzkr6ckmmvmgvk4p7mcf02dsqdux247zasxsrmqs02",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "300000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9as270fs0yaaw3dx9qgv7f34hyrcp54np5f60uxadvrzt8sz9kezzz53m6ttnfdt4jr5n2ekpg238sjgwv5qnf5jczqlwfj5s",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "655781557"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116803146
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "42f86c4f1f17e448180f92c69995745904eab6136ea62f576772980d160f8e7b",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "ba8216bb8619d38a7261823ec0b323119706160b6f767218d448921b37094665",
+                    "10505c8fb7785d507599f4ff64dcd1250d5b0cc2257e1c9961b3bc1d360890de7edb02d0a14031d263d9a6fdcea01e9d686fe5d746f670e7d763c60ba08a680a"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "178745"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "739647b996094852de69eacf8dc9664c6f6866f891362e4ed7ca534325206d7b"
+                },
+                {
+                  "index": 4,
+                  "txId": "d33fd9f4da21dc06e2179e5d65f5ec3a6c35642b3fdb1606475840e980857895"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1wxaptpmxcxawvr3pzlhgnpmzz3ql43n2tc8mn3av5kx0yzs09tqh8",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "51f55225cb45388c05903db1e5095382ceafa2d17ff13ffbecf31b037c7c4dc1",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1332276449"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9fy0hfmmukjlqu29uxfrvu0zf6jxaedysunnylpp7aaydv6gkspmpwysxp8xf0v5pfhj4alqjqwcdlf4knnrvryqrgqngmddj",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "10973510573"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": "365f9b98a5f9fb3a7e5397f55fdd1ed37b7752adb4b51305183fa14d48d952a9",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "0c829e9e3521d7b91ddf36075252cabdcd21f3dff76c57f2d6d7a4fc340101cd",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799f4108d8799fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a4f2442c1d8799f1b000000108fdb12acffffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f4108d8799fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a4f2442c1d8799f1b000000108fdb12acffffff",
+                    "items": [
+                      {
+                        "__type": "Buffer",
+                        "value": "08"
+                      },
+                      {
+                        "cbor": "d8799fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ffd87a80ff",
+                          "items": [
+                            {
+                              "cbor": "d8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80ff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff",
+                                            "items": [
+                                              {
+                                                "cbor": "d8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff",
+                                                "constructor": {
+                                                  "__type": "bigint",
+                                                  "value": "0"
+                                                },
+                                                "fields": {
+                                                  "cbor": "9fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff",
+                                                  "items": [
+                                                    {
+                                                      "cbor": "d8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff",
+                                                      "constructor": {
+                                                        "__type": "bigint",
+                                                        "value": "0"
+                                                      },
+                                                      "fields": {
+                                                        "cbor": "9f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff",
+                                                        "items": [
+                                                          {
+                                                            "__type": "Buffer",
+                                                            "value": "9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d87a80",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "1"
+                                    },
+                                    "fields": {
+                                      "cbor": "80",
+                                      "items": []
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d87a80",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "1"
+                              },
+                              "fields": {
+                                "cbor": "80",
+                                "items": []
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2500000"
+                      },
+                      {
+                        "cbor": "d8799fd879801a4f2442c1d8799f1b000000108fdb12acffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd879801a4f2442c1d8799f1b000000108fdb12acffff",
+                          "items": [
+                            {
+                              "cbor": "d87980",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "80",
+                                "items": []
+                              }
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "1327776449"
+                            },
+                            {
+                              "cbor": "d8799f1b000000108fdb12acff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f1b000000108fdb12acff",
+                                "items": [
+                                  {
+                                    "__type": "bigint",
+                                    "value": "71132975788"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "3246344d1b1e603fc5b4850711259cd52deef5dcf226664011b2c4ab90c1317d",
+                    "19ec23045d71f567224516f79709f8f0f928ff2a65ab54a860467ab0d124a57cb36dbc7ec74f119e3bb6b37302e2ee228cde10fc22278b2b5a31dab608375709"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "5F8CE17F08744613FF60C67CAF28659EBF303808DC29B032AEE7AC10A95E5D54"
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "f897554de9ee2c3b0a8d18a2f4ea9942dab682cdd99bd6ac1c1e40336ef575d2",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "174521"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "654d88c558151d7433c9ceed43bd9c2951f1922afe3b1863c2ff6c4a7abf7881"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "DdzFFzCqrhsx6uEgdThQPGXqhTWpoWJP1YceWCotjnacj4bYkmuKuQ1CTeYEZS3xtCfMdMmxuKYrbRpYLNi4hGFJk2469GvMz3RsZ9Zn",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "595443888"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qyzlkwf7jamyw4fc7sfwpkhnnj5rfsqha5tn055x6r45wdtdmjkmq4ktn0sg642g99wxmmyy5k9qyl4j65skaqlmq5hquqkeu0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2889193521"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116802976
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "1833b1214631d5e4662933d70e6661ded75d4d9fa4f1baf751f44f45ebec5c9d",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0c28859badf6e6bbf1cfa29c4eea2d9ef154b3c052ef3f04ac61e9aa77079ba3",
+                    "93fc8c65ee998d045944b3d29c53b8d367605d5b22f32efe74bbc35b5d82f41f81a1475f8857116911306b8afdb0457ce0e798b044d623a744c6d67dc836900f"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "VyFi: LP Order Process"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "84011fa48d284f783df73bea623ae974bc8fd254ce1d850ae88545772f0c2d8e",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": [
+                {
+                  "index": 0,
+                  "txId": "9828e034926c1185bea65ed51aa13d5ca98f30c0a6df379f8302044974fe27b7"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "496642"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "085f6a78b106e68c11ac68b42cb6c9aebe2b2445ca37d6b5faa6479b6c4db115"
+                },
+                {
+                  "index": 1,
+                  "txId": "0b674de279168b7e4a66c90398b6bfb149f887222b489169d33840c57141ad2f"
+                },
+                {
+                  "index": 3,
+                  "txId": "37858743b8f0cf3bdae1f12dd14119e900e0ba203f3e0f63739dd552a2ecb36e"
+                },
+                {
+                  "index": 0,
+                  "txId": "6e4c2cb5161f78290c950da1e38a78e0cc753fb03a74ab3b3f8ec581f3dfd898"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1z82ker9gjrlunvsfc6gl6xzvlwrpk5wk4xcwfemcgdyv36rwy7w4xmdgekdc6w8788z9a960cq3t3juayh2r8ad5um2sktfsg6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "326001096ed6c5b2abf6f2e39d3885f14b75156bf37598c6302da6c3158b29a8",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "46b0cd4e67ee7e7ea9f11b4723733d490b2d27b41d2b43d63e3448df",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f6958741414441",
+                          {
+                            "__type": "bigint",
+                            "value": "71362748959"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "387286087163"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q87ygsexzkz5jy3w0hecuryzdwapy38z44pttja839vcexl4t40unxg2t5h4t7yzflp9axsdkavjd27dtj9p40deagjqtqrqy0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "4d07e0ceae00e6c53598cea00a53c54a94c6b6aa071482244cc0adb5567946695f43726564656e7469616c",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx483zx9hkk6jyzfcn96m4nsxj6gg7ynvknz5apyvssr957s7j7aagcgd7nk0y7ztu0p80rg4k2jf0dfflz5zjqtnh6s2czhkw",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3418652998"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q87ygsexzkz5jy3w0hecuryzdwapy38z44pttja839vcexl4t40unxg2t5h4t7yzflp9axsdkavjd27dtj9p40deagjqtqrqy0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "e4bbbaa875a797578044ef27713d23dfe07ce74f33163e7c40d7f480544d494e",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2786279284"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": "94d3ce209899b98f6b26ec8a7bcdd2bb086a2cba721d8249fe3e62b8c746a20a",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116796058
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "829a759b834083e1d2416c862e907e92775578a3ec8d57de21a3fa2b6f0a1a62",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799f1a01bed4931a007b04be1b000000254fd9ba18ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f1a01bed4931a007b04be1b000000254fd9ba18ff",
+                    "items": [
+                      {
+                        "__type": "bigint",
+                        "value": "29283475"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "8062142"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "160253458968"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799f1a01bed4931a008491aa1b000000254fd9ba18ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f1a01bed4931a008491aa1b000000254fd9ba18ff",
+                    "items": [
+                      {
+                        "__type": "bigint",
+                        "value": "29283475"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "8688042"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "160253458968"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799f5838aa7888c5bdada91049c4cbadd67034b484789365a62a7424642032d3d0f4bddea3086fa76793c25f1e13bc68ad9524bda94fc541480b9df5d87d9f1acb9b8f80ffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f5838aa7888c5bdada91049c4cbadd67034b484789365a62a7424642032d3d0f4bddea3086fa76793c25f1e13bc68ad9524bda94fc541480b9df5d87d9f1acb9b8f80ffff",
+                    "items": [
+                      {
+                        "__type": "Buffer",
+                        "value": "aa7888c5bdada91049c4cbadd67034b484789365a62a7424642032d3d0f4bddea3086fa76793c25f1e13bc68ad9524bda94fc541480b9df5"
+                      },
+                      {
+                        "cbor": "d87d9f1acb9b8f80ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "4"
+                        },
+                        "fields": {
+                          "cbor": "9f1acb9b8f80ff",
+                          "items": [
+                            {
+                              "__type": "bigint",
+                              "value": "3415969664"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 410552,
+                    "steps": 119864964
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 385832,
+                    "steps": 113607371
+                  },
+                  "index": 3,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "590a8c010000332323232322232322322323253353330093333573466e1cd55cea803a40004646424660020060046464646666ae68cdc3a800a40184642444444460020106eb4d5d09aab9e500323333573466e1d4009200a232122222223002008375a6ae84d55cf280211999ab9a3370ea00690041190911111118018041bad357426aae7940148cccd5cd19b875004480188c848888888c010020dd69aba135573ca00c46666ae68cdc3a802a400842444444400a46666ae68cdc3a8032400446424444444600c0106464646666ae68cdc39aab9d5002480008cc8848cc00400c008dd69aba15002375a6ae84d5d1280111931a99ab9c01d01c01b01a135573ca00226ea8004d5d09aab9e500823333573466e1d401d2000232122222223007008375a6ae84d55cf280491931a99ab9c01a019018017016015014013012011135573aa00226ea8004d5d09aba25008375c6ae85401c8c98d4cd5ce0078070068061999ab9a3370ea0089001109100111999ab9a3370ea00a9000109100091931a99ab9c01000f00e00d00c3333573466e1cd55cea8012400046644246600200600464646464646464646464646666ae68cdc39aab9d500a480008cccccccccc888888888848cccccccccc00402c02802402001c01801401000c008d5d0a80519a80b90009aba1500935742a0106ae85401cd5d0a8031aba1500535742a00866a02eeb8d5d0a8019aba15002357426ae8940088c98d4cd5ce00d80d00c80c09aba25001135744a00226ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aab9e5001137540026ae854008c8c8c8cccd5cd19b875001480188c848888c010014c8c8c8c8c8c8cccd5cd19b8750014803084888888800c8cccd5cd19b875002480288488888880108cccd5cd19b875003480208cc8848888888cc004024020dd71aba15005375a6ae84d5d1280291999ab9a3370ea00890031199109111111198010048041bae35742a00e6eb8d5d09aba2500723333573466e1d40152004233221222222233006009008301b35742a0126eb8d5d09aba2500923333573466e1d40192002232122222223007008301c357426aae79402c8cccd5cd19b875007480008c848888888c014020c074d5d09aab9e500c23263533573804003e03c03a03803603403203002e26aae7540104d55cf280189aab9e5002135573ca00226ea8004d5d09aab9e500323333573466e1d400920042321222230020053011357426aae7940108cccd5cd19b875003480088c848888c004014c8c8c8cccd5cd19b8735573aa004900011991091980080180119191999ab9a3370e6aae75400520002375c6ae84d55cf280111931a99ab9c01c01b01a019137540026ae854008dd69aba135744a004464c6a66ae7006406005c0584d55cf280089baa001357426aae7940148cccd5cd19b875004480008c848888c00c014dd71aba135573ca00c464c6a66ae7005805405004c0480440404d55cea80089baa001357426ae8940088c98d4cd5ce007807006806080689931a99ab9c4901035054350000d00c135573ca00226ea80044d55ce9baa001135573ca00226ea800448c88c008dd60009900099180080091191999aab9f0022122002233221223300100400330053574200660046ae8800c01cc0080088c8c8c8c8cccd5cd19b875001480088ccc888488ccc00401401000cdd69aba15004375a6ae85400cdd69aba135744a00646666ae68cdc3a8012400046424460040066464646666ae68cdc3a800a400446424460020066eb8d5d09aab9e500323333573466e1d400920002321223002003375c6ae84d55cf280211931a99ab9c00f00e00d00c00b135573aa00226ea8004d5d09aab9e500623263533573801401201000e00c26aae75400c4d5d1280089aab9e5001137540029309000a481035054310033232323322323232323232323232332223222253350021350012232350032222222222533533355301512001321233001225335002210031001002501e25335333573466e3c0300040540504d40800045407c00c84054404cd4c8c8d4cc8848cc00400c008ccdc624000030004a66a666ae68cdc7a800a4410000b00a150151350165001223355011002001133371802e02e0026a00a4400444004260086a6464646464a66a6666666ae900148cccd5cd19b8735573aa00a900011999aab9f500525019233335573ea00a4a03446666aae7d40149406c8cccd55cf9aba2500625335323232323333333574800846666ae68cdc39aab9d5004480008cccd55cfa8021281191999aab9f500425024233335573e6ae89401494cd4c088d5d0a80390a99a99a811119191919191999999aba400623333573466e1d40092002233335573ea00c4a05e46666aae7d4018940c08cccd55cfa8031281891999aab9f35744a00e4a66a605a6ae854028854cd4c0b8d5d0a80510a99a98179aba1500a21350361223330010050040031503415033150322503203303203103023333573466e1d400d2000233335573ea00e4a06046666aae7cd5d128041299a98171aba150092135033122300200315031250310320312502f02c02b2502d2502d2502d2502d02e135573aa00826ae8940044d5d1280089aab9e5001137540026ae85401c84d40a048cc00400c0085409854094940940980940909408807c940849408494084940840884d5d1280089aab9e5001137540026ae854024854cd4ccd54054070cd54054070060d5d0a80490a99a99a80d00e9aba150092135020123330010040030021501e1501d1501c2501c01d01c01b01a250180152501725017250172501701821001135626135744a00226ae8940044d55cf280089baa00135001223500222222222225335009132635335738921035054380001f01b22100222200232001355011225335001100422135002225335333573466e3c00801c02402040244c01800c488008488004c8004d5403488448894cd40044d400c88004884ccd401488008c010008ccd54c01c480040140100044488c88ccccccd5d2000aa8029299a98019bab002213500f0011500d55005550055500500e3200135500e223233335573e00446a01e2440044a66a600c6aae754008854cd4c018d55cf280190a99a98031aba200521350123212233001003004335500b003002150101500f1500e00f135742002224a0102244246600200600446666666ae900049401c9401c9401c8d4020dd6801128038040911919191999999aba400423333573466e1d40092000233335573ea0084a01846666aae7cd5d128029299a98049aba15006213500f3500f0011500d2500d00e00d23333573466e1d400d2002233335573ea00a46a01ca01a4a01a01c4a0180120104a0144a0144a0144a01401626aae7540084d55cf280089baa00123232323333333574800846666ae68cdc3a8012400446666aae7d4010940288cccd55cf9aba2500525335300a35742a00c426a01a24460020062a0164a01601801646666ae68cdc3a801a400046666aae7d40149402c8cccd55cf9aba2500625335300b35742a00e426a01c24460040062a0184a01801a0184a01400e00c4a0104a0104a0104a01001226aae7540084d55cf280089baa0014988ccccccd5d20009280192801928019280191a8021bae002004121223002003112200112001480e0448c8c00400488cc00cc00800800522011c46b0cd4e67ee7e7ea9f11b4723733d490b2d27b41d2b43d63e3448df0001",
+                  "version": 0
+                },
+                {
+                  "__type": "plutus",
+                  "bytes": "590a19010000332323232322232323223223232533533300a3333573466e1cd55cea804240004646464246660020080060046eb4d5d09aba25009375a6ae854020dd69aba1500823263533573802001e01c01a6666ae68cdc3a80224004424400446666ae68cdc3a802a40004244002464c6a66ae7004404003c038034cccd5cd19b8735573aa004900011991091980080180119191919191919191919191999ab9a3370e6aae754029200023333333333222222222212333333333300100b00a00900800700600500400300235742a01466a03040026ae854024d5d0a8041aba1500735742a00c6ae854014d5d0a80219a80c3ae35742a0066ae854008d5d09aba2500223263533573803803603403226ae8940044d5d1280089aba25001135744a00226ae8940044d5d1280089aba25001135744a00226aae7940044dd50009aba150023232323333573466e1d400520062321222230040053232323232323333573466e1d4005200c21222222200323333573466e1d4009200a21222222200423333573466e1d400d2008233221222222233001009008375c6ae854014dd69aba135744a00a46666ae68cdc3a8022400c4664424444444660040120106eb8d5d0a8039bae357426ae89401c8cccd5cd19b875005480108cc8848888888cc018024020c070d5d0a8049bae357426ae8940248cccd5cd19b875006480088c848888888c01c020c074d5d09aab9e500b23333573466e1d401d2000232122222223005008301e357426aae7940308c98d4cd5ce01081000f80f00e80e00d80d00c80c09aab9d5004135573ca00626aae7940084d55cf280089baa001357426aae79400c8cccd5cd19b875002480108c848888c008014c048d5d09aab9e500423333573466e1d400d20022321222230010053232323333573466e1cd55cea8012400046644246600200600464646666ae68cdc39aab9d5001480008dd71aba135573ca004464c6a66ae7007407006c0684dd50009aba15002375a6ae84d5d1280111931a99ab9c01a019018017135573ca00226ea8004d5d09aab9e500523333573466e1d40112000232122223003005375c6ae84d55cf280311931a99ab9c017016015014013012011135573aa00226ea8004d5d09aba2500223263533573802001e01c01a201c264c6a66ae71241035054350000e00d135573ca00226ea80044d55ce9baa001135744a00226aae7940044dd50008919118011bac00132001323001001223233335573e00442440044664424466002008006600a6ae8400cc008d5d100180398010011191919191999ab9a3370ea002900111999110911998008028020019bad35742a0086eb4d5d0a8019bad357426ae89400c8cccd5cd19b875002480008c8488c00800cc8c8c8cccd5cd19b875001480088c8488c00400cdd71aba135573ca00646666ae68cdc3a8012400046424460040066eb8d5d09aab9e500423263533573801e01c01a01801626aae7540044dd50009aba135573ca00c464c6a66ae7002802402001c0184d55cea80189aba25001135573ca00226ea8005261200149010350543100332332233223232323232323232323222232322300235323232323253353333333574800a46666ae68cdc39aab9d5005480008cccd55cfa8029280d91999aab9f50052501c233335573ea00a4a03a46666aae7cd5d128031299a991919191999999aba400423333573466e1cd55cea8022400046666aae7d4010940948cccd55cfa8021281311999aab9f35744a00a4a66a603e6ae85401c854cd4cd407c8c8c8c8c8c8ccccccd5d200311999ab9a3370ea004900111999aab9f500625031233335573ea00c4a06446666aae7d4018940cc8cccd55cf9aba2500725335302a35742a01442a66a60566ae854028854cd4c0b0d5d0a805109a81c0911998008028020018a81b0a81a8a81a1281a01801781701691999ab9a3370ea006900011999aab9f500725032233335573e6ae89402094cd4c0acd5d0a804909a81a89118010018a81992819817817128188160159281792817928179281781589aab9d5004135744a00226ae8940044d55cf280089baa00135742a00e426a05424660020060042a0502a04e4a04e0460440424a04803e4a0464a0464a0464a04603e26ae8940044d55cf280089baa00135742a01242a66a666aa02603066aa02603002a6ae854024854cd4cd405c064d5d0a804909a811091998008020018010a8100a80f8a80f1280f00d00c80c00b9280d00a9280c9280c9280c9280c80a9080089ab1309aba25001135744a00226aae7940044dd500099a9806890009a800911a8011111111111004a4004444004640026aa02644a66a00220224426a00444a66a666ae68cdc780100380b00a880b098030019a80191111111a8039100108911911999999aba4001550052533530033756004426a0260022a022aa00aaa00aaa00a01a640026aa02044646666aae7c0088d404c48800894cd4c018d55cea80110a99a98031aab9e500321533530063574400a426a02c24466002246600200c00a0062a0282a0262a02401c26ae8400444940308ccccccd5d200092806128061280611a8069bad0022500c0081223232323333333574800846666ae68cdc3a8012400046666aae7d4010940448cccd55cf9aba2500525335300935742a00c426a0286a0280022a0244a02401c01a46666ae68cdc3a801a400446666aae7d40148d404d4048940480389404403002c9403c9403c9403c9403c02c4d55cea80109aab9e50011375400246464646666666ae900108cccd5cd19b875002480088cccd55cfa8021280791999aab9f35744a00a4a66a60126ae85401884d4048488c00400c540409404003002c8cccd5cd19b875003480008cccd55cfa8029280811999aab9f35744a00c4a66a60146ae85401c84d404c488c00800c54044940440340309403c028024940349403494034940340244d55cea80109aab9e50011375400246666666ae90004940249402494024940248d4028dd7001002990009aa80411091299a999ab9a33710002900000480409a802a481035054360015335002135005490103505437002215335333573466e1c00d200000b00a10021335300612001001337020069001091931a99ab9c0010030024984800448800848800448488c00800c4488004448c8c00400488cc00cc008008004cd4488ccd44888cd4488cd4488ccccccc008cd540112211c4d07e0ceae00e6c53598cea00a53c54a94c6b6aa071482244cc0adb50048810f567946695f43726564656e7469616c0033550044891c46b0cd4e67ee7e7ea9f11b4723733d490b2d27b41d2b43d63e3448df00488100488110567946695f4144412f414144415f4c500033300948303df9c052014480a0cd540112210048810033550044891c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587004881044141444100350074891c6e279d536da8cd9b8d38fe39c45e974fc022b8cb9d25d433f5b4e6d50022222221233333330010080070060050040030022001112212330010030021120011212230020031122001120012221233300100400300220011",
+                  "version": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "adca84345664f48d3b1276609b37d630809aca1af540d41b1af384f62aadabb5",
+                    "35ed67480b631b7c63c2e4364914d2fede422587848028ed34d8fb83b11bd01255bf1e8886508b872d66eb79a263253ca07d8dadeca767deb0918c74f49ba30f"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "MuesliSwap Match Order"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "5902745b46a76e6e88368dc6126ffabf472cdbe7561f66eb69456732f0a092dd",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qxnnuv6z75dxsh8q5dq4j27ga2nzlsp7mxkncayvmsxxmf9cvtjm8enawhyjjkcf6eves2cwz4c8y9tvhjuzpvmu4rwsmku8g0",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "undefined"
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "9952587"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 5,
+                  "txId": "36312cc2b3db0e188f5b3ed3c6a5cf90a869ab9ce69a070481215d47b2b38b43"
+                },
+                {
+                  "index": 2,
+                  "txId": "48289fbdaa4986d9cec4e35dd6e9aafdeccdb86085eb11b87873199c856971ee"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "1263868"
+              },
+              "inputs": [
+                {
+                  "index": 5,
+                  "txId": "36312cc2b3db0e188f5b3ed3c6a5cf90a869ab9ce69a070481215d47b2b38b43"
+                },
+                {
+                  "index": 2,
+                  "txId": "48289fbdaa4986d9cec4e35dd6e9aafdeccdb86085eb11b87873199c856971ee"
+                },
+                {
+                  "index": 0,
+                  "txId": "53ad652e8607f49e66312b1d28c666b5fc016664dfe1cb8e9c0f5a40602ad10a"
+                },
+                {
+                  "index": 3,
+                  "txId": "557690d0ebdda660cd520336f097755cc8a6c87be8dca8e061c8ef404418f004"
+                },
+                {
+                  "index": 0,
+                  "txId": "56d73145322ff79825f4229e1b993d2bf73b97be3625f1905bc67dd7516fc8a9"
+                },
+                {
+                  "index": 1,
+                  "txId": "583d6d36f43da4f370909a27444a92d58979526dc4d5c8e8379bfcd03070601c"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qxnnuv6z75dxsh8q5dq4j27ga2nzlsp7mxkncayvmsxxmf9cvtjm8enawhyjjkcf6eves2cwz4c8y9tvhjuzpvmu4rwsmku8g0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "5817c34e5702473304f3cf676299176d3824e55b8c0bfa94830429fd01941f297c00",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1344798"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxnnuv6z75dxsh8q5dq4j27ga2nzlsp7mxkncayvmsxxmf9cvtjm8enawhyjjkcf6eves2cwz4c8y9tvhjuzpvmu4rwsmku8g0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "b000000000000000000000000000000000000000000000000000000000000000",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "f94fd008635cf307663aadd995ed69d5fbbfd65f84679fc38254d66401941f297c00",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1689618"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxnnuv6z75dxsh8q5dq4j27ga2nzlsp7mxkncayvmsxxmf9cvtjm8enawhyjjkcf6eves2cwz4c8y9tvhjuzpvmu4rwsmku8g0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "cc00000000000000000000000000000000000000000000000000000000000000",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "6523247"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1z85t4tvj3rwf40wqnx6x72kqq6c6stra7jvkupnlqrqyarthhd58w0qrqpyv4dc2c2mk98sduawl7l4gjuc9rafyv98sgylfw3",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "f398b13d3d3788ea3ca0c53ba3fcaff18a4e4dfd02beade776bf5eb7e2091910",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "7a8041a0693e6605d010d5185b034d55c79eaf7ef878aae3bdcdbf673ef937764ed6b36a07b041ab5d1de7f7d776dc711e402d25a5f1d764c535fb4e",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa4d494c4b",
+                          {
+                            "__type": "bigint",
+                            "value": "77130"
+                          }
+                        ],
+                        [
+                          "ffcdbb9155da0602280c04d8b36efde35e3416567f9241aff09552694d7565736c69537761705f414d4d",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "270920981945"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx246wvycgjas952z4htwznr6hwjl27jzx4v4quql4l5g52cprd5h96vgjljrqd7gf20feyq6xtuxqmj738tganwfrnqgv7avd",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "20a0255f62f30b76a99fedad498353f5629c3c6aa75f4d07a9020100c697d1a7",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa4d494c4b",
+                          {
+                            "__type": "bigint",
+                            "value": "85"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1700000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxnnuv6z75dxsh8q5dq4j27ga2nzlsp7mxkncayvmsxxmf9cvtjm8enawhyjjkcf6eves2cwz4c8y9tvhjuzpvmu4rwsmku8g0",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4963774"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "a73e3342f51a685ce0a341592bc8eaa62fc03ed9ad3c748cdc0c6da4"
+              ],
+              "scriptIntegrityHash": "a4374aa8436ae0426483d11caa73596817026be67e694941d4ec831698363bf9",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "1895802"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116805773
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "0d8add0cd7c846b5c61fc33bc5f0f4b08b63b7262c261c7ef86b7f8b3bb2a7de",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799f4f4d7565736c69537761705f76322e32ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f4f4d7565736c69537761705f76322e32ff",
+                    "items": [
+                      {
+                        "__type": "Buffer",
+                        "value": "4d7565736c69537761705f76322e32"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799fd8799fd8799fd8799f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ffd8799fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffffff581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4b40401855d87a801a00286f90ffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799fd8799fd8799f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ffd8799fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffffff581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4b40401855d87a801a00286f90ffff",
+                    "items": [
+                      {
+                        "cbor": "d8799fd8799fd8799f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ffd8799fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffffff581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4b40401855d87a801a00286f90ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799fd8799f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ffd8799fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffffff581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4b40401855d87a801a00286f90ff",
+                          "items": [
+                            {
+                              "cbor": "d8799fd8799f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ffd8799fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ffd8799fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9f581c955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451ff",
+                                      "items": [
+                                        {
+                                          "__type": "Buffer",
+                                          "value": "955d3984c225d8168a156eb70a63d5dd2fabd211aaca8380fd7f4451"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d8799fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9fd8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ffff",
+                                            "items": [
+                                              {
+                                                "cbor": "d8799f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ff",
+                                                "constructor": {
+                                                  "__type": "bigint",
+                                                  "value": "0"
+                                                },
+                                                "fields": {
+                                                  "cbor": "9f581c5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6ff",
+                                                  "items": [
+                                                    {
+                                                      "__type": "Buffer",
+                                                      "value": "5808db4b974c44bf2181be4254f4e480d197c30372f44eb4766e48e6"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "4d494c4b"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "85"
+                            },
+                            {
+                              "cbor": "d87a80",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "1"
+                              },
+                              "fields": {
+                                "cbor": "80",
+                                "items": []
+                              }
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "2650000"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799fd8799f4040ffd8799f581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4bff1a078171d500d87a80181e06ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799f4040ffd8799f581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4bff1a078171d500d87a80181e06ff",
+                    "items": [
+                      {
+                        "cbor": "d8799f4040ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f4040ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799f581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4bff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f581c8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa444d494c4bff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": "8a1cfae21368b8bebbbed9800fec304e95cce39a2a57dc35e2e3ebaa"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "4d494c4b"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "125923797"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      },
+                      {
+                        "cbor": "d87a80",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        "fields": {
+                          "cbor": "80",
+                          "items": []
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "30"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "6"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87a9f05ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "9f05ff",
+                      "items": [
+                        {
+                          "__type": "bigint",
+                          "value": "5"
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 2654597,
+                    "steps": 778918902
+                  },
+                  "index": 3,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d87a9f02ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "9f02ff",
+                      "items": [
+                        {
+                          "__type": "bigint",
+                          "value": "2"
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 2596928,
+                    "steps": 772505873
+                  },
+                  "index": 4,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "591f5a01000032323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232322223232325335333355333573460f400426464244446600200c00a6eb4d5d09aba25002375a6ae85400454ccd5cd183c801098129bad357426aae7800c54ccd5cd183c001098121bad357426aae7800c54ccd5cd183b8010991909111198020030029bad357426ae894008c0e8d5d0a8008389119191a83091111111a80491111111aa99a9828807908008b1119191a9a9a80103f838911919191919191aa99a983a09119983b91299a9982528069a80103e89980200100088008008020b04800911191919191982a999981c00d00c8040019982a999aa98458084600982e82d982d299a9a8129119a80103a103b908008b1a8059111111043809982a99981a8181981e19a9844808460080501200f181e8059982a998278061983d0018109982a9982a1982580680fa4004660aa660a86609600603e90011982a9982a19825983f00580419b81001018330553333091012222533500315335002135001222223305e3305d0053305400c0233305e3305d0043305400c0223305e3305d00300a3305e3305d0023305400c0113305d001304700b09f0122153350041622153350071622153350081622133300c00300132323232323232353330820100500701e22222225335330763304c00348000cc1300092000161335004235500c22222223501f222223501d2223504d222222232323232323232323232533533090013306e002021330900153353306f00a003153353308a01010076133090013308f0133086010130763370066e0402800c06ccc23c04cc2180404c10c0084cc24004cc23c04cc2180404c1d806ccc24004cc23c04cc2180404c10c008cc23c04cdc080500199843008098080a99a998378041a80205d808a99a998450080883b099848009984780998430080983b19b80337020106a008176020366611e026610c02026086004266120026611e026610c020260ec03666120026611e026610c020260860046611e0266e04020d40102ec04cc2180404c0444cc24004cc23c04cc2180404c10c008cc23c04cc2180404c1d806ccc24004cc2200405007ccc21c040480784c8c8c8ccccc1b000c008cdc019b8001a00500133700032002a66a0082605a66e0800c00840614cd400c4ccccc0ac05c06c068064034520003370003200866e00064d40102ec0458c0a8030d40082c404d40042e404d54cd54ccd5cd19b89001480002a0044c94ccd5cd19b89001480002a4044c94ccd5cd19b89001480002a8044c2ac04ccc3300400c0080054ccd5cd19b8900400610041006350020c50121001160ca01350010c3015333573466e2400400c54ccd5cd19b880010031330b8010023370666e0800804804c4cc2e0040080104cc2e004cdc199b820040130120043370666e080040400494cd4cc208040241b84cdc09983f01300499b8001401313307e0260093370666e0800403803d4cd4cc200040181b04cdc09983e01200319b8001201113307c0240062235500d222222235020222223501e2223504e22222223232323253353308b013308b013306900301c3306900201b3308b015335330850100b07113308b013308a01330810100d00b3370000602a6611402661020201a0140042a66a6610a020140e2266116026611402661020201a01466e00008054cc22804cc2040403402c00c4cc22c04cc22804cc2040403402c00ccc22c04cc22804cc20404034028008cc22804cc204040341c4054cc22c04cc20c04038064cc208040300604c8c8c8ccccc19c00800ccdc019b8101400700133700026002a66a0082605066e0800800c40494cd400c4ccccc09804405405004c01c520003370202800866e0404800858c094018cdc199b8200201000f3370666e08004040038cc1f40940e8888894ccd5cd19b8900548000520001325333573466e24004018520001325333573466e2400520001480004004cdc199b820033370200200c66e00cdc100099b8100248008018c018cdc10020019192999ab9a3371000490000b0a999ab9a30af0100214800054ccd5cd1858008010a40042a666ae68c2c404008520021330010023370066e0c009200448008c28c048894ccd5cd19b880010021330030013370666e00cdc1802000800a400820044a66a0024132021040226660fc002006034464a666ae68c2b004d55ce80089919191919191919199999984e00983b9aba100830773574200e660f4eb8d5d08032999ab9a30b501003132330ab01375a6ae84004dd69aba1357440026aae7801054ccd5cd185a0080189845009bad357426aae780102b804dd69aba1002375a6ae84004dd71aba1357440026ae88004d5d10019aab9d00137546ae84004d5d10009aba2001357440026aae7800429804dd50009a800847009a80204d00983d89119983f11299a9982c9998180349a801048809a80a848809998180289a9a80104900842008148998020010008800800806183d89119983f11299a9982c9998180289a801042009a804042009998180289a801042008148998020010008800800805999998171982580680d1982580680c80c1982580680400b9982a9982780d183a8011982a9982780c983b0011982a9982a00a983c8011982a00a183b8011a800911111100299983682e0010049a80083f299a983b89119983d11299a99826a8081a8010400089980200100088008008038b049809983d80c1a80204300983b00118398009a80b841009983700080a9a9a8020408083a09a9a80083f038299a9829808908008b180e803981d804119191a83011111111a80491111111aa99a9828007908008b1119191a9a9a80103f038111919191a9983780180b911919191aa99a983a89119983c11299a998259a80103f28078a99a99829198249a80103f805a4004266008004002200220020020062c12202444646464646464660b0666607603c03a01e00a660b0660a4020660fa00a04a660b0660ae6609c02204690011982c1982b99827002811a4004660b0660ae6609c02201e6609c00a01e660b0660aa61020201811602660b0660b06606e00490001982c1981b800a4000660b06606e00890001982c1981b801a40006606c66e08cdc099b820040303370466068900019b810040020193370266e0800c0c0cdc11981a2400066e0400c004064cdc119b8233704060060004002660b0660a204e6660e40c200c018660b06660700666607e66a61180211e020160500426080018660d20160186609a0200386609801e03866096004034660940020346a0020fea66a60f02446660f644a66a6609c6a00410202a0242a66a660aa660986a0041040201c9001099802001000880088008008030b04a00983c001183a8009a80d042009983b80a9a800841009983680080a9a9a8020400083989a9a80083e837a99a9829008908008b180e003181d003919191a830111111119191919191919198209981f003001998209981d99833003007198330018071982099823299a99982d0230059a9a99a983a83c00100883d036840008b00499820a99a9981d0080008398998201815000a4000660826607c60d400a0e866082660a400400a660826607660c202060c2002660826607660c402060c4002660826608060ca02060ca0026608060c602060c60026660b409200600860ce0066a0020d4a66a60c62446660cc44a66a6607a6a6a6a00e0f40d80f26a6a0040d80f2266008004002200200260d20062c0fe6a0140e86a6a0020e80cea66a6092010420022c603800c607400e4464646a0c24444444a66a6a01244440d44264646464646464646464646464660926608402e0086609266086016660dc00602a6609266092660906607e6a0040ea01401266092660826a0040e86a01c10202660806a0040d86a01c10402660926608c66aa60f41000246a00244660f400466aa60fa1060246a00244660fa004666a0026e012000700466e0000520000013304a00c3500a2233088013307900233088013307900100a07e07e003330493304e533533306204e0123535335307d080010010190820107508801160103304933046307200707c330493305a0010073304933043306901730690043304933043306a017306a0043304933048306d017306d00433048306b017306b0043070006335307b07e0040163500207233305f04e0010035335306a12233306d22533533040353500c081010733500207313300400200110010010031608601306d0013500f07a333501b07a353501b07907a001330360030013306d00a350010783306300100a35350010760695335304b0092100116057301d007303b00811200116135573c0046aae74004dd5001111299a9980180100082402f24141380244444246666600200c00a008006004660a8660a8e012000702246666666600204a44a666ae68cdc38010008050a999ab9a3371200400203603444666ae68cdc400100082d823801802802001112999ab9a337120040022004200244a666ae68cdc48010008800880111199ab9a337120040020b008844666ae68cdc400100082182b91199ab9a337120040020840ac446446a002446a0024644a666aa666a00e42a666a00842a666a01242600a930980224c2a666a00a42600a930980224c01a0382a666a0104260089309801a4c2a666a0084260089309801a4c0182a666a006403a0160382a666a00642a666a0104260089309801a4c2a666a0084260089309801a4c0180362a666a00e426006930980124c2a666a006426006930980124c0162a66a00208a0b60b608a4a666a00442a666a00e42a666a008426660180160040022c2c2c0362a666a00c42a666a006426660160140040022c2c2c034036604c00246a0020c62209244644464646464a66a0082a66aa00e2666ae68c1c8cc028c170174cc18016401416411400400454cd400c00454cd540184ccd5cd183819804982d82e1982f82c00202c0220008a99a8010a99aa8028008999ab9a307133008305a05b3305e0570030570430011333573460de6600e60b20b4660ba0ac0040ac084666ae68cdc49980c000801240000820aa2a66a6603200400a0a226603200200a446666aa0046609844666a00a0b00020046a0060ae4466e00005200200148000cc124888c00cc0080048004cc1212210048810022323330582225333573466e1c008dc6802080089980199b8000248008cdc019b820014820010cdc70020012400090001982b91299a8008b1109a801112999ab9a3371e00400e2a66a0022c4426a00444a66a0062004442c2600c0066a004446a00209246a0024440c046a0020b8464a666ae68c17cd55ce800899191919198252999ab9a306335573a00626464646464646464646464646464646464646464646424666666666600201a01801601401201000e00a00600460446ae84d5d10011980f1981f3ae2001357420026ae88008cc071d71aba100135744016a666ae68c1ccd55ce80489919191982ea999ab9a307635573a004264660bc66038eb4d5d0800980d9aba1357440026aae780081c14ccd5cd183b1aab9d0011323305e3301c75a6ae84004c06cd5d09aba200135573c0020e06ea8d5d09aba200237546ae84004d55cf0048369980c9981c81b3ad35742014660300326ae84028ccc059d70029aba100a33301575c0086ae84028cc054008d5d08051980a1192999ab9a306f35573a002264660ae60326ae84004c010d5d09aba200135573c0020d26ea8004d5d08051192999ab9a306e35573a002264646660ce60666ae84008ccc059d70029aba10013303675c6ae84d5d10009aba200135573c0020d06ea8004cc045d73ad37546ae84004d5d10009aba2001357440026ae88004d5d10009aba200135573c0060baa666ae68c1980044c848888c010014c02cd5d09aab9e00215333573460ca00226022604e6ae84d55cf0010a999ab9a3064001132122223001005300c357426aae7800854ccd5cd1831800898081bae357426aae78008174d55ce8009baa357426ae88008dd51aba100135573c0020b26ea80048c94ccd5cd182f8008248a999ab9a305e00103305835573a6ea800488c8c94ccd5cd18308008058a999ab9a30600011301c3004357426aae7800854ccd5cd182f80080502c9aab9d00137540024464460046eac004c14488cccd55cf80090259191982b1982398031aab9d001300535573c00260086ae8800cd5d0801027119118011bac001304f2233335573e00240924660a660086ae84008c00cd5d100102611919192999ab9a306200211222204415333573460c2004220b22a666ae68c1800084c8c848888888cc004024020dd69aba135744a0046eb8d5d0a8008a999ab9a305f002132321222222233002009008375c6ae84d5d128011bae35742a0022a666ae68c1780084c8c848888888cc018024020dd71aba135744a00460406ae85400454ccd5cd182e80109909111111180380418101aba135573c0062a666ae68c1700084c848888888c014020c080d5d09aab9e003056135573c0046aae74004dd50009192999ab9a305935573a0022646608260086ae84004dd69aba1357440026aae7800414cdd50009192999ab9a305835573a00226eb8d5d09aab9e00105237540022207422060424444600600a424444600400a446a0024464660964466a0029000111a801112999ab9a3371e0040122600e0022600c00600a60944466a0029000111a801112999ab9a3371e00400e20022600c00644a66a00442a66a00442660240040020502a66a002405007a446a004446a006446666012008006004002446a00444444446a0104444444a66a6602201c00e2a66a6602201a00c2a666ae68cdc38060028a999ab9a3370e0160082a66a01442a66a008426a004446a004446a00a446a00444a66a666603800c00a0040022a66a00e42a66a008426605000400207c2a66a006407c0a607a0682a66a0064068092066066066066446a004446a00644a666ae68cdc780200109980880180081411111919a802919a80212999ab9a3371e0040020060504056466a00840564a666ae68cdc78010008018140a99a80190a99a8011099a801119a80111980480100091101711119a80210171112999ab9a3370e00c0062a666ae68cdc38028010998080020008168168130a99a800901301d9119a801119a8011198068010009013919a801101391980680100091199aa981d81e180680191a80091199aa981f01f980800311a80091199a800919805a40000020144660160029000000998030010009981800101a91199ab9a3370e00400206c04444a66a004200203c4466aa606407046a0024466064004666a002466aa606c07846a002446606c004601800200244666010016004002466aa606c07846a002446606c004601600200266600600c004002444666aa606207007c66aa606407046a00244660640046010002666aa6062070446a00444a66a666aa6076078601a01646a002446601400400a00c200626608400800606800266aa606407046a00244660640046608044a66a002260120064426a00444a66a6601800401022444660040140082600c00600800442444600200842444600600844666ae68cdc780100081800e1981400080c91299a801016880091981391199a8018198010009a8008191192999ab9a304035573a0022646464646464666666605c66601aeb9d71aba100633300d75ceb8d5d08029bad357420086eb4d5d0801998061192999ab9a304835573a0022646606060186ae84004cc03dd71aba1357440026aae78004108dd50009aba1002375a6ae84004dd69aba1357440026ae88004d5d10009aba2001357440026ae88004d55cf00081d1baa00123253335734607e6aae740044c8cc09cc014d5d0800998030021aba1357440026aae780040e4dd5000919192999ab9a304000113232333012375a6ae84008dd69aba1001375a6ae84d5d10009aba200135573c0042a666ae68c0fc0044c054c010d5d09aab9e00203935573a0026ea80048c8c94ccd5cd181f800898071bae357426aae7800854ccd5cd181f0008980a1bae357426aae780080e0d55ce8009baa00122323253335734607c0022602860086ae84d55cf0010a999ab9a303f00101303835573a0026ea8004888c94ccd5cd181e9aab9d0011323302530053574200260086ae84d5d10009aab9e001037375400246a002446a00444444444446666a016403c403c403c4666aa606a06c03a46a00244a66a660240040082603e00603c01644a666ae68cdc79a8010151a8008150999ab9a3370e6a0040566a00205604a02201c44a66a602e244666034446a004446a002444a66a00242a66a6a01644444444446604001600442a66a6666666ae900048c94ccd5cd18229aab9d00113233335573e002403e4646666aae7c00480848c8cccd55cf80090119191999aab9f001202523233335573e002404e4646666aae7c00480a48c8cccd55cf800901591999aab9f357440044a66a603e6ae8403c854cd4c080d5d080710a99a998120119aba100d21325335333333357480024646464a666ae68c1740084cccd55cfa800901a9191999aab9f0012037233335573e6ae8800894cd4c0bcd5d0a80290a99a98181aba100421303833058002001036035203804f04e35744a0040982a666ae68c1700084cccd55cfa800901a91999aab9f35744a0044a66a605a6ae85400c84c0d4c0d40040cc80d81341300c44d55cf0011aab9d0013754004406240624062406209042a66a60506ae84030854cd4c0a4d5d080590a99a98141aba100a213032333333304400800700600400300200103002f02e02d3574201805605405240580860846ae88008100d5d100101f1aba200203c357440040746ae880080e0d5d100101b1aab9e00101a3754004403840384038403806642a666ae68cdc79a800911101201e89980600500488048804080388030008020119100791999999aba40012325333573460706aae740044c8cccd55cf80090091191999aab9f0012014233335573e6ae8800894cd4c024d5d080290a99a9980611999999aba4001232323253335734608800426666aae7d400480708c8cccd55cf800900f1191999aab9f0012020233335573e6ae8800894cd4c060d5d0a80390a99a980c9aba1006215335301a3574200a42604466603a00600400204003e03c404207006e6ae880080d4d5d128010198a999ab9a3043002133335573ea002403846666aae7cd5d128011299a98089aba1500321301c301c00101a201d034033018135573c0046aae74004dd5001100c100c100c100c0179aba100421301533026002001013012201502c02b357440040526aae78004034dd5001100790079007900781311999999aba4001232323253335734607400426666aae7d400480488cccd55cf9aba2500225335300835742a006426024601800202040260540522a666ae68c0e40084cccd55cfa800900911999aab9f35744a0044a66a60106ae85400c84c048c048004040804c0a80a40384d55cf0011aab9d0013754004401c401c401c401c04a46666666ae9000480348034803480348c02cdd7001012111999999aba4001232323253335734607000426666aae7d400480448cccd55cf9aba2500225335300835742a006426022602200201e40240520502a666ae68c0e40084cccd55cfa80091807808900881400689aab9e00235573a0026ea800880348034803480340908ccccccd5d2000900590059005918049bad002200b0222122300100322212233300100500400322302522533500100722135002225335330080020071300c001130060032223500222253350012135005222222222253353301200b002213012001161622533533355301d01e005235001225333573466e3c0080144c01c00c01800484c014d400408400c400c8488c00800ccc040894cd40088400c400400440688d40040988d400488888880188d400488880188880048d4004888803488cc064894cd400458884d4008894ccd5cd19b8f00200715335300912233300c22350022253335734606200226600c00800620060020062c4426a00444a66a00626602a016004442c2600c006004466a00203001c44602e44a66a00220064426600c004600800246a002444444444401446a0024403a46a002444444444401244400644400466666660049111c7a8041a0693e6605d010d5185b034d55c79eaf7ef878aae3bdcdbf670048811c8c9a2d459d2d8dc7c11192f971ab647fac65833121b7e8181e583c6400330014891cffcdbb9155da0602280c04d8b36efde35e3416567f9241aff0955269000134891cb686e45c9181618e20e26cf0e2fc1e9f336bb0df914e645b5adad5bd0048811cf94fd008635cf307663aadd995ed69d5fbbfd65f84679fc38254d664004881054f574e45520048811cf1ec90d33208778214cdc7fa90858ac5620253d99f84c10335928cab002212330010030022222222123333333001008007006005004003002300c2211222533500110022213300500233355300700e005004001300b22112253350010052213301230040023355300600c004001100110053008221225333573466e200052000130054910350543600153350021300549103505437002215333573460320062004266a600c01200266e0400d2002253357380022c600c4422444a66a00226a006010442666a00a0126008004666aa600e01000a0080022400244004440026004444a66a00220044426a004446600e66601000400c00200660024444a66a00220044426a00444a666ae68c0500044ccc02001c01800c4ccc02001ccc028ccc02c01c00800401800c8c8c00400488cc00cc00800800488488cc00401000c88848ccc00401000c008854cd400458884d4008894cd400c40080312210e4d7565736c69537761705f414d4d00153357389201035054310016221533500110020062003222222200422222220072216370e90001b8748008dc3a40086e1d2006370e90041b8748028dc3a40181",
+                  "version": 0
+                },
+                {
+                  "__type": "plutus",
+                  "bytes": "59152a010000323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323223232323232322232323232323232323232533355333573460d000226464646424446600200a0086eb4d5d09aba2003355333573460d060da0022660a06eb4d5d098360009bad357426ae88c1b000458c1b88894ccd5cd18358008b0a999ab9a337100029000099801983500118350008991982a19b8400300133708004002660ce0040026ea8d5d080098350010a999ab9a306700113212223002004375a6ae84c1a800854ccd5cd18330008220b099180e1a9a805030911111111111299a999aa983583601892999ab9a3371e01c002260c80020c400840d20c2a020426038660946010002660946603a666aa60b40c06a0340c26a0340c4666aa60b40c044a66a6a0044444a66a6605060a4030008260ba0060b642660c200200420020ba60546a0140c2660366660486a01e0c26a01e0c460460246660486a01e0c26a01e0c466604c6a0120886a01e0c26a01e0c4660946008a0226020a00a4426464646464646046660a2601e00e660a2603e032660a2602ea018660a26016a030660a26a01044666ae68cdc499b8200248008cdc1240000020be0cc660a26a0104426ae68cdc419b8200248008cdc1011000998289982899814982980c98298029982899827981d00c981d0029982899827981700c98170029982899827980e00c980e0029982899827980e80c980e802a99a980f80c88020a99a80202e031998289a9980f1a804111919191982d99b8400300133708004002660dc00400266e0808c008cdc099b8202200133704004044660ac60540329001112999ab9a3370e00a0042660760440020bc66048660446a00c0d26660560040026a6a6603c010660ac66605a6a0200960040029001111982c19b84002001330583370a0040020020d0660446a0200966660566a02c0d06a02c0d26a6603c660ac6054032900100438435014068350130663027002301b00135001063533553353500b22350022222222222223333500d206620662066233355306f070035235001225335330470020041306a00306800d2135001223500122223501222350022222222222223335530700762235002222253353303e01800413307a006005100507300a16162215335001133052300a00235002204a2216306a00137540144666aa60b80ba604a04c400266aa60b00ba46a00244446a0084466a0044a666ae68cdc78048008a999a80282d102d90a99a9981a0009a80803390a99a9999999aba40012325333573460e060ea0022646666aae7c00481848cccd55cf9aba2002253353039357420064260c82460020040c240c40d60d460e80020bc6ea8008817881788178817819c84cc140d4004800522010f4d7565736c69537761705f76322e320005c05b061206230273500705e13306822533500105922132533553353035303735003062215335007213304a00200105615335006205605c15335333049034350030613500922200113305e30073500306200110011001300400130313500505c30513500304025333535001203f16216215335330290013500505c21533533333335748002464a666ae68c194c1a80044c8cccd55cf800902b11999aab9f35744004464a66a6666666ae900048c94ccd5cd183598380008991999aab9f001205c23233335573e00240bc4646666aae7c00481808c8cccd55cf80090311191999aab9f001206423233335573e00240cc4646666aae7c00481a08c8cccd55cf800903511999aab9f35744004464a66aa66aa66aa66aa66aa66aa66aa66a6666666ae900048c94ccd5cd183f9842008008991999aab9f001207023233335573e00240e446666aae7cd5d10011299a98241aba1005213253353333333574800246464a666ae68c224040044cccd55cf984680801103c91999aab9f35744611c02006464a66a6666666ae900048c8c94ccd5cd18480080089999aab9f309301002207f23233335573e0024102024646666aae7c004820c048cccd55cf9aba200225335305a3574261320201042a66a60b66ae84018854cd4c170d5d0802909844009998410080180100084280842008418090420084680846009aba200208a0135744612802006110022a666ae68c23c040044cccd55cf984980801103f91999aab9f357446128020064a66a60aa6ae84c2540401084c20804c208040041fc82000422404220041f4c24c04004dd5001103e103e103e103e0428090983e983e80083d1aba1308f01004207a083010820115333573461140200226666aae7cc234040088c1e81e481e4208041dcc23404004dd5001103b103b103b103b03f90983b9983780180083a1aba1004072207307c07b357440040f26106020020da6ea800881b481b481b481b41d884c1b8c1bc0041ac854cd4c110d5d0808909837980100083603590a99a98221aba100f21306f300200106c06b21533530443574201a4260de60040020d80d642a66a60886ae8402c84c1bcc0080041b01ac854cd4c10cd5d080490983798010008360359099299a9999999aba4001232325333573461060200226666aae7cc218040088c1cc1e481c81ec54ccd5cd18410080089999aab9f30860100223073072207207b070308601001375400440de40de40de40de0f04260e060060020da6ae8401c1ac854cd4c10cd5d080290983798010008360359aba1011206b074073357440040e26ae880081bcd5d10010369aba200206b357440040d26ae8800819cd5d1001032983780082c9baa002205920592059205906221305a305c0010573574200640ae0c00be60d20020a66ea8008814c814c814c814c17084d4004800458588c8d4d4d401016c888818888d40048c894ccd54ccd4018854ccd4010854ccd402084c0140c44c0100c054ccd401484c0140c44c0100c011810c54ccd401c84c0100c04c00c0bc54ccd401084c0100c04c00c0bc11454ccd400c810811010454ccd400c854ccd401c84c0100c04c00c0bc54ccd401084c0100c04c00c0bc11410854ccd401884c00c0bc4c0080b854ccd400c84c00c0bc4c0080b811054cd400415016c16c15094ccd4008854ccd4018854ccd401084ccc0d00c400800458585810854ccd4014854ccd400c84ccc0cc0c0008004585858104100c100ccc198888c94ccd5cd19b87003371a002200426600866e0000d20023370066e080092080043371c002006a66a660d244a66a0020a64426a00444a666ae68cdc78012451c5817c34e5702473304f3cf676299176d3824e55b8c0bfa94830429fd001305900113006003353533533069221225333573466e2000520001615335002162215333573460d20062004266a600c0c400266e0400d200205c30323500605d00405e204321533500116221350022253350031002221616480012000350012233335001262626232533530303032001213212333001003002005350022043163330672225335002162213500222533533035002005100113300700300530303500405b0015333573460ba60c400226464642466002006004606c6ae84d5d11831801a999ab9a305e3063001132323232323232323232323232323232323232323232321233333333333300101801601401201000e00c009007005003002304e357426ae88008ccc121d710009aba10013574400466608c09040026ae84004d5d100119822bae357420026ae8800d4ccd5cd1836983900089919191909198008020012999ab9a307030750011330583304175a6ae84c1d0004c158d5d09aba230740011637546ae84d5d11839801a999ab9a306e30730011323212330010030023055357426ae88c1cc008cc0fdd69aba130720011637546ae84c1c400458dd51aba10013574400466607e0a6eb4d5d08009aba20023303e040357420026ae88008ccc0edd701d1aba100135744004666072eb80e0d5d08009aba200233038035357420026ae88008cc0d80c8d5d08009aba23063002330340303574260c40022c6ea8d5d098308008b1baa00133041300700430080043304030240033018003305d22533500104e2213303e33303d03c303f3040002500530040011303a303b001355333573460aa60b40022646090a666ae68c158c16c0044c8c8c8c8c8c8cccccccc134c10cd5d098300039bae3574200c6eb8d5d08029bae357420086eb8d5d08019bad3574200460846ae84004dd69aba1357440026ae88004d5d10009aba2001357440026ae88004d5d1182d0008b1baa3574260b20022c40026ea80048d40041408d4004814488d400888d400c88c8c8c8cc104cdc200100099b84003001330540010023370400a00666e0800c0048d4004888880c9200233035001043223355304204723500122330390023355304504a235001223303c0023335001370090003802337000029000000998028010009299a8008890008b11199aa9822022980680711a80091199aa9823824180800891a80091199a80091980ea400000203846603a0029000000998018010009119aa981f82211a800911981b001199a800919aa982182411a800911981d001181900080091199804018801000919aa982182411a800911981d0011806000800999801816001000911199aa981f02202119aa981f82211a800911981b0011817000999aa981f022111a80111299a999aa98238241981b91199805025801000980402511a8009119805001002803080189982300200182080099aa981f82211a800911981b0011982a11299a800898050019109a80111299a9980600100408911198010050020980300180200111980091299a80101f880081b909111800802111a801111a801911919a802919a80212999ab9a3371e004002006078407a466a008407a4a666ae68cdc780100080181e0a99a80190a99a8011099a801119a801119a801119a8011198190010009020119a801102011981900100091102011119a80210201112999ab9a3370e00c0062a666ae68cdc380280109980f00200082082081d0a99a800901d02011a800911110149111981e998170019981e9981700100081e01e1981511299a801108018800818911198251119a800a4000446a00444a666ae68cdc78010040998281119a800a4000446a00444a666ae68cdc78010068800898030018008980300180191a8009111111100311981411199a80181e0010009a80081d891980081101a91a80091111111111100511999999aba40012323253335734608200226666aae7cc11000880c08cccd55cf9aba2304500325335300835742608c008426066605e00206040620740722a666ae68c1000044cccd55cf9822001101811999aab9f35744608a0064a66a60106ae84c11801084c0ccc0cc0040c080c40e80e40b8c110004dd5001101690169016901681b11999999aba4001202c202c202c2302d375a004405806a46666666ae9000480ac80ac80ac80ac8c0b0dd700101a111a8009111111111111982691299a80081b9109a801112999ab9a3371e0040282607a0022600c006004930919999999800801912999ab9a3370e0040020302a666ae68cdc480100080a80b1109ab9a337100040024426ae68cdc480100091199ab9a3371200400205206000444a666ae68cdc480100088008801112999ab9a337120040022004200244666ae68cdc40010008138171109ab9a3370e00400246a0024444444400e44a666ae68cdc79a8010179a800817889ab9a3370e6a0040606a00206004646a0024466a004404a04a46a00244444444444401846a0024444008446464a666ae68c0d400403854ccd5cd181a0008980998021aba13037002153335734606600201e2c606e0026ea80048c94ccd5cd1818181a80089919091980080180118021aba135744606a00460126ae84c0d000458dd50009192999ab9a302f3034001132323232323232321233330010090070030023302375c6ae84d5d10022999ab9a3037001132122230020043574260720042a666ae68c0d80044c84888c004010dd71aba13039002153335734606a0020262c60720026ea8d5d08009aba200233300675c00a6ae84004d5d1181a001180b1aba1303300116375400266002eb9d69111981a111999aab9f0012027232330293301a30073037001300630360013004357440066ae840080a4dd58009119819111999aab9f001202523302630053574200460066ae8800809cdd6000919192999ab9a302f00113212222300400530043574260600042a666ae68c0b80044c848888c008014c054d5d098180010a999ab9a302d00113212222300100530053574260600042a666ae68c0b00044c848888c00c014dd71aba13030002163030001375400246464a666ae68cdc3a401800222444401c2a666ae68cdc3a4014002220522a666ae68cdc3a40100022646424444444660020120106eb4d5d09aba23030003375c6ae84c0bc00854ccd5cd18170008991909111111198010048041bae357426ae88c0c000cdd71aba1302f002153335734605a00226464244444446600c0120106eb8d5d09aba23030003301435742605e0042a666ae68c0b00044c848888888c01c020c050d5d098178010a999ab9a302b001132122222223005008301435742605e0042c605e0026ea80048c94ccd5cd181498170008991909198008018011bad357426ae88c0b8008c00cd5d098168008b1baa001232533357346050605a00226eb8d5d098160008b1baa0011122200111001222002110012220032122230030042213573466e3c0080048894cd4cc00c00800403c058894cd400840040348d400488cd40088004988d4004888888880208c94ccd5cd180e8008088a999ab9a301c00100a1630203754002464a666ae68c06cc0800044cc00cc018d5d0980f800998040021aba135744603e0022c6ea80048848cc00400c0088c8c94ccd5cd180d8008991998029bad35742603e0066eb4d5d08009bad357426ae88004d5d1180f0010a999ab9a301a0011300a300535742603c0042c603c0026ea8004888488ccc00401401000c8c8c94ccd5cd180c800898021bae3574260380042a666ae68c0600044c020dd71aba1301c00216301c001375400242446002006446464a666ae68c05c0044c01cc010d5d0980d8010a999ab9a301800100516301b0013754002200220184244600400644444444246666666600201201000e00c00a008006004424600200460264422444a66a00220044426600a004666aa600e01a00a0080026024442244a66a00200a44266012600800466aa600c016008002200220084424466002008006601c4422444a66a00226a006010442666a00a0126008004666aa600e01000a0080022400244004440026014444a666ae68c01c00440084cc00c004cdc30010009111111100291111110021b8148000dc3a40006e1d2002370e90021b874801955cf2ab9d23230010012233003300200200101",
+                  "version": 1
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "64721ce902f13c3bbcd1827975a7679173270a0d97b3d3a3e3b1ece8853e5a95",
+                    "c4260a2444921adb1c8ac5abd995783557d2099eaa964a4b2c3bf73dd57c556342ce0c0e9989555f4b798e90f6598623bf8b57d9c8c928670283feb5f97bac0b"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "876277"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "412046005c24952b191346165a03c70dc928e0b070ba1a493e749bd9bdbfc4c8"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qy64kgvd5qfy3t98p0069m4cfskvzkwx3s9633ug6d4d7e8rzr27g03klu862usxqsru794d03gzkk8n86ta34n85z0szqc095",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "62954060000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qywgh46dqu7lq6mp5c6tzldpmzj6uwx335ydrpq8k7rru4q6yhkfqn5pc9f3z76e4cr64e5mf98aaeht6zwf8xl2nc9qr66sqg",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "656187446"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116802805
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "93253dddf2ee5f95e553325f66489ea6e47fd99fc33cd6948dbd2240adaa3102",
+            "isValid": true,
+            "witness": {
+              "bootstrap": [],
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "d19853ccd4935c5f91847788977ba2abe9d676b1ceef4215efaa809cc2f01f3b",
+                    "71fd70da8f48b8573295d6c794a80a9d472c6f09b6bfeece5a693bb6636b50c7f41591fee0d9b9f91ec6641537f24b43547bcdb91fd22318e5b2f24e6e98460f"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "1086120"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "742700eac3ed4ade12d765d030f25c893fa7f59e9cc66d260c8af3505bd26786"
+                },
+                {
+                  "index": 3,
+                  "txId": "ad98867ad94e0cbfab8265edce6917d96eb7a327422649b21a8dab9107f166f8"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1w9m9lddwalwddfvca6vcpywqt5mjg82wddmph549qvkzjdq40p92x",
+                  "datum": {
+                    "cbor": "d8799fd8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffd8799fd8799f581c771d5a28a99b9efa419d323f05605e7d89cdf22970617fe2069b3c24ffd8799fd8799fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffffffffd8799fd87a9f581c55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffd8799f581c5ab1d98396a5e4c7127a9f10578acd6968eb690b7f7c98a2b2f6b1174953505f4a4d4b756f46ffd87d9fd8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffffff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffd8799fd8799f581c771d5a28a99b9efa419d323f05605e7d89cdf22970617fe2069b3c24ffd8799fd8799fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffffffffd8799fd87a9f581c55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffd8799f581c5ab1d98396a5e4c7127a9f10578acd6968eb690b7f7c98a2b2f6b1174953505f4a4d4b756f46ffd87d9fd8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffffff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288c"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "c53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799fd8799f581c771d5a28a99b9efa419d323f05605e7d89cdf22970617fe2069b3c24ffd8799fd8799fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581c771d5a28a99b9efa419d323f05605e7d89cdf22970617fe2069b3c24ffd8799fd8799fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581c771d5a28a99b9efa419d323f05605e7d89cdf22970617fe2069b3c24ff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581c771d5a28a99b9efa419d323f05605e7d89cdf22970617fe2069b3c24ff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "771d5a28a99b9efa419d323f05605e7d89cdf22970617fe2069b3c24"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581ce63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "e63a9f069ef89da7fa8a1a18c6ffa9a1909a7d0b3fb50133f00259e5"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799fd87a9f581c55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd87a9f581c55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d87a9f581c55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7cff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "1"
+                                },
+                                "fields": {
+                                  "cbor": "9f581c55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7cff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7c"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "c53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d8799f581c5ab1d98396a5e4c7127a9f10578acd6968eb690b7f7c98a2b2f6b1174953505f4a4d4b756f46ff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9f581c5ab1d98396a5e4c7127a9f10578acd6968eb690b7f7c98a2b2f6b1174953505f4a4d4b756f46ff",
+                            "items": [
+                              {
+                                "__type": "Buffer",
+                                "value": "5ab1d98396a5e4c7127a9f10578acd6968eb690b7f7c98a2b2f6b117"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "53505f4a4d4b756f46"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "cbor": "d87d9fd8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "4"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cffd8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9f581c5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288cff",
+                                        "items": [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288c"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "cbor": "d8799fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9fd8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ffff",
+                                              "items": [
+                                                {
+                                                  "cbor": "d8799f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ff",
+                                                  "constructor": {
+                                                    "__type": "bigint",
+                                                    "value": "0"
+                                                  },
+                                                  "fields": {
+                                                    "cbor": "9f581cc53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0ff",
+                                                    "items": [
+                                                      {
+                                                        "__type": "Buffer",
+                                                        "value": "c53c3831eea73304c0d847a74612028d64e94872f4d364f6633aa8b0"
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "5ab1d98396a5e4c7127a9f10578acd6968eb690b7f7c98a2b2f6b11753505f4a4d4b756f46",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2685130"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9w3dv72z43k3k4jrluta6kdutdx3q7ekyg7ph7dd8cj3rx98surrm48xvzvpkz85arpyq5dvn55suh56dj0vce64zcq7znnza",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "0e14267a8020229adc0184dd25fa3174c3f7d6caadcb4425c70e7c04756e7369673133343434",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e",
+                          {
+                            "__type": "bigint",
+                            "value": "115795488"
+                          }
+                        ],
+                        [
+                          "420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a4441584f",
+                          {
+                            "__type": "bigint",
+                            "value": "4621351705766"
+                          }
+                        ],
+                        [
+                          "5d16cc1a177b5d9ba9cfa9793b07e60f1fb70fea1f8aef064415d114494147",
+                          {
+                            "__type": "bigint",
+                            "value": "3102426309"
+                          }
+                        ],
+                        [
+                          "7914fae20eb2903ed6fd5021a415c1bd2626b64a2d86a304cb40ff5e4c494649",
+                          {
+                            "__type": "bigint",
+                            "value": "4139428533"
+                          }
+                        ],
+                        [
+                          "8f52f6a88acf6127bc4758a16b6047afc4da7887feae121ec217b75a534e4f57",
+                          {
+                            "__type": "bigint",
+                            "value": "10"
+                          }
+                        ],
+                        [
+                          "9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d7753554e444145",
+                          {
+                            "__type": "bigint",
+                            "value": "1098252047"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4029850"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9w3dv72z43k3k4jrluta6kdutdx3q7ekyg7ph7dd8cj3rx98surrm48xvzvpkz85arpyq5dvn55suh56dj0vce64zcq7znnza",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "76424a9f0398f5076662528e4dd48b234445ed00b80db713568ef20153505f444d33394b61",
+                          {
+                            "__type": "bigint",
+                            "value": "2"
+                          }
+                        ],
+                        [
+                          "79bc6d517a5ea3f71d9f1436489a02c00a5c90fe87e6f59d8800f06553505f6a756c474a6c",
+                          {
+                            "__type": "bigint",
+                            "value": "2"
+                          }
+                        ],
+                        [
+                          "7cb89ef83c06341a0279b70397f6ed0e3243ce6fccbc209487dc1f6353505f33416f336659",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "88775555d374b46a44904d319ed5790be4ab7f24e69e353e10edc29653505f4f386e643549",
+                          {
+                            "__type": "bigint",
+                            "value": "2"
+                          }
+                        ],
+                        [
+                          "8c32122ce322755e724ab50ed655dbdfc076405d4678a9c247e7f80453505f6733334c6153",
+                          {
+                            "__type": "bigint",
+                            "value": "2"
+                          }
+                        ],
+                        [
+                          "910b3c77ff8f0229ab2255a000be54f966c089ecbbaaae661ae82c8353505f796455664f76",
+                          {
+                            "__type": "bigint",
+                            "value": "2"
+                          }
+                        ],
+                        [
+                          "9a641ceaa4fc034bc6bb1ecd48b9c1f12c36695020c4bad705ad8ec753505f6975384c4c37",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "9eb6de3af43583e7de8a4052f759e3153a015b1502c597940c3e795853505f375a4954566e",
+                          {
+                            "__type": "bigint",
+                            "value": "2"
+                          }
+                        ],
+                        [
+                          "9eea2b4feb5f4a4691b7da614764a8b1f2590b170a96906b4f363c6e53505f46734835434b",
+                          {
+                            "__type": "bigint",
+                            "value": "2"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2607550"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9w3dv72z43k3k4jrluta6kdutdx3q7ekyg7ph7dd8cj3rx98surrm48xvzvpkz85arpyq5dvn55suh56dj0vce64zcq7znnza",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3690735"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "5d16b3ca156368dab21ff8beeacde2da6883d9b111e0dfcd69f1288c"
+              ],
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "ffd76697b271fa24ea5e1b577f2651f6b8418d23b9b0181f8cd57a70ed1877dd",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "85144193c9b193de5602f0c44c2a93a2237b8b9c63c5e245b8897c951cc71b35",
+                    "1eea39f2d612f5edeb2cfde9a5f78fcbf4c7bc5edbaed9c904622eb0f6d02ebaa370376190e1edb2334a874055808d7e9eec01490f911e434eef119373c1ea07"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "384005"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "0ebb0857c491cb7ea52e7530cf6da44905cc592323cde0870c70e6a6501fefcc"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": 1,
+              "outputs": [
+                {
+                  "address": "addr1qyw2snk0l39xt6ua9a60purntuag02l0pm8w0yws8z9sghyj5dysang6xcyp62r6dwdm7pnv3nsdwwn7jzzhr03ur6tqmay0rd",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "350000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qyy895fwrv038kxdryten58hk9qcqevf9yeleeaae57yj5r68v37ge3f6qsu5c2ftzuhx2ef8wqpcan0eu8c868nd6tqzf8ukj",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "09f5f55fcad17503e6b7acc81de7c80f84b76e76d17085f0e32f1ce241574f4f",
+                          {
+                            "__type": "bigint",
+                            "value": "2059704682"
+                          }
+                        ],
+                        [
+                          "13e3f9964fe386930ec178d12a43c96a7f5841270c2146fc509a9f3e436c61794e6174696f6e5069746368383131",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "13e3f9964fe386930ec178d12a43c96a7f5841270c2146fc509a9f3e436c61794e6174696f6e50697463683239363732",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "19541495605af531f317cb14d1c5baa3618f7852c032ec4a83d3dd05446567656e657261747330393832",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "20cd68533b47565f3c61efb39c30fdace9963bfa4c0060b613448e3c50524f584945",
+                          {
+                            "__type": "bigint",
+                            "value": "246072811"
+                          }
+                        ],
+                        [
+                          "25245a6ae33492621c370c1a4cba8e944c085f28615f7b760a47b24643617264616e69616e734c6f79616c7479546872656530323138",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2afb448ef716bfbed1dcb676102194c3009bee5399e93b90def9db6a4249534f4e",
+                          {
+                            "__type": "bigint",
+                            "value": "2000000"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333031",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333035",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333037",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333038",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333234",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333430",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "2d405e869540dce011caa02ae9f39ced5f9d4b08e265b5bb2002b78e4368726973746d6173466c75666679333530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "4623ab311b7d982d8d26fcbe1a9439ca56661aafcdcd8d8a0ef31fd6475245454e53",
+                          {
+                            "__type": "bigint",
+                            "value": "94679899"
+                          }
+                        ],
+                        [
+                          "462d81b809c4cbc9039a536a6139393d640e3f54c563c0404ef92a5f57415249",
+                          {
+                            "__type": "bigint",
+                            "value": "503774406486"
+                          }
+                        ],
+                        [
+                          "4bf184e01e0f163296ab253edd60774e2d34367d0e7b6cbc689b567d50617669614d696e75733131394d696e75733234",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7330303039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7330313734",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7330363034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7330363534",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7331303138",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7331313235",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7331323737",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7331333839",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7331343533",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7331373236",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7331393835",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7332323233",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7332333039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7332333331",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7332343738",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7332373736",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333303338",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333313232",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333333033",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333343132",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333363231",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333383034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333383736",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7333383834",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7334353439",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7334373335",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7335333938",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "53d6297f4ede5cd3bfed7281b73fad3dac8dc86a950f7454d84c16ad000de140486f7573654f66546974616e7335393436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "551f1b35abe2e5d917f43505154f3f12a956c52ec07e5134ca464265736166617269",
+                          {
+                            "__type": "bigint",
+                            "value": "50928"
+                          }
+                        ],
+                        [
+                          "5bb7f3c67cb9bece3ae0f654ec5eed2f8c0b16ecd18e66157392eb3c43617264616e6f4b69647a30303632464330353135",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "5d2c310ba30ee79a9139defb690af87a110444492c9caf4b2038e0f143617264616e6f4b69647a303033324643313530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "6787a47e9f73efe4002d763337140da27afa8eb9a39413d2c39d4286524144546f6b656e73",
+                          {
+                            "__type": "bigint",
+                            "value": "876779"
+                          }
+                        ],
+                        [
+                          "6a7db6eaded6e08b6462a638f5adba08eeda2d4cd5ca548ebceab2c848616c6c6f7765656e4d6178303532",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "6a7db6eaded6e08b6462a638f5adba08eeda2d4cd5ca548ebceab2c848616c6c6f7765656e4d6178303735",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7530ac349de9364d105fc05260602f48566be06256202be1d152734f53746f726d",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "7713c4b49bf124dd69ccd3f9c5e4567656ee649c2c4a04cd003d949e50686f656e69784172656e614f7574706f7374",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "782c158a98aed3aa676d9c85117525dcf3acc5506a30a8d87369fbcb4d6f6e6574",
+                          {
+                            "__type": "bigint",
+                            "value": "14840000000"
+                          }
+                        ],
+                        [
+                          "8654e8b350e298c80d2451beb5ed80fc9eee9f38ce6b039fb8706bc34c4f4253544552",
+                          {
+                            "__type": "bigint",
+                            "value": "4000000"
+                          }
+                        ],
+                        [
+                          "8e51398904a5d3fc129fbf4f1589701de23c7824d5c90fdb9490e15a434841524c4933",
+                          {
+                            "__type": "bigint",
+                            "value": "15200000"
+                          }
+                        ],
+                        [
+                          "9a9693a9a37912a5097918f97918d15240c92ab729a0b7c4aa144d7753554e444145",
+                          {
+                            "__type": "bigint",
+                            "value": "325086458"
+                          }
+                        ],
+                        [
+                          "a0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235484f534b59",
+                          {
+                            "__type": "bigint",
+                            "value": "6000000"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930303230",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930303730",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930303738",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930313639",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930323130",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930323439",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930333436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930333831",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930333832",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930353034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930353036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930353330",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930353436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930363435",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930363438",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930363730",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930373434",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930373532",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930383232",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930383638",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930383937",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667930393134",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931303432",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931303933",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931313039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931313433",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931323533",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931333438",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931343436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931343937",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931353436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931363535",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931363837",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931383733",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931383738",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667931393937",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932303234",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932303832",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932313032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932323233",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932323531",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932323536",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932323939",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932343139",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932343336",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932343937",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932353237",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932353435",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932353535",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932353931",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932353936",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932363232",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932363335",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932363633",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932373539",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932373736",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932383233",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932393336",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667932393430",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933303938",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933313138",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933313338",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933313830",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933333035",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933333133",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933333338",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933333436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933333631",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933333637",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933363036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933363131",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933383238",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933383530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933383538",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933393930",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667933393935",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934303039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934303430",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934303534",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934303538",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934303636",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934303839",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934313238",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934313633",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934323636",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934333036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934333436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934333439",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934333634",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934333938",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934343535",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934343636",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934343639",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934343931",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934353134",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934353232",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934363031",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934373631",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934373839",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "a1a23483764117264791aa80adac1c597bef547dca9e955a4aa229b3466c7566667934383039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "af2e27f580f7f08e93190a81f72462f153026d06450924726645891b44524950",
+                          {
+                            "__type": "bigint",
+                            "value": "6000000000"
+                          }
+                        ],
+                        [
+                          "b166a1047a8cd275bf0a50201ece3d4f0b4da300094ffcc668a6f4084b49545550",
+                          {
+                            "__type": "bigint",
+                            "value": "188429"
+                          }
+                        ],
+                        [
+                          "b771be5a82843c7f50de45b6cb0860bc3ee1fc1646d13825710205056d6f6f6e",
+                          {
+                            "__type": "bigint",
+                            "value": "184469"
+                          }
+                        ],
+                        [
+                          "c0e6c802993aadbe53fccf26811d21965854109dc8d8ece113cca940436c6179427566667934393132",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c7e0049200851adec2cb4d9abf2e9a57e24bf1389181dc536c5bfc8952617269747944617767383736",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "c7e0049200851adec2cb4d9abf2e9a57e24bf1389181dc536c5bfc895261726974794461776738343138",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "cdc49d77a173e85a11f336d18f98313ee8d54434545f4c07edb81f3e52617363616c30353939",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "cdc49d77a173e85a11f336d18f98313ee8d54434545f4c07edb81f3e52617363616c30373831",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "d6f58216e602613eedec7cf3532c4038532c8bb6f5812bc4c280f6444164614b61776169694b616f7269303738",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dbfeef3c800e61b6613d2efade9a51863be48406bbaabfa0a8cab6644d656c74696e674d6f6f6e626f7953706163657375697430383130",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dbfeef3c800e61b6613d2efade9a51863be48406bbaabfa0a8cab6644d656c74696e674d6f6f6e626f7953706163657375697431373032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dbfeef3c800e61b6613d2efade9a51863be48406bbaabfa0a8cab6644d656c74696e674d6f6f6e626f7953706163657375697433313935",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dbfeef3c800e61b6613d2efade9a51863be48406bbaabfa0a8cab6644d656c74696e674d6f6f6e626f7953706163657375697434303938",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617830313830",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617830323932",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617830333938",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617830363037",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617830393631",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831303035",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831313530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831323039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831323739",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831333738",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831343036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831343137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831343238",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831343239",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831343630",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831363733",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831373136",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831373933",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831383239",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617831383739",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832303230",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832313131",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832313639",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832313836",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832323137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832333936",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832343036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832363331",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832363333",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832363334",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832373034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832373431",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832373530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832393530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617832393931",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833303438",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833323533",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833323737",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833333434",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833333637",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833343032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833363031",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833363232",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833373435",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833373733",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617833383735",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834303639",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834323036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834333130",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834333436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834333637",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834343032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834343236",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834353537",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834353630",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834363539",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834373431",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834393335",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "dd69528872e351a402d3edbc6d484cdc45119d6aa5d1869a09473daa4d617834393937",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230323235",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230323332",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230333437",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230343134",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230353239",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230353532",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230363534",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230373336",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230373736",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657230383634",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657232303632",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657232323034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657232333135",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657232373131",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657233313031",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657233323730",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657233333633",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657233383230",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657233393036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657234363032",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657234373436",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657235323137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657235323932",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657235323937",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657235343138",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657235363031",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236303634",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236313230",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236313632",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236323932",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236333338",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236353238",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236373632",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236383037",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657236393735",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237353039",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237353137",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237353530",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237363136",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237363233",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237363538",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237363739",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237373437",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657237393733",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657238303238",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657238303930",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657238313430",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657238343036",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ac75a5f1b0412cc683ad95293819953d03b5b49c664b628174cdd8446976657238353633",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e0ce53ac76789dc00b607a551a54a0c2e454e1b68affd60120e63711746f6e694343536f67",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "e965ea5ba5564662242dcbe7b0301bf77840bf6e0f57ec838dc7eb0353616e74614469766572303133",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000de140534832383034",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000de140534833313135",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "435300407"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "2ab177d9158814c84493f4030c6b779d3ccc5fbbe5038a17728042502e819268",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "66d473ca13784f4971d689154b95ec00339b38c553a317f43d97e3d405eb433b",
+                    "47d8977e4a5a4e3c34d076134eb441b5fdcb7f7bc974202633dd62b83e5af26110654d9396fde1e16249b07e07b2b6499fdf94d1659080782c5f256532c6a70c"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "179845"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "4a771c8325ca91df3e78a77cc5828eb24d790614a9d57964afd06482c0ccf49f"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qy485ar8fl7tmvjjpnnuv2u0wllrh9psq59zsz2uy7xlewwymcvmc75670x7572swp795pn0a6dpd6ty4y89c4g39wxq2fyuv9",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "50000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9q3d8rac700yf9qnevrmvsfmsrhxy6qqejsh88ft5kvu4akj247pl2n0n4ph954l3u034udgvhd8rw67p9x5cg2dcqqegdr9q",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1452531231"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9q3d8rac700yf9qnevrmvsfmsrhxy6qqejsh88ft5kvu4akj247pl2n0n4ph954l3u034udgvhd8rw67p9x5cg2dcqqegdr9q",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "726355538"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9q3d8rac700yf9qnevrmvsfmsrhxy6qqejsh88ft5kvu4akj247pl2n0n4ph954l3u034udgvhd8rw67p9x5cg2dcqqegdr9q",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "363177769"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9q3d8rac700yf9qnevrmvsfmsrhxy6qqejsh88ft5kvu4akj247pl2n0n4ph954l3u034udgvhd8rw67p9x5cg2dcqqegdr9q",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "363177769"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9q3d8rac700yf9qnevrmvsfmsrhxy6qqejsh88ft5kvu4akj247pl2n0n4ph954l3u034udgvhd8rw67p9x5cg2dcqqegdr9q",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5000000"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116806535
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "e53bfbc47bbdab4044f48a5e3f27b231b9574006d529d60431406d1e3f5cf047",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "f32a467d838a4eb60344079fab70d51744403a444e8477ebdcddef83b76bafd6",
+                    "6710240cc29459a59718292e37517e53cc247f680b80c45b62ba48aab1bb22800deb802dbdebd0a0bcc2dc62a98e5f79287e0b9ca55cdec0f737b84d8bce6b0a"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "174741"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "2c3ae9a778cd5959f85fbf2cc9026c5bf97b9950ce4dbd75f03386d7bea64efe"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1w87a8c4kfdmwlwwetkrlj47pnxsta8c3vqzsgh5dazja29cmjc2p9",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "07095f97de598af62e80a85735470ed4e549a9a72c273e5fe6b5dfe1e7a3bf9a",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1595039120"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9fy0hfmmukjlqu29uxfrvu0zf6jxaedysunnylpp7aaydv6gkspmpwysxp8xf0v5pfhj4alqjqwcdlf4knnrvryqrgqngmddj",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "6336915971"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": "0460a616449dcc41e5dd83b9e7c98bff1cf5b324003418829ab1876c85fe6378",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "f20e2c8fe2e29047a7cdca276850e243d529e58e3325bf31186f8ac83b1465f8",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799f58385247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd2359a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0d87c9f1b000000014585eec1ffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9f58385247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd2359a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0d87c9f1b000000014585eec1ffff",
+                    "items": [
+                      {
+                        "__type": "Buffer",
+                        "value": "5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd2359a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0"
+                      },
+                      {
+                        "cbor": "d87c9f1b000000014585eec1ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "3"
+                        },
+                        "fields": {
+                          "cbor": "9f1b000000014585eec1ff",
+                          "items": [
+                            {
+                              "__type": "bigint",
+                              "value": "5461372609"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "3246344d1b1e603fc5b4850711259cd52deef5dcf226664011b2c4ab90c1317d",
+                    "eb36fa8df8d67192efe4290d7e71a4cd4972908e7360c10b17715de78fd5556a4d60849d78ded0f0b5c24407be12f524f0464c0e8efe78fd6c05066fb2d73e0f"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "172057"
+              },
+              "inputs": [
+                {
+                  "index": 3,
+                  "txId": "56d32c997effd9ebeb6470f6dcd6199fd704d28e9f02a970d35aea54b1db98ac"
+                },
+                {
+                  "index": 1,
+                  "txId": "a36441ea25b379a9f1e76f3014845d40e1f84aab6d399bbb7dcafd475c8bdad1"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q8emddg38ct20zxe36f6a7myxf69jw7r599h424mxzcrrt6r4e3njq3423k40ahfkjqpms00tsn02fhxet7l83hmewzs80p94m",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "119c9a9cc5cb1e1f178d30e287f5db0e32c9eb0ed7d10397bee56dff5363617279546572727930393631",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1180940"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8emddg38ct20zxe36f6a7myxf69jw7r599h424mxzcrrt6r4e3njq3423k40ahfkjqpms00tsn02fhxet7l83hmewzs80p94m",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "114054580"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116817335
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "37068b0df5fe3842370685bb23d6e432bb4728d958358681bc124fdfb76dce23",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "b082a10d484692bd5b7975b304eb997e6a3fca7491b2d175df0fd6399a373cee",
+                    "4c77532d7a30e6abe98ab3f512a45766ab9c329d855f3b1d80d77a72f0414eac5c1382db2dcae7859e7040fde5edd16db9818cacfe9d0a258a33e68b03b5a508"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "234361"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "2c4ca4d5d2f9ed2115d30373735ce625ea59e14b5080f3477cff0ef331baa400"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000643b0534832303037",
+                    {
+                      "__type": "bigint",
+                      "value": "1"
+                    }
+                  ],
+                  [
+                    "ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000de140534832303037",
+                    {
+                      "__type": "bigint",
+                      "value": "1"
+                    }
+                  ]
+                ]
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1q84ru49qm9r9s0za95twe6terjan74ekc7us66u6cdgkfwyj5dysang6xcyp62r6dwdm7pnv3nsdwwn7jzzhr03ur6tqq6k59k",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "fc84c1c15ff266833dc160677a0e467009d20aff9f66fa413452db698844fb82",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000643b0534832303037",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1331790"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q88sjtjez8q0c5ea5y0hg4a7u93rw0q7ud6acluk7hpk6eyxhdfpc48nqynv4l50dwxlk5ph469qg9xs5vnecs6e4njsfq9lr6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "ecd0970cb2d599a8bdb61f6eb597e25eaf34d76bdf8ade17b6a8fa59000de140534832303037",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1172320"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8769efx37h6z50at8etxce7lw2uvgl6egqf4zt6fxtmvkvj5dysang6xcyp62r6dwdm7pnv3nsdwwn7jzzhr03ur6tquwsr9y",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "15750000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qxak84gz9a6qyuaatmsayzh7dk895d446m0cav0ykv9sx9yc37k3hvexf3v9542phkvwet6fqr0vs4j9xznpgk07cqvqe7wqt3",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "8287788"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qyuuuhxxqkzv0l5ejyu3sfwns5zk2whx2vrc8pend7khdlsxqxp26k0s46y8vajrtjmv2pwkslemrp2ej0dcyndxa97q6xm5q3",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "24863365"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8v8k67fhzlk5ugzyhd9hdsfgzxw7nm82s6lq5jf4hvsccuvlygsvaadjq8tg3yell7gaa8kcrd906fy03t7722l6t0qx66z27",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "298360376"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": "164e71e7f78dae403c75c6b88319afdba4aa2359dceddff75a2ce31214a7c97b",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795713,
+                "invalidHereafter": 117054913
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "709df121fc14ccd25da874b2d8631058d580be7bf11a8750e64e935847ea7d95",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799fab446e616d655145766572676c6f77204761727269736f6e45696d6167655f5840697066733a2f2f6261666b72656967716668616f6a656d66726c6a356b666b696d6832637a3371663469346f356b347778366470327762666b736d33326b6475426969ff496d65646961547970654a696d6167652f6a7065674566696c65739fa3446e616d655145766572676c6f77204761727269736f6e437372635f5840697066733a2f2f6261667962656963326f697a6366727a6a356a697870356a367037777a6536746f64666733736b7a6d677537786f7470687a6b363574686c7142676dff496d65646961547970654a696d6167652f6a706567ff455265616c6d4c456c64617220466f7265737445436c617373484761727269736f6e49546f776e2048616c6c474c6576656c2031484261727261636b73474c6576656c20314e466f7274696669636174696f6e73474c6576656c2032444d696e65474c6576656c20344553697465739f5244697374696c6c657279204c6576656c2032544d7973746963204775696c64204c6576656c2031ff01ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fab446e616d655145766572676c6f77204761727269736f6e45696d6167655f5840697066733a2f2f6261666b72656967716668616f6a656d66726c6a356b666b696d6832637a3371663469346f356b347778366470327762666b736d33326b6475426969ff496d65646961547970654a696d6167652f6a7065674566696c65739fa3446e616d655145766572676c6f77204761727269736f6e437372635f5840697066733a2f2f6261667962656963326f697a6366727a6a356a697870356a367037777a6536746f64666733736b7a6d677537786f7470687a6b363574686c7142676dff496d65646961547970654a696d6167652f6a706567ff455265616c6d4c456c64617220466f7265737445436c617373484761727269736f6e49546f776e2048616c6c474c6576656c2031484261727261636b73474c6576656c20314e466f7274696669636174696f6e73474c6576656c2032444d696e65474c6576656c20344553697465739f5244697374696c6c657279204c6576656c2032544d7973746963204775696c64204c6576656c2031ff01ff",
+                    "items": [
+                      {
+                        "cbor": "ab446e616d655145766572676c6f77204761727269736f6e45696d6167655f5840697066733a2f2f6261666b72656967716668616f6a656d66726c6a356b666b696d6832637a3371663469346f356b347778366470327762666b736d33326b6475426969ff496d65646961547970654a696d6167652f6a7065674566696c65739fa3446e616d655145766572676c6f77204761727269736f6e437372635f5840697066733a2f2f6261667962656963326f697a6366727a6a356a697870356a367037777a6536746f64666733736b7a6d677537786f7470687a6b363574686c7142676dff496d65646961547970654a696d6167652f6a706567ff455265616c6d4c456c64617220466f7265737445436c617373484761727269736f6e49546f776e2048616c6c474c6576656c2031484261727261636b73474c6576656c20314e466f7274696669636174696f6e73474c6576656c2032444d696e65474c6576656c20344553697465739f5244697374696c6c657279204c6576656c2032544d7973746963204775696c64204c6576656c2031ff",
+                        "data": {
+                          "__type": "Map",
+                          "value": [
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "6e616d65"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "45766572676c6f77204761727269736f6e"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "696d616765"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "697066733a2f2f6261666b72656967716668616f6a656d66726c6a356b666b696d6832637a3371663469346f356b347778366470327762666b736d33326b64756969"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "6d6564696154797065"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "696d6167652f6a706567"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "66696c6573"
+                              },
+                              {
+                                "cbor": "9fa3446e616d655145766572676c6f77204761727269736f6e437372635f5840697066733a2f2f6261667962656963326f697a6366727a6a356a697870356a367037777a6536746f64666733736b7a6d677537786f7470687a6b363574686c7142676dff496d65646961547970654a696d6167652f6a706567ff",
+                                "items": [
+                                  {
+                                    "cbor": "a3446e616d655145766572676c6f77204761727269736f6e437372635f5840697066733a2f2f6261667962656963326f697a6366727a6a356a697870356a367037777a6536746f64666733736b7a6d677537786f7470687a6b363574686c7142676dff496d65646961547970654a696d6167652f6a706567",
+                                    "data": {
+                                      "__type": "Map",
+                                      "value": [
+                                        [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "6e616d65"
+                                          },
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "45766572676c6f77204761727269736f6e"
+                                          }
+                                        ],
+                                        [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "737263"
+                                          },
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "697066733a2f2f6261667962656963326f697a6366727a6a356a697870356a367037777a6536746f64666733736b7a6d677537786f7470687a6b363574686c71676d"
+                                          }
+                                        ],
+                                        [
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "6d6564696154797065"
+                                          },
+                                          {
+                                            "__type": "Buffer",
+                                            "value": "696d6167652f6a706567"
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "5265616c6d"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "456c64617220466f72657374"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "436c617373"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "4761727269736f6e"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "546f776e2048616c6c"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "4c6576656c2031"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "4261727261636b73"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "4c6576656c2031"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "466f7274696669636174696f6e73"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "4c6576656c2032"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "4d696e65"
+                              },
+                              {
+                                "__type": "Buffer",
+                                "value": "4c6576656c2034"
+                              }
+                            ],
+                            [
+                              {
+                                "__type": "Buffer",
+                                "value": "5369746573"
+                              },
+                              {
+                                "cbor": "9f5244697374696c6c657279204c6576656c2032544d7973746963204775696c64204c6576656c2031ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "44697374696c6c657279204c6576656c2032"
+                                  },
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "4d7973746963204775696c64204c6576656c2031"
+                                  }
+                                ]
+                              }
+                            ]
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": [
+                {
+                  "__type": "native",
+                  "kind": 1,
+                  "scripts": [
+                    {
+                      "__type": "native",
+                      "kind": 4,
+                      "slot": 116548313
+                    },
+                    {
+                      "__type": "native",
+                      "kind": 5,
+                      "slot": 149220909
+                    },
+                    {
+                      "__type": "native",
+                      "keyHash": "48eec758b97885490cb16f5109df4d0b685940f6578ef9d30469e9f6",
+                      "kind": 0
+                    }
+                  ]
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "481de6f96033c580a4aab24b2213fbe126231bff7c67090e5043fd38f4a19a95",
+                    "5ac0c567078f00cd5fec8b413bdbd0f6adc49ba187d3636c81482d88175d987cde5487acdff19f37114f2657a6b4604f9110944b33bdcd1b78f08c8472d4f007"
+                  ],
+                  [
+                    "ce081bc9413e0508497c5b3f946e6febb3a23cac7ecbb91230c3a5c3b7cb3e74",
+                    "636f47e1e20773e06cb5c69d5a8713ac301d1d287f0b724383f48d53eedeedf3ef5671729660e64fe4b645e8cb9fbb60165b3b6476b104cdbf5d85c4285a3f05"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": []
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "d36a2619a672494604e11bb447cbcf5231e9f2ba25c2169177edc941bd50ad6c",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "undefined"
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "7335892302"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 1,
+                  "txId": "5cb012092baa331e074a820c0d4d14560a4d1c1eef6fde1d8b604af9654a08d6"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "629752"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "5cb012092baa331e074a820c0d4d14560a4d1c1eef6fde1d8b604af9654a08d6"
+                },
+                {
+                  "index": 1,
+                  "txId": "5cb012092baa331e074a820c0d4d14560a4d1c1eef6fde1d8b604af9654a08d6"
+                },
+                {
+                  "index": 1,
+                  "txId": "a70752c6cc8597b0fe16dbcad09656091aa7b28a330a1380fa18249cff51ba76"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": 1,
+              "outputs": [
+                {
+                  "address": "addr1w8gevlndywtzz58my5tgs2gqypylawgnxaq05uuw6n99h4c0lgwjl",
+                  "datum": {
+                    "cbor": "9f0000000000ff",
+                    "items": [
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "75020c2213c82a7b8588b27ea667eb178c7ab10e4bf8b0a476dcf449",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1wx8fg8ynnhva0pc4mvwc3jdh7jccmxh39v5gu0u0ssc52fgzxxd9y",
+                  "datum": {
+                    "cbor": "9f1b00000007b4575e2f1a0d43bd571b000005f94185318a1b000000173074835b1b000000015bdb10bd1b00400895094492d79fc24a08a116fac6f752b691abc24c081029bc91c0000000000000ff1b0000018dc247e8881b0000018dc25e1c209f1b000000055483749f1b000000fee040dd97ff1a002dc6c0ff",
+                    "items": [
+                      {
+                        "__type": "bigint",
+                        "value": "33090395695"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "222543191"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "6568104243594"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "99597189979"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "5836050621"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "18023834708120279"
+                      },
+                      {
+                        "cbor": "9fc24a08a116fac6f752b691abc24c081029bc91c0000000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "40750513513402958516651"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "2495419987200672460471009280"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "1708361509000"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "1708362964000"
+                      },
+                      {
+                        "cbor": "9f1b000000055483749f1b000000fee040dd97ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "22892737695"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "1094684040599"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "3000000"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "4d79e8ef7e91551617b2dcc87261b7e119ae95c58f32642ff5101688",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bd5ff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908949"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058680"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1w86zqk0cht7renhvjn446zwx266kshh30xcnk4d6amrktcsrwhssg",
+                  "datum": {
+                    "cbor": "9f9f0000000000ff1a00d43bdcff",
+                    "items": [
+                      {
+                        "cbor": "9f0000000000ff",
+                        "items": [
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          {
+                            "__type": "bigint",
+                            "value": "0"
+                          }
+                        ]
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "13908956"
+                      }
+                    ]
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "25c5de5f5b286073c593edfd77b48abc7a48e5a4f3d4cd9d428ff935444149",
+                          {
+                            "__type": "bigint",
+                            "value": "2082058686"
+                          }
+                        ],
+                        [
+                          "c5649c7f38dbf411ffae320c89ab817f640fc4b98a600f44afa95557",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681253"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681252"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681252"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681252"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8dzn92ccu9gjurcrqrde2farqqm5tem8z2zy7nm9prcdeym4wser9dhew93cmltkxfvcjrmt69ed4ehhtwm3wcfsehszzqvk6",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "407681252"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": [
+                {
+                  "index": 0,
+                  "txId": "42507158d13ab11d477132eebfdc2dbda8a8db95ffef0482cc02df8f2b6bdaee"
+                },
+                {
+                  "index": 0,
+                  "txId": "d30512815500828fae592bca5ea6f3a9510053798a61bb2ab26553e151e57155"
+                },
+                {
+                  "index": 0,
+                  "txId": "f35caecb5c53e4e31710ce9a681bbeea68eb879c7ae384d1dee0a51a7abb6f49"
+                }
+              ],
+              "requiredExtraSignatures": [
+                "da299558c70a8970781806dca93d1801ba2f3b3894227a7b284786e4"
+              ],
+              "scriptIntegrityHash": "8c8c815654ee503a2dc60e9ac027a41577b3fc5becd030df7c02c2b4fed7d7e8",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "3000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795773,
+                "invalidHereafter": 116796673
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "6217bb76102b816845375638423bd369cd1b71c4ed35484d0a9f500637e2d414",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [],
+              "redeemers": [
+                {
+                  "data": {
+                    "__type": "bigint",
+                    "value": "3000000"
+                  },
+                  "executionUnits": {
+                    "memory": 3121190,
+                    "steps": 1361065217
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 23776,
+                    "steps": 8949203
+                  },
+                  "index": 2,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "f44ce6186d190f8776fd871d753df7ae503972e4793a2360a423d2f96021e601",
+                    "2972834891fe149111c0eee7fe6b8ed628d6d170881382a9e4543884f063d3653088296fe6cf0dca2746192c977210e8f59703804fbb55ad0cb016cd9943de06"
+                  ],
+                  [
+                    "63179f731829d60aade12a1398c07b7a905cc38e7d9901850c9b186946f5ca3e",
+                    "20c100ec3cfcd56e5281298a4a7ba008de32e780709a5ebb0607b2dfbf3b87734f646d69aa76f9b611b0c0e014d4d4b6eced7adb5891f0f474dfb3c0e9e05f03"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": [
+                {
+                  "__typename": "StakeRegistrationCertificate",
+                  "stakeCredential": {
+                    "hash": "f58275e60199a9da1c6893cd32d4cddae4864eaddef11a8a398a677f",
+                    "type": 0
+                  }
+                },
+                {
+                  "__typename": "StakeDelegationCertificate",
+                  "poolId": "pool1kv53mzjwqjp4aw48rczj8vm6hejwfnfwa634czyx5tw5qq3tata",
+                  "stakeCredential": {
+                    "hash": "f58275e60199a9da1c6893cd32d4cddae4864eaddef11a8a398a677f",
+                    "type": 0
+                  }
+                }
+              ],
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "174125"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "f4009e40d7c812f9fc750cb7e56e307434c9132f71f5397e5b46d285807cdc64"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qyhu92hzyy8wgmf8j9utmnvf8z0uhad6jcuvhhuz80m8m7h4sf67vqve48dpc6yne5edfnw6ujryatw77ydg5wv2valslhgqyu",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "398015875"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116802922
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "a9fb9050e7a337241fed0fded0022a92a15a69400abdc46d0289ae5bbdbc2e37",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "7be42894790375c534be9f41946ab392071eedff16c7818923f485d4fb499283",
+                    "d1ed5ca82e0a5a32ec6e9ef4238d02348917990bbef8de073b0b72a015e1c3d1ed7f916a03b3ec7d57725ddf903fdcd94b39a6a3de055d52f6c5814892af3200"
+                  ],
+                  [
+                    "8a75717ca1a00207cce71c39042d8e5ad76e6ced240be1e020eaa9b03c220aa7",
+                    "ed6314de07b9bdd63b2fc2fb3fa87164e7f9519dc13c23a34dfb95d565115b58c3607b3ce910906511d54573eee3f1d4cec2958c3489b7c5d068dd3789ae5600"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "172585"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "25b668b8b4a940fada325b632e9e9b43f92eb48eb92adcffd3c0ec64c201c68d"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1vx93yznppjjnqa54rjkkcfhcht2072ctdmjhk7qaan83evqp3j6am",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "78554510"
+                    }
+                  }
+                },
+                {
+                  "address": "DdzFFzCqrhshyEgy3FpFi83YZC3YQbZdAMnfkRTUvG3X8xaCaL8NQcfAfRqmj17egKzRagdQDi1bs5jHAotyTBSH6NBbvGWzgfNwEyXV",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "23899369634"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": {
+                "__type": "undefined"
+              },
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116802985
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "2396ae3990f1ed67e2fe0fa5a0e8718d5a130679145a481a7422e0b084d244a9",
+            "isValid": true,
+            "witness": {
+              "bootstrap": [
+                {
+                  "addressAttributes": "oQFYHlgcmxdxvTBeSnfvoaupmCZsXNFJe//f/swiSe61Sg==",
+                  "chainCode": "4f3782bdcc7c13fcfafb62877ed6c91f797ecbc9011a4d7f3680b2547777f12b",
+                  "key": "ea216cd5596a3ee1da8e3d2135f22da3c150eec378ee6c810ea31ad93831167d",
+                  "signature": "caa9abcf02995af660d346047ba60874bf9c9b4f0ec7acb194179d1a3c0dfb5029a779bc90c671b1cacdb2c873a4352c29e4088eb9ff78223810eb80e6b04200"
+                }
+              ],
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": []
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Dexhunter Trade"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "bfd6dd1e96e4fd26c6379aa3093aaef25639d58ee76d045bd4528ef9f2fed808",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "223461"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "d12c6f6742708e01f83d0b192b3e3b4f9397b1ebe7d33f299210a80038c82f79"
+                },
+                {
+                  "index": 1,
+                  "txId": "42f8bf7313ad78c3edef5146555647deb91a4dbddf02ae9b11153067a414ce01"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1zxn9efv2f6w82hagxqtn62ju4m293tqvw0uhmdl64ch8uw6j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq6s3z70",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "c40b6b698cd243ad1f9ed6aa2d5770fe77bd0ced2caaa1abc2c29220de62d547",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "65bdf33f8f7fd4debeb2ad659473749eb4eac177e06650bb75a8fe504d69746872546f6b656e",
+                          {
+                            "__type": "bigint",
+                            "value": "22844"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx9sltr8w7y3hyjav340zunarmegsvu009ny2k5neccal0p3yzmswj59yx7vn630qh3ce7yjflahhjr3a0a2xkhf30eq3rd5k5",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8l9cgry9gd6vzcd7x3yzewwhq3che0lpa99u7e2u2a0zm3dhcqhrtxk07x5laf48dumqzus5d0h437l787uzu65x40qc4r89z",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "511520873"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "fe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16e",
+                "2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355e"
+              ],
+              "scriptIntegrityHash": "44eb28c4a824d52158107d1ab84757c43705024393e813d92e324c5b6e29e442",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795758,
+                "invalidHereafter": 116796658
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "bf1826dab71bdf132257057b59c6a1c8c4392fb2ff0fccd72f99f7450eb66d86",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799fd8799fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffffd8799fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffffd87a80d8799fd8799f4040ff1a04f7b211ff1a001e84801a001e8480ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffffd8799fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffffd87a80d8799fd8799f4040ff1a04f7b211ff1a001e84801a001e8480ff",
+                    "items": [
+                      {
+                        "cbor": "d8799fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16eff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16eff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "fe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16e"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355eff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355eff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355e"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16effd8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16eff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581cfe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16eff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "fe5c20642a1ba60b0df1a24165ceb8238be5ff0f4a5e7b2ae2baf16e"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355effff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355eff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581c2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355eff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "2dbe0171acd67f8d4ff5353b79b00b90a35f7ac7dff1fdc17354355e"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d87a80",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        "fields": {
+                          "cbor": "80",
+                          "items": []
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f4040ff1a04f7b211ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f4040ff1a04f7b211ff",
+                          "items": [
+                            {
+                              "cbor": "d8799f4040ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f4040ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": ""
+                                  },
+                                  {
+                                    "__type": "Buffer",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "83341841"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "9eabff3359274d0d1f386f02fb0b9f300ec650cb20fe5c500c08aa722f5feee6",
+                    "180b87d95b3783775d2eace93c2a7055aabefdbe9be9573235a9249e073f16e7b37df4ec56c7aba7e994d6c1fc78711288198569bf15874f23eeb1f80c2ef00f"
+                  ],
+                  [
+                    "226c143655fa5d1b62837a0e3f8ff4a8b3ed416a6d38266eb2dd118e52b85bba",
+                    "411949c346b9867fac5923e7b8f9e6043988420138b26fafafc657509f455fe6fe79fa44644ffdfbb702e60fad614bd34b8a1bd90eaa2f67d1085142f8364702"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "__type": "undefined"
+            },
+            "body": {
+              "auxiliaryDataHash": {
+                "__type": "undefined"
+              },
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qy7tqx20vaclfa8lhqwumfg563mlfszdwmygp2ej463duj5rptrl3v8nel4chpzuladq4udk28tnfwcxny07ej6w69ysz7g26y",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "undefined"
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "8528285"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "31ebd038f6990eeaad851952d1b2ac80c750bcb523021cf8c13e53edcab11ebb"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "195722"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "9447d1e632b85bbf549e3c4ade98b366486e987380307b9de07117419db7a7bf"
+                },
+                {
+                  "index": 2,
+                  "txId": "31ebd038f6990eeaad851952d1b2ac80c750bcb523021cf8c13e53edcab11ebb"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1qy7tqx20vaclfa8lhqwumfg563mlfszdwmygp2ej463duj5rptrl3v8nel4chpzuladq4udk28tnfwcxny07ej6w69ysz7g26y",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "0029cb7c88c7567b63d1a512c0ed626aa169688ec980730c0473b9136c702008",
+                          {
+                            "__type": "bigint",
+                            "value": "40901201"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1155080"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qy7tqx20vaclfa8lhqwumfg563mlfszdwmygp2ej463duj5rptrl3v8nel4chpzuladq4udk28tnfwcxny07ej6w69ysz7g26y",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "12471066"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": [
+                {
+                  "index": 0,
+                  "txId": "006ddd85cfc2e2d8b7238daa37b37a5db2ac63de2df35884a5e501667981e1e3"
+                }
+              ],
+              "requiredExtraSignatures": [
+                "3cb0194f6771f4f4ffb81dcda514d477f4c04d76c880ab32aea2de4a",
+                "830ac7f8b0f3cfeb8b845cff5a0af1b651d734bb06991feccb4ed149"
+              ],
+              "scriptIntegrityHash": "53e3d6ef302b3dec2642cfca33d164fb36b2343cc1fc734f57a91715314a889f",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "293583"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "__type": "undefined"
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "bd516c8f14466fc8480d10f1e7153e962f3d179c36c47569b47cb2139c701d72",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": {
+                "__type": "undefined"
+              },
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87a80",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "1"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 98865,
+                    "steps": 36118546
+                  },
+                  "index": 1,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "ba346cad4a79548fc716d8fd2657cda7c94f0493f679920164c8c8a7b36663d6",
+                    "34f06aacde62915c149fd83c67d3cd9d363f265f4738acef2bda35410c62e02d1bb28f00417fb3326efc07bcc501075b82329dceecaf378004a54cd6f2763208"
+                  ],
+                  [
+                    "cb2c80b8d8e8c05c0cfab2c4318ac8cff2610160c10040297dc82b07ad2f73b8",
+                    "9d674f70fa0444b8049da9278f98bf139d65f6af235e5c4fa466596221575862b5d1867e65d05b2203a3a9c111d1c88445cf91ddeb774ace6b23e994f32d7407"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: Withdraw Order"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "7cce1809afd843fd63688ede0a360bd003722f6f5652d327c4baa5edaace3db9",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "__type": "undefined"
+              },
+              "collaterals": {
+                "__type": "undefined"
+              },
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "193925"
+              },
+              "inputs": [
+                {
+                  "index": 1,
+                  "txId": "545d8ee66111c7dea02be520ac33be031095659fba63670e08eb97834e7b3746"
+                },
+                {
+                  "index": 2,
+                  "txId": "6766734e9001c6a8469838348215573b8562ee53806c779a16ec86324a28dd8b"
+                },
+                {
+                  "index": 1,
+                  "txId": "97d09e995aa48feda3fa517453acf68d16f4491522cb40a9536d906edbf4da1c"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1zxn9efv2f6w82hagxqtn62ju4m293tqvw0uhmdl64ch8uw6j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq6s3z70",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "f838cb6a67aac9e15e7809596675d23abed8227994797adaa77d36be21e22f80",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "e4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d86e83cedfd19e096ec4aff8134f14871d82e7ab5e5bb094aa822096fcb0badf6c7",
+                          {
+                            "__type": "bigint",
+                            "value": "236370850"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "3986817"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8xehwn4n5mathu7lkqhtcq4nwd9y0ym68v5ts9pn0wn9c42fl0te5f5j5lc5g58c7ekjuvhglkdpvh6pw28juyyqagsd8frzv",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "117737654"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8xehwn4n5mathu7lkqhtcq4nwd9y0ym68v5ts9pn0wn9c42fl0te5f5j5lc5g58c7ekjuvhglkdpvh6pw28juyyqagsd8frzv",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e",
+                          {
+                            "__type": "bigint",
+                            "value": "1318327101"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "1150770"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": {
+                "__type": "undefined"
+              },
+              "scriptIntegrityHash": "9f05eda945a3889b49b79121b47adae3ab8a40653882464086d1dabfb77c834e",
+              "totalCollateral": {
+                "__type": "undefined"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": {
+                  "__type": "undefined"
+                },
+                "invalidHereafter": 116806569
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "c4585db07254341275751d67c5a16572e5959418b6546ec57c2a419b3d329025",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799fd8799fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffffd8799fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffffd87a80d87c9f1a011d0ba81aec4711b8ff1a001e51011a001e8480ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffffd8799fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffffd87a80d87c9f1a011d0ba81aec4711b8ff1a001e51011a001e8480ff",
+                    "items": [
+                      {
+                        "cbor": "d8799fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "cd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "aa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ffd8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581ccd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "cd9bba759d37d5df9efd8175e0159b9a523c9bd1d945c0a19bdd32e2"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581caa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "aa4fdebcd134953f8a2287c7b369719747ecd0b2fa0b947970840751"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d87a80",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        "fields": {
+                          "cbor": "80",
+                          "items": []
+                        }
+                      },
+                      {
+                        "cbor": "d87c9f1a011d0ba81aec4711b8ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "3"
+                        },
+                        "fields": {
+                          "cbor": "9f1a011d0ba81aec4711b8ff",
+                          "items": [
+                            {
+                              "__type": "bigint",
+                              "value": "18680744"
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "3964080568"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "1986817"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": {
+                "__type": "undefined"
+              },
+              "scripts": {
+                "__type": "undefined"
+              },
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "94837b5be11efb250081a516b5f0cd8e7a3fbef7a8e18528397766869cc83910",
+                    "604b3fea9c93e75b9ba888da3dc641db2398d58ba749bc929936772273ac167366475380492f1ccc5fbc2de05d290b00bfa4242afe85591aeef01f65fcb2050d"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: Order Executed"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "5160f88b929bf8a6c57c285b889488f9137c0ef3cfd0bcf408a10020e69146d5",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "Map",
+                    "value": [
+                      [
+                        "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    ]
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "5224562829"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "0d34dd8d80d99b1acc99779a8be0aa02d9ba1f6943558250ef6341ad35d75207"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "791171"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "0d34dd8d80d99b1acc99779a8be0aa02d9ba1f6943558250ef6341ad35d75207"
+                },
+                {
+                  "index": 0,
+                  "txId": "27d3536351840dda84be0aa2f8f7269dbf81aa7c1e1b080c32251c7d76162b43"
+                },
+                {
+                  "index": 0,
+                  "txId": "c6e3a940d509ac3a48ba8fa021f11902175900dd23ea9fe47241f2e9fac91174"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxzvwhd0c7uupv5nyfc2u8ee50plxurkydxaq3ghdckfpvnyqwd9fm9",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "d62e43e9c5a156dedb55d889a82b76a1bd89a0da81c8e5ae2322062765bae5ba",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb139b9b709ac8605fc82116a2efc308181ba297c11950f0f350001e28f0e50868b",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f4d494e53574150",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f6958741414441",
+                          {
+                            "__type": "bigint",
+                            "value": "488738052107"
+                          }
+                        ],
+                        [
+                          "e4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d8639b9b709ac8605fc82116a2efc308181ba297c11950f0f350001e28f0e50868b",
+                          {
+                            "__type": "bigint",
+                            "value": "18361433"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2657968492335"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q8ehgu4e7kk39vvnrxq7hucc7r7xc8aqusf0fd7krzu3yrlyt93jsm9d9sdfmuzc33kh7zymcepay3hwj9r45wggkwkqlmutrh",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f6958741414441",
+                          {
+                            "__type": "bigint",
+                            "value": "1840172341"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "5230771658"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+              ],
+              "scriptIntegrityHash": "c6b49b3c3827d1707557df7bd97070fc0c6ec4dfe04416789b409b5f7bc448e4",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "5000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795773,
+                "invalidHereafter": 116796773
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "08977be5ccca39e7f1d2ee065b44cb9ed2f84933e86c7076a90b8b6bf735c570",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799fd8799fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffffd8799fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffffd87a80d8799fd8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff1a6b61a927ff1a001e84801a001e8480ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffffd8799fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffffd87a80d8799fd8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff1a6b61a927ff1a001e84801a001e8480ff",
+                    "items": [
+                      {
+                        "cbor": "d8799fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "f37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120f"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "e45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3ac"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fffd8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581cf37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120fff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "f37472b9f5ad12b1931981ebf318f0fc6c1fa0e412f4b7d618b9120f"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581ce45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3acff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "e45963286cad2c1a9df0588c6d7f089bc643d246ee91475a3908b3ac"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d87a80",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        "fields": {
+                          "cbor": "80",
+                          "items": []
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff1a6b61a927ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff1a6b61a927ff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587"
+                                  },
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "41414441"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "1801562407"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799fd8799f4040ffd8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff1b000000ec290002b31b000001095dcc15a1d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799f4040ffd8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff1b000000ec290002b31b000001095dcc15a1d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                    "items": [
+                      {
+                        "cbor": "d8799f4040ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f4040ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f581c8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f695874441414441ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": "8fef2d34078659493ce161a6c7fba4b56afefa8535296a5743f69587"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "41414441"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "1014300148403"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "1139739989409"
+                      },
+                      {
+                        "cbor": "d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                          "items": [
+                            {
+                              "cbor": "d8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "aafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                            "items": [
+                                              {
+                                                "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                "constructor": {
+                                                  "__type": "bigint",
+                                                  "value": "0"
+                                                },
+                                                "fields": {
+                                                  "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                  "items": [
+                                                    {
+                                                      "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                      "constructor": {
+                                                        "__type": "bigint",
+                                                        "value": "0"
+                                                      },
+                                                      "fields": {
+                                                        "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                        "items": [
+                                                          {
+                                                            "__type": "Buffer",
+                                                            "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d87a80",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "1"
+                                    },
+                                    "fields": {
+                                      "cbor": "80",
+                                      "items": []
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 42061,
+                    "steps": 14890343
+                  },
+                  "index": 2,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d8799fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff00ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff00ff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 2626685,
+                    "steps": 785820917
+                  },
+                  "index": 1,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "59014c01000032323232323232322223232325333009300e30070021323233533300b3370e9000180480109118011bae30100031225001232533300d3300e22533301300114a02a66601e66ebcc04800400c5288980118070009bac3010300c300c300c300c300c300c300c007149858dd48008b18060009baa300c300b3754601860166ea80184ccccc0288894ccc04000440084c8c94ccc038cd4ccc038c04cc030008488c008dd718098018912800919b8f0014891ce1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec133090014a0266008444a00226600a446004602600a601a00626600a008601a006601e0026ea8c03cc038dd5180798071baa300f300b300e3754601e00244a0026eb0c03000c92616300a001375400660106ea8c024c020dd5000aab9d5744ae688c8c0088cc0080080048c0088cc00800800555cf2ba15573e6e1d200201",
+                  "version": 0
+                },
+                {
+                  "__type": "plutus",
+                  "bytes": "591e1801000032323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232222323232533533355333573460cc0042646424446600200a0086eb4d5d09aba25002375a6ae85400454ccd5cd1832801099091118010021bad357426aae7800c54ccd5cd1832001099190911198018028021bad357426ae894008c0ccd5d0a80082e1119191a827911111a80391191111aa99a9824806108008b1119191a9a9a80103102d91191919191919191aa99a982a89119982d91299a99820a8071a80103409980200100088008008020b03c9111919191919191919191919191982a299a8050a99aa8100999ab9a3094013303a307908101330820106700b06706e0060063305433355307908101305c05a305953353502b2233500206e2071210011635014222222207a33054353501422208e0122350012322533355333500a2153335004215333500c2130054984c011261533350052130054984c0112603c04f15333500b2130044984c00d261533350042130044984c00d2603b153335003205003a04f153335003215333500b2130044984c00d261533350042130044984c00d2603b04e15333500a2130034984c009261533350032130034984c0092603a153350010700820108201070253335002215333500a21533350042133303a03b00200116161604e15333500921533350032133303903a00200116161604d04e33054330500153306f00b02733054330533306301602548008cc150cc14ccc18c02c0952002330543305333063001010002330543333084012222533500315335002135001222223305d3305c0053306c01402b3305d3305c0043306c01402a3305d3305c00300c3305d3305c0023306c0140193305c001304800d0910122153350041622153350071622153350081622133300c003001323232323232323533307d0050070272222225335330743305100248000cc1440052000161333335003235500b2222223501d222223501b22235051222223232323232323232323253353308b013308b013306e00848000cc1b802920003308b013306d00201e3308b0153353306e00a00315335330870100e07013308b013308a013309a010110703370066e0402800c060cc22804cc2680404411c0084cc22c04cc22804cc268040441c0060cc22c04cc22804cc2680404411c008cc22804cdc08050019984d008088070a99a998370041a802055008a99a99843808078380998458099845009984d0080883819b80337020106a008154020306611402661340202208e00426611602661140266134020220e003066116026611402661340202208e004661140266e04020d40102a804cc2680404403c4cc22c04cc22804cc2680404411c008cc22804cc268040441c0060cc22c04cc20c04048070cc2080404006c4c8c8c8ccccc2c80400c008cdc019b800180050013370002e002a66a0082605466e0800c00840594cd400c4cccc0a005406406005c520003370002e00866e0005cd40102a80458c27c04028d40082a404d40042a404d54cd54ccd5cd19b8900148000278044c94ccd5cd19b890014800027c044c94ccd5cd19b8900148000280044c28404ccc2ec0400c0080054ccd5cd19b8900400610041006350020ad0121001160b901350010b0015333573466e2400400c54ccd5cd19b880010031330a8010023370666e080080400444cc2a0040080104cc2a004cdc199b820040110100043370666e080040380414cd4cc1fc01c1a04cdc0998490081100399b80011010133092010220073370666e080040300354cd4cc1f40101984cdc0998480081000219b8000f00e133090010200042235500c2222223501e222223501c222350522222232323232323232323253353308b013306e00748000cc22c04cc1b4008074cc22c04cc22c04cc22804cc2680404011c008cc22804cc268040401c005ccc22c04cc20c0404406ccc2080403c0684c8c8c8c8ccccc2cc0400c008cdc019b800180060013370002e002a66a00a2605666e0800c00840594cd40104cccc0a405406406005c52000350020b301350010b60153353330690870100e01e1330ae013370002c00e02a26615c0202c66e0005401c58c27c04024cdc199b820010123370200400266604400600266e0ccdc0981219b803370400400466e08cdc119b82337049004241941e90680780200198600080199b824801120ca0f350050a70130be01001350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4009200033086013306800101833086015335330820101906b13308501330950100b0193370000202426610c026610a026612a020160320026610a026612a020160d60246610c02660fc01802c660fa01402a2a66a6660c8104020120322666661540266e00044008cdc08080008078070068999998550099b810110013370002000401e01c01a2c66603e6a00614c026a00614a02002a66a66100020020d2266e04cc24c0408c004cdc0008808099849808118009a800851009aa99a99983003f00280a899985a00802806806099985a008020060069111a8019119985c80802802001911aa8061111111a80f111111a80e1111a82911111191919191919299a998440099835802240006611002660d80020086611002a66a66108020360da266110026610e026612e0201a03666e00068050cc21c04cc25c04034014cdc08020008a99a99842008028368998440099843809984b8080680d80d19843809984b8080680299b8033702008002028266110026610e026612e0201a03603466110026610e026612e0201a00a66e04010004cc21c04cc25c040341b4050cc22004cc20004038060cc1fc03005c54cd4ccc1982100402c06c4ccccc2b004cdc000980099b8101201a01101000f1333330ac013370202603466e0004800404404003c594cd54ccd5cd19b880190011309f013370066e0ccdc119b82002019483403ccdc119b81001019483283d200209e012100116350040a601350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4011200033086013308601330680030193306800201833086015335330820100906b133086013308501330950100b009337000060246610a026612a020160100042a66a66104020100d626610c026610a026612a0201601066e00008048cc21404cc2540402c02400c4cc21804cc21404cc2540402c02400ccc21804cc21404cc2540402c020008cc21404cc2540402c1ac048cc21804cc1f8030058cc1f40280544c8c8c8ccccc2b40400800ccdc019b8101200700133700022002a66a0082604a66e0800800c40414cd400c4cccc08c03c04c048044520003370202400866e0404000858c26804010cdc199b8200200e00d3370666e08004038030cc244040840f8888c8cdc199b820010033370066e0801120d00f0013370400290650791112999ab9a3371200890000a4000264a666ae68cdc48008028a4000264a666ae68cdc4800a400029000080099b833370400466e04004014cdc019b8200148028014c014cdc10018011192999ab9a33710004900004d808a999ab9a30a10100214800054ccd5cd1851008010a40042a666ae68c28c04008520021330010023370066e0c009200448008c254048894ccd5cd19b880010021330030013370666e00cdc1802000800a4008200426660f2002006046464a666ae68c27c04d55ce80089919191919191919191919191919091999998008050048040028018011bad357426ae88008dd69aba100135744010a666ae68c2b4040084c8c8488888cc01001c018dd69aba135744a0046660f8eb9d71aba15001153335734615802004264642444446600200e00c6eb4d5d09aba25002375a6ae85400454ccd5cd18558080109909111118028031bad357426aae7801854ccd5cd18550080109919091111198010038031bad357426ae894008ccc1f1d73ae35742a0022a666ae68c2a4040084c8c8488888cc00c01c018dd69aba135744a0046660f8eb9d71aba150010a101135573c00a6aae74010cc1e1d71aba100530743574200a60e66ae84014dd51aba1001357440026ae88004d5d10009aab9e0010970137540026a002104026a00810c0260c82446660d444a66a660b066606c0d46a004104026a03c1040266606c0a06a6a0040fc0ee05e266008004002200200202a60c82446660d444a66a660b066606c0a06a0040ee6a0200ee66606c0a06a0040ee05e2660080040022002002026666660f0660c602c044660c602c04203e660c602c02003c660a8660a0044607a008660a8660a0042607c008660a8024660a8a66a60c82446660d444a66a660a66aa03a104026a6a0040ee1040226600800400220020020260d6442a66a0020fe440dea66a6660640a600490000998299981d183c840809984100833800a40042660a66607460f21020266104020ce0029000183800999b8100101d303d001333066059008010305333307f22322325333573466e1c010dc680488010a999ab9a308f0100415333573466e1d205a500313370290001980299b800044800800800400454ccd5cd19b885002481805854ccd5cd19b8950023370090302402426600866e0000d20023370066e08005201433702a00490300b099b8e0060014800120001533500400115335501a13335734611a026606860e60f6660f80c200a0c20d00022a66a0062a66aa0320022666ae68c23804cc0ccc1c81e8cc1ec18001018019c0044ccd5cd18460099819183883c9983d02f80182f833299a9983d91299a8008321109a80111299a9982b00101089834800898030019a9a99a983b03c00501083883610a99a8008b1109a80111299a8018a99a99827800a400420042c112022c666ae68cdc49982c800803240000c80ba6a0020d4a66a60b02446660bc44a66a66088a0226a0040d6266008004002200200200e2c0f8660ce02c6a00a0d460c2006a66a60a42446660b044a66a660826aa0160e06a6a6a0040d80ca0e026600800400220020020060b2442a66a0020da440ba60ba0026a0280d4660b40020246a6a0080c80be26a6a0020c20b4a66a609601c420022c2a66a660600040320ba266060002032603200e6068010464646a09c4444464646464646464660706606a00c0066607066068660a600c018660a6006018660706606e6608e6a6a66a60c60ca00401e0bc0b2660b601201090011981c1981f998188070009981c1981b9811800a40006607066068604201c60420026607066068604401c60440026606e604801c6048002660706606a60aa00a09666070a66a609024466609c44a66a60a26a6a0040c40b8266008004002200200200809e442a66a0020c6440a6a66a609024466609c44a66a60a26a0040b8266008004002200200260b000e09e442a66a0020c6440a666609a08000600860a40066a0020aca66a608824466609444a66a660666a6a6a00e0bc0ae0c46a6a0040ae0c4266008004002200200260a80062c0d06a0100ba6a6a0020b00a6a66a608400c420022c603000c606600e4464646a09e44444a66a6a00e440a8426464646464646464646464646607e660700286660aa09000800c6607e66076014660b40060246607e6607e6607c6609c6a0040c00120106607e6606e6a0040bc6a01a0d26606c6a0040be6a01a0ca6607e6607866aa60ce0d846a00244660ca00466aa60d40de46a00244660d0004666a0026e012000700466e0000520000013304000b3500922330723306400233072330640010090540540033303f3303e3304e3535335306a06c0010160650603306200f00e48008cc0fccc0f0c1700181494cd4c13c488ccc154894cd4c160d4d40081a418c4cc010008004400400400c1588854cd40041a888168c168014cd4c1a01a800c04cd40041754cd4c12c488ccc144894cd4cc0dcd4d4030194178d40081784cc010008004400400400c581bcc160004d403418cccd4080178d4d4080188178004cc11800c004cc164020d4004170cc140004020d4d40041681554cd4c11001c8400458124c06401cc0d0020448004584d55cf0011aab9d0013754004444a66a6600600400207809c46a0020b0246666666600204044a666ae68cdc38010008020a999ab9a3371200400203203044666ae68cdc400100081b01e802802001912999ab9a337120040022002200444a666ae68cdc4801000880108008881f11199ab9a3371000400207406644666ae68cdc480100081c81911199ab9a337120040020620706607c91100488100223333550023303f2233350050480010023500304222337000029001000a4000660784446006600400240026607666076e01200070246a0024444400a46a0020a246a0024407246a0024406c464a666ae68c140d55ce8008991919191981e2999ab9a305435573a00626464646464646464646464646464646464646464646424666666666600201a01801601401201000e00a00600460446ae84d5d10011980f1981dbae2001357420026ae88008cc071d71aba100135744016a666ae68c190d55ce804899191919827a999ab9a306735573a004264660a066038eb4d5d0800980d9aba1357440026aae7800817d4ccd5cd18339aab9d001132330503301c75a6ae84004c06cd5d09aba200135573c0020be6ea8d5d09aba200237546ae84004d55cf00482e1980c9981b019bad35742014660300326ae84028ccc059d70029aba100a33301575c0086ae84028cc054008d5d08051980a1192999ab9a306035573a0022646609260326ae84004c010d5d09aba200135573c0020b06ea8004d5d08051192999ab9a305f35573a002264646660b060606ae84008ccc059d70029aba10013303375c6ae84d5d10009aba200135573c0020ae6ea8004cc045d73ad37546ae84004d5d10009aba2001357440026ae88004d5d10009aba200135573c006098a666ae68c15c0044c848888c010014c02cd5d09aab9e00215333573460ac00226424444600400a60486ae84d55cf0010a999ab9a3055001132122223001005300c357426aae7800854ccd5cd182a0008990911118018029bae357426aae78008130d55ce8009baa357426ae88008dd51aba100135573c0020906ea80048c94ccd5cd182800081e8a999ab9a304f00102b04735573a6ea800488c8c94ccd5cd18290008058a999ab9a3051001130193004357426aae7800854ccd5cd18280008050241aab9d00137540024464460046eac004c10888cccd55cf8009014119198239981c98031aab9d001300535573c00260086ae8800cd5d0801020919118011bac00130402233335573e002404c46608860086ae84008c00cd5d100101f91919192999ab9a305300211222203515333573460a4004220922a666ae68c1440084c8c848888888cc004024020dd69aba135744a0046eb8d5d0a8008a999ab9a3050002132321222222233002009008375c6ae84d5d128011bae35742a0022a666ae68c13c0084c8c848888888cc018024020dd71aba135744a004603a6ae85400454ccd5cd1827001099091111111803804180e9aba135573c0062a666ae68c1340084c848888888c014020c074d5d09aab9e003045135573c0046aae74004dd50009192999ab9a304a35573a0022646606660086ae84004dd69aba1357440026aae78004108dd50009192999ab9a304935573a00226eb8d5d09aab9e0010413754002220582205444a66a00442a66a00442660240040020462a66a0024046068446a004446a006446666010008006004002446a004444446a00c44444a66a6601e01400a2a66a6601e0120082a666ae68cdc38040018a999ab9a3370e00e0042a66a00c42a66a004426a004446a004446a00a446a00444a66a666602e00c00a0040022a66a00e42a66a008426604800400206a2a66a006406a08c0680562a66a002405607805405405405444446466a00a466a0084a666ae68cdc78010008018121013919a802101392999ab9a3371e0040020060482a66a00642a66a0044266a004466a00446601200400244405444466a0084054444a666ae68cdc38030018a999ab9a3370e00a0042660220080020520520442a66a00240440664466a004466a00446601c0040024046466a004404646601c004002446a004446a00644a666ae68cdc780200109980780180081091199aa9815019180680191a80091199aa981681a980800311a80091199a800919805a40000020144660160029000000998030010009981280100a91199ab9a3370e00400202c03a44a66a00420020324466aa605205c46a002446604e004666a002466aa605a06446a0024466056004601800200244666010016004002466aa605a06446a0024466056004601600200266600600c004002444666aa605005c06466aa605205c46a002446604e0046010002666aa605005c446a00444a66a666aa6054064601a01646a002446601400400a00c200626606c00800602800266aa605205c46a002446604e0046606844a66a002260120064426a00444a66a6601800401022444660040140082600c00600800442444600200842444600600844666ae68cdc780100080800b9980e80080a11299a801012080091980e11199a8018128010009a80080f9192999ab9a303435573a00226464646466666042666016eb9d71aba100433300b75ceb8d5d08019bad357420046eb4d5d0800998051192999ab9a303a35573a0022646604660146ae84004cc035d71aba1357440026aae780040c8dd50009aba1357440026ae88004d5d10009aba200135573c0020586ea80048c94ccd5cd18199aab9d0011323301c3005357420026600c0086ae84d5d10009aab9e00102b375400246464a666ae68c0d00044c8c8c8c8c8488ccc00401801000cdd69aba1357440046eb4d5d08009aba2002375a6ae84004d55cf0010a999ab9a3033001130103004357426aae780080acd55ce8009baa0012323253335734606600226424460020066eb8d5d09aab9e00215333573460640022601e6eb8d5d09aab9e00202a35573a0026ea800488c8c94ccd5cd18190008980798021aba135573c0042a666ae68c0cc0040380a8d55ce8009baa001222325333573460626aae740044c8cc068c014d5d080098021aba1357440026aae780040a4dd5000911a8009119198131119a800a4000446a00444a666ae68cdc7801004898038008980300180298129119a800a4000446a00444a666ae68cdc7801003880089803001919a80081100211a800911a80111111111111999a805900b900b900b9199aa981101500b11a80091299a998090010020980c00180b805912999ab9a3371e6a0040346a0020342666ae68cdc39a80100b1a80080b001805003880b91180f11299a80088019109980300118020009299a800900b0019111a801111299a800909a8029111111111299aa99a999aa981001400a11a800912999ab9a3371e00401c2602c00602a0044260286a0020440244260240022c2c2006424460040066601444a66a0044200620020022018446602e44a66a00203c4426a00444a666ae68cdc78010038a99a8008111109a80111299a8018a999ab9a302d00113301400b0020262202813006003002235001222222222200a2350012201c23500122222222220092220032220012220023333300248811c0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb10048811ce4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d8600330014891c13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f004881074d494e535741500048811c2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e179816004881054f574e455200221233001003002222221233333001006005004003002300b22112225335001135003006221333500500c300400233355300700f0050040012200130092211222533500110022213300500233355300700d005004001300822112253350010052213300f30040023355300600b00400111001220023005221225333573466e20005200013005490103505436001533500213005491035054370022153335734602c0062004266a600c01000266e0400d2002253357380022c240026004444a66a00220044426a004446600e66601000400c00200660024444a66a00220044426a00444a666ae68c0500044ccc02001c01800c4ccc02001ccc028ccc02c01c00800401800c8c8c00400488cc00cc00800800488488cc00401000c88848ccc00401000c00854cd5ce2490350543100162215335001100200715335738921001622222222007220053704904d0f910b111110021b8748000dc3a40046e1d2004370e90031b8748020dc3a40146e1d200c01",
+                  "version": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0303157375f23161027902abff500a6268c00a69f45f7bfe5adbc2f70f15df94",
+                    "82b7a3219723d38cef1c6b4f29654ad451931d6c9440c947fcb482762688eee1fb6ea7f011862063345374a2ff568dcc48eecb35a4581b664a05af92d6dbe907"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: Order Executed"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "5160f88b929bf8a6c57c285b889488f9137c0ef3cfd0bcf408a10020e69146d5",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "Map",
+                    "value": [
+                      [
+                        "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    ]
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "2690283978"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "65f6878ce5aa6fc856f06827028b3cf3d5b101401b8c0930f1ffd4a96e159879"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "778115"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "65f6878ce5aa6fc856f06827028b3cf3d5b101401b8c0930f1ffd4a96e159879"
+                },
+                {
+                  "index": 2,
+                  "txId": "65f6878ce5aa6fc856f06827028b3cf3d5b101401b8c0930f1ffd4a96e159879"
+                },
+                {
+                  "index": 0,
+                  "txId": "ddaef72811c778511124f315335060d3378700443b5e7bdc93a4d8da5d308aab"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxzguhn087t5snzl62lpnlueatqku8jwkcjkv32m9spva7hmsa7qwnd",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "34f61af343b33eb19e0e00d6e5af46f8ab2e62bfbdc49e55442156a277e0dcc9",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab9447261676f6e",
+                          {
+                            "__type": "bigint",
+                            "value": "1575941796"
+                          }
+                        ],
+                        [
+                          "0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb1cc56afef0d6035e5e0b770bdc5f56ae65dc78855addc8e8c9afdad7d11df42f5",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f4d494e53574150",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "31932653"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9z043j0hakw8yw3smxxerpv8ex4mjce9w9yw7r57f4pdxwqwrhwdc29vme4lexqd2aykef2pz3hjwlxzzw85pz4zg7qz5p4vd",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "undefined"
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "56067347"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2696505863"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+              ],
+              "scriptIntegrityHash": "69d4c59c94af11fcd07e26f3d84432f5595f781e916a361e9bbf39d71fda94ea",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "5000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795773,
+                "invalidHereafter": 116796773
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "a916ce465380a1889b3e4dac709f9da37c3feb569936c675aeb3130f2790bc39",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799fd8799fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffffd8799fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffffd87a80d8799fd8799f4040ff0aff1a001e84801a001e8480ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffffd8799fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffffd87a80d8799fd8799f4040ff0aff1a001e84801a001e8480ff",
+                    "items": [
+                      {
+                        "cbor": "d8799fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "c070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123c"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ffd8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "44fac64fbf6ce391d186cc6c8c2c3e4d5dcb192b8a477874f26a1699"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581cc070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123cff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "c070eee6e14566f35fe4c06aba4b652a08a3793be6109c7a0455123c"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d87a80",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        "fields": {
+                          "cbor": "80",
+                          "items": []
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f4040ff0aff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f4040ff0aff",
+                          "items": [
+                            {
+                              "cbor": "d8799f4040ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f4040ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": ""
+                                  },
+                                  {
+                                    "__type": "Buffer",
+                                    "value": ""
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "10"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799fd8799f4040ffd8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff1a0d53f80e00d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799f4040ffd8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff1a0d53f80e00d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                    "items": [
+                      {
+                        "cbor": "d8799f4040ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f4040ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": "05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab9"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "447261676f6e"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "223606798"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      },
+                      {
+                        "cbor": "d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                          "items": [
+                            {
+                              "cbor": "d8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "aafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                            "items": [
+                                              {
+                                                "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                "constructor": {
+                                                  "__type": "bigint",
+                                                  "value": "0"
+                                                },
+                                                "fields": {
+                                                  "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                  "items": [
+                                                    {
+                                                      "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                      "constructor": {
+                                                        "__type": "bigint",
+                                                        "value": "0"
+                                                      },
+                                                      "fields": {
+                                                        "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                        "items": [
+                                                          {
+                                                            "__type": "Buffer",
+                                                            "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d87a80",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "1"
+                                    },
+                                    "fields": {
+                                      "cbor": "80",
+                                      "items": []
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 42061,
+                    "steps": 14890343
+                  },
+                  "index": 2,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d8799fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff01ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff01ff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 2554817,
+                    "steps": 765991051
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "59014c01000032323232323232322223232325333009300e30070021323233533300b3370e9000180480109118011bae30100031225001232533300d3300e22533301300114a02a66601e66ebcc04800400c5288980118070009bac3010300c300c300c300c300c300c300c007149858dd48008b18060009baa300c300b3754601860166ea80184ccccc0288894ccc04000440084c8c94ccc038cd4ccc038c04cc030008488c008dd718098018912800919b8f0014891ce1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec133090014a0266008444a00226600a446004602600a601a00626600a008601a006601e0026ea8c03cc038dd5180798071baa300f300b300e3754601e00244a0026eb0c03000c92616300a001375400660106ea8c024c020dd5000aab9d5744ae688c8c0088cc0080080048c0088cc00800800555cf2ba15573e6e1d200201",
+                  "version": 0
+                },
+                {
+                  "__type": "plutus",
+                  "bytes": "591e1801000032323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232222323232533533355333573460cc0042646424446600200a0086eb4d5d09aba25002375a6ae85400454ccd5cd1832801099091118010021bad357426aae7800c54ccd5cd1832001099190911198018028021bad357426ae894008c0ccd5d0a80082e1119191a827911111a80391191111aa99a9824806108008b1119191a9a9a80103102d91191919191919191aa99a982a89119982d91299a99820a8071a80103409980200100088008008020b03c9111919191919191919191919191982a299a8050a99aa8100999ab9a3094013303a307908101330820106700b06706e0060063305433355307908101305c05a305953353502b2233500206e2071210011635014222222207a33054353501422208e0122350012322533355333500a2153335004215333500c2130054984c011261533350052130054984c0112603c04f15333500b2130044984c00d261533350042130044984c00d2603b153335003205003a04f153335003215333500b2130044984c00d261533350042130044984c00d2603b04e15333500a2130034984c009261533350032130034984c0092603a153350010700820108201070253335002215333500a21533350042133303a03b00200116161604e15333500921533350032133303903a00200116161604d04e33054330500153306f00b02733054330533306301602548008cc150cc14ccc18c02c0952002330543305333063001010002330543333084012222533500315335002135001222223305d3305c0053306c01402b3305d3305c0043306c01402a3305d3305c00300c3305d3305c0023306c0140193305c001304800d0910122153350041622153350071622153350081622133300c003001323232323232323533307d0050070272222225335330743305100248000cc1440052000161333335003235500b2222223501d222223501b22235051222223232323232323232323253353308b013308b013306e00848000cc1b802920003308b013306d00201e3308b0153353306e00a00315335330870100e07013308b013308a013309a010110703370066e0402800c060cc22804cc2680404411c0084cc22c04cc22804cc268040441c0060cc22c04cc22804cc2680404411c008cc22804cdc08050019984d008088070a99a998370041a802055008a99a99843808078380998458099845009984d0080883819b80337020106a008154020306611402661340202208e00426611602661140266134020220e003066116026611402661340202208e004661140266e04020d40102a804cc2680404403c4cc22c04cc22804cc2680404411c008cc22804cc268040441c0060cc22c04cc20c04048070cc2080404006c4c8c8c8ccccc2c80400c008cdc019b800180050013370002e002a66a0082605466e0800c00840594cd400c4cccc0a005406406005c520003370002e00866e0005cd40102a80458c27c04028d40082a404d40042a404d54cd54ccd5cd19b8900148000278044c94ccd5cd19b890014800027c044c94ccd5cd19b8900148000280044c28404ccc2ec0400c0080054ccd5cd19b8900400610041006350020ad0121001160b901350010b0015333573466e2400400c54ccd5cd19b880010031330a8010023370666e080080400444cc2a0040080104cc2a004cdc199b820040110100043370666e080040380414cd4cc1fc01c1a04cdc0998490081100399b80011010133092010220073370666e080040300354cd4cc1f40101984cdc0998480081000219b8000f00e133090010200042235500c2222223501e222223501c222350522222232323232323232323253353308b013306e00748000cc22c04cc1b4008074cc22c04cc22c04cc22804cc2680404011c008cc22804cc268040401c005ccc22c04cc20c0404406ccc2080403c0684c8c8c8c8ccccc2cc0400c008cdc019b800180060013370002e002a66a00a2605666e0800c00840594cd40104cccc0a405406406005c52000350020b301350010b60153353330690870100e01e1330ae013370002c00e02a26615c0202c66e0005401c58c27c04024cdc199b820010123370200400266604400600266e0ccdc0981219b803370400400466e08cdc119b82337049004241941e90680780200198600080199b824801120ca0f350050a70130be01001350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4009200033086013306800101833086015335330820101906b13308501330950100b0193370000202426610c026610a026612a020160320026610a026612a020160d60246610c02660fc01802c660fa01402a2a66a6660c8104020120322666661540266e00044008cdc08080008078070068999998550099b810110013370002000401e01c01a2c66603e6a00614c026a00614a02002a66a66100020020d2266e04cc24c0408c004cdc0008808099849808118009a800851009aa99a99983003f00280a899985a00802806806099985a008020060069111a8019119985c80802802001911aa8061111111a80f111111a80e1111a82911111191919191919299a998440099835802240006611002660d80020086611002a66a66108020360da266110026610e026612e0201a03666e00068050cc21c04cc25c04034014cdc08020008a99a99842008028368998440099843809984b8080680d80d19843809984b8080680299b8033702008002028266110026610e026612e0201a03603466110026610e026612e0201a00a66e04010004cc21c04cc25c040341b4050cc22004cc20004038060cc1fc03005c54cd4ccc1982100402c06c4ccccc2b004cdc000980099b8101201a01101000f1333330ac013370202603466e0004800404404003c594cd54ccd5cd19b880190011309f013370066e0ccdc119b82002019483403ccdc119b81001019483283d200209e012100116350040a601350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4011200033086013308601330680030193306800201833086015335330820100906b133086013308501330950100b009337000060246610a026612a020160100042a66a66104020100d626610c026610a026612a0201601066e00008048cc21404cc2540402c02400c4cc21804cc21404cc2540402c02400ccc21804cc21404cc2540402c020008cc21404cc2540402c1ac048cc21804cc1f8030058cc1f40280544c8c8c8ccccc2b40400800ccdc019b8101200700133700022002a66a0082604a66e0800800c40414cd400c4cccc08c03c04c048044520003370202400866e0404000858c26804010cdc199b8200200e00d3370666e08004038030cc244040840f8888c8cdc199b820010033370066e0801120d00f0013370400290650791112999ab9a3371200890000a4000264a666ae68cdc48008028a4000264a666ae68cdc4800a400029000080099b833370400466e04004014cdc019b8200148028014c014cdc10018011192999ab9a33710004900004d808a999ab9a30a10100214800054ccd5cd1851008010a40042a666ae68c28c04008520021330010023370066e0c009200448008c254048894ccd5cd19b880010021330030013370666e00cdc1802000800a4008200426660f2002006046464a666ae68c27c04d55ce80089919191919191919191919191919091999998008050048040028018011bad357426ae88008dd69aba100135744010a666ae68c2b4040084c8c8488888cc01001c018dd69aba135744a0046660f8eb9d71aba15001153335734615802004264642444446600200e00c6eb4d5d09aba25002375a6ae85400454ccd5cd18558080109909111118028031bad357426aae7801854ccd5cd18550080109919091111198010038031bad357426ae894008ccc1f1d73ae35742a0022a666ae68c2a4040084c8c8488888cc00c01c018dd69aba135744a0046660f8eb9d71aba150010a101135573c00a6aae74010cc1e1d71aba100530743574200a60e66ae84014dd51aba1001357440026ae88004d5d10009aab9e0010970137540026a002104026a00810c0260c82446660d444a66a660b066606c0d46a004104026a03c1040266606c0a06a6a0040fc0ee05e266008004002200200202a60c82446660d444a66a660b066606c0a06a0040ee6a0200ee66606c0a06a0040ee05e2660080040022002002026666660f0660c602c044660c602c04203e660c602c02003c660a8660a0044607a008660a8660a0042607c008660a8024660a8a66a60c82446660d444a66a660a66aa03a104026a6a0040ee1040226600800400220020020260d6442a66a0020fe440dea66a6660640a600490000998299981d183c840809984100833800a40042660a66607460f21020266104020ce0029000183800999b8100101d303d001333066059008010305333307f22322325333573466e1c010dc680488010a999ab9a308f0100415333573466e1d205a500313370290001980299b800044800800800400454ccd5cd19b885002481805854ccd5cd19b8950023370090302402426600866e0000d20023370066e08005201433702a00490300b099b8e0060014800120001533500400115335501a13335734611a026606860e60f6660f80c200a0c20d00022a66a0062a66aa0320022666ae68c23804cc0ccc1c81e8cc1ec18001018019c0044ccd5cd18460099819183883c9983d02f80182f833299a9983d91299a8008321109a80111299a9982b00101089834800898030019a9a99a983b03c00501083883610a99a8008b1109a80111299a8018a99a99827800a400420042c112022c666ae68cdc49982c800803240000c80ba6a0020d4a66a60b02446660bc44a66a66088a0226a0040d6266008004002200200200e2c0f8660ce02c6a00a0d460c2006a66a60a42446660b044a66a660826aa0160e06a6a6a0040d80ca0e026600800400220020020060b2442a66a0020da440ba60ba0026a0280d4660b40020246a6a0080c80be26a6a0020c20b4a66a609601c420022c2a66a660600040320ba266060002032603200e6068010464646a09c4444464646464646464660706606a00c0066607066068660a600c018660a6006018660706606e6608e6a6a66a60c60ca00401e0bc0b2660b601201090011981c1981f998188070009981c1981b9811800a40006607066068604201c60420026607066068604401c60440026606e604801c6048002660706606a60aa00a09666070a66a609024466609c44a66a60a26a6a0040c40b8266008004002200200200809e442a66a0020c6440a6a66a609024466609c44a66a60a26a0040b8266008004002200200260b000e09e442a66a0020c6440a666609a08000600860a40066a0020aca66a608824466609444a66a660666a6a6a00e0bc0ae0c46a6a0040ae0c4266008004002200200260a80062c0d06a0100ba6a6a0020b00a6a66a608400c420022c603000c606600e4464646a09e44444a66a6a00e440a8426464646464646464646464646607e660700286660aa09000800c6607e66076014660b40060246607e6607e6607c6609c6a0040c00120106607e6606e6a0040bc6a01a0d26606c6a0040be6a01a0ca6607e6607866aa60ce0d846a00244660ca00466aa60d40de46a00244660d0004666a0026e012000700466e0000520000013304000b3500922330723306400233072330640010090540540033303f3303e3304e3535335306a06c0010160650603306200f00e48008cc0fccc0f0c1700181494cd4c13c488ccc154894cd4c160d4d40081a418c4cc010008004400400400c1588854cd40041a888168c168014cd4c1a01a800c04cd40041754cd4c12c488ccc144894cd4cc0dcd4d4030194178d40081784cc010008004400400400c581bcc160004d403418cccd4080178d4d4080188178004cc11800c004cc164020d4004170cc140004020d4d40041681554cd4c11001c8400458124c06401cc0d0020448004584d55cf0011aab9d0013754004444a66a6600600400207809c46a0020b0246666666600204044a666ae68cdc38010008020a999ab9a3371200400203203044666ae68cdc400100081b01e802802001912999ab9a337120040022002200444a666ae68cdc4801000880108008881f11199ab9a3371000400207406644666ae68cdc480100081c81911199ab9a337120040020620706607c91100488100223333550023303f2233350050480010023500304222337000029001000a4000660784446006600400240026607666076e01200070246a0024444400a46a0020a246a0024407246a0024406c464a666ae68c140d55ce8008991919191981e2999ab9a305435573a00626464646464646464646464646464646464646464646424666666666600201a01801601401201000e00a00600460446ae84d5d10011980f1981dbae2001357420026ae88008cc071d71aba100135744016a666ae68c190d55ce804899191919827a999ab9a306735573a004264660a066038eb4d5d0800980d9aba1357440026aae7800817d4ccd5cd18339aab9d001132330503301c75a6ae84004c06cd5d09aba200135573c0020be6ea8d5d09aba200237546ae84004d55cf00482e1980c9981b019bad35742014660300326ae84028ccc059d70029aba100a33301575c0086ae84028cc054008d5d08051980a1192999ab9a306035573a0022646609260326ae84004c010d5d09aba200135573c0020b06ea8004d5d08051192999ab9a305f35573a002264646660b060606ae84008ccc059d70029aba10013303375c6ae84d5d10009aba200135573c0020ae6ea8004cc045d73ad37546ae84004d5d10009aba2001357440026ae88004d5d10009aba200135573c006098a666ae68c15c0044c848888c010014c02cd5d09aab9e00215333573460ac00226424444600400a60486ae84d55cf0010a999ab9a3055001132122223001005300c357426aae7800854ccd5cd182a0008990911118018029bae357426aae78008130d55ce8009baa357426ae88008dd51aba100135573c0020906ea80048c94ccd5cd182800081e8a999ab9a304f00102b04735573a6ea800488c8c94ccd5cd18290008058a999ab9a3051001130193004357426aae7800854ccd5cd18280008050241aab9d00137540024464460046eac004c10888cccd55cf8009014119198239981c98031aab9d001300535573c00260086ae8800cd5d0801020919118011bac00130402233335573e002404c46608860086ae84008c00cd5d100101f91919192999ab9a305300211222203515333573460a4004220922a666ae68c1440084c8c848888888cc004024020dd69aba135744a0046eb8d5d0a8008a999ab9a3050002132321222222233002009008375c6ae84d5d128011bae35742a0022a666ae68c13c0084c8c848888888cc018024020dd71aba135744a004603a6ae85400454ccd5cd1827001099091111111803804180e9aba135573c0062a666ae68c1340084c848888888c014020c074d5d09aab9e003045135573c0046aae74004dd50009192999ab9a304a35573a0022646606660086ae84004dd69aba1357440026aae78004108dd50009192999ab9a304935573a00226eb8d5d09aab9e0010413754002220582205444a66a00442a66a00442660240040020462a66a0024046068446a004446a006446666010008006004002446a004444446a00c44444a66a6601e01400a2a66a6601e0120082a666ae68cdc38040018a999ab9a3370e00e0042a66a00c42a66a004426a004446a004446a00a446a00444a66a666602e00c00a0040022a66a00e42a66a008426604800400206a2a66a006406a08c0680562a66a002405607805405405405444446466a00a466a0084a666ae68cdc78010008018121013919a802101392999ab9a3371e0040020060482a66a00642a66a0044266a004466a00446601200400244405444466a0084054444a666ae68cdc38030018a999ab9a3370e00a0042660220080020520520442a66a00240440664466a004466a00446601c0040024046466a004404646601c004002446a004446a00644a666ae68cdc780200109980780180081091199aa9815019180680191a80091199aa981681a980800311a80091199a800919805a40000020144660160029000000998030010009981280100a91199ab9a3370e00400202c03a44a66a00420020324466aa605205c46a002446604e004666a002466aa605a06446a0024466056004601800200244666010016004002466aa605a06446a0024466056004601600200266600600c004002444666aa605005c06466aa605205c46a002446604e0046010002666aa605005c446a00444a66a666aa6054064601a01646a002446601400400a00c200626606c00800602800266aa605205c46a002446604e0046606844a66a002260120064426a00444a66a6601800401022444660040140082600c00600800442444600200842444600600844666ae68cdc780100080800b9980e80080a11299a801012080091980e11199a8018128010009a80080f9192999ab9a303435573a00226464646466666042666016eb9d71aba100433300b75ceb8d5d08019bad357420046eb4d5d0800998051192999ab9a303a35573a0022646604660146ae84004cc035d71aba1357440026aae780040c8dd50009aba1357440026ae88004d5d10009aba200135573c0020586ea80048c94ccd5cd18199aab9d0011323301c3005357420026600c0086ae84d5d10009aab9e00102b375400246464a666ae68c0d00044c8c8c8c8c8488ccc00401801000cdd69aba1357440046eb4d5d08009aba2002375a6ae84004d55cf0010a999ab9a3033001130103004357426aae780080acd55ce8009baa0012323253335734606600226424460020066eb8d5d09aab9e00215333573460640022601e6eb8d5d09aab9e00202a35573a0026ea800488c8c94ccd5cd18190008980798021aba135573c0042a666ae68c0cc0040380a8d55ce8009baa001222325333573460626aae740044c8cc068c014d5d080098021aba1357440026aae780040a4dd5000911a8009119198131119a800a4000446a00444a666ae68cdc7801004898038008980300180298129119a800a4000446a00444a666ae68cdc7801003880089803001919a80081100211a800911a80111111111111999a805900b900b900b9199aa981101500b11a80091299a998090010020980c00180b805912999ab9a3371e6a0040346a0020342666ae68cdc39a80100b1a80080b001805003880b91180f11299a80088019109980300118020009299a800900b0019111a801111299a800909a8029111111111299aa99a999aa981001400a11a800912999ab9a3371e00401c2602c00602a0044260286a0020440244260240022c2c2006424460040066601444a66a0044200620020022018446602e44a66a00203c4426a00444a666ae68cdc78010038a99a8008111109a80111299a8018a999ab9a302d00113301400b0020262202813006003002235001222222222200a2350012201c23500122222222220092220032220012220023333300248811c0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb10048811ce4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d8600330014891c13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f004881074d494e535741500048811c2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e179816004881054f574e455200221233001003002222221233333001006005004003002300b22112225335001135003006221333500500c300400233355300700f0050040012200130092211222533500110022213300500233355300700d005004001300822112253350010052213300f30040023355300600b00400111001220023005221225333573466e20005200013005490103505436001533500213005491035054370022153335734602c0062004266a600c01000266e0400d2002253357380022c240026004444a66a00220044426a004446600e66601000400c00200660024444a66a00220044426a00444a666ae68c0500044ccc02001c01800c4ccc02001ccc028ccc02c01c00800401800c8c8c00400488cc00cc00800800488488cc00401000c88848ccc00401000c00854cd5ce2490350543100162215335001100200715335738921001622222222007220053704904d0f910b111110021b8748000dc3a40046e1d2004370e90031b8748020dc3a40146e1d200c01",
+                  "version": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0303157375f23161027902abff500a6268c00a69f45f7bfe5adbc2f70f15df94",
+                    "22bfd62ec6afc74fa19caf03f89648f079e48ff0cd1efb237778bb807a42ffd2832d03c4922d56e60e8f201b131a802375b2f27d044e8e9df7dcedc88c7cba0c"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: Order Executed"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "5160f88b929bf8a6c57c285b889488f9137c0ef3cfd0bcf408a10020e69146d5",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "Map",
+                    "value": [
+                      [
+                        "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    ]
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "4253100278"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "67848a4200b10354813a8d8a8a9b0c18e4c82162296700adbbaa9c424469ccc4"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "790336"
+              },
+              "inputs": [
+                {
+                  "index": 2,
+                  "txId": "67848a4200b10354813a8d8a8a9b0c18e4c82162296700adbbaa9c424469ccc4"
+                },
+                {
+                  "index": 0,
+                  "txId": "7efe9d3dac4e1f0854350ae034cd6da393cc1a11598f4f54456655b59ea4163e"
+                },
+                {
+                  "index": 0,
+                  "txId": "b5d62a7c3f5879c196dda2851bcdfcf3943dab631466b3dfcc6e33abe0acf017"
+                }
+              ],
+              "mint": {
+                "__type": "undefined"
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxz2j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq0xmsha",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "6d3778f425b967ee2e80ff1a6a8066d8acaf0ea903de12814469b9146fdf8da2",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb1266bcaff5b083b87b9ce9ef18fc2a904f18f1d4a5329033d0bb4a4466725ded3",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f4d494e53574150",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb78524a56",
+                          {
+                            "__type": "bigint",
+                            "value": "3502779878660"
+                          }
+                        ],
+                        [
+                          "e4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d86266bcaff5b083b87b9ce9ef18fc2a904f18f1d4a5329033d0bb4a4466725ded3",
+                          {
+                            "__type": "bigint",
+                            "value": "21017205"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "195783926807"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q9fy0hfmmukjlqu29uxfrvu0zf6jxaedysunnylpp7aaydv6gkspmpwysxp8xf0v5pfhj4alqjqwcdlf4knnrvryqrgqngmddj",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb78524a56",
+                          {
+                            "__type": "bigint",
+                            "value": "16509636862"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2000000"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "4258809942"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+              ],
+              "scriptIntegrityHash": "dda30b0a033f49ac878d7ac8e64364f32fe8974646ee15d03ecea2eab338972f",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "5000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795773,
+                "invalidHereafter": 116796773
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "2f67f5c859fa01235d8ee93a33c23c84dd2c80907c6049ef50ffe389cc7fcd4e",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80d8799fd8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff1b00000003d672c5baff1a0016e3601a001e8480ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffffd87a80d8799fd8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff1b00000003d672c5baff1a0016e3601a001e8480ff",
+                    "items": [
+                      {
+                        "cbor": "d8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ffd8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "5247dd3bdf2d2f838a2f0c91b38f127523772d24393993e10fbbd235"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581c9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "9a45a01d85c481827325eca0537957bf0480ec37e9ada731b06400d0"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d87a80",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        "fields": {
+                          "cbor": "80",
+                          "items": []
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff1b00000003d672c5baff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff1b00000003d672c5baff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb78"
+                                  },
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "524a56"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "16482747834"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "1500000"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799fd8799f4040ffd8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff1b000000af20809a441b000000c0cb44bd44d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799f4040ffd8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff1b000000af20809a441b000000c0cb44bd44d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                    "items": [
+                      {
+                        "cbor": "d8799f4040ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f4040ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f581c8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb7843524a56ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": "8cfd6893f5f6c1cc954cec1a0a1460841b74da6e7803820dde62bb78"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "524a56"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "752164575812"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "828044000580"
+                      },
+                      {
+                        "cbor": "d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                          "items": [
+                            {
+                              "cbor": "d8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "aafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                            "items": [
+                                              {
+                                                "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                "constructor": {
+                                                  "__type": "bigint",
+                                                  "value": "0"
+                                                },
+                                                "fields": {
+                                                  "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                  "items": [
+                                                    {
+                                                      "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                      "constructor": {
+                                                        "__type": "bigint",
+                                                        "value": "0"
+                                                      },
+                                                      "fields": {
+                                                        "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                        "items": [
+                                                          {
+                                                            "__type": "Buffer",
+                                                            "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d87a80",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "1"
+                                    },
+                                    "fields": {
+                                      "cbor": "80",
+                                      "items": []
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 42061,
+                    "steps": 14890343
+                  },
+                  "index": 2,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d8799fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff00ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff00ff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "0"
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 2616827,
+                    "steps": 782122426
+                  },
+                  "index": 1,
+                  "purpose": "spend"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "59014c01000032323232323232322223232325333009300e30070021323233533300b3370e9000180480109118011bae30100031225001232533300d3300e22533301300114a02a66601e66ebcc04800400c5288980118070009bac3010300c300c300c300c300c300c300c007149858dd48008b18060009baa300c300b3754601860166ea80184ccccc0288894ccc04000440084c8c94ccc038cd4ccc038c04cc030008488c008dd718098018912800919b8f0014891ce1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec133090014a0266008444a00226600a446004602600a601a00626600a008601a006601e0026ea8c03cc038dd5180798071baa300f300b300e3754601e00244a0026eb0c03000c92616300a001375400660106ea8c024c020dd5000aab9d5744ae688c8c0088cc0080080048c0088cc00800800555cf2ba15573e6e1d200201",
+                  "version": 0
+                },
+                {
+                  "__type": "plutus",
+                  "bytes": "591e1801000032323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232222323232533533355333573460cc0042646424446600200a0086eb4d5d09aba25002375a6ae85400454ccd5cd1832801099091118010021bad357426aae7800c54ccd5cd1832001099190911198018028021bad357426ae894008c0ccd5d0a80082e1119191a827911111a80391191111aa99a9824806108008b1119191a9a9a80103102d91191919191919191aa99a982a89119982d91299a99820a8071a80103409980200100088008008020b03c9111919191919191919191919191982a299a8050a99aa8100999ab9a3094013303a307908101330820106700b06706e0060063305433355307908101305c05a305953353502b2233500206e2071210011635014222222207a33054353501422208e0122350012322533355333500a2153335004215333500c2130054984c011261533350052130054984c0112603c04f15333500b2130044984c00d261533350042130044984c00d2603b153335003205003a04f153335003215333500b2130044984c00d261533350042130044984c00d2603b04e15333500a2130034984c009261533350032130034984c0092603a153350010700820108201070253335002215333500a21533350042133303a03b00200116161604e15333500921533350032133303903a00200116161604d04e33054330500153306f00b02733054330533306301602548008cc150cc14ccc18c02c0952002330543305333063001010002330543333084012222533500315335002135001222223305d3305c0053306c01402b3305d3305c0043306c01402a3305d3305c00300c3305d3305c0023306c0140193305c001304800d0910122153350041622153350071622153350081622133300c003001323232323232323533307d0050070272222225335330743305100248000cc1440052000161333335003235500b2222223501d222223501b22235051222223232323232323232323253353308b013308b013306e00848000cc1b802920003308b013306d00201e3308b0153353306e00a00315335330870100e07013308b013308a013309a010110703370066e0402800c060cc22804cc2680404411c0084cc22c04cc22804cc268040441c0060cc22c04cc22804cc2680404411c008cc22804cdc08050019984d008088070a99a998370041a802055008a99a99843808078380998458099845009984d0080883819b80337020106a008154020306611402661340202208e00426611602661140266134020220e003066116026611402661340202208e004661140266e04020d40102a804cc2680404403c4cc22c04cc22804cc2680404411c008cc22804cc268040441c0060cc22c04cc20c04048070cc2080404006c4c8c8c8ccccc2c80400c008cdc019b800180050013370002e002a66a0082605466e0800c00840594cd400c4cccc0a005406406005c520003370002e00866e0005cd40102a80458c27c04028d40082a404d40042a404d54cd54ccd5cd19b8900148000278044c94ccd5cd19b890014800027c044c94ccd5cd19b8900148000280044c28404ccc2ec0400c0080054ccd5cd19b8900400610041006350020ad0121001160b901350010b0015333573466e2400400c54ccd5cd19b880010031330a8010023370666e080080400444cc2a0040080104cc2a004cdc199b820040110100043370666e080040380414cd4cc1fc01c1a04cdc0998490081100399b80011010133092010220073370666e080040300354cd4cc1f40101984cdc0998480081000219b8000f00e133090010200042235500c2222223501e222223501c222350522222232323232323232323253353308b013306e00748000cc22c04cc1b4008074cc22c04cc22c04cc22804cc2680404011c008cc22804cc268040401c005ccc22c04cc20c0404406ccc2080403c0684c8c8c8c8ccccc2cc0400c008cdc019b800180060013370002e002a66a00a2605666e0800c00840594cd40104cccc0a405406406005c52000350020b301350010b60153353330690870100e01e1330ae013370002c00e02a26615c0202c66e0005401c58c27c04024cdc199b820010123370200400266604400600266e0ccdc0981219b803370400400466e08cdc119b82337049004241941e90680780200198600080199b824801120ca0f350050a70130be01001350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4009200033086013306800101833086015335330820101906b13308501330950100b0193370000202426610c026610a026612a020160320026610a026612a020160d60246610c02660fc01802c660fa01402a2a66a6660c8104020120322666661540266e00044008cdc08080008078070068999998550099b810110013370002000401e01c01a2c66603e6a00614c026a00614a02002a66a66100020020d2266e04cc24c0408c004cdc0008808099849808118009a800851009aa99a99983003f00280a899985a00802806806099985a008020060069111a8019119985c80802802001911aa8061111111a80f111111a80e1111a82911111191919191919299a998440099835802240006611002660d80020086611002a66a66108020360da266110026610e026612e0201a03666e00068050cc21c04cc25c04034014cdc08020008a99a99842008028368998440099843809984b8080680d80d19843809984b8080680299b8033702008002028266110026610e026612e0201a03603466110026610e026612e0201a00a66e04010004cc21c04cc25c040341b4050cc22004cc20004038060cc1fc03005c54cd4ccc1982100402c06c4ccccc2b004cdc000980099b8101201a01101000f1333330ac013370202603466e0004800404404003c594cd54ccd5cd19b880190011309f013370066e0ccdc119b82002019483403ccdc119b81001019483283d200209e012100116350040a601350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4011200033086013308601330680030193306800201833086015335330820100906b133086013308501330950100b009337000060246610a026612a020160100042a66a66104020100d626610c026610a026612a0201601066e00008048cc21404cc2540402c02400c4cc21804cc21404cc2540402c02400ccc21804cc21404cc2540402c020008cc21404cc2540402c1ac048cc21804cc1f8030058cc1f40280544c8c8c8ccccc2b40400800ccdc019b8101200700133700022002a66a0082604a66e0800800c40414cd400c4cccc08c03c04c048044520003370202400866e0404000858c26804010cdc199b8200200e00d3370666e08004038030cc244040840f8888c8cdc199b820010033370066e0801120d00f0013370400290650791112999ab9a3371200890000a4000264a666ae68cdc48008028a4000264a666ae68cdc4800a400029000080099b833370400466e04004014cdc019b8200148028014c014cdc10018011192999ab9a33710004900004d808a999ab9a30a10100214800054ccd5cd1851008010a40042a666ae68c28c04008520021330010023370066e0c009200448008c254048894ccd5cd19b880010021330030013370666e00cdc1802000800a4008200426660f2002006046464a666ae68c27c04d55ce80089919191919191919191919191919091999998008050048040028018011bad357426ae88008dd69aba100135744010a666ae68c2b4040084c8c8488888cc01001c018dd69aba135744a0046660f8eb9d71aba15001153335734615802004264642444446600200e00c6eb4d5d09aba25002375a6ae85400454ccd5cd18558080109909111118028031bad357426aae7801854ccd5cd18550080109919091111198010038031bad357426ae894008ccc1f1d73ae35742a0022a666ae68c2a4040084c8c8488888cc00c01c018dd69aba135744a0046660f8eb9d71aba150010a101135573c00a6aae74010cc1e1d71aba100530743574200a60e66ae84014dd51aba1001357440026ae88004d5d10009aab9e0010970137540026a002104026a00810c0260c82446660d444a66a660b066606c0d46a004104026a03c1040266606c0a06a6a0040fc0ee05e266008004002200200202a60c82446660d444a66a660b066606c0a06a0040ee6a0200ee66606c0a06a0040ee05e2660080040022002002026666660f0660c602c044660c602c04203e660c602c02003c660a8660a0044607a008660a8660a0042607c008660a8024660a8a66a60c82446660d444a66a660a66aa03a104026a6a0040ee1040226600800400220020020260d6442a66a0020fe440dea66a6660640a600490000998299981d183c840809984100833800a40042660a66607460f21020266104020ce0029000183800999b8100101d303d001333066059008010305333307f22322325333573466e1c010dc680488010a999ab9a308f0100415333573466e1d205a500313370290001980299b800044800800800400454ccd5cd19b885002481805854ccd5cd19b8950023370090302402426600866e0000d20023370066e08005201433702a00490300b099b8e0060014800120001533500400115335501a13335734611a026606860e60f6660f80c200a0c20d00022a66a0062a66aa0320022666ae68c23804cc0ccc1c81e8cc1ec18001018019c0044ccd5cd18460099819183883c9983d02f80182f833299a9983d91299a8008321109a80111299a9982b00101089834800898030019a9a99a983b03c00501083883610a99a8008b1109a80111299a8018a99a99827800a400420042c112022c666ae68cdc49982c800803240000c80ba6a0020d4a66a60b02446660bc44a66a66088a0226a0040d6266008004002200200200e2c0f8660ce02c6a00a0d460c2006a66a60a42446660b044a66a660826aa0160e06a6a6a0040d80ca0e026600800400220020020060b2442a66a0020da440ba60ba0026a0280d4660b40020246a6a0080c80be26a6a0020c20b4a66a609601c420022c2a66a660600040320ba266060002032603200e6068010464646a09c4444464646464646464660706606a00c0066607066068660a600c018660a6006018660706606e6608e6a6a66a60c60ca00401e0bc0b2660b601201090011981c1981f998188070009981c1981b9811800a40006607066068604201c60420026607066068604401c60440026606e604801c6048002660706606a60aa00a09666070a66a609024466609c44a66a60a26a6a0040c40b8266008004002200200200809e442a66a0020c6440a6a66a609024466609c44a66a60a26a0040b8266008004002200200260b000e09e442a66a0020c6440a666609a08000600860a40066a0020aca66a608824466609444a66a660666a6a6a00e0bc0ae0c46a6a0040ae0c4266008004002200200260a80062c0d06a0100ba6a6a0020b00a6a66a608400c420022c603000c606600e4464646a09e44444a66a6a00e440a8426464646464646464646464646607e660700286660aa09000800c6607e66076014660b40060246607e6607e6607c6609c6a0040c00120106607e6606e6a0040bc6a01a0d26606c6a0040be6a01a0ca6607e6607866aa60ce0d846a00244660ca00466aa60d40de46a00244660d0004666a0026e012000700466e0000520000013304000b3500922330723306400233072330640010090540540033303f3303e3304e3535335306a06c0010160650603306200f00e48008cc0fccc0f0c1700181494cd4c13c488ccc154894cd4c160d4d40081a418c4cc010008004400400400c1588854cd40041a888168c168014cd4c1a01a800c04cd40041754cd4c12c488ccc144894cd4cc0dcd4d4030194178d40081784cc010008004400400400c581bcc160004d403418cccd4080178d4d4080188178004cc11800c004cc164020d4004170cc140004020d4d40041681554cd4c11001c8400458124c06401cc0d0020448004584d55cf0011aab9d0013754004444a66a6600600400207809c46a0020b0246666666600204044a666ae68cdc38010008020a999ab9a3371200400203203044666ae68cdc400100081b01e802802001912999ab9a337120040022002200444a666ae68cdc4801000880108008881f11199ab9a3371000400207406644666ae68cdc480100081c81911199ab9a337120040020620706607c91100488100223333550023303f2233350050480010023500304222337000029001000a4000660784446006600400240026607666076e01200070246a0024444400a46a0020a246a0024407246a0024406c464a666ae68c140d55ce8008991919191981e2999ab9a305435573a00626464646464646464646464646464646464646464646424666666666600201a01801601401201000e00a00600460446ae84d5d10011980f1981dbae2001357420026ae88008cc071d71aba100135744016a666ae68c190d55ce804899191919827a999ab9a306735573a004264660a066038eb4d5d0800980d9aba1357440026aae7800817d4ccd5cd18339aab9d001132330503301c75a6ae84004c06cd5d09aba200135573c0020be6ea8d5d09aba200237546ae84004d55cf00482e1980c9981b019bad35742014660300326ae84028ccc059d70029aba100a33301575c0086ae84028cc054008d5d08051980a1192999ab9a306035573a0022646609260326ae84004c010d5d09aba200135573c0020b06ea8004d5d08051192999ab9a305f35573a002264646660b060606ae84008ccc059d70029aba10013303375c6ae84d5d10009aba200135573c0020ae6ea8004cc045d73ad37546ae84004d5d10009aba2001357440026ae88004d5d10009aba200135573c006098a666ae68c15c0044c848888c010014c02cd5d09aab9e00215333573460ac00226424444600400a60486ae84d55cf0010a999ab9a3055001132122223001005300c357426aae7800854ccd5cd182a0008990911118018029bae357426aae78008130d55ce8009baa357426ae88008dd51aba100135573c0020906ea80048c94ccd5cd182800081e8a999ab9a304f00102b04735573a6ea800488c8c94ccd5cd18290008058a999ab9a3051001130193004357426aae7800854ccd5cd18280008050241aab9d00137540024464460046eac004c10888cccd55cf8009014119198239981c98031aab9d001300535573c00260086ae8800cd5d0801020919118011bac00130402233335573e002404c46608860086ae84008c00cd5d100101f91919192999ab9a305300211222203515333573460a4004220922a666ae68c1440084c8c848888888cc004024020dd69aba135744a0046eb8d5d0a8008a999ab9a3050002132321222222233002009008375c6ae84d5d128011bae35742a0022a666ae68c13c0084c8c848888888cc018024020dd71aba135744a004603a6ae85400454ccd5cd1827001099091111111803804180e9aba135573c0062a666ae68c1340084c848888888c014020c074d5d09aab9e003045135573c0046aae74004dd50009192999ab9a304a35573a0022646606660086ae84004dd69aba1357440026aae78004108dd50009192999ab9a304935573a00226eb8d5d09aab9e0010413754002220582205444a66a00442a66a00442660240040020462a66a0024046068446a004446a006446666010008006004002446a004444446a00c44444a66a6601e01400a2a66a6601e0120082a666ae68cdc38040018a999ab9a3370e00e0042a66a00c42a66a004426a004446a004446a00a446a00444a66a666602e00c00a0040022a66a00e42a66a008426604800400206a2a66a006406a08c0680562a66a002405607805405405405444446466a00a466a0084a666ae68cdc78010008018121013919a802101392999ab9a3371e0040020060482a66a00642a66a0044266a004466a00446601200400244405444466a0084054444a666ae68cdc38030018a999ab9a3370e00a0042660220080020520520442a66a00240440664466a004466a00446601c0040024046466a004404646601c004002446a004446a00644a666ae68cdc780200109980780180081091199aa9815019180680191a80091199aa981681a980800311a80091199a800919805a40000020144660160029000000998030010009981280100a91199ab9a3370e00400202c03a44a66a00420020324466aa605205c46a002446604e004666a002466aa605a06446a0024466056004601800200244666010016004002466aa605a06446a0024466056004601600200266600600c004002444666aa605005c06466aa605205c46a002446604e0046010002666aa605005c446a00444a66a666aa6054064601a01646a002446601400400a00c200626606c00800602800266aa605205c46a002446604e0046606844a66a002260120064426a00444a66a6601800401022444660040140082600c00600800442444600200842444600600844666ae68cdc780100080800b9980e80080a11299a801012080091980e11199a8018128010009a80080f9192999ab9a303435573a00226464646466666042666016eb9d71aba100433300b75ceb8d5d08019bad357420046eb4d5d0800998051192999ab9a303a35573a0022646604660146ae84004cc035d71aba1357440026aae780040c8dd50009aba1357440026ae88004d5d10009aba200135573c0020586ea80048c94ccd5cd18199aab9d0011323301c3005357420026600c0086ae84d5d10009aab9e00102b375400246464a666ae68c0d00044c8c8c8c8c8488ccc00401801000cdd69aba1357440046eb4d5d08009aba2002375a6ae84004d55cf0010a999ab9a3033001130103004357426aae780080acd55ce8009baa0012323253335734606600226424460020066eb8d5d09aab9e00215333573460640022601e6eb8d5d09aab9e00202a35573a0026ea800488c8c94ccd5cd18190008980798021aba135573c0042a666ae68c0cc0040380a8d55ce8009baa001222325333573460626aae740044c8cc068c014d5d080098021aba1357440026aae780040a4dd5000911a8009119198131119a800a4000446a00444a666ae68cdc7801004898038008980300180298129119a800a4000446a00444a666ae68cdc7801003880089803001919a80081100211a800911a80111111111111999a805900b900b900b9199aa981101500b11a80091299a998090010020980c00180b805912999ab9a3371e6a0040346a0020342666ae68cdc39a80100b1a80080b001805003880b91180f11299a80088019109980300118020009299a800900b0019111a801111299a800909a8029111111111299aa99a999aa981001400a11a800912999ab9a3371e00401c2602c00602a0044260286a0020440244260240022c2c2006424460040066601444a66a0044200620020022018446602e44a66a00203c4426a00444a666ae68cdc78010038a99a8008111109a80111299a8018a999ab9a302d00113301400b0020262202813006003002235001222222222200a2350012201c23500122222222220092220032220012220023333300248811c0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb10048811ce4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d8600330014891c13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f004881074d494e535741500048811c2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e179816004881054f574e455200221233001003002222221233333001006005004003002300b22112225335001135003006221333500500c300400233355300700f0050040012200130092211222533500110022213300500233355300700d005004001300822112253350010052213300f30040023355300600b00400111001220023005221225333573466e20005200013005490103505436001533500213005491035054370022153335734602c0062004266a600c01000266e0400d2002253357380022c240026004444a66a00220044426a004446600e66601000400c00200660024444a66a00220044426a00444a666ae68c0500044ccc02001c01800c4ccc02001ccc028ccc02c01c00800401800c8c8c00400488cc00cc00800800488488cc00401000c88848ccc00401000c00854cd5ce2490350543100162215335001100200715335738921001622222222007220053704904d0f910b111110021b8748000dc3a40046e1d2004370e90031b8748020dc3a40146e1d200c01",
+                  "version": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0303157375f23161027902abff500a6268c00a69f45f7bfe5adbc2f70f15df94",
+                    "876fd2ab171c56ae95ad626df3ce3e72882c49400b3570f76d0cb20eed5a838f11994a4e317c6d2d39468b781c6af2189e259acbe7897758df22103778504903"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          },
+          {
+            "auxiliaryData": {
+              "blob": {
+                "__type": "Map",
+                "value": [
+                  [
+                    {
+                      "__type": "bigint",
+                      "value": "674"
+                    },
+                    {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "msg",
+                          [
+                            "Minswap: Order Executed"
+                          ]
+                        ]
+                      ]
+                    }
+                  ]
+                ]
+              },
+              "scripts": {
+                "__type": "undefined"
+              }
+            },
+            "body": {
+              "auxiliaryDataHash": "5160f88b929bf8a6c57c285b889488f9137c0ef3cfd0bcf408a10020e69146d5",
+              "certificates": {
+                "__type": "undefined"
+              },
+              "collateralReturn": {
+                "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                "datum": {
+                  "__type": "undefined"
+                },
+                "datumHash": {
+                  "__type": "undefined"
+                },
+                "scriptReference": {
+                  "__type": "undefined"
+                },
+                "value": {
+                  "assets": {
+                    "__type": "Map",
+                    "value": [
+                      [
+                        "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    ]
+                  },
+                  "coins": {
+                    "__type": "bigint",
+                    "value": "2691505863"
+                  }
+                }
+              },
+              "collaterals": [
+                {
+                  "index": 2,
+                  "txId": "a916ce465380a1889b3e4dac709f9da37c3feb569936c675aeb3130f2790bc39"
+                }
+              ],
+              "donation": {
+                "__type": "undefined"
+              },
+              "fee": {
+                "__type": "bigint",
+                "value": "865295"
+              },
+              "inputs": [
+                {
+                  "index": 0,
+                  "txId": "a916ce465380a1889b3e4dac709f9da37c3feb569936c675aeb3130f2790bc39"
+                },
+                {
+                  "index": 2,
+                  "txId": "a916ce465380a1889b3e4dac709f9da37c3feb569936c675aeb3130f2790bc39"
+                },
+                {
+                  "index": 0,
+                  "txId": "ad3e9923f46afc9763df147585e425fd61bf19123e584b790ff85b08cabb5bc9"
+                }
+              ],
+              "mint": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "e4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d86cc56afef0d6035e5e0b770bdc5f56ae65dc78855addc8e8c9afdad7d11df42f5",
+                    {
+                      "__type": "bigint",
+                      "value": "-203482177"
+                    }
+                  ]
+                ]
+              },
+              "networkId": {
+                "__type": "undefined"
+              },
+              "outputs": [
+                {
+                  "address": "addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxzguhn087t5snzl62lpnlueatqku8jwkcjkv32m9spva7hmsa7qwnd",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": "596463e74f517ba056097c750bfb9cb055aed89910a4fd172eac2956718729a3",
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab9447261676f6e",
+                          {
+                            "__type": "bigint",
+                            "value": "141834827"
+                          }
+                        ],
+                        [
+                          "0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb1cc56afef0d6035e5e0b770bdc5f56ae65dc78855addc8e8c9afdad7d11df42f5",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ],
+                        [
+                          "13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f4d494e53574150",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2873941"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1q978l2xqej3xgwgxtjsy6500zl0wvj8pf96jv72mu9yy2gtm3upq4udhtgp9z3sseapcjvdpltxfmgpqza7xlg2tajfsyz0xuw",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab9447261676f6e",
+                          {
+                            "__type": "bigint",
+                            "value": "1434106969"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "31058712"
+                    }
+                  }
+                },
+                {
+                  "address": "addr1qx7tzh4qen0p50ntefz8yujwgqt7zulef6t6vrf7dq4xa82j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pqrkj6fh",
+                  "datum": {
+                    "__type": "undefined"
+                  },
+                  "datumHash": {
+                    "__type": "undefined"
+                  },
+                  "scriptReference": {
+                    "__type": "undefined"
+                  },
+                  "value": {
+                    "assets": {
+                      "__type": "Map",
+                      "value": [
+                        [
+                          "2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e17981631373038363231323030303030",
+                          {
+                            "__type": "bigint",
+                            "value": "1"
+                          }
+                        ]
+                      ]
+                    },
+                    "coins": {
+                      "__type": "bigint",
+                      "value": "2697640568"
+                    }
+                  }
+                }
+              ],
+              "proposalProcedures": {
+                "__type": "undefined"
+              },
+              "referenceInputs": {
+                "__type": "undefined"
+              },
+              "requiredExtraSignatures": [
+                "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+              ],
+              "scriptIntegrityHash": "1c023d20b9c601f829a4ef4fa32989545691959bb3e97d4655b1cd18d9c521a8",
+              "totalCollateral": {
+                "__type": "bigint",
+                "value": "5000000"
+              },
+              "treasuryValue": {
+                "__type": "undefined"
+              },
+              "update": {
+                "__type": "undefined"
+              },
+              "validityInterval": {
+                "invalidBefore": 116795773,
+                "invalidHereafter": 116796773
+              },
+              "votingProcedures": {
+                "__type": "undefined"
+              },
+              "withdrawals": {
+                "__type": "undefined"
+              }
+            },
+            "id": "d982302529b64ebc96cbd19d0dd3e7e264dba023345d0f9fcc9798b7b2703f9e",
+            "isValid": true,
+            "witness": {
+              "bootstrap": {
+                "__type": "undefined"
+              },
+              "datums": [
+                {
+                  "cbor": "d8799fd8799fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffffd8799fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffffd87a80d87c9f1a00f9f05f1a25c5f87bff1a001e84801a001e8480ff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffffd8799fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffffd87a80d87c9f1a00f9f05f1a25c5f87bff1a001e84801a001e8480ff",
+                    "items": [
+                      {
+                        "cbor": "d8799fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ffd8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffffff",
+                          "items": [
+                            {
+                              "cbor": "d8799f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9f581c7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521ff",
+                                "items": [
+                                  {
+                                    "__type": "Buffer",
+                                    "value": "7c7fa8c0cca26439065ca04d51ef17dee648e1497526795be1484521"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "cbor": "d8799fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffffff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581c7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "7b8f020af1b75a02514610cf438931a1facc9da020177c6fa14bec93"
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d87a80",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "1"
+                        },
+                        "fields": {
+                          "cbor": "80",
+                          "items": []
+                        }
+                      },
+                      {
+                        "cbor": "d87c9f1a00f9f05f1a25c5f87bff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "3"
+                        },
+                        "fields": {
+                          "cbor": "9f1a00f9f05f1a25c5f87bff",
+                          "items": [
+                            {
+                              "__type": "bigint",
+                              "value": "16379999"
+                            },
+                            {
+                              "__type": "bigint",
+                              "value": "633731195"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "2000000"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799fd8799f4040ffd8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff1a0d53f80e00d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799f4040ffd8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff1a0d53f80e00d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                    "items": [
+                      {
+                        "cbor": "d8799f4040ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f4040ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": "05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab9"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "447261676f6e"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "223606798"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "0"
+                      },
+                      {
+                        "cbor": "d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                          "items": [
+                            {
+                              "cbor": "d8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "aafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                            "items": [
+                                              {
+                                                "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                "constructor": {
+                                                  "__type": "bigint",
+                                                  "value": "0"
+                                                },
+                                                "fields": {
+                                                  "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                  "items": [
+                                                    {
+                                                      "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                      "constructor": {
+                                                        "__type": "bigint",
+                                                        "value": "0"
+                                                      },
+                                                      "fields": {
+                                                        "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                        "items": [
+                                                          {
+                                                            "__type": "Buffer",
+                                                            "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d87a80",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "1"
+                                    },
+                                    "fields": {
+                                      "cbor": "80",
+                                      "items": []
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cbor": "d8799fd8799f4040ffd8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff1a013313cd1a0134121bd8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                  "constructor": {
+                    "__type": "bigint",
+                    "value": "0"
+                  },
+                  "fields": {
+                    "cbor": "9fd8799f4040ffd8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff1a013313cd1a0134121bd8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffffff",
+                    "items": [
+                      {
+                        "cbor": "d8799f4040ff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f4040ff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": ""
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "cbor": "d8799f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9f581c05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab946447261676f6eff",
+                          "items": [
+                            {
+                              "__type": "Buffer",
+                              "value": "05a2233ae2d59ff06173a13553521ea42165d8d3aa2f55e1c3041ab9"
+                            },
+                            {
+                              "__type": "Buffer",
+                              "value": "447261676f6e"
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "20124621"
+                      },
+                      {
+                        "__type": "bigint",
+                        "value": "20189723"
+                      },
+                      {
+                        "cbor": "d8799fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                        "constructor": {
+                          "__type": "bigint",
+                          "value": "0"
+                        },
+                        "fields": {
+                          "cbor": "9fd8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ffff",
+                          "items": [
+                            {
+                              "cbor": "d8799fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                              "constructor": {
+                                "__type": "bigint",
+                                "value": "0"
+                              },
+                              "fields": {
+                                "cbor": "9fd8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffffd87a80ff",
+                                "items": [
+                                  {
+                                    "cbor": "d8799fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "0"
+                                    },
+                                    "fields": {
+                                      "cbor": "9fd8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                                      "items": [
+                                        {
+                                          "cbor": "d8799f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9f581caafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56ff",
+                                            "items": [
+                                              {
+                                                "__type": "Buffer",
+                                                "value": "aafb1196434cb837fd6f21323ca37b302dff6387e8a84b3fa28faf56"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        {
+                                          "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                          "constructor": {
+                                            "__type": "bigint",
+                                            "value": "0"
+                                          },
+                                          "fields": {
+                                            "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                            "items": [
+                                              {
+                                                "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                "constructor": {
+                                                  "__type": "bigint",
+                                                  "value": "0"
+                                                },
+                                                "fields": {
+                                                  "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                                  "items": [
+                                                    {
+                                                      "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                      "constructor": {
+                                                        "__type": "bigint",
+                                                        "value": "0"
+                                                      },
+                                                      "fields": {
+                                                        "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                                        "items": [
+                                                          {
+                                                            "__type": "Buffer",
+                                                            "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "cbor": "d87a80",
+                                    "constructor": {
+                                      "__type": "bigint",
+                                      "value": "1"
+                                    },
+                                    "fields": {
+                                      "cbor": "80",
+                                      "items": []
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "redeemers": [
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 42061,
+                    "steps": 14890343
+                  },
+                  "index": 2,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d8799fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff01ff",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "9fd8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff01ff",
+                      "items": [
+                        {
+                          "cbor": "d8799fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                          "constructor": {
+                            "__type": "bigint",
+                            "value": "0"
+                          },
+                          "fields": {
+                            "cbor": "9fd8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dffd8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffffff",
+                            "items": [
+                              {
+                                "cbor": "d8799f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9f581cbcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9dff",
+                                  "items": [
+                                    {
+                                      "__type": "Buffer",
+                                      "value": "bcb15ea0ccde1a3e6bca4472724e4017e173f94e97a60d3e682a6e9d"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "cbor": "d8799fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                "constructor": {
+                                  "__type": "bigint",
+                                  "value": "0"
+                                },
+                                "fields": {
+                                  "cbor": "9fd8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffffff",
+                                  "items": [
+                                    {
+                                      "cbor": "d8799fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                      "constructor": {
+                                        "__type": "bigint",
+                                        "value": "0"
+                                      },
+                                      "fields": {
+                                        "cbor": "9fd8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ffff",
+                                        "items": [
+                                          {
+                                            "cbor": "d8799f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                            "constructor": {
+                                              "__type": "bigint",
+                                              "value": "0"
+                                            },
+                                            "fields": {
+                                              "cbor": "9f581c52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2ff",
+                                              "items": [
+                                                {
+                                                  "__type": "Buffer",
+                                                  "value": "52563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "__type": "bigint",
+                          "value": "1"
+                        }
+                      ]
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 2757237,
+                    "steps": 857079712
+                  },
+                  "index": 0,
+                  "purpose": "spend"
+                },
+                {
+                  "data": {
+                    "cbor": "d87980",
+                    "constructor": {
+                      "__type": "bigint",
+                      "value": "0"
+                    },
+                    "fields": {
+                      "cbor": "80",
+                      "items": []
+                    }
+                  },
+                  "executionUnits": {
+                    "memory": 276320,
+                    "steps": 81356225
+                  },
+                  "index": 0,
+                  "purpose": "mint"
+                }
+              ],
+              "scripts": [
+                {
+                  "__type": "plutus",
+                  "bytes": "59014c01000032323232323232322223232325333009300e30070021323233533300b3370e9000180480109118011bae30100031225001232533300d3300e22533301300114a02a66601e66ebcc04800400c5288980118070009bac3010300c300c300c300c300c300c300c007149858dd48008b18060009baa300c300b3754601860166ea80184ccccc0288894ccc04000440084c8c94ccc038cd4ccc038c04cc030008488c008dd718098018912800919b8f0014891ce1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec133090014a0266008444a00226600a446004602600a601a00626600a008601a006601e0026ea8c03cc038dd5180798071baa300f300b300e3754601e00244a0026eb0c03000c92616300a001375400660106ea8c024c020dd5000aab9d5744ae688c8c0088cc0080080048c0088cc00800800555cf2ba15573e6e1d200201",
+                  "version": 0
+                },
+                {
+                  "__type": "plutus",
+                  "bytes": "591e1801000032323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232323232222323232533533355333573460cc0042646424446600200a0086eb4d5d09aba25002375a6ae85400454ccd5cd1832801099091118010021bad357426aae7800c54ccd5cd1832001099190911198018028021bad357426ae894008c0ccd5d0a80082e1119191a827911111a80391191111aa99a9824806108008b1119191a9a9a80103102d91191919191919191aa99a982a89119982d91299a99820a8071a80103409980200100088008008020b03c9111919191919191919191919191982a299a8050a99aa8100999ab9a3094013303a307908101330820106700b06706e0060063305433355307908101305c05a305953353502b2233500206e2071210011635014222222207a33054353501422208e0122350012322533355333500a2153335004215333500c2130054984c011261533350052130054984c0112603c04f15333500b2130044984c00d261533350042130044984c00d2603b153335003205003a04f153335003215333500b2130044984c00d261533350042130044984c00d2603b04e15333500a2130034984c009261533350032130034984c0092603a153350010700820108201070253335002215333500a21533350042133303a03b00200116161604e15333500921533350032133303903a00200116161604d04e33054330500153306f00b02733054330533306301602548008cc150cc14ccc18c02c0952002330543305333063001010002330543333084012222533500315335002135001222223305d3305c0053306c01402b3305d3305c0043306c01402a3305d3305c00300c3305d3305c0023306c0140193305c001304800d0910122153350041622153350071622153350081622133300c003001323232323232323533307d0050070272222225335330743305100248000cc1440052000161333335003235500b2222223501d222223501b22235051222223232323232323232323253353308b013308b013306e00848000cc1b802920003308b013306d00201e3308b0153353306e00a00315335330870100e07013308b013308a013309a010110703370066e0402800c060cc22804cc2680404411c0084cc22c04cc22804cc268040441c0060cc22c04cc22804cc2680404411c008cc22804cdc08050019984d008088070a99a998370041a802055008a99a99843808078380998458099845009984d0080883819b80337020106a008154020306611402661340202208e00426611602661140266134020220e003066116026611402661340202208e004661140266e04020d40102a804cc2680404403c4cc22c04cc22804cc2680404411c008cc22804cc268040441c0060cc22c04cc20c04048070cc2080404006c4c8c8c8ccccc2c80400c008cdc019b800180050013370002e002a66a0082605466e0800c00840594cd400c4cccc0a005406406005c520003370002e00866e0005cd40102a80458c27c04028d40082a404d40042a404d54cd54ccd5cd19b8900148000278044c94ccd5cd19b890014800027c044c94ccd5cd19b8900148000280044c28404ccc2ec0400c0080054ccd5cd19b8900400610041006350020ad0121001160b901350010b0015333573466e2400400c54ccd5cd19b880010031330a8010023370666e080080400444cc2a0040080104cc2a004cdc199b820040110100043370666e080040380414cd4cc1fc01c1a04cdc0998490081100399b80011010133092010220073370666e080040300354cd4cc1f40101984cdc0998480081000219b8000f00e133090010200042235500c2222223501e222223501c222350522222232323232323232323253353308b013306e00748000cc22c04cc1b4008074cc22c04cc22c04cc22804cc2680404011c008cc22804cc268040401c005ccc22c04cc20c0404406ccc2080403c0684c8c8c8c8ccccc2cc0400c008cdc019b800180060013370002e002a66a00a2605666e0800c00840594cd40104cccc0a405406406005c52000350020b301350010b60153353330690870100e01e1330ae013370002c00e02a26615c0202c66e0005401c58c27c04024cdc199b820010123370200400266604400600266e0ccdc0981219b803370400400466e08cdc119b82337049004241941e90680780200198600080199b824801120ca0f350050a70130be01001350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4009200033086013306800101833086015335330820101906b13308501330950100b0193370000202426610c026610a026612a020160320026610a026612a020160d60246610c02660fc01802c660fa01402a2a66a6660c8104020120322666661540266e00044008cdc08080008078070068999998550099b810110013370002000401e01c01a2c66603e6a00614c026a00614a02002a66a66100020020d2266e04cc24c0408c004cdc0008808099849808118009a800851009aa99a99983003f00280a899985a00802806806099985a008020060069111a8019119985c80802802001911aa8061111111a80f111111a80e1111a82911111191919191919299a998440099835802240006611002660d80020086611002a66a66108020360da266110026610e026612e0201a03666e00068050cc21c04cc25c04034014cdc08020008a99a99842008028368998440099843809984b8080680d80d19843809984b8080680299b8033702008002028266110026610e026612e0201a03603466110026610e026612e0201a00a66e04010004cc21c04cc25c040341b4050cc22004cc20004038060cc1fc03005c54cd4ccc1982100402c06c4ccccc2b004cdc000980099b8101201a01101000f1333330ac013370202603466e0004800404404003c594cd54ccd5cd19b880190011309f013370066e0ccdc119b82002019483403ccdc119b81001019483283d200209e012100116350040a601350030a60153353308001001069133702661260204600266e000440404cc24c0408c004d400428804d54cd4ccc1801f80140544ccc2d0040140340304ccc2d004010030034888d400c88ccc2e40401401000c88d54030888888d407888888d4070888d414888888c8c8c8c94cd4cc21804cc1a4011200033086013308601330680030193306800201833086015335330820100906b133086013308501330950100b009337000060246610a026612a020160100042a66a66104020100d626610c026610a026612a0201601066e00008048cc21404cc2540402c02400c4cc21804cc21404cc2540402c02400ccc21804cc21404cc2540402c020008cc21404cc2540402c1ac048cc21804cc1f8030058cc1f40280544c8c8c8ccccc2b40400800ccdc019b8101200700133700022002a66a0082604a66e0800800c40414cd400c4cccc08c03c04c048044520003370202400866e0404000858c26804010cdc199b8200200e00d3370666e08004038030cc244040840f8888c8cdc199b820010033370066e0801120d00f0013370400290650791112999ab9a3371200890000a4000264a666ae68cdc48008028a4000264a666ae68cdc4800a400029000080099b833370400466e04004014cdc019b8200148028014c014cdc10018011192999ab9a33710004900004d808a999ab9a30a10100214800054ccd5cd1851008010a40042a666ae68c28c04008520021330010023370066e0c009200448008c254048894ccd5cd19b880010021330030013370666e00cdc1802000800a4008200426660f2002006046464a666ae68c27c04d55ce80089919191919191919191919191919091999998008050048040028018011bad357426ae88008dd69aba100135744010a666ae68c2b4040084c8c8488888cc01001c018dd69aba135744a0046660f8eb9d71aba15001153335734615802004264642444446600200e00c6eb4d5d09aba25002375a6ae85400454ccd5cd18558080109909111118028031bad357426aae7801854ccd5cd18550080109919091111198010038031bad357426ae894008ccc1f1d73ae35742a0022a666ae68c2a4040084c8c8488888cc00c01c018dd69aba135744a0046660f8eb9d71aba150010a101135573c00a6aae74010cc1e1d71aba100530743574200a60e66ae84014dd51aba1001357440026ae88004d5d10009aab9e0010970137540026a002104026a00810c0260c82446660d444a66a660b066606c0d46a004104026a03c1040266606c0a06a6a0040fc0ee05e266008004002200200202a60c82446660d444a66a660b066606c0a06a0040ee6a0200ee66606c0a06a0040ee05e2660080040022002002026666660f0660c602c044660c602c04203e660c602c02003c660a8660a0044607a008660a8660a0042607c008660a8024660a8a66a60c82446660d444a66a660a66aa03a104026a6a0040ee1040226600800400220020020260d6442a66a0020fe440dea66a6660640a600490000998299981d183c840809984100833800a40042660a66607460f21020266104020ce0029000183800999b8100101d303d001333066059008010305333307f22322325333573466e1c010dc680488010a999ab9a308f0100415333573466e1d205a500313370290001980299b800044800800800400454ccd5cd19b885002481805854ccd5cd19b8950023370090302402426600866e0000d20023370066e08005201433702a00490300b099b8e0060014800120001533500400115335501a13335734611a026606860e60f6660f80c200a0c20d00022a66a0062a66aa0320022666ae68c23804cc0ccc1c81e8cc1ec18001018019c0044ccd5cd18460099819183883c9983d02f80182f833299a9983d91299a8008321109a80111299a9982b00101089834800898030019a9a99a983b03c00501083883610a99a8008b1109a80111299a8018a99a99827800a400420042c112022c666ae68cdc49982c800803240000c80ba6a0020d4a66a60b02446660bc44a66a66088a0226a0040d6266008004002200200200e2c0f8660ce02c6a00a0d460c2006a66a60a42446660b044a66a660826aa0160e06a6a6a0040d80ca0e026600800400220020020060b2442a66a0020da440ba60ba0026a0280d4660b40020246a6a0080c80be26a6a0020c20b4a66a609601c420022c2a66a660600040320ba266060002032603200e6068010464646a09c4444464646464646464660706606a00c0066607066068660a600c018660a6006018660706606e6608e6a6a66a60c60ca00401e0bc0b2660b601201090011981c1981f998188070009981c1981b9811800a40006607066068604201c60420026607066068604401c60440026606e604801c6048002660706606a60aa00a09666070a66a609024466609c44a66a60a26a6a0040c40b8266008004002200200200809e442a66a0020c6440a6a66a609024466609c44a66a60a26a0040b8266008004002200200260b000e09e442a66a0020c6440a666609a08000600860a40066a0020aca66a608824466609444a66a660666a6a6a00e0bc0ae0c46a6a0040ae0c4266008004002200200260a80062c0d06a0100ba6a6a0020b00a6a66a608400c420022c603000c606600e4464646a09e44444a66a6a00e440a8426464646464646464646464646607e660700286660aa09000800c6607e66076014660b40060246607e6607e6607c6609c6a0040c00120106607e6606e6a0040bc6a01a0d26606c6a0040be6a01a0ca6607e6607866aa60ce0d846a00244660ca00466aa60d40de46a00244660d0004666a0026e012000700466e0000520000013304000b3500922330723306400233072330640010090540540033303f3303e3304e3535335306a06c0010160650603306200f00e48008cc0fccc0f0c1700181494cd4c13c488ccc154894cd4c160d4d40081a418c4cc010008004400400400c1588854cd40041a888168c168014cd4c1a01a800c04cd40041754cd4c12c488ccc144894cd4cc0dcd4d4030194178d40081784cc010008004400400400c581bcc160004d403418cccd4080178d4d4080188178004cc11800c004cc164020d4004170cc140004020d4d40041681554cd4c11001c8400458124c06401cc0d0020448004584d55cf0011aab9d0013754004444a66a6600600400207809c46a0020b0246666666600204044a666ae68cdc38010008020a999ab9a3371200400203203044666ae68cdc400100081b01e802802001912999ab9a337120040022002200444a666ae68cdc4801000880108008881f11199ab9a3371000400207406644666ae68cdc480100081c81911199ab9a337120040020620706607c91100488100223333550023303f2233350050480010023500304222337000029001000a4000660784446006600400240026607666076e01200070246a0024444400a46a0020a246a0024407246a0024406c464a666ae68c140d55ce8008991919191981e2999ab9a305435573a00626464646464646464646464646464646464646464646424666666666600201a01801601401201000e00a00600460446ae84d5d10011980f1981dbae2001357420026ae88008cc071d71aba100135744016a666ae68c190d55ce804899191919827a999ab9a306735573a004264660a066038eb4d5d0800980d9aba1357440026aae7800817d4ccd5cd18339aab9d001132330503301c75a6ae84004c06cd5d09aba200135573c0020be6ea8d5d09aba200237546ae84004d55cf00482e1980c9981b019bad35742014660300326ae84028ccc059d70029aba100a33301575c0086ae84028cc054008d5d08051980a1192999ab9a306035573a0022646609260326ae84004c010d5d09aba200135573c0020b06ea8004d5d08051192999ab9a305f35573a002264646660b060606ae84008ccc059d70029aba10013303375c6ae84d5d10009aba200135573c0020ae6ea8004cc045d73ad37546ae84004d5d10009aba2001357440026ae88004d5d10009aba200135573c006098a666ae68c15c0044c848888c010014c02cd5d09aab9e00215333573460ac00226424444600400a60486ae84d55cf0010a999ab9a3055001132122223001005300c357426aae7800854ccd5cd182a0008990911118018029bae357426aae78008130d55ce8009baa357426ae88008dd51aba100135573c0020906ea80048c94ccd5cd182800081e8a999ab9a304f00102b04735573a6ea800488c8c94ccd5cd18290008058a999ab9a3051001130193004357426aae7800854ccd5cd18280008050241aab9d00137540024464460046eac004c10888cccd55cf8009014119198239981c98031aab9d001300535573c00260086ae8800cd5d0801020919118011bac00130402233335573e002404c46608860086ae84008c00cd5d100101f91919192999ab9a305300211222203515333573460a4004220922a666ae68c1440084c8c848888888cc004024020dd69aba135744a0046eb8d5d0a8008a999ab9a3050002132321222222233002009008375c6ae84d5d128011bae35742a0022a666ae68c13c0084c8c848888888cc018024020dd71aba135744a004603a6ae85400454ccd5cd1827001099091111111803804180e9aba135573c0062a666ae68c1340084c848888888c014020c074d5d09aab9e003045135573c0046aae74004dd50009192999ab9a304a35573a0022646606660086ae84004dd69aba1357440026aae78004108dd50009192999ab9a304935573a00226eb8d5d09aab9e0010413754002220582205444a66a00442a66a00442660240040020462a66a0024046068446a004446a006446666010008006004002446a004444446a00c44444a66a6601e01400a2a66a6601e0120082a666ae68cdc38040018a999ab9a3370e00e0042a66a00c42a66a004426a004446a004446a00a446a00444a66a666602e00c00a0040022a66a00e42a66a008426604800400206a2a66a006406a08c0680562a66a002405607805405405405444446466a00a466a0084a666ae68cdc78010008018121013919a802101392999ab9a3371e0040020060482a66a00642a66a0044266a004466a00446601200400244405444466a0084054444a666ae68cdc38030018a999ab9a3370e00a0042660220080020520520442a66a00240440664466a004466a00446601c0040024046466a004404646601c004002446a004446a00644a666ae68cdc780200109980780180081091199aa9815019180680191a80091199aa981681a980800311a80091199a800919805a40000020144660160029000000998030010009981280100a91199ab9a3370e00400202c03a44a66a00420020324466aa605205c46a002446604e004666a002466aa605a06446a0024466056004601800200244666010016004002466aa605a06446a0024466056004601600200266600600c004002444666aa605005c06466aa605205c46a002446604e0046010002666aa605005c446a00444a66a666aa6054064601a01646a002446601400400a00c200626606c00800602800266aa605205c46a002446604e0046606844a66a002260120064426a00444a66a6601800401022444660040140082600c00600800442444600200842444600600844666ae68cdc780100080800b9980e80080a11299a801012080091980e11199a8018128010009a80080f9192999ab9a303435573a00226464646466666042666016eb9d71aba100433300b75ceb8d5d08019bad357420046eb4d5d0800998051192999ab9a303a35573a0022646604660146ae84004cc035d71aba1357440026aae780040c8dd50009aba1357440026ae88004d5d10009aba200135573c0020586ea80048c94ccd5cd18199aab9d0011323301c3005357420026600c0086ae84d5d10009aab9e00102b375400246464a666ae68c0d00044c8c8c8c8c8488ccc00401801000cdd69aba1357440046eb4d5d08009aba2002375a6ae84004d55cf0010a999ab9a3033001130103004357426aae780080acd55ce8009baa0012323253335734606600226424460020066eb8d5d09aab9e00215333573460640022601e6eb8d5d09aab9e00202a35573a0026ea800488c8c94ccd5cd18190008980798021aba135573c0042a666ae68c0cc0040380a8d55ce8009baa001222325333573460626aae740044c8cc068c014d5d080098021aba1357440026aae780040a4dd5000911a8009119198131119a800a4000446a00444a666ae68cdc7801004898038008980300180298129119a800a4000446a00444a666ae68cdc7801003880089803001919a80081100211a800911a80111111111111999a805900b900b900b9199aa981101500b11a80091299a998090010020980c00180b805912999ab9a3371e6a0040346a0020342666ae68cdc39a80100b1a80080b001805003880b91180f11299a80088019109980300118020009299a800900b0019111a801111299a800909a8029111111111299aa99a999aa981001400a11a800912999ab9a3371e00401c2602c00602a0044260286a0020440244260240022c2c2006424460040066601444a66a0044200620020022018446602e44a66a00203c4426a00444a666ae68cdc78010038a99a8008111109a80111299a8018a999ab9a302d00113301400b0020262202813006003002235001222222222200a2350012201c23500122222222220092220032220012220023333300248811c0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb10048811ce4214b7cce62ac6fbba385d164df48e157eae5863521b4b67ca71d8600330014891c13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f004881074d494e535741500048811c2f2e0404310c106e2a260e8eb5a7e43f00cff42c667489d30e179816004881054f574e455200221233001003002222221233333001006005004003002300b22112225335001135003006221333500500c300400233355300700f0050040012200130092211222533500110022213300500233355300700d005004001300822112253350010052213300f30040023355300600b00400111001220023005221225333573466e20005200013005490103505436001533500213005491035054370022153335734602c0062004266a600c01000266e0400d2002253357380022c240026004444a66a00220044426a004446600e66601000400c00200660024444a66a00220044426a00444a666ae68c0500044ccc02001c01800c4ccc02001ccc028ccc02c01c00800401800c8c8c00400488cc00cc00800800488488cc00401000c88848ccc00401000c00854cd5ce2490350543100162215335001100200715335738921001622222222007220053704904d0f910b111110021b8748000dc3a40046e1d2004370e90031b8748020dc3a40146e1d200c01",
+                  "version": 0
+                },
+                {
+                  "__type": "plutus",
+                  "bytes": "590308010000323232323232323232323232323232322232323232323253353300a53353301322533500100b2213232325335533553335734603c002260286eb8d5d09aab9e002153335734603e002026038402202626603600a00620066aae74004dd51a801911000980200098081bac35500222222222220091622153350011533533300d00c48811c0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb10033301075c0066a00444400442a66a0022c4426a00444a66a0062a666ae68c07c004400858074580614cd4ccc02c028cccd54ccd5cd19b874801800c4c848888c010014d5d09aab9e00415333573466e1d2004003132122223002005357426aae7801054ccd5cd180c0018990911118008029aba135573c0082a666ae68c05c00c4c848888c00c014d5d09aab9e0040152675c4c4c66601ceb8004d54008888888888801c854cd400458884d4008894cd400c400806c5844800458cc035d73ad13253335734602c6aae740044c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c848cccccccccc00404c04403c03402c02401c01400c008d5d09aba2002357420026ae88008d5d08009aba2002357420026ae88008d5d08009aba2002357420026ae88008d5d08009aba2002357420026ae88008d5d08009aba2002357420026aae78004050dd51a801910011aab9d00137546a00244002a666ae68c048d55ce800899198059aba1001357426ae88004d55cf0008081baa001100922333573466e3c00800402848800488c028894cd4004014884d4008894cd4cc02000801c4c0280044c01800c44880048488c00800c88c88c008dd58009803911999aab9f00120092323300c33007300635573a002600a6aae78004c010d5d10019aba100200722123300100300230032233335573e002400a46466010a666ae68c02cd55ce80089919191919091998008028018011aba1357440046ae84004d5d10011aba100135573c00201260086ae8800cdd51aba1002003120011220022323001001223300330020020012212233001004003153357389210350543100162216370e90001b87480081",
+                  "version": 0
+                }
+              ],
+              "signatures": {
+                "__type": "Map",
+                "value": [
+                  [
+                    "0303157375f23161027902abff500a6268c00a69f45f7bfe5adbc2f70f15df94",
+                    "801ebfb6c2547d91251aea259709197c108a6ac68bf082d64495f838d49556961438652fb7c6de2e51c38232bfd904d1a8ab2f3b1474f397ca9c8c54a5f1b80c"
+                  ]
+                ]
+              }
+            },
+            "inputSource": "inputs"
+          }
+        ],
+        "fees": {
+          "__type": "bigint",
+          "value": "10687625"
+        },
+        "header": {
+          "blockNo": 9953726,
+          "hash": "5d58907b8b49147605339e01d4dbe22810e121d649aed36e98534b0dfd717d81",
+          "slot": 116795796
+        },
+        "issuerVk": "ece2bd7433345120aaf22f587d3e755b0e8663841d32c770733ce43cde862375",
+        "previousBlock": "02a489c9080a02e436a455896787c54fc7e14a974dd6f79abc9c819ea2e0d0f7",
+        "size": 84318,
+        "totalOutput": {
+          "__type": "bigint",
+          "value": "3659160047580"
+        },
+        "txCount": 23,
+        "vrf": "vrf_vk1kqeqcyhxkk6y9e3wsk95hfdnsw2pgj05rt06sr6emnh3w2dm9uns8ll28m"
+      },
+      "eventType": 0,
+      "tip": {
+        "blockNo": 9953726,
+        "hash": "5d58907b8b49147605339e01d4dbe22810e121d649aed36e98534b0dfd717d81",
+        "slot": 116795796
+      }
+    }
+  ],
+  "metadata": {
+    "cardano": {
+      "compactGenesis": {
+        "era": "shelley",
+        "startTime": "2017-09-23T21:44:51Z",
+        "networkMagic": 764824073,
+        "network": "mainnet",
+        "activeSlotsCoefficient": 0.05,
+        "securityParameter": 2160,
+        "epochLength": 432000,
+        "slotsPerKesPeriod": 129600,
+        "maxKesEvolutions": 62,
+        "slotLength": 1,
+        "updateQuorum": 5,
+        "maxLovelaceSupply": {
+          "__type": "bigint",
+          "value": "45000000000000000"
+        },
+        "initialDelegates": [
+          {
+            "issuer": {
+              "id": "162f94554ac8c225383a2248c245659eda870eaa82d0ef25fc7dcd82"
+            },
+            "delegate": {
+              "id": "4485708022839a7b9b8b639a939c85ec0ed6999b5b6dc651b03c43f6",
+              "vrfVerificationKeyHash": "aba81e764b71006c515986bf7b37a72fbb5554f78e6775f08e384dbd572a4b32"
+            }
+          },
+          {
+            "issuer": {
+              "id": "2075a095b3c844a29c24317a94a643ab8e22d54a3a3a72a420260af6"
+            },
+            "delegate": {
+              "id": "6535db26347283990a252313a7903a45e3526ec25ddba381c071b25b",
+              "vrfVerificationKeyHash": "fcaca997b8105bd860876348fc2c6e68b13607f9bbd23515cd2193b555d267af"
+            }
+          },
+          {
+            "issuer": {
+              "id": "268cfc0b89e910ead22e0ade91493d8212f53f3e2164b2e4bef0819b"
+            },
+            "delegate": {
+              "id": "1d4f2e1fda43070d71bb22a5522f86943c7c18aeb4fa47a362c27e23",
+              "vrfVerificationKeyHash": "63ef48bc5355f3e7973100c371d6a095251c80ceb40559f4750aa7014a6fb6db"
+            }
+          },
+          {
+            "issuer": {
+              "id": "60baee25cbc90047e83fd01e1e57dc0b06d3d0cb150d0ab40bbfead1"
+            },
+            "delegate": {
+              "id": "7f72a1826ae3b279782ab2bc582d0d2958de65bd86b2c4f82d8ba956",
+              "vrfVerificationKeyHash": "c0546d9aa5740afd569d3c2d9c412595cd60822bb6d9a4e8ce6c43d12bd0f674"
+            }
+          },
+          {
+            "issuer": {
+              "id": "ad5463153dc3d24b9ff133e46136028bdc1edbb897f5a7cf1b37950c"
+            },
+            "delegate": {
+              "id": "d9e5c76ad5ee778960804094a389f0b546b5c2b140a62f8ec43ea54d",
+              "vrfVerificationKeyHash": "64fa87e8b29a5b7bfbd6795677e3e878c505bc4a3649485d366b50abadec92d7"
+            }
+          },
+          {
+            "issuer": {
+              "id": "b9547b8a57656539a8d9bc42c008e38d9c8bd9c8adbb1e73ad529497"
+            },
+            "delegate": {
+              "id": "855d6fc1e54274e331e34478eeac8d060b0b90c1f9e8a2b01167c048",
+              "vrfVerificationKeyHash": "66d5167a1f426bd1adcc8bbf4b88c280d38c148d135cb41e3f5a39f948ad7fcc"
+            }
+          },
+          {
+            "issuer": {
+              "id": "f7b341c14cd58fca4195a9b278cce1ef402dc0e06deb77e543cd1757"
+            },
+            "delegate": {
+              "id": "69ae12f9e45c0c9122356c8e624b1fbbed6c22a2e3b4358cf0cb5011",
+              "vrfVerificationKeyHash": "6394a632af51a32768a6f12dac3485d9c0712d0b54e3f389f355385762a478f2"
+            }
+          }
+        ],
+        "initialFunds": {},
+        "initialStakePools": {
+          "stakePools": {},
+          "delegators": {}
+        },
+        "networkId": 1,
+        "systemStart": {
+          "__type": "Date",
+          "value": 1506203091000
+        }
+      },
+      "intersection": {
+        "point": {
+          "hash": "02a489c9080a02e436a455896787c54fc7e14a974dd6f79abc9c819ea2e0d0f7",
+          "slot": 116795773
+        },
+        "tip": {
+          "blockNo": 10826922,
+          "hash": "565e43d44d0f581a66ad7573f3f6fb3ea0022fbba7a0d96d43f1922fd8b5c403",
+          "slot": 134603628
+        }
+      }
+    },
+    "options": {
+      "blockHeights": "9953726"
+    },
+    "software": {
+      "commit": {
+        "hash": "2e0e2c79bf24475ca7ceaefa16118b283c43e21f",
+        "tags": [
+          "@cardano-sdk/cardano-services-client@0.21.3",
+          "@cardano-sdk/cardano-services@0.31.3",
+          "@cardano-sdk/e2e@0.44.4",
+          "@cardano-sdk/golden-test-generator@0.8.5",
+          "@cardano-sdk/ogmios@0.18.5",
+          "@cardano-sdk/projection-typeorm@0.9.5",
+          "@cardano-sdk/projection@0.12.5",
+          "@cardano-sdk/util-dev@0.23.5",
+          "@cardano-sdk/wallet@0.44.10",
+          "@cardano-sdk/web-extension@0.34.9"
+        ]
+      },
+      "name": "@cardano-sdk/golden-test-generator",
+      "version": "0.8.5"
+    }
+  }
+}

--- a/packages/util-dev/src/chainSync/index.ts
+++ b/packages/util-dev/src/chainSync/index.ts
@@ -105,6 +105,7 @@ export enum ChainSyncDataSet {
   AssetNameUtf8Problem = 'asset-name-utf8-problem.json',
   MissingExtraDatumMetadataProblem = 'missing-extra-datum-metadata-problem.json',
   ExtraDataNullCharactersProblem = 'extra-data-null-characters-problem.json',
+  Cip68WitnessDatumProblem = 'cip68-witness-datum-problem.json',
   WithPoolRetirement = 'with-pool-retirement.json',
   WithStakeKeyDeregistration = 'with-stake-key-deregistration.json',
   WithMint = 'with-mint.json',


### PR DESCRIPTION
# Context

Some CIP-68 NFT metadata is not being projected LW-11682

Some IPFS URIs are not recognized LW-11673

# Proposed Solution

Some CIP-68 NFTs are created by using transaction witness datum instead of inline datum.

Mappers will now look up witness datum by hash.

# Important Changes Introduced

https://input-output.atlassian.net/browse/LW-11682