### PR TITLE
fix(cardano-services-client): txSubmitApiProvider now computes the tx id correctly

### DIFF
--- a/packages/cardano-services-client/src/TxSubmitProvider/TxSubmitApiProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/TxSubmitApiProvider.ts
@@ -42,7 +42,7 @@ export class TxSubmitApiProvider implements TxSubmitProvider {
     let txId: Cardano.TransactionId | undefined;
 
     try {
-      txId = Serialization.TransactionBody.fromCbor(signedTransaction).hash();
+      txId = Serialization.Transaction.fromCbor(signedTransaction).getId();
 
       this.#logger.debug(`Submitting tx ${txId} ...`);
 


### PR DESCRIPTION
# Context

TxSubmitApiProvider was trying to deserialize the transaction CBOR as transaction body, which was causing a failure in deserialization.

# Proposed Solution

TxSubmitApiProvider now deserializes the CBOR as a transaction when computing the tx hash.
