### PR TITLE
chore: update enpoint to ready

### DIFF
--- a/nix/cardano-services/deployments/backend.provider.nix
+++ b/nix/cardano-services/deployments/backend.provider.nix
@@ -11,10 +11,10 @@
     metricsPath = "${values.cardano-services.httpPrefix}/metrics";
 
     livenessProbe = {
-      timeoutSeconds = 30;
-      periodSeconds = 60;
+      timeoutSeconds = 5;
+      periodSeconds = 10;
       httpGet = {
-        path = "${values.cardano-services.httpPrefix}/health";
+        path = "${values.cardano-services.httpPrefix}/ready";
         port = 3000;
       };
     };

--- a/nix/cardano-services/deployments/chain-history.nix
+++ b/nix/cardano-services/deployments/chain-history.nix
@@ -13,8 +13,9 @@
 
     livenessProbe = {
       timeoutSeconds = 5;
+      periodSeconds = 10;
       httpGet = {
-        path = "${values.cardano-services.httpPrefix}/health";
+        path = "${values.cardano-services.httpPrefix}/ready";
         port = 3000;
       };
     };


### PR DESCRIPTION
# Context

Updating backend and chain-history health endpoings to use `/ready` 