### PR TITLE
fix(cardano-services): disable cors if allowedOrigins is empty array

### DIFF
--- a/packages/cardano-services/src/Http/HttpServer.ts
+++ b/packages/cardano-services/src/Http/HttpServer.ts
@@ -86,7 +86,7 @@ export class HttpServer extends RunnableModule {
   protected async initializeImpl(): Promise<void> {
     this.app = express();
 
-    if (this.#config.allowedOrigins) {
+    if (this.#config.allowedOrigins?.length) {
       this.app.use(cors(corsOptions(new Set(this.#config.allowedOrigins))));
     }
 


### PR DESCRIPTION
# Context

Firefox extensions use uniquely generated uuid per each install.
Update dev-preprod to allow for requests with any origin

# Proposed Solution

# Important Changes Introduced
