### PR TITLE
NativeScript signing

### DIFF
--- a/packages/key-management/src/InMemoryKeyAgent.ts
+++ b/packages/key-management/src/InMemoryKeyAgent.ts
@@ -134,7 +134,7 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
 
   async signTransaction(
     txBody: Serialization.TransactionBody,
-    { txInKeyPathMap, knownAddresses }: SignTransactionContext,
+    { txInKeyPathMap, knownAddresses, scripts }: SignTransactionContext,
     { additionalKeyPaths = [] }: SignTransactionOptions = {}
   ): Promise<Cardano.Signatures> {
     // Possible optimization is casting strings to OpaqueString types directly and skipping validation
@@ -143,7 +143,7 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
     const dRepKeyHash = (
       await Crypto.Ed25519PublicKey.fromHex(await this.derivePublicKey(DREP_KEY_DERIVATION_PATH)).hash()
     ).hex();
-    const derivationPaths = ownSignatureKeyPaths(body, knownAddresses, txInKeyPathMap, dRepKeyHash);
+    const derivationPaths = ownSignatureKeyPaths(body, knownAddresses, txInKeyPathMap, dRepKeyHash, scripts);
     const keyPaths = uniqBy([...derivationPaths, ...additionalKeyPaths], ({ role, index }) => `${role}.${index}`);
     // TODO:
     // if (keyPaths.length === 0) {

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -175,6 +175,7 @@ export interface SignTransactionContext {
   handleResolutions?: HandleResolution[];
   dRepKeyHashHex?: Crypto.Ed25519KeyHashHex;
   sender?: MessageSender;
+  scripts?: Cardano.Script[];
 }
 
 export type SignDataContext = Cip8SignDataContext & { sender?: MessageSender };

--- a/packages/key-management/src/util/stubSignTransaction.ts
+++ b/packages/key-management/src/util/stubSignTransaction.ts
@@ -17,7 +17,7 @@ export interface StubSignTransactionProps {
 
 export const stubSignTransaction = async ({
   txBody,
-  context: { knownAddresses, txInKeyPathMap, dRepKeyHashHex: dRepKeyHash },
+  context: { knownAddresses, txInKeyPathMap, dRepKeyHashHex: dRepKeyHash, scripts },
   signTransactionOptions: { extraSigners, additionalKeyPaths = [] } = {}
 }: StubSignTransactionProps): Promise<Cardano.Signatures> => {
   const mockSignature = Crypto.Ed25519SignatureHex(
@@ -25,7 +25,7 @@ export const stubSignTransaction = async ({
     'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
   );
   const signatureKeyPaths = uniqWith(
-    [...ownSignatureKeyPaths(txBody, knownAddresses, txInKeyPathMap, dRepKeyHash), ...additionalKeyPaths],
+    [...ownSignatureKeyPaths(txBody, knownAddresses, txInKeyPathMap, dRepKeyHash, scripts), ...additionalKeyPaths],
     deepEquals
   );
 

--- a/packages/key-management/test/InMemoryKeyAgent.test.ts
+++ b/packages/key-management/test/InMemoryKeyAgent.test.ts
@@ -111,7 +111,8 @@ describe('InMemoryKeyAgent', () => {
       knownAddresses,
       txInKeyPathMap
     });
-    expect(ownSignatureKeyPaths).toBeCalledWith(body.toCore(), knownAddresses, txInKeyPathMap, expect.anything());
+    const expectedArgs = [body.toCore(), knownAddresses, txInKeyPathMap, expect.anything(), undefined] as const;
+    expect(ownSignatureKeyPaths).toBeCalledWith(...expectedArgs);
     expect(witnessSet.size).toBe(2);
     expect(typeof [...witnessSet.values()][0]).toBe('string');
   });

--- a/packages/key-management/test/util/stubSignTransaction.test.ts
+++ b/packages/key-management/test/util/stubSignTransaction.test.ts
@@ -34,6 +34,7 @@ describe('KeyManagement.util.stubSignTransaction', () => {
         })
       ).size
     ).toBe(2);
-    expect(ownSignatureKeyPaths).toBeCalledWith(txBody, knownAddresses, txInKeyPathMap, dRepKeyHash);
+    const expectedArgs = [txBody, knownAddresses, txInKeyPathMap, dRepKeyHash, undefined] as const;
+    expect(ownSignatureKeyPaths).toBeCalledWith(...expectedArgs);
   });
 });


### PR DESCRIPTION
# Context

Lace currently fails to identify when it is being requested to sign a transaction on behalf of a NativeScript where it's signature may be one of the signatures required by that NativeScript.

# Proposed Solution

Evaluate NativeScript(s) used as witnesses to determine keypaths which must be used to sign (if any).

# Important Changes Introduced

Added the capability described above to enhance Lace's functionality with CIP-30 dApps that leverage NativeScripts.
