### PR TITLE
fix: reject PRs without `@esbuild/linux-x64@npm` in `yarn-project.nix` & fix the NixBuild.net integration

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -195,6 +195,12 @@ jobs:
         shell: bash
         run: |
           echo commit: ${{ github.sha }}
+      - name: Manual NixBuild.net
+        shell: bash
+        run: |
+          nix build --no-link --print-build-logs --log-format raw-with-logs \
+            --eval-store auto --builders "''" --store ssh-ng://eu.nixbuild.net \
+            github:input-output-hk/cardano-js-sdk/${{ github.sha }}#__std.actions.x86_64-linux.cardano-services.oci-images.cardano-services.publish
       - uses: michalrus/std-action/run@debug2
         if: matrix.target != 'dummy-target'
         with: { ffBuildInstructions: true, remoteStore: 'ssh-ng://eu.nixbuild.net' }

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -196,12 +196,14 @@ jobs:
         run: |
           echo commit: ${{ github.sha }}
       - name: Manual NixBuild.net
+        if: matrix.target != 'dummy-target'
         shell: bash
         run: |
+          # We trigger this manually, because some integration has broken between std-action and nixbuild.net:
           nix build --no-link --print-build-logs --log-format raw-with-logs \
             --eval-store auto --builders "''" --store ssh-ng://eu.nixbuild.net \
             github:input-output-hk/cardano-js-sdk/${{ github.sha }}#__std.actions.x86_64-linux.cardano-services.oci-images.cardano-services.publish
-      - uses: michalrus/std-action/run@debug2
+      - uses: divnix/std-action/run@main
         if: matrix.target != 'dummy-target'
         with: { ffBuildInstructions: true, remoteStore: 'ssh-ng://eu.nixbuild.net' }
 
@@ -216,7 +218,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
-      - uses: nixbuild/nixbuild-action@20
+      - uses: nixbuild/nixbuild-action@v20
         with:
           nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}
           generate_summary_for: job
@@ -321,7 +323,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v30
-      - uses: nixbuild/nixbuild-action@20
+      - uses: nixbuild/nixbuild-action@v20
         with:
           nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}
           generate_summary_for: job

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -183,7 +183,7 @@ jobs:
       - uses: nixbuild/nixbuild-action@v20
         if: matrix.target != 'dummy-target'
         with:
-          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}
           generate_summary_for: job
       - uses: divnix/std-action/setup-discovery-ssh@main
         if: matrix.target != 'dummy-target'
@@ -212,7 +212,7 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v30
       - uses: nixbuild/nixbuild-action@20
         with:
-          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}
           generate_summary_for: job
       # Further steps assume AWS_PROFILE=lw, while the official action has no way to specify that profile:
       - name: Set up AWS credentials
@@ -317,7 +317,7 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@v30
       - uses: nixbuild/nixbuild-action@20
         with:
-          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          nixbuild_token: ${{ secrets.NIXBUILD_TOKEN }}
           generate_summary_for: job
       # Further steps assume AWS_PROFILE=lw, while the official action has no way to specify that profile:
       - name: Set up AWS credentials

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -195,7 +195,7 @@ jobs:
         shell: bash
         run: |
           echo commit: ${{ github.sha }}
-      - uses: divnix/std-action/run@main
+      - uses: michalrus/std-action/run@debug2
         if: matrix.target != 'dummy-target'
         with: { ffBuildInstructions: true, remoteStore: 'ssh-ng://eu.nixbuild.net' }
 

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -69,7 +69,24 @@ concurrency:
   group: std-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  check-yarn-project-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - run: |
+          if ! grep -qF '"@esbuild/linux-x64@npm:' yarn-project.nix ; then
+            echo ' '
+            echo "Please, make sure that the 'yarn-project.nix' on $(git rev-parse HEAD) still contains '@esbuild/linux-x64@npm' (see your diff)."
+            echo ' '
+            echo "Its accidental removal can be caused by running 'yarn install' on macOS."
+            echo ' '
+            exit 1
+          fi
+
   discover:
+    needs: check-yarn-project-nix
     # Don’t run on PRs from forks (no access to secrets):
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -178,9 +178,9 @@ jobs:
         if: matrix.target != 'dummy-target'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      - uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nix-quick-install-action@v30
         if: matrix.target != 'dummy-target'
-      - uses: nixbuild/nixbuild-action@v17
+      - uses: nixbuild/nixbuild-action@v20
         if: matrix.target != 'dummy-target'
         with:
           nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -209,8 +209,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v25
-      - uses: nixbuild/nixbuild-action@v17
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nixbuild/nixbuild-action@20
         with:
           nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           generate_summary_for: job
@@ -314,8 +314,8 @@ jobs:
       url: ${{ matrix.url }}
     steps:
       - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v25
-      - uses: nixbuild/nixbuild-action@v17
+      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nixbuild/nixbuild-action@20
         with:
           nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           generate_summary_for: job


### PR DESCRIPTION
# Context

## Bug 1

Our build breaks if the last `yarn install` that updates the lock file was done on a non-`x86_64-linux` machine.

Unfortunately, `.yarn/plugins/yarn-plugin-nixify.cjs` then removes Linux-specific dependencies from `yarn-project.nix`, adding ARM64 Darwin-specific ones, and a Nix build can no longer succeed on Linux.

## Bug 2

Additionally, some integration has broken between `std-action` and [nixbuild.net](https://nixbuild.net/), so now we trigger the build manually there. After that, it works.

# Proposed Solution

## Bug 1

Reject PRs without `@esbuild/linux-x64@npm` in `yarn-project.nix`.

* Here you can see an example of a **failed run** based on a broken commit (b81902d61ff438c4f5ab76763ebe8e00ab8d4993): [actions/runs/14400727809/job/40385721936](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/14400727809/job/40385721936?pr=1614).

* And here is a correct run, rebased onto `master` (4f2b40afcf07a8033fa0002aa63e93318d54145a): [actions/runs/14400799480/job/40385942986](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/14400799480/job/40385942986?pr=1614)

## Bug 2

* Successful building & publishing:
  * [actions/runs/14513989763/job/40718862045](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/14513989763/job/40718862045)
  * of `docker://926093910549.dkr.ecr.us-east-1.amazonaws.com/cardano-services:wycw9mc4hbwhxsc7jplqk749wn4a0k94`.

* Successful diff:
  * [actions/runs/14514517472/job/40720514799](https://github.com/input-output-hk/cardano-js-sdk/actions/runs/14514517472/job/40720514799),
  * and https://github.com/input-output-hk/cardano-js-sdk/pull/1614#issuecomment-2812566231 below.

# Important Changes Introduced

Umm, CI’s working again.