### PR TITLE
refactor(web-extension)!: make KeyAgentFactory methods async

### DIFF
--- a/packages/e2e/test/web-extension/extension/ui.ts
+++ b/packages/e2e/test/web-extension/extension/ui.ts
@@ -198,8 +198,6 @@ const passphraseByteArray = Uint8Array.from(
 );
 
 const initSigningCoordinator = async () => {
-  const bip32Ed25519 = await Crypto.SodiumBip32Ed25519.create();
-
   const signingCoordinator = new SigningCoordinator(
     {
       hwOptions: {
@@ -212,7 +210,7 @@ const initSigningCoordinator = async () => {
     },
     {
       keyAgentFactory: createKeyAgentFactory({
-        bip32Ed25519,
+        getBip32Ed25519: Crypto.SodiumBip32Ed25519.create,
         logger
       }),
       logger

--- a/packages/web-extension/README.md
+++ b/packages/web-extension/README.md
@@ -127,7 +127,7 @@ const signingCoordinator = new SigningCoordinator(
   },
   {
     keyAgentFactory: createKeyAgentFactory({
-      bip32Ed25519: new Crypto.SodiumBip32Ed25519(),
+      getBip32Ed25519: Crypto.SodiumBip32Ed25519.create,
       logger
     }),
     logger

--- a/packages/web-extension/src/walletManager/SigningCoordinator/KeyAgentFactory.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/KeyAgentFactory.ts
@@ -1,11 +1,21 @@
-import { InMemoryKeyAgent, InMemoryKeyAgentProps, KeyAgentDependencies } from '@cardano-sdk/key-management';
+import { Bip32Ed25519 } from '@cardano-sdk/crypto';
+import { InMemoryKeyAgent, InMemoryKeyAgentProps } from '@cardano-sdk/key-management';
 import { LedgerKeyAgent, LedgerKeyAgentProps } from '@cardano-sdk/hardware-ledger';
+import { Logger } from 'ts-log';
 import { TrezorKeyAgent, TrezorKeyAgentProps } from '@cardano-sdk/hardware-trezor';
 
-export const createKeyAgentFactory = (dependencies: KeyAgentDependencies) => ({
-  InMemory: (props: InMemoryKeyAgentProps) => new InMemoryKeyAgent(props, dependencies),
-  Ledger: (props: LedgerKeyAgentProps) => new LedgerKeyAgent(props, dependencies),
-  Trezor: (props: TrezorKeyAgentProps) => new TrezorKeyAgent(props, dependencies)
+export type KeyAgentFactoryDependencies = {
+  logger: Logger;
+  getBip32Ed25519: () => Promise<Bip32Ed25519>;
+};
+
+export const createKeyAgentFactory = ({ logger, getBip32Ed25519 }: KeyAgentFactoryDependencies) => ({
+  InMemory: async (props: InMemoryKeyAgentProps) =>
+    new InMemoryKeyAgent(props, { bip32Ed25519: await getBip32Ed25519(), logger }),
+  Ledger: async (props: LedgerKeyAgentProps) =>
+    new LedgerKeyAgent(props, { bip32Ed25519: await getBip32Ed25519(), logger }),
+  Trezor: async (props: TrezorKeyAgentProps) =>
+    new TrezorKeyAgent(props, { bip32Ed25519: await getBip32Ed25519(), logger })
 });
 
 export type KeyAgentFactory = ReturnType<typeof createKeyAgentFactory>;

--- a/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
+++ b/packages/web-extension/src/walletManager/SigningCoordinator/SigningCoordinator.ts
@@ -154,7 +154,7 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
                     const wallet = request.requestContext.wallet as InMemoryWallet<WalletMetadata, AccountMetadata>;
                     try {
                       const result = await sign(
-                        this.#keyAgentFactory.InMemory({
+                        await this.#keyAgentFactory.InMemory({
                           accountIndex: account.accountIndex,
                           chainId: request.requestContext.chainId,
                           encryptedRootPrivateKeyBytes: [
@@ -184,14 +184,14 @@ export class SigningCoordinator<WalletMetadata extends {}, AccountMetadata exten
                   async (options?: SignOptions) =>
                     sign(
                       request.walletType === WalletType.Ledger
-                        ? this.#keyAgentFactory.Ledger({
+                        ? await this.#keyAgentFactory.Ledger({
                             accountIndex: request.requestContext.accountIndex,
                             chainId: request.requestContext.chainId,
                             communicationType: this.#hwOptions.communicationType,
                             extendedAccountPublicKey: account.extendedAccountPublicKey,
                             purpose: account.purpose || KeyPurpose.STANDARD
                           })
-                        : this.#keyAgentFactory.Trezor({
+                        : await this.#keyAgentFactory.Trezor({
                             accountIndex: request.requestContext.accountIndex,
                             chainId: request.requestContext.chainId,
                             extendedAccountPublicKey: account.extendedAccountPublicKey,

--- a/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
+++ b/packages/web-extension/test/walletManager/SigningCoordinator.test.ts
@@ -73,7 +73,7 @@ describe('SigningCoordinator', () => {
       signCip8Data: jest.fn(),
       signTransaction: jest.fn()
     } as unknown as jest.Mocked<InMemoryKeyAgent>;
-    keyAgentFactory.InMemory.mockReturnValue(keyAgent);
+    keyAgentFactory.InMemory.mockResolvedValue(keyAgent);
   });
 
   describe('signTransaction', () => {


### PR DESCRIPTION
# Context

Bip32Ed25519 was refactored to synchronous methods by hoisting sodium await to top level in #1558, which makes it difficult to use SigningCoordinator without top level await

# Proposed Solution

# Important Changes Introduced
