### PR TITLE
fix: [lw-12235] handle expected blockfrost 404 errors

### DIFF
--- a/packages/cardano-services-client/src/blockfrost/BlockfrostProvider.ts
+++ b/packages/cardano-services-client/src/blockfrost/BlockfrostProvider.ts
@@ -2,6 +2,7 @@ import { BlockfrostClient, BlockfrostError } from './BlockfrostClient';
 import { HealthCheckResponse, Provider, ProviderError, ProviderFailure } from '@cardano-sdk/core';
 import { Logger } from 'ts-log';
 import { contextLogger } from '@cardano-sdk/util';
+import { isBlockfrostNotFoundError } from './util';
 import type { AsyncReturnType } from 'type-fest';
 import type { BlockFrostAPI } from '@blockfrost/blockfrost-js';
 
@@ -46,7 +47,7 @@ export abstract class BlockfrostProvider implements Provider {
       this.logger.debug('response', response);
       return response;
     } catch (error) {
-      this.logger.error('error', error);
+      isBlockfrostNotFoundError(error) ? this.logger.debug('Blockfrost not found', error) : this.logger.error(error);
       throw this.toProviderError(error);
     }
   }


### PR DESCRIPTION
# Context

Blockfrost 404s are already handled in the [fetchSequentially util](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/cardano-services-client/src/blockfrost/util.ts#L52), but these errors are still logged in the [request method of BlockfrostProbider class](https://github.com/input-output-hk/cardano-js-sdk/blob/master/packages/cardano-services-client/src/blockfrost/BlockfrostProvider.ts#L49) via logger.error.

# Proposed Solution
Change log level to `debug` instead of `error` in case this is blockfrost not found error.

# Important Changes Introduced
