### PR TITLE
fix: [lw-12169] map pool id in blockfrost rewards provider response

### DIFF
--- a/packages/cardano-services-client/src/RewardsProvider/BlockfrostRewardsProvider.ts
+++ b/packages/cardano-services-client/src/RewardsProvider/BlockfrostRewardsProvider.ts
@@ -44,9 +44,10 @@ export class BlockfrostRewardsProvider extends BlockfrostProvider implements Rew
       responseTranslator: (rewardsPage) =>
         rewardsPage
           .filter(({ epoch }) => lowerBound <= epoch && epoch <= upperBound)
-          .map(({ epoch, amount }) => ({
+          .map(({ epoch, amount, pool_id }) => ({
             epoch: Cardano.EpochNo(epoch),
-            rewards: stringToBigInt(amount)
+            rewards: stringToBigInt(amount),
+            ...(pool_id && { poolId: Cardano.PoolId(pool_id) })
           }))
     });
   }

--- a/packages/cardano-services-client/test/RewardProvider/BlockfrostRewardsProvider.test.ts
+++ b/packages/cardano-services-client/test/RewardProvider/BlockfrostRewardsProvider.test.ts
@@ -71,8 +71,8 @@ describe('blockfrostRewardsProvider', () => {
 
       expect(response).toEqual(
         new Map([
-          [rewardAccounts[0], [{ epoch: 98, rewards: 1000n }]],
-          [rewardAccounts[1], [{ epoch: 98, rewards: 1000n }]]
+          [rewardAccounts[0], [{ epoch: 98, poolId: Cardano.PoolId(pool_id), rewards: 1000n }]],
+          [rewardAccounts[1], [{ epoch: 98, poolId: Cardano.PoolId(pool_id), rewards: 1000n }]]
         ])
       );
     });
@@ -95,8 +95,8 @@ describe('blockfrostRewardsProvider', () => {
           [
             rewardAccounts[0],
             [
-              { epoch: 98, rewards: 1000n },
-              { epoch: 99, rewards: 1000n }
+              { epoch: 98, poolId: Cardano.PoolId(pool_id), rewards: 1000n },
+              { epoch: 99, poolId: Cardano.PoolId(pool_id), rewards: 1000n }
             ]
           ]
         ])


### PR DESCRIPTION
# Context

Pool id is not mapped in the response of blockfrost rewards providers requests.

# Proposed Solution

# Important Changes Introduced
