### PR TITLE
test: remove scheduled K6 wallets test run

### DIFF
--- a/.github/workflows/k6-wallets.yaml
+++ b/.github/workflows/k6-wallets.yaml
@@ -1,7 +1,5 @@
 name: K6 Wallets Restoration load test
 on:
-  schedule:
-    - cron: '0 0 * * 6' # 00:00 every Saturday
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
# Context

Test is targeting SDK services, which have been partially replaced by Blockfrost services

# Proposed Solution

Disable scheduled run.
Leave manual run for now.

# Important Changes Introduced
