### PR TITLE
Feat/cache data from blockfrost locally

### DIFF
--- a/packages/cardano-services-client/test/ChainHistoryProvider/BlockfrostChainHistoryProvider.test.ts
+++ b/packages/cardano-services-client/test/ChainHistoryProvider/BlockfrostChainHistoryProvider.test.ts
@@ -590,5 +590,25 @@ describe('blockfrostChainHistoryProvider', () => {
         expect(response[0]).toEqual(expectedHydratedTxCBOR);
       });
     });
+
+    test('caches transactions and returns them from the cache on subsequent calls', async () => {
+      const firstResponse = await provider.transactionsByHashes({
+        ids: ['1e043f100dce12d107f679685acd2fc0610e10f72a92d412794c9773d11d8477' as Cardano.TransactionId]
+      });
+
+      expect(firstResponse).toHaveLength(1);
+      expect(firstResponse[0]).toEqual(expectedHydratedTxCBOR);
+      expect(request).toHaveBeenCalled();
+
+      request.mockClear();
+
+      const secondResponse = await provider.transactionsByHashes({
+        ids: ['1e043f100dce12d107f679685acd2fc0610e10f72a92d412794c9773d11d8477' as Cardano.TransactionId]
+      });
+
+      expect(secondResponse).toHaveLength(1);
+      expect(secondResponse[0]).toEqual(expectedHydratedTxCBOR);
+      expect(request).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
# Context

We want to reduce the amount of request we make to blockfrost. Now ChainHistoryProvider and UtxoProvider use a local volatile cache to reuse when requesting the same data several times.

