### PR TITLE
fix(wallet): preserve pouchdb collection documents when bulkDocs fails

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -81,7 +81,8 @@
     "pouchdb": "^7.3.0",
     "rxjs": "^7.4.0",
     "ts-custom-error": "^3.2.0",
-    "ts-log": "^2.2.3"
+    "ts-log": "^2.2.3",
+    "uuid": "^8.3.2"
   },
   "files": [
     "dist/*",

--- a/packages/wallet/src/persistence/pouchDbStores/PouchDbStore.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/PouchDbStore.ts
@@ -9,7 +9,7 @@ export abstract class PouchDbStore<T extends {}> {
   destroyed = false;
   protected idle: Promise<void> = Promise.resolve();
   protected readonly logger: Logger;
-  protected readonly db: PouchDB.Database<T>;
+  public readonly db: PouchDB.Database<T>;
 
   constructor(public dbName: string, logger: Logger) {
     this.logger = logger;

--- a/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
+++ b/packages/wallet/src/persistence/pouchDbStores/pouchDbWalletStores.ts
@@ -85,7 +85,11 @@ export const createPouchDbWalletStores = (
     // However it is extremely unlikely that it would have inline datums,
     // and renaming this store is not an option as it's being used
     // for storing collateral settings
-    unspendableUtxo: new PouchDbUtxoStore({ dbName: `${baseDbName}UnspendableUtxo` }, logger),
+    unspendableUtxo: new PouchDbUtxoStore(
+      // random doc id; setAll will always delete and re-insert all docs
+      { dbName: `${baseDbName}UnspendableUtxo` },
+      logger
+    ),
     utxo: new PouchDbUtxoStore({ dbName: `${baseDbName}Utxo_v2` }, logger),
     volatileTransactions: new PouchDbVolatileTransactionsStore(docsDbName, 'volatileTransactions_v3', logger)
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,6 +4085,7 @@ __metadata:
     ts-log: ^2.2.3
     tsc-alias: ^1.8.10
     typescript: ^4.7.4
+    uuid: ^8.3.2
     wait-on: ^6.0.1
     webextension-polyfill: ^0.9.0
   languageName: unknown


### PR DESCRIPTION
# Context

PouchDbCollectionStore.setAll used to
1. delete all documents
2. insert the new documents

This approach has a problem that when step 2. fails, all documents from db are gone and not re-created. For some collections such as transactions or utxo this is not a problem, because it can recover, but for it is a big problem for WalletRepository, because there is no way to recover the wallets if they are lost.

LW-11760

# Proposed Solution

This fix updates setAll to perform the following steps:
1. delete *only* the documents that are intended to be deleted
2. upsert all new documents
