### PR TITLE
fix(cardano-services-client): comply HttpProvider with 'normal' Object behavior

### DIFF
--- a/packages/cardano-services-client/src/HttpProvider.ts
+++ b/packages/cardano-services-client/src/HttpProvider.ts
@@ -78,11 +78,9 @@ export const createHttpProvider = <T extends Provider>({
   new Proxy<T>({} as T, {
     // eslint-disable-next-line sonarjs/cognitive-complexity
     get(_, prop) {
-      if (prop === 'then') return;
       const method = prop as keyof T;
       const urlPath = paths[method];
-      if (!urlPath)
-        throw new ProviderError(ProviderFailure.NotImplemented, `HttpProvider missing path for '${prop.toString()}'`);
+      if (!urlPath) return;
       return async (...args: any[]) => {
         try {
           const req: AxiosRequestConfig = {
@@ -123,5 +121,9 @@ export const createHttpProvider = <T extends Provider>({
           throw new ProviderError(ProviderFailure.Unknown, error);
         }
       };
+    },
+
+    has(_, prop) {
+      return prop in paths;
     }
   });

--- a/packages/cardano-services-client/test/HttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HttpProvider.test.ts
@@ -63,10 +63,16 @@ describe('createHttpProvider', () => {
     if (closeServer) await closeServer();
   });
 
-  it('attempting to access unimplemented method throws ProviderError', async () => {
+  it('attempting to access unimplemented method returns undefined', async () => {
     const provider = createTxSubmitProviderClient();
+    expect('doesNotExist' in provider).toBe(false);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(() => (provider as any).doesNotExist).toThrowError(ProviderError);
+    expect((provider as any).doesNotExist).toBeUndefined();
+  });
+
+  it('"in" operator for implemented property returns true', async () => {
+    const provider = createTxSubmitProviderClient();
+    expect('healthCheck' in provider).toBe(true);
   });
 
   it('passes through axios options, merging custom header with the included provider version headers', async () => {


### PR DESCRIPTION
# Context

HttpProvider is implemented as a Proxy object, which is currently not compatible with SDK's web-extension messaging utilities that are checking exposed/underlying object properties with 'in' operator

LW-11796

# Proposed Solution

This commit has 2 fixes:
- do not throw an error when trying to access an undefined property of an object
- return 'true' with with 'in' operator for defined properties

# Important Changes Introduced
