### PR TITLE
Feat/can set base wallet input resolver

### DIFF
--- a/packages/core/src/Cardano/Address/PaymentAddress.ts
+++ b/packages/core/src/Cardano/Address/PaymentAddress.ts
@@ -8,7 +8,7 @@ import {
   assertIsHexString
 } from '@cardano-sdk/util';
 import type { HydratedTx, Tx } from '../types/Transaction';
-import type { HydratedTxIn, TxIn, TxOut } from '../types/Utxo';
+import type { HydratedTxIn, TxIn, TxOut, Utxo } from '../types/Utxo';
 import type { NetworkId } from '../ChainId';
 import type { RewardAccount } from './RewardAccount';
 
@@ -69,7 +69,7 @@ export const inputsWithAddresses = (tx: HydratedTx, ownAddresses: PaymentAddress
   tx.body.inputs.filter(isAddressWithin(ownAddresses));
 
 export type ResolveOptions = {
-  hints: Tx[];
+  hints: { transactions?: Tx[]; utxos?: Utxo[] };
 };
 
 /**

--- a/packages/wallet/src/Wallets/BaseWallet.ts
+++ b/packages/wallet/src/Wallets/BaseWallet.ts
@@ -189,6 +189,7 @@ export interface BaseWalletDependencies {
   readonly connectionStatusTracker$?: ConnectionStatusTracker;
   readonly publicCredentialsManager: PublicCredentialsManager;
   readonly drepProvider: DRepProvider;
+  readonly inputResolver?: Cardano.InputResolver;
 }
 
 export interface SubmitTxOptions {
@@ -326,7 +327,8 @@ export class BaseWallet implements ObservableWallet {
       publicCredentialsManager,
       stores = createInMemoryWalletStores(),
       connectionStatusTracker$ = createSimpleConnectionStatusTracker(),
-      drepProvider
+      drepProvider,
+      inputResolver
     }: BaseWalletDependencies
   ) {
     this.#logger = contextLogger(logger, name);
@@ -607,6 +609,10 @@ export class BaseWallet implements ObservableWallet {
       transactions: this.transactions,
       utxo: this.utxo
     });
+
+    if (inputResolver) {
+      this.util.resolveInput = inputResolver.resolveInput.bind(inputResolver);
+    }
 
     const getPubDRepKey = async (): Promise<Ed25519PublicKeyHex | undefined> => {
       if (isBip32PublicCredentialsManager(this.#publicCredentialsManager)) {

--- a/packages/wallet/src/services/WalletUtil.ts
+++ b/packages/wallet/src/services/WalletUtil.ts
@@ -59,7 +59,7 @@ export const createInputResolver = ({ utxo, transactions }: InputResolverContext
     if (availableUtxo) return availableUtxo[1];
 
     if (options?.hints) {
-      const tx = options?.hints.find((hint) => hint.id === input.txId);
+      const tx = options?.hints?.transactions?.find((hint) => hint.id === input.txId);
 
       if (tx && tx.body.outputs.length > input.index) {
         return tx.body.outputs[input.index];
@@ -106,8 +106,8 @@ export const createBackendInputResolver = (provider: ChainHistoryProvider): Card
   return {
     async resolveInput(input: Cardano.TxIn, options?: Cardano.ResolveOptions) {
       // Add hints to the cache
-      if (options?.hints) {
-        for (const hint of options.hints) {
+      if (options?.hints && options.hints?.transactions) {
+        for (const hint of options.hints.transactions) {
           txCache.set(hint.id, hint);
         }
       }

--- a/packages/wallet/test/PersonalWallet/methods.test.ts
+++ b/packages/wallet/test/PersonalWallet/methods.test.ts
@@ -201,6 +201,42 @@ describe('BaseWallet methods', () => {
           })
         ).toBe(null);
       });
+
+      it('can override default input resolver', async () => {
+        const output = {
+          address: Cardano.PaymentAddress(
+            'addr_test1qpu5vlrf4xkxv2qpwngf6cjhtw542ayty80v8dyr49rf5ewvxwdrt70qlcpeeagscasafhffqsxy36t90ldv06wqrk2qum8x5w'
+          ),
+          value: { coins: 77n }
+        };
+
+        const input: Cardano.TxIn = { index: 0, txId: 'a' as Cardano.TransactionId };
+        const inputResolver = { resolveInput: jest.fn().mockResolvedValue(output) };
+
+        const walletWithInputResolver = createPersonalWallet(
+          { name: 'Test Wallet' },
+          {
+            addressDiscovery,
+            assetProvider,
+            bip32Account,
+            chainHistoryProvider,
+            drepProvider,
+            handleProvider,
+            inputResolver,
+            logger,
+            networkInfoProvider,
+            rewardsProvider,
+            stakePoolProvider,
+            txSubmitProvider,
+            utxoProvider,
+            witnesser
+          }
+        );
+
+        const result = await walletWithInputResolver.util.resolveInput(input);
+        expect(result).toEqual(output);
+        expect(inputResolver.resolveInput).toBeCalledTimes(1);
+      });
     });
   });
 

--- a/packages/wallet/test/services/WalletUtil.test.ts
+++ b/packages/wallet/test/services/WalletUtil.test.ts
@@ -145,7 +145,7 @@ describe('WalletUtil', () => {
             index: 0,
             txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
           },
-          { hints: [tx] }
+          { hints: { transactions: [tx] } }
         )
       ).toEqual({
         address:
@@ -159,7 +159,7 @@ describe('WalletUtil', () => {
             index: 1,
             txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
           },
-          { hints: [tx] }
+          { hints: { transactions: [tx] } }
         )
       ).toEqual({
         address:
@@ -269,7 +269,7 @@ describe('WalletUtil', () => {
             index: 0,
             txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
           },
-          { hints: [tx] }
+          { hints: { transactions: [tx] } }
         )
       ).toEqual({
         address:
@@ -283,7 +283,7 @@ describe('WalletUtil', () => {
             index: 1,
             txId: Cardano.TransactionId('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5')
           },
-          { hints: [tx] }
+          { hints: { transactions: [tx] } }
         )
       ).toEqual({
         address:
@@ -387,21 +387,23 @@ describe('WalletUtil', () => {
     });
 
     it('can resolve inputs from own transactions, hints and from chain history provider', async () => {
-      const hints = [
-        {
-          body: {
-            outputs: [
-              {
-                address: Cardano.PaymentAddress(
-                  'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
-                ),
-                value: { coins: 200_000_000n }
-              }
-            ]
-          },
-          id: Cardano.TransactionId('0000bbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0FFFFFFFFFF')
-        } as Cardano.HydratedTx
-      ];
+      const hints = {
+        transactions: [
+          {
+            body: {
+              outputs: [
+                {
+                  address: Cardano.PaymentAddress(
+                    'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+                  ),
+                  value: { coins: 200_000_000n }
+                }
+              ]
+            },
+            id: Cardano.TransactionId('0000bbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0FFFFFFFFFF')
+          } as Cardano.HydratedTx
+        ]
+      };
 
       const tx = {
         body: {


### PR DESCRIPTION
# Context

We want the be able to set the base wallet input resolver strategy.

# Proposed Solution

- BaseWallet can now take an additional dependency 'inputResolver'

# Important Changes Introduced

- BaseWallet has a new dependency 'inputResolver'
- InputResolver interface now has an additional optional hint parameter 'utxos'