### PR TITLE
perf(wallet): cache mapped addresses and utxo

### DIFF
--- a/packages/wallet/src/Wallets/BaseWallet.ts
+++ b/packages/wallet/src/Wallets/BaseWallet.ts
@@ -88,6 +88,7 @@ import {
   map,
   mergeMap,
   of,
+  shareReplay,
   switchMap,
   take,
   tap,
@@ -474,7 +475,9 @@ export class BaseWallet implements ObservableWallet {
     );
 
     const addresses$ = this.addresses$.pipe(
-      map((addresses) => addresses.map((groupedAddress) => groupedAddress.address))
+      map((addresses) => addresses.map((groupedAddress) => groupedAddress.address)),
+      distinctUntilChanged(deepEquals),
+      shareReplay(1)
     );
     this.#failedFromReemitter$ = new Subject<FailedTx>();
     this.transactions = createTransactionsTracker({

--- a/packages/wallet/test/services/UtxoTracker.test.ts
+++ b/packages/wallet/test/services/UtxoTracker.test.ts
@@ -267,10 +267,8 @@ describe('createUtxoTracker', () => {
       );
       expectObservable(utxoTracker.total$).toBe('-a--b---|', { a: utxo, b: utxo2 });
       expectObservable(utxoTracker.unspendable$).toBe('-a--b---|', { a: [utxo[0]], b: [] });
-      expectObservable(utxoTracker.available$).toBe('-a--b---|', {
-        a: utxo2,
-        b: utxo2
-      });
+      // utxo2 = utxo-unspendable
+      expectObservable(utxoTracker.available$).toBe('-a------|', { a: utxo2 });
     });
   });
 });


### PR DESCRIPTION
# Context

wallets with large # of utxo were performing poorly, because every subscription to utxo ran some computation

notably, each call to input resolver was running `firstValueFrom(utxo.available$)` which triggered a series of computations

# Proposed Solution

# Important Changes Introduced
