### PR TITLE
Fix/reject prs without linux in esbuild

### DIFF
--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -73,11 +73,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v25
+      - uses: nixbuild/nixbuild-action@v17
+        with:
+          nixbuild_ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          generate_summary_for: job
+      # Further steps assume AWS_PROFILE=lw, while the official action has no way to specify that profile:
       - run: |
-          if ! grep -qF '"@esbuild/linux-x64@npm:' yarn-project.nix ; then
-            echo >&2 'Please, make sure that they ‘yarn-project.nix’ contains “@esbuild/linux-x64@npm” (see your diff).'
-            exit 1
+          if ! grep -F '"@esbuild/linux-x64@npm:' yarn-project.nix ; then
+               echo >&2 'Please, make sure that the "yarn-project.nix" contains "@esbuild/linux-x64@npm" (see your diff).'
+               exit 1
           fi
+        shell: bash
 
   discover:
     needs: check-yarn-project-nix

--- a/.github/workflows/std.yml
+++ b/.github/workflows/std.yml
@@ -69,7 +69,18 @@ concurrency:
   group: std-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  check-yarn-project-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if ! grep -qF '"@esbuild/linux-x64@npm:' yarn-project.nix ; then
+            echo >&2 'Please, make sure that they ‘yarn-project.nix’ contains “@esbuild/linux-x64@npm” (see your diff).'
+            exit 1
+          fi
+
   discover:
+    needs: check-yarn-project-nix
     # Don’t run on PRs from forks (no access to secrets):
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:


### PR DESCRIPTION
# Context

Our build breaks if the last yarn install that updates the lock file was done on a non-x86_64-linux machine.

Unfortunately, .yarn/plugins/yarn-plugin-nixify.cjs then removes Linux-specific dependencies from yarn-project.nix, adding ARM64 Darwin-specific ones, and a Nix build can no longer succeed on Linux.

# Proposed Solution
Reject PRs without @esbuild/linux-x64@npm in yarn-project.nix.
