### PR TITLE
ci: update ubuntu action runner image to 22.04

### DIFF
--- a/.github/workflows/continuous-integration-blockfrost-e2e.yaml
+++ b/.github/workflows/continuous-integration-blockfrost-e2e.yaml
@@ -42,7 +42,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/continuous-integration-e2e.yaml
+++ b/.github/workflows/continuous-integration-e2e.yaml
@@ -42,7 +42,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/continuous-integration-side-tests.yaml
+++ b/.github/workflows/continuous-integration-side-tests.yaml
@@ -14,7 +14,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/continuous-integration-unit-tests.yaml
+++ b/.github/workflows/continuous-integration-unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/git-checks.yaml
+++ b/.github/workflows/git-checks.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/post_integration.yml
+++ b/.github/workflows/post_integration.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v2.3.3
@@ -19,7 +19,7 @@ jobs:
 
       - name: 🔨 Build Docs
         env:
-          NODE_OPTIONS: "--max-old-space-size=10240"
+          NODE_OPTIONS: '--max-old-space-size=10240'
         run: |
           yarn install --immutable --inline-builds
           yarn build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
   publish:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/test-deploy-e2e.yaml
+++ b/.github/workflows/test-deploy-e2e.yaml
@@ -42,7 +42,7 @@ jobs:
   build_and_test:
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 📥 Checkout repository


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01

https://github.com/actions/runner-images/issues/11101