### PR TITLE
LW-12621 subhandles and virtual subhandles tests

### DIFF
--- a/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/KoraLabsHandleProvider.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore kora koralabs
 import {
   Asset,
   Cardano,

--- a/packages/e2e/test/handle/KoraLabsHandleProvider.test.ts
+++ b/packages/e2e/test/handle/KoraLabsHandleProvider.test.ts
@@ -1,3 +1,4 @@
+// cSpell:ignore kora subhandles
 /* eslint-disable no-magic-numbers */
 /* eslint-disable camelcase */
 import { Cardano, HandleResolution } from '@cardano-sdk/core';
@@ -51,6 +52,16 @@ describe('KoraLabsHandleProvider', () => {
 
       expect(resultN).toBe(null);
       checkHandleResolution('test_handle_1', result1);
+    });
+
+    test('HandleProvider should resolve handle, subhandles and virtual subhandles', async () => {
+      const [result1, result2, result3] = await provider.resolveHandles({
+        handles: ['handle', 'ada.handle', 'space@ada.handle']
+      });
+
+      checkHandleResolution('handle', result1);
+      checkHandleResolution('ada.handle', result2);
+      checkHandleResolution('space@ada.handle', result3);
     });
   });
 


### PR DESCRIPTION
# Context

We need to test the `LoraLabsHandleProvider` for subhandles and virtual subhandles as well.

# Proposed Solution

Added the required tests.