### PR TITLE
feat(tx-construction): throw when deregistering reward accounts with …

### DIFF
--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -41,6 +41,7 @@ import {
 import { SelectionSkeleton } from '@cardano-sdk/input-selection';
 import { contextLogger, deepEquals } from '@cardano-sdk/util';
 import { createOutputValidator } from '../output-validation';
+import { ensureNoDeRegistrationsWithRewardsLocked } from './ensureNoDeRegistrationsWithRewardsLocked';
 import { initializeTx } from './initializeTx';
 import { lastValueFrom } from 'rxjs';
 import { poll } from '@cardano-sdk/util-rxjs';
@@ -638,6 +639,8 @@ export class GenericTxBuilder implements TxBuilder {
       certificates.push(Cardano.createDelegationCert(rewardAccount.address, newPoolId));
       rewardAccountsWithWeights.set(rewardAccount.address, weight);
     }
+
+    ensureNoDeRegistrationsWithRewardsLocked(availableRewardAccounts);
 
     // Deregister stake keys no longer needed
     this.#logger.debug(`De-registering ${availableRewardAccounts.length} stake keys`);

--- a/packages/tx-construction/src/tx-builder/ensureNoDeRegistrationsWithRewardsLocked.ts
+++ b/packages/tx-construction/src/tx-builder/ensureNoDeRegistrationsWithRewardsLocked.ts
@@ -1,0 +1,14 @@
+import { DeRegistrationsWithRewardsLocked } from './types';
+import { hasCorrectVoteDelegation } from './hasCorrectVoteDelegation';
+import type { RewardAccountWithPoolId } from '../types';
+
+export const ensureNoDeRegistrationsWithRewardsLocked = (rewardAccountsToBeDeRegistered: RewardAccountWithPoolId[]) => {
+  const rewardAccountsWithLockedRewards = rewardAccountsToBeDeRegistered.filter(
+    (rewardAccountWithPoolId) =>
+      rewardAccountWithPoolId.rewardBalance > 0n && !hasCorrectVoteDelegation(rewardAccountWithPoolId)
+  );
+
+  if (rewardAccountsWithLockedRewards.length > 0) {
+    throw new DeRegistrationsWithRewardsLocked(rewardAccountsWithLockedRewards);
+  }
+};

--- a/packages/tx-construction/src/tx-builder/hasCorrectVoteDelegation.ts
+++ b/packages/tx-construction/src/tx-builder/hasCorrectVoteDelegation.ts
@@ -1,0 +1,9 @@
+import { Cardano } from '@cardano-sdk/core';
+import { RewardAccountWithPoolId } from '../types';
+
+export const hasCorrectVoteDelegation = ({
+  dRepDelegatee
+}: Pick<RewardAccountWithPoolId, 'dRepDelegatee'>): boolean => {
+  const drep = dRepDelegatee?.delegateRepresentative;
+  return !!drep && (!Cardano.isDrepInfo(drep) || drep.active);
+};


### PR DESCRIPTION
…rewards without drep

# Context

After Chang Fork it will become impossible to deregister stake keys with rewards but without vote delegation. We want to show an error in lace when this situation occur during removing stake pools from portfolio.

# Proposed Solution

Detect such case and throw an error with a set of required data so lace could list the affected keys.

# Important Changes Introduced

