### PR TITLE
Feat/lw 11842 performance improvements

### DIFF
--- a/packages/wallet/src/Wallets/BaseWallet.ts
+++ b/packages/wallet/src/Wallets/BaseWallet.ts
@@ -51,7 +51,6 @@ import {
   createUtxoTracker,
   createWalletUtil,
   currentEpochTracker,
-  distinctBlock,
   distinctEraSummaries
 } from '../services';
 import { AddressType, Bip32Account, GroupedAddress, WitnessedTx, Witnesser, util } from '@cardano-sdk/key-management';
@@ -397,7 +396,6 @@ export class BaseWallet implements ObservableWallet {
       store: stores.tip,
       syncStatus: this.syncStatus
     });
-    const tipBlockHeight$ = distinctBlock(this.tip$);
 
     this.txSubmitProvider = new SmartTxSubmitProvider(
       { retryBackoffConfig },
@@ -499,11 +497,11 @@ export class BaseWallet implements ObservableWallet {
 
     this.utxo = createUtxoTracker({
       addresses$,
+      history$: this.transactions.history$,
       logger: contextLogger(this.#logger, 'utxo'),
       onFatalError,
       retryBackoffConfig,
       stores,
-      tipBlockHeight$,
       transactionsInFlight$: this.transactions.outgoing.inFlight$,
       utxoProvider: this.utxoProvider
     });

--- a/packages/wallet/src/services/util/equals.ts
+++ b/packages/wallet/src/services/util/equals.ts
@@ -19,7 +19,11 @@ export const sameSortedArrayItems = <T>(arrayA: T[], arrayB: T[], itemEquals: (a
   return true;
 };
 
-export const transactionsEquals = (a: Cardano.HydratedTx[], b: Cardano.HydratedTx[]) => sameArrayItems(a, b, txEquals);
+export const transactionsEquals = (a: Cardano.HydratedTx[], b: Cardano.HydratedTx[]) => {
+  if (a === b) return true;
+
+  return sameSortedArrayItems(a, b, txEquals);
+};
 
 export const txInEquals = (a: Cardano.TxIn, b: Cardano.TxIn) => a.txId === b.txId && a.index === b.index;
 

--- a/packages/wallet/src/services/util/equals.ts
+++ b/packages/wallet/src/services/util/equals.ts
@@ -7,12 +7,27 @@ export const tipEquals = (a: Cardano.Tip, b: Cardano.Tip) => a.hash === b.hash;
 
 export const txEquals = (a: Cardano.HydratedTx, b: Cardano.HydratedTx) => a.id === b.id;
 
+export const sameSortedArrayItems = <T>(arrayA: T[], arrayB: T[], itemEquals: (a: T, b: T) => boolean): boolean => {
+  if (arrayA.length !== arrayB.length) return false;
+
+  for (const [i, element] of arrayA.entries()) {
+    if (!itemEquals(element, arrayB[i])) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 export const transactionsEquals = (a: Cardano.HydratedTx[], b: Cardano.HydratedTx[]) => sameArrayItems(a, b, txEquals);
 
 export const txInEquals = (a: Cardano.TxIn, b: Cardano.TxIn) => a.txId === b.txId && a.index === b.index;
 
-export const utxoEquals = (a: Cardano.Utxo[], b: Cardano.Utxo[]) =>
-  sameArrayItems(a, b, ([aTxIn], [bTxIn]) => txInEquals(aTxIn, bTxIn));
+export const utxoEquals = (a: Cardano.Utxo[], b: Cardano.Utxo[]) => {
+  if (a === b) return true;
+
+  return sameSortedArrayItems(a, b, ([aTxIn], [bTxIn]) => txInEquals(aTxIn, bTxIn));
+};
 
 export const eraSummariesEquals = (a: EraSummary[], b: EraSummary[]) =>
   sameArrayItems(a, b, (es1, es2) => es1.start.slot === es2.start.slot);

--- a/packages/wallet/test/services/UtxoTracker.test.ts
+++ b/packages/wallet/test/services/UtxoTracker.test.ts
@@ -20,7 +20,7 @@ const createStubOutputs = (numOutputs: number) =>
 describe('createUtxoTracker', () => {
   // these variables are not relevant for this test, overwriting utxoSource$
   let retryBackoffConfig: RetryBackoffConfig;
-  let tipBlockHeight$: Observable<Cardano.BlockNo>;
+  let history$: Observable<Cardano.HydratedTx[]>;
   let utxoProvider: UtxoProvider;
   const logger = dummyLogger;
 
@@ -88,13 +88,13 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [ownAddress!] }),
+          history$,
           logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,
             utxo: store
           },
-          tipBlockHeight$,
           transactionsInFlight$,
           utxoProvider
         },
@@ -142,13 +142,13 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a', { a: [address!] }),
+          history$,
           logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,
             utxo: store
           },
-          tipBlockHeight$,
           transactionsInFlight$,
           utxoProvider
         },
@@ -172,13 +172,13 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [address!] }),
+          history$,
           logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,
             utxo: store
           },
-          tipBlockHeight$,
           transactionsInFlight$,
           utxoProvider
         },
@@ -211,13 +211,13 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [address!] }),
+          history$,
           logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,
             utxo: store
           },
-          tipBlockHeight$,
           transactionsInFlight$,
           utxoProvider
         },
@@ -241,13 +241,13 @@ describe('createUtxoTracker', () => {
       const utxoTracker = createUtxoTracker(
         {
           addresses$: cold('a|', { a: [address!] }),
+          history$,
           logger,
           retryBackoffConfig,
           stores: {
             unspendableUtxo: store,
             utxo: store
           },
-          tipBlockHeight$,
           transactionsInFlight$,
           utxoProvider
         },


### PR DESCRIPTION
# Context

Currently transactions are always compared (in quadratic time) and stored. This one is probably the main culprit of the performance issues in wallets with high TX history count. The Wallet fetches the transaction from last known slot up to tip, then it has some heuristic to determine if there were changes (such as rollbacks or new transactions), and if so applies the changes, after that it stores the transactions and returns them. It has a guard to avoid emitting the same transactions several time by comparing them to last emitted. It is using an algorithm of complexity O(N x M).

Additionally, Lace fetches the whole UTXO set of the wallet on every tip update.

- [x] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-11849)>
- [x] JIRA - \<[link](https://input-output.atlassian.net/browse/LW-11850)>

# Proposed Solution

- Only compare new transactions with the latest known transaction of the same block. The comparison between the transactions is now done in linear time O(N).
- Only fetch UTXOs when there are changes to the transaction history.
