### PR TITLE
feat: [lw-12170] await for libsodium(Crypto) ready in wallet manager

### DIFF
--- a/packages/web-extension/src/walletManager/walletManager.ts
+++ b/packages/web-extension/src/walletManager/walletManager.ts
@@ -17,6 +17,7 @@ import {
 import { WalletRepository } from './WalletRepository';
 import { Witnesser } from '@cardano-sdk/key-management';
 import { buildBip32Witnesser, buildNativeScriptWitnesser } from './util';
+import { ready } from '@cardano-sdk/crypto';
 
 /**
  * Checks if the wallet is a bip32 wallet.
@@ -108,6 +109,7 @@ export class WalletManager<WalletMetadata extends { name: string }, AccountMetad
 
   /** `activate` the wallet with props of last activated wallet (load from `managerStorage`) */
   async initialize() {
+    await ready();
     const { [this.#managerStorageKey]: lastActivateProps } = await this.#managerStorage.get(this.#managerStorageKey);
 
     if (!lastActivateProps) {


### PR DESCRIPTION
# Context

Since [this commit](https://github.com/input-output-hk/cardano-js-sdk/commit/91b7fa29961cfb11fe7270aef259be19ac215f08#diff-7ffbb42afcc1767fcaf404a58014c832b3a9a354933d4e6529cb76b997f270d2) most of the Crypto related utils are now sync. But [we still need ](https://www.npmjs.com/package/libsodium-wrappers#usage-as-a-module) to await for libsodium lib readiness before we can use all the utils. Current change fixes an error thrown from [derivePublic util from Bip32KeyDeriviation.ts](https://github.com/input-output-hk/cardano-js-sdk/blob/91b7fa29961cfb11fe7270aef259be19ac215f08/packages/crypto/src/Bip32/Bip32KeyDerivation.ts#L125), that is triggered (not directly) by wallet manager.

# Proposed Solution

# Important Changes Introduced
