### PR TITLE
refactor(cardano-services-client): use CIP129 when querying dreps/:drepId - LW-12316

### DIFF
--- a/compose/common.yml
+++ b/compose/common.yml
@@ -121,7 +121,7 @@ x-sdk-environment: &sdk-environment
 services:
   blockfrost-ryo:
     build:
-      context: 'https://github.com/mkazlauskas/blockfrost-backend-ryo.git#feat/custom-network-support'
+      context: 'https://github.com/blockfrost/blockfrost-backend-ryo.git#v3.1.0'
       dockerfile: Dockerfile
     environment:
       BLOCKFROST_CONFIG_SERVER_LISTEN_ADDRESS: 0.0.0.0

--- a/packages/cardano-services-client/src/DRepProvider/BlockfrostDRepProvider.ts
+++ b/packages/cardano-services-client/src/DRepProvider/BlockfrostDRepProvider.ts
@@ -11,8 +11,8 @@ export class BlockfrostDRepProvider extends BlockfrostProvider implements DRepPr
 
   async getDRepInfo({ id }: GetDRepInfoArgs): Promise<DRepInfo> {
     try {
-      const cip105DRepId = Cardano.DRepID.toCip105DRepID(id); // Blockfrost only supports CIP-105 DRep IDs
-      const response = await this.request<Responses['drep']>(`governance/dreps/${cip105DRepId.toString()}`);
+      const cip129DRepId = Cardano.DRepID.toCip129DRepID(id).toString();
+      const response = await this.request<Responses['drep']>(`governance/dreps/${cip129DRepId}`);
       const amount = BigInt(response.amount);
       const activeEpoch = response.active_epoch ? Cardano.EpochNo(response.active_epoch) : undefined;
       const active = response.active;

--- a/packages/cardano-services-client/test/DRepProvider/BlockfrostDRepProvider.test.ts
+++ b/packages/cardano-services-client/test/DRepProvider/BlockfrostDRepProvider.test.ts
@@ -19,11 +19,12 @@ describe('BlockfrostDRepProvider', () => {
 
   describe('getDRep', () => {
     const mockedDRepId = Cardano.DRepID('drep15cfxz9exyn5rx0807zvxfrvslrjqfchrd4d47kv9e0f46uedqtc');
+    const mockedCip129DrepID = Cardano.DRepID.toCip129DRepID(mockedDRepId).toString();
     const mockedAssetResponse = {
       active: true,
       active_epoch: 420,
       amount: '2000000',
-      drep_id: 'drep15cfxz9exyn5rx0807zvxfrvslrjqfchrd4d47kv9e0f46uedqtc',
+      drep_id: mockedCip129DrepID,
       has_script: true,
       hex: 'a61261172624e8333ceff098648d90f8e404e2e36d5b5f5985cbd35d'
     } as Responses['drep'];
@@ -31,7 +32,7 @@ describe('BlockfrostDRepProvider', () => {
     test('getDRepInfo', async () => {
       mockResponses(request, [
         [
-          `governance/dreps/${mockedDRepId}`,
+          `governance/dreps/${mockedCip129DrepID}`,
           {
             ...mockedAssetResponse
           }


### PR DESCRIPTION
# Context

In the inception of governance DReps ids were bech32 encoded using CIP105 spec.

Later a new standard, CIP129 because the defacto bech32 way to encode DRep ids

Blockfrost supports querying for specific DReps using both standards.

We should aim to use a single format throughout the code, to avoid confusion and to be consistent



# Proposed Solution

# Important Changes Introduced
