### PR TITLE
feat(web-extension): detect bg script when on firefox - LW-11944

### DIFF
--- a/packages/web-extension/src/messaging/index.ts
+++ b/packages/web-extension/src/messaging/index.ts
@@ -1,6 +1,6 @@
 import { BackgroundMessenger, createBackgroundMessenger, generalizeBackgroundMessenger } from './BackgroundMessenger';
 import { ChannelName, ConsumeRemoteApiOptions, ExposeApiProps, MessengerDependencies } from './types';
-import { FinalizationRegistryDestructor } from './util';
+import { FinalizationRegistryDestructor, isBackgroundProcess } from './util';
 import { consumeMessengerRemoteApi, exposeMessengerApi } from './remoteApi';
 import { createNonBackgroundMessenger } from './NonBackgroundMessenger';
 
@@ -15,7 +15,7 @@ export * from './errors';
 
 export type BaseChannel = { baseChannel: ChannelName };
 
-const isInBackgroundProcess = typeof window === 'undefined';
+const isInBackgroundProcess = isBackgroundProcess();
 
 const getBackgroundMessenger = (() => {
   let backgroundMessenger: BackgroundMessenger | null = null;

--- a/packages/web-extension/src/messaging/util.ts
+++ b/packages/web-extension/src/messaging/util.ts
@@ -77,3 +77,7 @@ export class FinalizationRegistryDestructor implements Destructor {
     this.#registry.register(obj, objectId);
   }
 }
+
+// Firefox addons use a generated background page to run the background script, so they have a window object
+export const isBackgroundProcess = () =>
+  typeof window === 'undefined' || window.location.href.includes('_generated_background');


### PR DESCRIPTION

# Context

Make bg script detection more robust
Firefox runs background script in a hidden page,
so it has a window object.

# Proposed Solution

Check for `runtime.getBackgroundPage` function which exists in firefox only on background page.

# Important Changes Introduced
