### PR TITLE
fix(cardano-services-client): correct blockfrost tx submit request body

### DIFF
--- a/packages/cardano-services-client/src/TxSubmitProvider/BlockfrostTxSubmitProvider.ts
+++ b/packages/cardano-services-client/src/TxSubmitProvider/BlockfrostTxSubmitProvider.ts
@@ -10,7 +10,7 @@ export class BlockfrostTxSubmitProvider extends BlockfrostProvider implements Tx
   async submitTx({ signedTransaction }: SubmitTxArgs): Promise<void> {
     // @ todo handle context and resolutions
     await this.request<string>('tx/submit', {
-      body: signedTransaction,
+      body: Buffer.from(signedTransaction, 'hex'),
       headers: { 'Content-Type': 'application/cbor' },
       method: 'POST'
     });

--- a/packages/cardano-services-client/test/TxSubmitProvider/BlockfrostTxSubmitProvider.test.ts
+++ b/packages/cardano-services-client/test/TxSubmitProvider/BlockfrostTxSubmitProvider.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BlockfrostClient, BlockfrostTxSubmitProvider } from '../../src';
+import { HexBlob } from '@cardano-sdk/util';
 import { ProviderError } from '@cardano-sdk/core';
 import { logger } from '@cardano-sdk/util-dev';
 import { mockResponses } from '../util';
@@ -17,7 +18,7 @@ describe('blockfrostTxSubmitProvider', () => {
   describe('submitTx', () => {
     it('wraps error in UnknownTxSubmissionError', async () => {
       mockResponses(request, [['tx/submit', new Error('some error')]]);
-      await expect(provider.submitTx({ signedTransaction: null as any })).rejects.toThrowError(ProviderError);
+      await expect(provider.submitTx({ signedTransaction: HexBlob('abc') })).rejects.toThrowError(ProviderError);
     });
   });
 });


### PR DESCRIPTION
# Context

it has to be binary, otherwise Blockfrost responds with 400

this bug wasn't caught initially because we're not using BlockfrostTxSubmitProvider in our e2e test suite

LW-11695
