### PR TITLE
feature(cardano-services): support Blockfrost NetworkInfoProvider in PgBossWorker

### DIFF
--- a/nix/cardano-services/deployments/pg-boss-worker-deployment.nix
+++ b/nix/cardano-services/deployments/pg-boss-worker-deployment.nix
@@ -48,7 +48,7 @@
                 METADATA_FETCH_MODE = values.pg-boss-worker.metadata-fetch-mode;
 
                 STAKE_POOL_PROVIDER_URL = "http://${config.name}-backend.${config.namespace}.svc.cluster.local";
-                NETWORK_INFO_PROVIDER_URL = "http://${config.name}-backend.${config.namespace}.svc.cluster.local";
+                NETWORK_INFO_PROVIDER = "blockfrost";
 
                 POSTGRES_POOL_MAX_STAKE_POOL = "5";
                 POSTGRES_HOST_STAKE_POOL = values.postgresName;

--- a/packages/cardano-services/src/Program/options/providers.ts
+++ b/packages/cardano-services/src/Program/options/providers.ts
@@ -19,7 +19,7 @@ export type ProviderImplementations = {
   stakePoolProvider?: ProviderImplementation;
 };
 export const ProviderImplementationDescription = 'Select one of the available provider implementations';
-const argParser = (impl: string) => ProviderImplementation[impl.toUpperCase() as keyof typeof ProviderImplementation];
+export const argParser = (impl: string) => ProviderImplementation[impl.toUpperCase() as keyof typeof ProviderImplementation];
 export const providerSelectionOptions = [
   newOption(
     '--asset-provider <assetProvider>',

--- a/packages/cardano-services/src/Program/programs/pgBossWorker.ts
+++ b/packages/cardano-services/src/Program/programs/pgBossWorker.ts
@@ -13,6 +13,7 @@ export const PARALLEL_JOBS_DEFAULT = 10;
 export const PG_BOSS_WORKER_API_URL_DEFAULT = new URL('http://localhost:3003');
 
 export enum PgBossWorkerOptionDescriptions {
+  NetworkInfoProvider = 'Select one of the available provider implementations',
   ParallelJobs = 'Parallel jobs to run',
   Queues = 'Comma separated queue names',
   Schedules = 'File path for schedules configurations'
@@ -21,6 +22,7 @@ export enum PgBossWorkerOptionDescriptions {
 export interface LoadPgBossWorkerDependencies {
   dnsResolver?: (serviceName: string) => Promise<SrvRecord>;
   logger?: Logger;
+  networkInfoProvider?: string;
 }
 
 const pgBossWorker = 'pg-boss-worker';

--- a/packages/cardano-services/src/Program/services/pgboss.ts
+++ b/packages/cardano-services/src/Program/services/pgboss.ts
@@ -12,7 +12,7 @@ import {
   createPgBoss,
   isRecoverableTypeormError
 } from '@cardano-sdk/projection-typeorm';
-import { CommonProgramOptions, PosgresProgramOptions } from '../options';
+import { CommonProgramOptions, PosgresProgramOptions, ProviderImplementation } from '../options';
 import { DataSource } from 'typeorm';
 import { HealthCheckResponse } from '@cardano-sdk/core';
 import { HttpService } from '../../Http/HttpService';
@@ -88,6 +88,7 @@ export type PgBossWorkerArgs = CommonProgramOptions &
   StakePoolMetadataProgramOptions &
   PosgresProgramOptions<'DbSync'> &
   PosgresProgramOptions<'StakePool'> & {
+    networkInfoProvider?: ProviderImplementation;
     parallelJobs: number;
     queues: PgBossQueue[];
     schedules: Array<ScheduleConfig>;

--- a/packages/cardano-services/src/cli.ts
+++ b/packages/cardano-services/src/cli.ts
@@ -50,7 +50,10 @@ import {
   withHandlePolicyIdsOptions,
   withOgmiosOptions,
   withPostgresOptions,
-  withStakePoolMetadataOptions
+  withStakePoolMetadataOptions,
+  ProviderImplementationDescription,
+  ProviderImplementation,
+  argParser as providerImplArgParser,
 } from './Program';
 import { Command } from 'commander';
 import { DB_CACHE_TTL_DEFAULT } from './InMemoryCache';
@@ -491,7 +494,14 @@ addOptions(
         return readScheduleConfig(schedules);
       },
       []
-    )
+    ),
+    newOption(
+        '--network-info-provider <networkInfoProvider>',
+        ProviderImplementationDescription,
+        'NETWORK_INFO_PROVIDER',
+        providerImplArgParser,
+        ProviderImplementation.DBSYNC
+    ).choices([ProviderImplementation.BLOCKFROST, ProviderImplementation.DBSYNC]),
   ]
 ).action(async (args: PgBossWorkerArgs) =>
   runServer('pg-boss worker', { args }, () =>


### PR DESCRIPTION
# Context
As part of LW-12232 there's a need to remove the db-sync database dependency within the PgBossWorker

# Proposed Solution
- Add a new option to `start-pg-boss-worker` allowing `blockfrost` to be set as `network-info-provider`, or `NETWORK_INFO_PROVIDER` as an ENV.  

# Important Changes Introduced
- Changes the deployment code
- If using this new option, the existing Blockfrost config must be set for [the client](https://github.com/input-output-hk/cardano-js-sdk/blob/b13c33d75cf9de842b4f61a04828827ecaf77197/packages/cardano-services/src/util/BlockfrostProvider/BlockfrostClientFactory.ts#L16)
- No tests have been changed, planning to verify this via deployment