### PR TITLE
feat: remove async from crypto API

### DIFF
--- a/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
+++ b/packages/cardano-services/src/StakePool/HttpStakePoolMetadata/HttpStakePoolMetadataService.ts
@@ -124,10 +124,10 @@ export const createHttpStakePoolMetadataService = (
           const signature = (await axiosClient.get<Crypto.Ed25519SignatureHex>(metadata.extSigUrl)).data;
           const message = HexBlob.fromBytes(Buffer.from(JSON.stringify(extMetadata)));
           const publicKey = Crypto.Ed25519PublicKeyHex(metadata.extVkey);
-          const bip32Ed25519 = new Crypto.SodiumBip32Ed25519();
+          const bip32Ed25519 = await Crypto.SodiumBip32Ed25519.create();
 
           // Verify the signature
-          const isSignatureValid = await bip32Ed25519.verify(signature, message, publicKey);
+          const isSignatureValid = bip32Ed25519.verify(signature, message, publicKey);
 
           // If not valid -> omit extended metadata from response and add specific error
           if (!isSignatureValid) {

--- a/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
+++ b/packages/core/test/Cardano/util/computeImplicitCoin.test.ts
@@ -7,6 +7,8 @@ describe('Cardano.util.computeImplicitCoin', () => {
   let dRepPublicKey: Crypto.Ed25519PublicKeyHex;
   let dRepKeyHash: Crypto.Ed25519KeyHashHex;
 
+  beforeAll(() => Crypto.ready());
+
   beforeEach(async () => {
     rewardAccount = Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27');
     stakeCredential = {
@@ -14,7 +16,7 @@ describe('Cardano.util.computeImplicitCoin', () => {
       type: Cardano.CredentialType.KeyHash
     };
     dRepPublicKey = Crypto.Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01');
-    dRepKeyHash = (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex();
+    dRepKeyHash = Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash().hex();
   });
 
   describe('calculates deposit', () => {

--- a/packages/crypto/src/Bip32/Bip32PrivateKey.ts
+++ b/packages/crypto/src/Bip32/Bip32PrivateKey.ts
@@ -71,6 +71,8 @@ export class Bip32PrivateKey {
    *   - 32 bytes: Ed25519 curve scalar from which few bits have been tweaked according to ED25519-BIP32
    *   - 32 bytes: Ed25519 binary blob used as IV for signing
    *
+   * NOTE: You must await `Crypto.ready()` at least once before calling this function.
+   *
    * @param entropy Random stream of bytes generated from a BIP39 seed phrase.
    * @param password The second factor authentication password for the mnemonic phrase.
    * @returns The secret extended key.
@@ -123,11 +125,12 @@ export class Bip32PrivateKey {
    * This is why deriving the private key should not fail while deriving
    * the public key may fail (if the derivation index is invalid).
    *
+   * NOTE: You must await `Crypto.ready()` at least once before calling this function.
+   *
    * @param derivationIndices The derivation indices.
    * @returns The child BIP-32 key.
    */
-  async derive(derivationIndices: number[]): Promise<Bip32PrivateKey> {
-    await sodium.ready;
+  derive(derivationIndices: number[]): Bip32PrivateKey {
     let key = Buffer.from(this.#key);
 
     for (const index of derivationIndices) {
@@ -145,10 +148,11 @@ export class Bip32PrivateKey {
   /**
    * Computes the BIP-32 public key from this BIP-32 private key.
    *
+   * NOTE: You must await `Crypto.ready()` at least once before calling this function.
+   *
    * @returns the public key.
    */
-  async toPublic(): Promise<Bip32PublicKey> {
-    await sodium.ready;
+  toPublic(): Bip32PublicKey {
     const scalar = extendedScalar(this.#key.slice(0, EXTENDED_ED25519_PRIVATE_KEY_LENGTH));
     const publicKey = sodium.crypto_scalarmult_ed25519_base_noclamp(scalar);
 

--- a/packages/crypto/src/Bip32/Bip32PublicKey.ts
+++ b/packages/crypto/src/Bip32/Bip32PublicKey.ts
@@ -53,11 +53,12 @@ export class Bip32PublicKey {
   /**
    * Given a set of indices, this function computes the corresponding child extended key.
    *
+   * NOTE: You must await `Crypto.ready()` at least once before calling this function.
+   *
    * @param derivationIndices The list of derivation indices.
    * @returns The child extended private key.
    */
-  async derive(derivationIndices: number[]): Promise<Bip32PublicKey> {
-    await sodium.ready;
+  derive(derivationIndices: number[]): Bip32PublicKey {
     let key = Buffer.from(this.#key);
 
     for (const index of derivationIndices) {
@@ -77,9 +78,8 @@ export class Bip32PublicKey {
     return Bip32PublicKeyHex(Buffer.from(this.#key).toString('hex'));
   }
 
-  /** Gets the blake2 hash of the key. */
-  async hash(): Promise<Bip32PublicKeyHashHex> {
-    await sodium.ready;
+  /** Gets the blake2 hash of the key. NOTE: You must await `Crypto.ready()` at least once before calling this function. */
+  hash(): Bip32PublicKeyHashHex {
     const hash = sodium.crypto_generichash(BIP32_PUBLIC_KEY_HASH_LENGTH, this.#key);
     return Bip32PublicKeyHashHex(Buffer.from(hash).toString('hex'));
   }

--- a/packages/crypto/src/Bip32Ed25519.ts
+++ b/packages/crypto/src/Bip32Ed25519.ts
@@ -37,7 +37,7 @@ export interface Bip32Ed25519 {
    * @param privateKey The private key to generate the public key from.
    * @returns The matching public key.
    */
-  getPublicKey(privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex): Promise<Ed25519PublicKeyHex>;
+  getPublicKey(privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex): Ed25519PublicKeyHex;
 
   /**
    * Computes the hash of the given public key.
@@ -45,16 +45,16 @@ export interface Bip32Ed25519 {
    * @param publicKey The public key to compute the hash from.
    * @returns The public key hash.
    */
-  getPubKeyHash(publicKey: Ed25519PublicKeyHex): Promise<Ed25519KeyHashHex>;
+  getPubKeyHash(publicKey: Ed25519PublicKeyHex): Ed25519KeyHashHex;
 
   /** Gets the Ed25519 raw private key. This key can be used for cryptographically signing messages. */
-  getRawPrivateKey(bip32PrivateKey: Bip32PrivateKeyHex): Promise<Ed25519PrivateExtendedKeyHex>;
+  getRawPrivateKey(bip32PrivateKey: Bip32PrivateKeyHex): Ed25519PrivateExtendedKeyHex;
 
   /**
    * Gets the Ed25519 raw public key. This key can be used for cryptographically verifying messages
    * previously signed with the matching Ed25519 raw private key.
    */
-  getRawPublicKey(bip32PublicKey: Bip32PublicKeyHex): Promise<Ed25519PublicKeyHex>;
+  getRawPublicKey(bip32PublicKey: Bip32PublicKeyHex): Ed25519PublicKeyHex;
 
   /**
    * The function computes the BIP-32 public key from the provided BIP-32 private key.
@@ -62,7 +62,7 @@ export interface Bip32Ed25519 {
    * @param privateKey The extended private key to generate the public key from.
    * @returns The extended public key.
    */
-  getBip32PublicKey(privateKey: Bip32PrivateKeyHex): Promise<Bip32PublicKeyHex>;
+  getBip32PublicKey(privateKey: Bip32PrivateKeyHex): Bip32PublicKeyHex;
 
   /**
    * Given a parent extended key and a set of indices, this function computes the corresponding child extended key.
@@ -71,7 +71,7 @@ export interface Bip32Ed25519 {
    * @param derivationIndices The list of derivation indices.
    * @returns The child extended private key.
    */
-  derivePrivateKey(parentKey: Bip32PrivateKeyHex, derivationIndices: BIP32Path): Promise<Bip32PrivateKeyHex>;
+  derivePrivateKey(parentKey: Bip32PrivateKeyHex, derivationIndices: BIP32Path): Bip32PrivateKeyHex;
 
   /**
    * Given a parent extended key and a set of indices, this function computes the corresponding child extended key.
@@ -80,7 +80,7 @@ export interface Bip32Ed25519 {
    * @param derivationIndices The list of derivation indices.
    * @returns The child extended public key.
    */
-  derivePublicKey(parentKey: Bip32PublicKeyHex, derivationIndices: BIP32Path): Promise<Bip32PublicKeyHex>;
+  derivePublicKey(parentKey: Bip32PublicKeyHex, derivationIndices: BIP32Path): Bip32PublicKeyHex;
 
   /**
    * Generates an Ed25519 signature using an extended private key.
@@ -89,10 +89,7 @@ export interface Bip32Ed25519 {
    * @param message The message to be signed.
    * @returns The Ed25519 digital signature.
    */
-  sign(
-    privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex,
-    message: HexBlob
-  ): Promise<Ed25519SignatureHex>;
+  sign(privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex, message: HexBlob): Ed25519SignatureHex;
 
   /**
    * Verifies that the passed-in signature was generated with a extended private key that matches
@@ -103,5 +100,5 @@ export interface Bip32Ed25519 {
    * @param publicKey The Ed25519 public key that validates the given signature.
    * @returns true if the signature is valid; otherwise; false.
    */
-  verify(signature: Ed25519SignatureHex, message: HexBlob, publicKey: Ed25519PublicKeyHex): Promise<boolean>;
+  verify(signature: Ed25519SignatureHex, message: HexBlob, publicKey: Ed25519PublicKeyHex): boolean;
 }

--- a/packages/crypto/src/Ed25519e/Ed25519PrivateKey.ts
+++ b/packages/crypto/src/Ed25519e/Ed25519PrivateKey.ts
@@ -78,11 +78,11 @@ export class Ed25519PrivateKey {
   /**
    * Computes the raw public key from this raw private key.
    *
+   * NOTE: You must await `Crypto.ready()` at least once before calling this function.
+   *
    * @returns the public key.
    */
-  async toPublic(): Promise<Ed25519PublicKey> {
-    await sodium.ready;
-
+  toPublic(): Ed25519PublicKey {
     return Ed25519PublicKey.fromBytes(
       this.__type === Ed25519PrivateKeyType.Extended
         ? sodium.crypto_scalarmult_ed25519_base_noclamp(extendedScalar(this.#keyMaterial))
@@ -93,17 +93,18 @@ export class Ed25519PrivateKey {
   /**
    * Generates an Ed25519 signature.
    *
+   * NOTE: You must await `Crypto.ready()` at least once before calling this function.
+   *
    * @param message The message to be signed.
    * @returns The Ed25519 digital signature.
    */
-  async sign(message: HexBlob): Promise<Ed25519Signature> {
-    await sodium.ready;
+  sign(message: HexBlob): Ed25519Signature {
     return Ed25519Signature.fromBytes(
       this.__type === Ed25519PrivateKeyType.Extended
         ? signExtendedDetached(this.#keyMaterial, Buffer.from(message, 'hex'))
         : sodium.crypto_sign_detached(
             Buffer.from(message, 'hex'),
-            Buffer.concat([this.#keyMaterial, (await this.toPublic()).bytes()])
+            Buffer.concat([this.#keyMaterial, this.toPublic().bytes()])
           )
     );
   }

--- a/packages/crypto/src/Ed25519e/Ed25519PublicKey.ts
+++ b/packages/crypto/src/Ed25519e/Ed25519PublicKey.ts
@@ -26,12 +26,13 @@ export class Ed25519PublicKey {
    * Verifies that the passed-in signature was generated with a private key that matches
    * the given public key.
    *
+   * NOTE: You must await `Crypto.ready()` at least once before calling this function.
+   *
    * @param signature The signature bytes to be verified.
    * @param message The original message the signature was computed from.
    * @returns true if the signature is valid; otherwise; false.
    */
-  async verify(signature: Ed25519Signature, message: HexBlob): Promise<boolean> {
-    await sodium.ready;
+  verify(signature: Ed25519Signature, message: HexBlob): boolean {
     return sodium.crypto_sign_verify_detached(signature.bytes(), Buffer.from(message, 'hex'), this.#keyMaterial);
   }
 
@@ -58,9 +59,8 @@ export class Ed25519PublicKey {
     return Ed25519PublicKey.fromBytes(Buffer.from(keyMaterial, 'hex'));
   }
 
-  /** Gets the blake2 hash of the key material. */
-  async hash(): Promise<Ed25519KeyHash> {
-    await sodium.ready;
+  /** Gets the blake2 hash of the key material. NOTE: You must await `Crypto.ready()` at least once before calling this function. */
+  hash(): Ed25519KeyHash {
     const hash = sodium.crypto_generichash(ED25519_PUBLIC_KEY_HASH_LENGTH, this.#keyMaterial);
     return Ed25519KeyHash.fromBytes(hash);
   }

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,4 +1,5 @@
 import blake2b from 'blake2b';
+import sodium from 'libsodium-wrappers-sumo';
 export { blake2b };
 
 export * from './Bip32';
@@ -7,3 +8,6 @@ export * from './Ed25519e';
 export * from './strategies';
 export * from './hexTypes';
 export * from './types';
+
+/** This function must be awaited before calling any other function in this module. It is safe to await this function multiple times. */
+export const ready = async (): Promise<void> => await sodium.ready;

--- a/packages/crypto/src/strategies/CmlBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/CmlBip32Ed25519.ts
@@ -30,9 +30,7 @@ export class CmlBip32Ed25519 implements Bip32Ed25519 {
     return Bip32PrivateKeyHex(Buffer.from(hexKey).toString('hex'));
   }
 
-  public getPublicKey(
-    privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex
-  ): Promise<Ed25519PublicKeyHex> {
+  public getPublicKey(privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex): Ed25519PublicKeyHex {
     return usingAutoFree((scope) => {
       const cmlPrivateKey =
         privateKey.length === EXTENDED_KEY_HEX_LENGTH
@@ -41,44 +39,44 @@ export class CmlBip32Ed25519 implements Bip32Ed25519 {
 
       const pubKeyBytes = scope.manage(cmlPrivateKey.to_public()).as_bytes();
 
-      return Promise.resolve(Ed25519PublicKeyHex(Buffer.from(pubKeyBytes).toString('hex')));
+      return Ed25519PublicKeyHex(Buffer.from(pubKeyBytes).toString('hex'));
     });
   }
 
-  public getPubKeyHash(publicKey: Ed25519PublicKeyHex): Promise<Ed25519KeyHashHex> {
+  public getPubKeyHash(publicKey: Ed25519PublicKeyHex): Ed25519KeyHashHex {
     return usingAutoFree((scope) => {
       const cmlPubKey = scope.manage(this.#CML.PublicKey.from_bytes(Buffer.from(publicKey, 'hex')));
       const keyHash = scope.manage(cmlPubKey.hash()).to_bytes();
 
-      return Promise.resolve(Ed25519KeyHashHex(Buffer.from(keyHash).toString('hex')));
+      return Ed25519KeyHashHex(Buffer.from(keyHash).toString('hex'));
     });
   }
 
-  public getRawPrivateKey(bip32PrivateKey: Bip32PrivateKeyHex): Promise<Ed25519PrivateExtendedKeyHex> {
+  public getRawPrivateKey(bip32PrivateKey: Bip32PrivateKeyHex): Ed25519PrivateExtendedKeyHex {
     return usingAutoFree((scope) => {
       const cmlPrivateKey = scope.manage(this.#CML.Bip32PrivateKey.from_bytes(Buffer.from(bip32PrivateKey, 'hex')));
       const bytes = scope.manage(cmlPrivateKey.to_raw_key()).as_bytes();
-      return Promise.resolve(Ed25519PrivateExtendedKeyHex(Buffer.from(bytes).toString('hex')));
+      return Ed25519PrivateExtendedKeyHex(Buffer.from(bytes).toString('hex'));
     });
   }
 
-  public getRawPublicKey(bip32PublicKey: Bip32PublicKeyHex): Promise<Ed25519PublicKeyHex> {
+  public getRawPublicKey(bip32PublicKey: Bip32PublicKeyHex): Ed25519PublicKeyHex {
     return usingAutoFree((scope) => {
       const cmlPublicKey = scope.manage(this.#CML.Bip32PublicKey.from_bytes(Buffer.from(bip32PublicKey, 'hex')));
       const bytes = scope.manage(cmlPublicKey.to_raw_key()).as_bytes();
-      return Promise.resolve(Ed25519PublicKeyHex(Buffer.from(bytes).toString('hex')));
+      return Ed25519PublicKeyHex(Buffer.from(bytes).toString('hex'));
     });
   }
 
-  public getBip32PublicKey(privateKey: Bip32PrivateKeyHex): Promise<Bip32PublicKeyHex> {
+  public getBip32PublicKey(privateKey: Bip32PrivateKeyHex): Bip32PublicKeyHex {
     return usingAutoFree((scope) => {
       const cmlPrivateKey = scope.manage(this.#CML.Bip32PrivateKey.from_bytes(Buffer.from(privateKey, 'hex')));
       const pubKeyBytes = scope.manage(cmlPrivateKey.to_public()).as_bytes();
-      return Promise.resolve(Bip32PublicKeyHex(Buffer.from(pubKeyBytes).toString('hex')));
+      return Bip32PublicKeyHex(Buffer.from(pubKeyBytes).toString('hex'));
     });
   }
 
-  public derivePrivateKey(parentKey: Bip32PrivateKeyHex, derivationIndices: BIP32Path): Promise<Bip32PrivateKeyHex> {
+  public derivePrivateKey(parentKey: Bip32PrivateKeyHex, derivationIndices: BIP32Path): Bip32PrivateKeyHex {
     return usingAutoFree((scope) => {
       let cmlKey = scope.manage(this.#CML.Bip32PrivateKey.from_bytes(Buffer.from(parentKey, 'hex')));
 
@@ -86,11 +84,11 @@ export class CmlBip32Ed25519 implements Bip32Ed25519 {
         cmlKey = scope.manage(cmlKey.derive(index));
       }
 
-      return Promise.resolve(Bip32PrivateKeyHex(Buffer.from(cmlKey.as_bytes()).toString('hex')));
+      return Bip32PrivateKeyHex(Buffer.from(cmlKey.as_bytes()).toString('hex'));
     });
   }
 
-  public derivePublicKey(parentKey: Bip32PublicKeyHex, derivationIndices: BIP32Path): Promise<Bip32PublicKeyHex> {
+  public derivePublicKey(parentKey: Bip32PublicKeyHex, derivationIndices: BIP32Path): Bip32PublicKeyHex {
     return usingAutoFree((scope) => {
       let cmlKey = scope.manage(this.#CML.Bip32PublicKey.from_bytes(Buffer.from(parentKey, 'hex')));
 
@@ -98,33 +96,29 @@ export class CmlBip32Ed25519 implements Bip32Ed25519 {
         cmlKey = scope.manage(cmlKey.derive(index));
       }
 
-      return Promise.resolve(Bip32PublicKeyHex(Buffer.from(cmlKey.as_bytes()).toString('hex')));
+      return Bip32PublicKeyHex(Buffer.from(cmlKey.as_bytes()).toString('hex'));
     });
   }
 
-  public async sign(
+  public sign(
     privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex,
     message: HexBlob
-  ): Promise<Ed25519SignatureHex> {
+  ): Ed25519SignatureHex {
     return usingAutoFree((scope) => {
       const cmlPrivateKey =
         privateKey.length === EXTENDED_KEY_HEX_LENGTH
           ? scope.manage(this.#CML.PrivateKey.from_extended_bytes(Buffer.from(privateKey, 'hex')))
           : scope.manage(this.#CML.PrivateKey.from_normal_bytes(Buffer.from(privateKey, 'hex')));
       const signature = scope.manage(cmlPrivateKey.sign(Buffer.from(message, 'hex'))).to_bytes();
-      return Promise.resolve(Ed25519SignatureHex(Buffer.from(signature).toString('hex')));
+      return Ed25519SignatureHex(Buffer.from(signature).toString('hex'));
     });
   }
 
-  public async verify(
-    signature: Ed25519SignatureHex,
-    message: HexBlob,
-    publicKey: Ed25519PublicKeyHex
-  ): Promise<boolean> {
+  public verify(signature: Ed25519SignatureHex, message: HexBlob, publicKey: Ed25519PublicKeyHex): boolean {
     return usingAutoFree((scope) => {
       const cmlKey = scope.manage(this.#CML.PublicKey.from_bytes(Buffer.from(publicKey, 'hex')));
       const cmlSignature = scope.manage(this.#CML.Ed25519Signature.from_bytes(Buffer.from(signature, 'hex')));
-      return Promise.resolve(cmlKey.verify(Buffer.from(message, 'hex'), cmlSignature));
+      return cmlKey.verify(Buffer.from(message, 'hex'), cmlSignature);
     });
   }
 }

--- a/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
@@ -12,77 +12,79 @@ import {
 } from '../hexTypes';
 import { Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature } from '../Ed25519e';
 import { HexBlob } from '@cardano-sdk/util';
+import sodium from 'libsodium-wrappers-sumo';
 
 const EXTENDED_KEY_HEX_LENGTH = 128;
 
 export class SodiumBip32Ed25519 implements Bip32Ed25519 {
+  // Prevent instantiation
+  private constructor() {
+    // Empty
+  }
+
+  public static async create(): Promise<SodiumBip32Ed25519> {
+    await sodium.ready;
+    return Promise.resolve(new SodiumBip32Ed25519());
+  }
+
   public fromBip39Entropy(entropy: Buffer, passphrase: string): Bip32PrivateKeyHex {
     return Bip32PrivateKey.fromBip39Entropy(entropy, passphrase).hex();
   }
 
-  public async getPublicKey(
-    privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex
-  ): Promise<Ed25519PublicKeyHex> {
+  public getPublicKey(privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex): Ed25519PublicKeyHex {
     const key =
       privateKey.length === EXTENDED_KEY_HEX_LENGTH
         ? Ed25519PrivateKey.fromExtendedHex(privateKey)
         : Ed25519PrivateKey.fromNormalHex(privateKey);
 
-    return (await key.toPublic()).hex();
+    return key.toPublic().hex();
   }
 
-  public async getPubKeyHash(publicKey: Ed25519PublicKeyHex): Promise<Ed25519KeyHashHex> {
-    const pubKey = await Ed25519PublicKey.fromHex(publicKey);
+  public getPubKeyHash(publicKey: Ed25519PublicKeyHex): Ed25519KeyHashHex {
+    const pubKey = Ed25519PublicKey.fromHex(publicKey);
 
-    return (await pubKey.hash()).hex();
+    return pubKey.hash().hex();
   }
 
-  public async getRawPrivateKey(bip32PrivateKey: Bip32PrivateKeyHex): Promise<Ed25519PrivateExtendedKeyHex> {
-    return (await Bip32PrivateKey.fromHex(bip32PrivateKey)).toRawKey().hex();
+  public getRawPrivateKey(bip32PrivateKey: Bip32PrivateKeyHex): Ed25519PrivateExtendedKeyHex {
+    return Bip32PrivateKey.fromHex(bip32PrivateKey).toRawKey().hex();
   }
 
-  public async getRawPublicKey(bip32PublicKey: Bip32PublicKeyHex): Promise<Ed25519PublicKeyHex> {
-    const pubKey = await Bip32PublicKey.fromHex(bip32PublicKey);
-    return (await pubKey.toRawKey()).hex();
+  public getRawPublicKey(bip32PublicKey: Bip32PublicKeyHex): Ed25519PublicKeyHex {
+    const pubKey = Bip32PublicKey.fromHex(bip32PublicKey);
+    return pubKey.toRawKey().hex();
   }
 
-  public async getBip32PublicKey(privateKey: Bip32PrivateKeyHex): Promise<Bip32PublicKeyHex> {
-    const privKey = await Bip32PrivateKey.fromHex(privateKey);
-    return (await privKey.toPublic()).hex();
+  public getBip32PublicKey(privateKey: Bip32PrivateKeyHex): Bip32PublicKeyHex {
+    const privKey = Bip32PrivateKey.fromHex(privateKey);
+    return privKey.toPublic().hex();
   }
 
-  public async derivePrivateKey(
-    parentKey: Bip32PrivateKeyHex,
-    derivationIndices: BIP32Path
-  ): Promise<Bip32PrivateKeyHex> {
-    const privKey = await Bip32PrivateKey.fromHex(parentKey);
-    return (await privKey.derive(derivationIndices)).hex();
+  public derivePrivateKey(parentKey: Bip32PrivateKeyHex, derivationIndices: BIP32Path): Bip32PrivateKeyHex {
+    const privKey = Bip32PrivateKey.fromHex(parentKey);
+    return privKey.derive(derivationIndices).hex();
   }
 
-  public async derivePublicKey(parentKey: Bip32PublicKeyHex, derivationIndices: BIP32Path): Promise<Bip32PublicKeyHex> {
-    const pubKey = await Bip32PublicKey.fromHex(parentKey);
-    return (await pubKey.derive(derivationIndices)).hex();
+  public derivePublicKey(parentKey: Bip32PublicKeyHex, derivationIndices: BIP32Path): Bip32PublicKeyHex {
+    const pubKey = Bip32PublicKey.fromHex(parentKey);
+    return pubKey.derive(derivationIndices).hex();
   }
 
-  public async sign(
+  public sign(
     privateKey: Ed25519PrivateExtendedKeyHex | Ed25519PrivateNormalKeyHex,
     message: HexBlob
-  ): Promise<Ed25519SignatureHex> {
+  ): Ed25519SignatureHex {
     const key =
       privateKey.length === EXTENDED_KEY_HEX_LENGTH
         ? Ed25519PrivateKey.fromExtendedHex(privateKey)
         : Ed25519PrivateKey.fromNormalHex(privateKey);
 
-    return (await key.sign(message)).hex();
+    return key.sign(message).hex();
   }
 
-  public async verify(
-    signature: Ed25519SignatureHex,
-    message: HexBlob,
-    publicKey: Ed25519PublicKeyHex
-  ): Promise<boolean> {
-    const key = await Ed25519PublicKey.fromHex(publicKey);
+  public verify(signature: Ed25519SignatureHex, message: HexBlob, publicKey: Ed25519PublicKeyHex): boolean {
+    const key = Ed25519PublicKey.fromHex(publicKey);
 
-    return await key.verify(Ed25519Signature.fromHex(signature), message);
+    return key.verify(Ed25519Signature.fromHex(signature), message);
   }
 }

--- a/packages/crypto/test/bip32/Bip32PrivateKey.test.ts
+++ b/packages/crypto/test/bip32/Bip32PrivateKey.test.ts
@@ -3,6 +3,8 @@ import { InvalidStringError } from '@cardano-sdk/util';
 import { bip32TestVectorMessageOneLength, extendedVectors } from '../ed25519e/Ed25519TestVectors';
 
 describe('Bip32PrivateKey', () => {
+  beforeAll(() => Crypto.ready());
+
   it('can create an instance from a valid normal BIP-32 private key hex representation', async () => {
     const privateKey = Crypto.Bip32PrivateKey.fromHex(
       Crypto.Bip32PrivateKeyHex(bip32TestVectorMessageOneLength.rootKey)

--- a/packages/crypto/test/bip32/Bip32PublicKey.test.ts
+++ b/packages/crypto/test/bip32/Bip32PublicKey.test.ts
@@ -7,6 +7,8 @@ import {
 } from '../ed25519e/Ed25519TestVectors';
 
 describe('Bip32PublicKey', () => {
+  beforeAll(() => Crypto.ready());
+
   it('can create an instance from a valid normal BIP-32 public key hex representation', async () => {
     const publicKey = Crypto.Bip32PublicKey.fromHex(
       Crypto.Bip32PublicKeyHex(bip32TestVectorMessageOneLength.publicKey)

--- a/packages/crypto/test/ed25519e/Ed25519PrivateKey.test.ts
+++ b/packages/crypto/test/ed25519e/Ed25519PrivateKey.test.ts
@@ -8,6 +8,8 @@ import {
 } from './Ed25519TestVectors';
 
 describe('Ed25519PrivateKey', () => {
+  beforeAll(() => Crypto.ready());
+
   it('can create an instance from a valid normal Ed25519 private key hex representation', () => {
     const privateKey = Crypto.Ed25519PrivateKey.fromNormalHex(
       Crypto.Ed25519PrivateNormalKeyHex(testVectorMessageZeroLength.secretKey)
@@ -62,7 +64,7 @@ describe('Ed25519PrivateKey', () => {
 
     for (const vector of vectors) {
       const privateKey = Crypto.Ed25519PrivateKey.fromNormalHex(Crypto.Ed25519PrivateNormalKeyHex(vector.secretKey));
-      const publicKey = await privateKey.toPublic();
+      const publicKey = privateKey.toPublic();
 
       expect(publicKey.hex()).toBe(vector.publicKey);
     }
@@ -75,7 +77,7 @@ describe('Ed25519PrivateKey', () => {
       const privateKey = Crypto.Ed25519PrivateKey.fromExtendedHex(
         Crypto.Ed25519PrivateExtendedKeyHex(vector.ed25519eVector.secretKey)
       );
-      const publicKey = await privateKey.toPublic();
+      const publicKey = privateKey.toPublic();
 
       expect(publicKey.hex()).toBe(vector.ed25519eVector.publicKey);
     }
@@ -88,9 +90,9 @@ describe('Ed25519PrivateKey', () => {
       const privateKey = Crypto.Ed25519PrivateKey.fromNormalHex(Crypto.Ed25519PrivateNormalKeyHex(vector.secretKey));
       const publicKey = Crypto.Ed25519PublicKey.fromHex(Crypto.Ed25519PublicKeyHex(vector.publicKey));
       const message = HexBlob(vector.message);
-      const signature = await privateKey.sign(HexBlob(vector.message));
+      const signature = privateKey.sign(HexBlob(vector.message));
 
-      const isSignatureValid = await publicKey.verify(signature, message);
+      const isSignatureValid = publicKey.verify(signature, message);
       expect(signature.hex()).toBe(vector.signature);
       expect(isSignatureValid).toBeTruthy();
     }
@@ -106,9 +108,9 @@ describe('Ed25519PrivateKey', () => {
       );
       const publicKey = Crypto.Ed25519PublicKey.fromHex(Crypto.Ed25519PublicKeyHex(vector.publicKey));
       const message = HexBlob(vector.message);
-      const signature = await privateKey.sign(HexBlob(vector.message));
+      const signature = privateKey.sign(HexBlob(vector.message));
 
-      const isSignatureValid = await publicKey.verify(signature, message);
+      const isSignatureValid = publicKey.verify(signature, message);
       expect(signature.hex()).toBe(vector.signature);
       expect(isSignatureValid).toBeTruthy();
     }

--- a/packages/crypto/test/ed25519e/Ed25519PublicKey.test.ts
+++ b/packages/crypto/test/ed25519e/Ed25519PublicKey.test.ts
@@ -3,6 +3,8 @@ import { HexBlob, InvalidStringError } from '@cardano-sdk/util';
 import { InvalidSignature, testVectorMessageZeroLength, vectors } from './Ed25519TestVectors';
 
 describe('Ed25519PublicKey', () => {
+  beforeAll(() => Crypto.ready());
+
   it('can create an instance from a valid Ed25519 public key hex representation', () => {
     const publicKey = Crypto.Ed25519PublicKey.fromHex(
       Crypto.Ed25519PublicKeyHex(testVectorMessageZeroLength.publicKey)

--- a/packages/crypto/test/ed25519e/Ed25519Signature.test.ts
+++ b/packages/crypto/test/ed25519e/Ed25519Signature.test.ts
@@ -3,6 +3,8 @@ import { InvalidStringError } from '@cardano-sdk/util';
 import { testVectorMessageZeroLength } from './Ed25519TestVectors';
 
 describe('Ed25519Signature', () => {
+  beforeAll(() => Crypto.ready());
+
   it('can create an instance from a valid Ed25519 signature hex representation', () => {
     const signature = Crypto.Ed25519Signature.fromHex(
       Crypto.Ed25519SignatureHex(testVectorMessageZeroLength.signature)

--- a/packages/e2e/src/factories.ts
+++ b/packages/e2e/src/factories.ts
@@ -104,7 +104,7 @@ addressDiscoveryFactory.register(
 // bip32Ed25519
 
 bip32Ed25519Factory.register('CML', async () => new Crypto.CmlBip32Ed25519(CML));
-bip32Ed25519Factory.register('Sodium', async () => new Crypto.SodiumBip32Ed25519());
+bip32Ed25519Factory.register('Sodium', async () => Crypto.SodiumBip32Ed25519.create());
 
 // Web Socket
 

--- a/packages/e2e/src/scripts/mnemonic.ts
+++ b/packages/e2e/src/scripts/mnemonic.ts
@@ -17,7 +17,7 @@ import { localNetworkChainId } from '../util';
       mnemonicWords: mnemonicArray
     },
     {
-      bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
+      bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(),
       logger: console
     }
   );

--- a/packages/e2e/src/util/createMockKeyAgent.ts
+++ b/packages/e2e/src/util/createMockKeyAgent.ts
@@ -8,11 +8,13 @@ const extendedAccountPublicKey = Bip32PublicKeyHex(
   '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
 );
 
-export const createMockKeyAgent = (deriveAddressesReturn: GroupedAddress[] = []): jest.Mocked<KeyAgent> => {
+export const createMockKeyAgent = async (
+  deriveAddressesReturn: GroupedAddress[] = []
+): Promise<jest.Mocked<KeyAgent>> => {
   const remainingDeriveAddressesReturn = [...deriveAddressesReturn];
   return {
     accountIndex,
-    bip32Ed25519: new SodiumBip32Ed25519(),
+    bip32Ed25519: await SodiumBip32Ed25519.create(),
     chainId,
     deriveAddress: jest.fn().mockImplementation(async () => remainingDeriveAddressesReturn.shift()),
     derivePublicKey: jest.fn(),

--- a/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.ts
+++ b/packages/e2e/test/artillery/wallet-restoration/WalletRestoration.ts
@@ -89,7 +89,7 @@ export const walletRestoration: FunctionHook<WalletVars> = async ({ vars, _uid }
 
   try {
     // Creates Stub KeyAgent
-    const keyAgent = util.createAsyncKeyAgent(createMockKeyAgent([currentAddress]));
+    const keyAgent = util.createAsyncKeyAgent(await createMockKeyAgent([currentAddress]));
 
     // Start to measure wallet restoration time
     const startedAt = Date.now();

--- a/packages/e2e/test/load-test-custom/wallet-restoration/wallet-restoration.test.ts
+++ b/packages/e2e/test/load-test-custom/wallet-restoration/wallet-restoration.test.ts
@@ -41,7 +41,7 @@ const initWallets = async (walletsNum: number, addresses: GroupedAddress[]): Pro
   for (let i = 0; i < walletsNum; i++) {
     currentAddress = addresses[i];
     testLogger.info('  address:', currentAddress.address);
-    const keyAgent = util.createAsyncKeyAgent(createMockKeyAgent([currentAddress]));
+    const keyAgent = util.createAsyncKeyAgent(await createMockKeyAgent([currentAddress]));
     const { wallet } = await getWallet({
       env,
       idx: 0,

--- a/packages/governance/test/cip36.test.ts
+++ b/packages/governance/test/cip36.test.ts
@@ -52,7 +52,7 @@ describe('cip36', () => {
       );
       const signedCip36Metadata = await cip36.metadataBuilder.signVotingRegistration(votingRegistrationMetadata, {
         signBlob: async (blob) => {
-          const bip32Ed25519 = new Crypto.SodiumBip32Ed25519();
+          const bip32Ed25519 = await Crypto.SodiumBip32Ed25519.create();
           const privateStakeKey = Crypto.Ed25519PrivateNormalKeyHex(
             '852fa5d17df3efdfdcd6dac53ec9fe5593f3c0bd7cadb3c2af76c7e15dfa8a5c'
           );

--- a/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
+++ b/packages/hardware-ledger/test/LedgerKeyAgent.test.ts
@@ -368,7 +368,7 @@ describe('LedgerKeyAgent', () => {
       txInKeyPathMap: {}
     };
 
-    beforeAll(() => {
+    beforeAll(async () => {
       LedgerKeyAgent.checkDeviceConnection = async () => new Ada(new Transport());
 
       keyAgentMock = new LedgerKeyAgent(
@@ -382,7 +382,7 @@ describe('LedgerKeyAgent', () => {
           purpose: KeyPurpose.STANDARD
         },
         {
-          bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
+          bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(),
           logger: dummyLogger
         }
       );

--- a/packages/key-management/test/Bip32Account.test.ts
+++ b/packages/key-management/test/Bip32Account.test.ts
@@ -13,7 +13,7 @@ describe('Bip32Account', () => {
   beforeEach(async () => {
     const mnemonicWords = util.generateMnemonicWords();
     const getPassphrase = jest.fn().mockResolvedValue(Buffer.from('password'));
-    const keyAgentDependencies = { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger: dummyLogger };
+    const keyAgentDependencies = { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger: dummyLogger };
     const testnetKeyAgent = await InMemoryKeyAgent.fromBip39MnemonicWords(
       {
         accountIndex,

--- a/packages/key-management/test/InMemoryKeyAgent.test.ts
+++ b/packages/key-management/test/InMemoryKeyAgent.test.ts
@@ -8,6 +8,7 @@ import {
   SerializableInMemoryKeyAgentData,
   util
 } from '../src';
+import { Bip32Ed25519 } from '@cardano-sdk/crypto';
 import { Cardano, Serialization } from '@cardano-sdk/core';
 import { HexBlob } from '@cardano-sdk/util';
 import { dummyLogger } from 'ts-log';
@@ -19,7 +20,11 @@ describe('InMemoryKeyAgent', () => {
   let keyAgent: InMemoryKeyAgent;
   let getPassphrase: jest.Mock;
   let mnemonicWords: string[];
-  const bip32Ed25519 = new Crypto.SodiumBip32Ed25519();
+  let bip32Ed25519: Bip32Ed25519;
+
+  beforeAll(async () => {
+    bip32Ed25519 = await Crypto.SodiumBip32Ed25519.create();
+  });
 
   beforeEach(async () => {
     mnemonicWords = util.generateMnemonicWords();
@@ -160,7 +165,7 @@ describe('InMemoryKeyAgent', () => {
           accountIndex: 0,
           chainId: Cardano.ChainIds.Preview,
           encryptedRootPrivateKeyBytes: [...Buffer.from(yoroiEncryptedRootPrivateKeyHex, 'hex')],
-          extendedAccountPublicKey: await bip32Ed25519.getBip32PublicKey(
+          extendedAccountPublicKey: bip32Ed25519.getBip32PublicKey(
             await util.deriveAccountPrivateKey({
               accountIndex: 0,
               bip32Ed25519,
@@ -259,7 +264,7 @@ describe('InMemoryKeyAgent', () => {
           accountIndex: 0,
           chainId: Cardano.ChainIds.Preview,
           encryptedRootPrivateKeyBytes: [...Buffer.from(daedelusEncryptedRootPrivateKeyHex, 'hex')],
-          extendedAccountPublicKey: await bip32Ed25519.getBip32PublicKey(
+          extendedAccountPublicKey: bip32Ed25519.getBip32PublicKey(
             await util.deriveAccountPrivateKey({
               accountIndex: 0,
               bip32Ed25519,

--- a/packages/key-management/test/KeyAgentBase.test.ts
+++ b/packages/key-management/test/KeyAgentBase.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, KeyAgentBase, KeyAgentType, KeyPurpose, KeyRole, SerializableInMemoryKeyAgentData } from '../src';
+import { Bip32Ed25519 } from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
 import { dummyLogger } from 'ts-log';
 
 const ACCOUNT_INDEX = 1;
-const bip32Ed25519 = new Crypto.SodiumBip32Ed25519();
 
 class MockKeyAgent extends KeyAgentBase {
-  constructor(data: SerializableInMemoryKeyAgentData) {
+  constructor(data: SerializableInMemoryKeyAgentData, bip32Ed25519: Bip32Ed25519) {
     super(data, {
       bip32Ed25519,
       logger: dummyLogger
@@ -27,18 +27,21 @@ class MockKeyAgent extends KeyAgentBase {
 describe('KeyAgentBase', () => {
   let keyAgent: MockKeyAgent;
 
-  beforeEach(() => {
-    keyAgent = new MockKeyAgent({
-      __typename: KeyAgentType.InMemory,
-      accountIndex: ACCOUNT_INDEX,
-      chainId: Cardano.ChainIds.Preview,
-      encryptedRootPrivateKeyBytes: [],
-      extendedAccountPublicKey: Crypto.Bip32PublicKeyHex(
-        // eslint-disable-next-line max-len
-        'fc5ab25e830b67c47d0a17411bf7fdabf711a597fb6cf04102734b0a2934ceaaa65ff5e7c52498d52c07b8ddfcd436fc2b4d2775e2984a49d0c79f65ceee4779'
-      ),
-      purpose: KeyPurpose.STANDARD
-    });
+  beforeEach(async () => {
+    keyAgent = new MockKeyAgent(
+      {
+        __typename: KeyAgentType.InMemory,
+        accountIndex: ACCOUNT_INDEX,
+        chainId: Cardano.ChainIds.Preview,
+        encryptedRootPrivateKeyBytes: [],
+        extendedAccountPublicKey: Crypto.Bip32PublicKeyHex(
+          // eslint-disable-next-line max-len
+          'fc5ab25e830b67c47d0a17411bf7fdabf711a597fb6cf04102734b0a2934ceaaa65ff5e7c52498d52c07b8ddfcd436fc2b4d2775e2984a49d0c79f65ceee4779'
+        ),
+        purpose: KeyPurpose.STANDARD
+      },
+      await Crypto.SodiumBip32Ed25519.create()
+    );
   });
 
   // eslint-disable-next-line max-len

--- a/packages/key-management/test/mocks/mockKeyAgentDependencies.ts
+++ b/packages/key-management/test/mocks/mockKeyAgentDependencies.ts
@@ -2,7 +2,7 @@ import { KeyAgentDependencies } from '../../src/';
 import { SodiumBip32Ed25519 } from '@cardano-sdk/crypto';
 import { dummyLogger } from 'ts-log';
 
-export const mockKeyAgentDependencies = (): jest.Mocked<KeyAgentDependencies> => ({
-  bip32Ed25519: new SodiumBip32Ed25519(),
+export const mockKeyAgentDependencies = async (): Promise<jest.Mocked<KeyAgentDependencies>> => ({
+  bip32Ed25519: await SodiumBip32Ed25519.create(),
   logger: dummyLogger
 });

--- a/packages/key-management/test/util/ensureStakeKeys.test.ts
+++ b/packages/key-management/test/util/ensureStakeKeys.test.ts
@@ -1,3 +1,4 @@
+import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, Bip32Account, util } from '../../src';
 import { Bip32PublicKeyHex } from '@cardano-sdk/crypto';
 import { Cardano } from '@cardano-sdk/core';
@@ -6,6 +7,8 @@ import { Logger, dummyLogger } from 'ts-log';
 describe('ensureStakeKeys', () => {
   let bip32Account: Bip32Account;
   let logger: Logger;
+
+  beforeAll(() => Crypto.ready());
 
   beforeEach(async () => {
     logger = dummyLogger;

--- a/packages/key-management/test/util/ownSignaturePaths.test.ts
+++ b/packages/key-management/test/util/ownSignaturePaths.test.ts
@@ -59,9 +59,11 @@ describe('KeyManagement.util.ownSignaturePaths', () => {
 
   const knownAddress1 = createGroupedAddress(address1, ownRewardAccount, AddressType.External, 0, stakeKeyPath);
 
+  beforeAll(() => Crypto.ready());
+
   beforeEach(async () => {
     dRepPublicKey = Crypto.Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01');
-    dRepKeyHash = (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex();
+    dRepKeyHash = Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash().hex();
   });
 
   it('returns distinct derivation paths required to sign the transaction', async () => {

--- a/packages/key-management/test/util/stubSignTransaction.test.ts
+++ b/packages/key-management/test/util/stubSignTransaction.test.ts
@@ -1,5 +1,5 @@
 import { Cardano } from '@cardano-sdk/core';
-import { Ed25519PublicKey, Ed25519PublicKeyHex } from '@cardano-sdk/crypto';
+import { Ed25519PublicKey, Ed25519PublicKeyHex, ready } from '@cardano-sdk/crypto';
 
 import { GroupedAddress, util } from '../../src';
 
@@ -7,11 +7,15 @@ jest.mock('../../src/util/ownSignatureKeyPaths');
 const { ownSignatureKeyPaths } = jest.requireMock('../../src/util/ownSignatureKeyPaths');
 
 describe('KeyManagement.util.stubSignTransaction', () => {
+  beforeAll(async () => {
+    await ready();
+  });
+
   it('returns as many signatures as number of keys returned by ownSignaturePaths', async () => {
     const txBody = {} as Cardano.HydratedTxBody;
     const knownAddresses = [{} as GroupedAddress];
     const dRepPublicKey = Ed25519PublicKeyHex('0b1c96fad4179d7910bd9485ac28c4c11368c83d18d01b29d4cf84d8ff6a06c4');
-    const dRepKeyHash = (await Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex();
+    const dRepKeyHash = Ed25519PublicKey.fromHex(dRepPublicKey).hash().hex();
     const txInKeyPathMap = {};
     ownSignatureKeyPaths.mockReturnValueOnce(['a']).mockReturnValueOnce(['a', 'b']);
     expect(

--- a/packages/tx-construction/test/tx-builder/TxBuilder.bootstrap.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.bootstrap.test.ts
@@ -37,7 +37,7 @@ describe.each([
           getPassphrase: async () => Buffer.from([]),
           mnemonicWords: util.generateMnemonicWords()
         },
-        { bip32Ed25519: new SodiumBip32Ed25519(), logger }
+        { bip32Ed25519: await SodiumBip32Ed25519.create(), logger }
       )
     );
     const txBuilderProviders: jest.Mocked<TxBuilderProviders> = {

--- a/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilder.test.ts
@@ -84,7 +84,7 @@ describe.each([
         getPassphrase: async () => Buffer.from('passphrase'),
         mnemonicWords: util.generateMnemonicWords()
       },
-      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger: dummyLogger }
+      { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger: dummyLogger }
     );
 
     knownAddresses = [

--- a/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderDelegatePortfolio.test.ts
@@ -157,7 +157,7 @@ describe('TxBuilder/delegatePortfolio', () => {
         getPassphrase: async () => Buffer.from('passphrase'),
         mnemonicWords: util.generateMnemonicWords()
       },
-      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger: dummyLogger }
+      { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger: dummyLogger }
     );
   });
 

--- a/packages/tx-construction/test/tx-builder/TxBuilderPlutusScripts.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderPlutusScripts.test.ts
@@ -201,7 +201,7 @@ describe('TxBuilder/plutusScripts', () => {
         getPassphrase: async () => Buffer.from('passphrase'),
         mnemonicWords: util.generateMnemonicWords()
       },
-      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger: dummyLogger }
+      { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger: dummyLogger }
     );
 
     const txBuilderFactory = await createTxBuilder({

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.integration.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.integration.test.ts
@@ -49,10 +49,10 @@ const createWallet = async (keyAgent: KeyAgent) => {
 
 const getAddress = async (wallet: ObservableWallet) => (await firstValueFrom(wallet.addresses$))[0].address;
 
-const keyAgentDependencies = { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger };
-
 describe('LedgerKeyAgent+BaseWallet', () => {
   test('creating and restoring LedgerKeyAgent wallet', async () => {
+    const keyAgentDependencies = { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger };
+
     const freshKeyAgent = await LedgerKeyAgent.createWithDevice(
       {
         chainId: Cardano.ChainIds.Preprod,

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -110,7 +110,7 @@ describe('LedgerKeyAgent', () => {
           chainId: Cardano.ChainIds.Preprod,
           communicationType: CommunicationType.Node
         },
-        { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger }
+        { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger }
       );
     });
 
@@ -126,7 +126,7 @@ describe('LedgerKeyAgent', () => {
           communicationType: CommunicationType.Node,
           deviceConnection: ledgerKeyAgent.deviceConnection
         },
-        mockKeyAgentDependencies()
+        await mockKeyAgentDependencies()
       );
       expect(ledgerKeyAgentWithRandomIndex).toBeInstanceOf(LedgerKeyAgent);
       expect(ledgerKeyAgentWithRandomIndex.accountIndex).toEqual(5);
@@ -718,12 +718,12 @@ describe('LedgerKeyAgent', () => {
               const { coseSign1, publicKeyHex, signedData } = await signAndDecode(signWith, wallet);
               const signedDataBytes = HexBlob.fromBytes(signedData.to_bytes());
               const signatureBytes = HexBlob.fromBytes(coseSign1.signature()) as unknown as Crypto.Ed25519SignatureHex;
-              const cryptoProvider = new Crypto.SodiumBip32Ed25519();
+              const cryptoProvider = await Crypto.SodiumBip32Ed25519.create();
 
               testAddressHeader(signedData, signWith);
 
               expect(
-                await cryptoProvider.verify(
+                cryptoProvider.verify(
                   signatureBytes,
                   signedDataBytes,
                   publicKeyHex as unknown as Crypto.Ed25519PublicKeyHex
@@ -736,12 +736,12 @@ describe('LedgerKeyAgent', () => {
               const { coseSign1, publicKeyHex, signedData } = await signAndDecode(signWith, wallet);
               const signedDataBytes = HexBlob.fromBytes(signedData.to_bytes());
               const signatureBytes = HexBlob.fromBytes(coseSign1.signature()) as unknown as Crypto.Ed25519SignatureHex;
-              const cryptoProvider = new Crypto.SodiumBip32Ed25519();
+              const cryptoProvider = await Crypto.SodiumBip32Ed25519.create();
 
               testAddressHeader(signedData, signWith);
 
               expect(
-                await cryptoProvider.verify(
+                cryptoProvider.verify(
                   signatureBytes,
                   signedDataBytes,
                   publicKeyHex as unknown as Crypto.Ed25519PublicKeyHex
@@ -755,12 +755,12 @@ describe('LedgerKeyAgent', () => {
               const { coseSign1, publicKeyHex, signedData } = await signAndDecode(signWith!, wallet);
               const signedDataBytes = HexBlob.fromBytes(signedData.to_bytes());
               const signatureBytes = HexBlob.fromBytes(coseSign1.signature()) as unknown as Crypto.Ed25519SignatureHex;
-              const cryptoProvider = new Crypto.SodiumBip32Ed25519();
+              const cryptoProvider = await Crypto.SodiumBip32Ed25519.create();
 
               expect(publicKeyHex).toEqual(drepPubKey);
 
               expect(
-                await cryptoProvider.verify(
+                cryptoProvider.verify(
                   signatureBytes,
                   signedDataBytes,
                   publicKeyHex as unknown as Crypto.Ed25519PublicKeyHex

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.integration.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.integration.test.ts
@@ -17,8 +17,6 @@ const {
   mockUtxoProvider
 } = mockProviders;
 
-const keyAgentDependencies = { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger };
-
 const createWallet = async (keyAgent: KeyAgent) => {
   const txSubmitProvider = mockTxSubmitProvider();
   const stakePoolProvider = createStubStakePoolProvider();
@@ -51,6 +49,8 @@ const getAddress = async (wallet: ObservableWallet) => (await firstValueFrom(wal
 
 describe('TrezorKeyAgent+BaseWallet', () => {
   test('creating and restoring TrezorKeyAgent wallet', async () => {
+    const keyAgentDependencies = { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger };
+
     const freshKeyAgent = await TrezorKeyAgent.createWithDevice(
       {
         chainId: Cardano.ChainIds.Preprod,

--- a/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/trezor/TrezorKeyAgent.test.ts
@@ -46,7 +46,7 @@ describe('TrezorKeyAgent', () => {
         chainId: Cardano.ChainIds.Preprod,
         trezorConfig
       },
-      { bip32Ed25519: new Crypto.SodiumBip32Ed25519(), logger }
+      { bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(), logger }
     );
     const groupedAddress = await trezorKeyAgent.deriveAddress({ index: 0, type: AddressType.External }, 0);
     address = groupedAddress.address;
@@ -460,7 +460,7 @@ describe('TrezorKeyAgent', () => {
         chainId: Cardano.ChainIds.Preprod,
         trezorConfig
       },
-      mockKeyAgentDependencies()
+      await mockKeyAgentDependencies()
     );
     expect(trezorKeyAgentWithRandomIndex).toBeInstanceOf(TrezorKeyAgent);
     expect(trezorKeyAgentWithRandomIndex.accountIndex).toEqual(5);

--- a/packages/wallet/test/services/DRepRegistrationTracker.test.ts
+++ b/packages/wallet/test/services/DRepRegistrationTracker.test.ts
@@ -6,6 +6,8 @@ import { createTestScheduler } from '@cardano-sdk/util-dev';
 import { of } from 'rxjs';
 
 describe('createDRepRegistrationTracker', () => {
+  beforeAll(() => Crypto.ready());
+
   let dRepPublicKey: Crypto.Ed25519PublicKeyHex;
   let dRepKeyHash: Crypto.Hash28ByteBase16;
   let dRepPublicKeyHash: Crypto.Ed25519KeyHashHex;
@@ -26,9 +28,9 @@ describe('createDRepRegistrationTracker', () => {
   beforeEach(async () => {
     dRepPublicKey = Crypto.Ed25519PublicKeyHex('deeb8f82f2af5836ebbc1b450b6dbf0b03c93afe5696f10d49e8a8304ebfac01');
     dRepKeyHash = Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(
-      (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex()
+      Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash().hex()
     );
-    dRepPublicKeyHash = (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex();
+    dRepPublicKeyHash = Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash().hex();
   });
 
   test('computes proper isRegisteredDrep value from historyTransactions$', () => {

--- a/packages/wallet/test/services/KeyAgent/restoreKeyAgent.test.ts
+++ b/packages/wallet/test/services/KeyAgent/restoreKeyAgent.test.ts
@@ -16,10 +16,14 @@ import { dummyLogger } from 'ts-log';
 import { restoreKeyAgent } from '../../../src';
 
 describe('KeyManagement/restoreKeyAgent', () => {
-  const dependencies: KeyAgentDependencies = {
-    bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
-    logger: dummyLogger
-  };
+  let dependencies: KeyAgentDependencies;
+
+  beforeAll(async () => {
+    dependencies = {
+      bip32Ed25519: await Crypto.SodiumBip32Ed25519.create(),
+      logger: dummyLogger
+    };
+  });
 
   describe('InMemoryKeyAgent', () => {
     const encryptedRootPrivateKeyBytes = [

--- a/packages/wallet/test/util.ts
+++ b/packages/wallet/test/util.ts
@@ -59,7 +59,7 @@ export const buildDRepAddressFromDRepKey = async (
   dRepKey: Crypto.Ed25519PublicKeyHex,
   type: Cardano.CredentialType = Cardano.CredentialType.KeyHash
 ) => {
-  const drepKeyHash = (await Crypto.Ed25519PublicKey.fromHex(dRepKey).hash()).hex();
+  const drepKeyHash = Crypto.Ed25519PublicKey.fromHex(dRepKey).hash().hex();
   const drepId = Cardano.DRepID.cip129FromCredential({
     hash: Crypto.Hash28ByteBase16.fromEd25519KeyHashHex(drepKeyHash),
     type
@@ -76,7 +76,7 @@ export const createAsyncKeyAgent = async () =>
         mnemonicWords: util.generateMnemonicWords()
       },
       {
-        bip32Ed25519: new SodiumBip32Ed25519(),
+        bip32Ed25519: await SodiumBip32Ed25519.create(),
         logger
       }
     )


### PR DESCRIPTION
# Context

The crypto interface currently is async because it uses libsodium underneath which requires an async call to sodium.ready. We can remove the async from the interface and hoist it to the strategy constructor or a global method async Crypto.ready, that can be called by the client code at their convenience.

Resolves #1529

