### PR TITLE
fix(wallet): include voteDelegation certs in delegationTracker

### DIFF
--- a/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
+++ b/packages/wallet/src/services/DelegationTracker/DelegationTracker.ts
@@ -139,7 +139,13 @@ export const createDelegationTracker = ({
     transactionsTracker,
     rewardAccountAddresses$,
     slotEpochCalc$,
-    [...Cardano.RegAndDeregCertificateTypes, ...Cardano.StakeDelegationCertificateTypes]
+    [
+      ...new Set([
+        ...Cardano.RegAndDeregCertificateTypes,
+        ...Cardano.StakeDelegationCertificateTypes,
+        ...Cardano.VoteDelegationCredentialCertificateTypes
+      ])
+    ]
   ).pipe(tap((transactionsWithEpochs) => logger.debug(`Found ${transactionsWithEpochs.length} staking transactions`)));
 
   const rewardsHistory$ = new TrackerSubject(


### PR DESCRIPTION
# Context

Delegation tracker was recently updated to follow voting delegations in addition to stake delegations, but the transactions were filtered only for staking certificates.

# Proposed Solution
Include voting certificates in the transaction filter.

# Important Changes Introduced
