### PR TITLE
LW-12624: Fix output mapping on hardware wallets

### DIFF
--- a/packages/core/src/Serialization/TransactionBody/TransactionBody.ts
+++ b/packages/core/src/Serialization/TransactionBody/TransactionBody.ts
@@ -948,6 +948,19 @@ export class TransactionBody {
   }
 
   /**
+   * Checks if the transaction body has Babbage outputs.
+   *
+   * @returns true if the transaction body has Babbage outputs, false otherwise.
+   */
+  hasBabbageOutput(): boolean {
+    if (this.#outputs.length === 0) return false;
+
+    const reader = new CborReader(this.#outputs[0].toCbor());
+
+    return reader.peekState() === CborReaderState.StartMap;
+  }
+
+  /**
    * Gets the size of the serialized map.
    *
    * @private

--- a/packages/core/test/Serialization/TransactionBody/TransactionBody.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/TransactionBody.test.ts
@@ -2,7 +2,7 @@
 import * as Cardano from '../../../src/Cardano';
 import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
-import { TransactionBody, TxBodyCBOR, TxCBOR } from '../../../src/Serialization';
+import { Transaction, TransactionBody, TxBodyCBOR, TxCBOR } from '../../../src/Serialization';
 import { babbageTx } from '../testData';
 import { mintTokenMap, params, txIn, txOut } from './testData';
 
@@ -271,6 +271,24 @@ describe('TransactionBody', () => {
   it('can encode TransactionBody with 6.248 tags to Core', () => {
     const body = TransactionBody.fromCbor(conwayCborWithSets);
     expect(body.toCore()).toEqual(expectedConwayCore);
+  });
+
+  it('can encode identify transactions output format - Babbage outputs', () => {
+    const tx = Transaction.fromCbor(
+      TxCBOR(
+        '84a500818258207aa1264bcd0c06f34a49ed1dd7307a2bdec5a97bdeb546498759ad5b8ed42fd5010182a200583930195bde3deacb613b7e9eb6280b14db4e353e475e96d19f3f7a5e2d66195bde3deacb613b7e9eb6280b14db4e353e475e96d19f3f7a5e2d66011a00e4e1c0a2005839003d3246dc0c50ab3c74a8ffdd8068313ff99d341c461a8fe31f416d0a8fba06d60d71edc077cc5ebcb8ff82137afbce68df98271909332348011b000000025106a838021a00029309031a04a07bc6081a04a07a40a0f5f6'
+      )
+    );
+    expect(tx.body().hasBabbageOutput()).toBeTruthy();
+  });
+
+  it('can encode identify transactions output format - Legacy outputs', () => {
+    const tx = Transaction.fromCbor(
+      TxCBOR(
+        '84a500818258207aa1264bcd0c06f34a49ed1dd7307a2bdec5a97bdeb546498759ad5b8ed42fd501018282583930195bde3deacb613b7e9eb6280b14db4e353e475e96d19f3f7a5e2d66195bde3deacb613b7e9eb6280b14db4e353e475e96d19f3f7a5e2d661a00e4e1c0825839003d3246dc0c50ab3c74a8ffdd8068313ff99d341c461a8fe31f416d0a8fba06d60d71edc077cc5ebcb8ff82137afbce68df982719093323481b000000025106a838021a00029309031a04a07bc6081a04a07a40a0f5f6'
+      )
+    );
+    expect(tx.body().hasBabbageOutput()).toBeFalsy();
   });
 
   it('sorts withdrawals canonically', () => {

--- a/packages/hardware-ledger/src/LedgerKeyAgent.ts
+++ b/packages/hardware-ledger/src/LedgerKeyAgent.ts
@@ -715,15 +715,18 @@ export class LedgerKeyAgent extends KeyAgentBase {
   ): Promise<Cardano.Signatures> {
     try {
       const body = txBody.toCore();
+
       const hash = txBody.hash() as unknown as HexBlob;
       const dRepPublicKey = await this.derivePublicKey(util.DREP_KEY_DERIVATION_PATH);
       const dRepKeyHashHex = (await Crypto.Ed25519PublicKey.fromHex(dRepPublicKey).hash()).hex();
+
       const ledgerTxData = await toLedgerTx(body, {
         accountIndex: this.accountIndex,
         chainId: this.chainId,
         dRepKeyHashHex,
         knownAddresses,
-        txInKeyPathMap
+        txInKeyPathMap,
+        useBabbageOutputs: txBody.hasBabbageOutput()
       });
 
       const deviceConnection = await LedgerKeyAgent.checkDeviceConnection(

--- a/packages/hardware-ledger/src/types.ts
+++ b/packages/hardware-ledger/src/types.ts
@@ -21,4 +21,6 @@ export type LedgerTxTransformerContext = {
   chainId: Cardano.ChainId;
   /** Non-hardened account in cip1852 */
   accountIndex: number;
+  /** Whether to use Babbage output format or not. */
+  useBabbageOutputs: boolean;
 } & SignTransactionContext;

--- a/packages/hardware-ledger/test/testData.ts
+++ b/packages/hardware-ledger/test/testData.ts
@@ -357,7 +357,8 @@ export const CONTEXT_WITH_KNOWN_ADDRESSES: LedgerTxTransformerContext = {
       type: AddressType.Internal
     }
   ],
-  txInKeyPathMap: {}
+  txInKeyPathMap: {},
+  useBabbageOutputs: true
 };
 
 export const CONTEXT_WITHOUT_KNOWN_ADDRESSES: LedgerTxTransformerContext = {
@@ -367,7 +368,8 @@ export const CONTEXT_WITHOUT_KNOWN_ADDRESSES: LedgerTxTransformerContext = {
     networkMagic: 999
   },
   knownAddresses: [],
-  txInKeyPathMap: {}
+  txInKeyPathMap: {},
+  useBabbageOutputs: true
 };
 
 export const votes = [

--- a/packages/hardware-ledger/test/transformers/certificates.test.ts
+++ b/packages/hardware-ledger/test/transformers/certificates.test.ts
@@ -85,7 +85,8 @@ const mockContext: LedgerTxTransformerContext = {
   txInKeyPathMap: createTxInKeyPathMapMock([
     createGroupedAddress(address1, ownRewardAccount, AddressType.External, 0, stakeKeyPath),
     createGroupedAddress(address2, ownRewardAccount, AddressType.External, 1, stakeKeyPath)
-  ])
+  ]),
+  useBabbageOutputs: true
 };
 
 const EXAMPLE_URL = 'https://example.com';

--- a/packages/hardware-ledger/test/transformers/tx.test.ts
+++ b/packages/hardware-ledger/test/transformers/tx.test.ts
@@ -15,7 +15,8 @@ describe('tx', () => {
           txInKeyPathMap: {
             [TxInId(tx.body.inputs[0])]: paymentKeyPath,
             [TxInId(tx.body.collaterals![0])]: paymentKeyPath
-          }
+          },
+          useBabbageOutputs: false
         })
       ).toEqual({
         auxiliaryData: {
@@ -267,7 +268,8 @@ describe('tx', () => {
 
       expect(
         await toLedgerTx(txBodyWithRegistrationCert, {
-          ...CONTEXT_WITH_KNOWN_ADDRESSES
+          ...CONTEXT_WITH_KNOWN_ADDRESSES,
+          useBabbageOutputs: false
         })
       ).toEqual({
         auxiliaryData: {

--- a/packages/hardware-ledger/test/transformers/txOut.test.ts
+++ b/packages/hardware-ledger/test/transformers/txOut.test.ts
@@ -64,7 +64,7 @@ describe('txOut', () => {
 
   describe('toTxOut', () => {
     it('can map a simple txOut to third party address', async () => {
-      const out = toTxOut(txOut, CONTEXT_WITH_KNOWN_ADDRESSES);
+      const out = toTxOut(txOut, { ...CONTEXT_WITH_KNOWN_ADDRESSES, useBabbageOutputs: false });
 
       expect(out).toEqual({
         amount: 10n,
@@ -114,7 +114,7 @@ describe('txOut', () => {
     });
 
     it('can map a simple txOut to owned address', async () => {
-      const out = toTxOut(txOutToOwnedAddress, CONTEXT_WITH_KNOWN_ADDRESSES);
+      const out = toTxOut(txOutToOwnedAddress, { ...CONTEXT_WITH_KNOWN_ADDRESSES, useBabbageOutputs: false });
 
       expect(out).toEqual({
         amount: 10n,

--- a/packages/hardware-trezor/src/TrezorKeyAgent.ts
+++ b/packages/hardware-trezor/src/TrezorKeyAgent.ts
@@ -251,7 +251,8 @@ export class TrezorKeyAgent extends KeyAgentBase {
         chainId: this.chainId,
         knownAddresses,
         tagCborSets: txBody.hasTaggedSets(),
-        txInKeyPathMap
+        txInKeyPathMap,
+        useBabbageOutputs: txBody.hasBabbageOutput()
       });
 
       const signingMode = TrezorKeyAgent.matchSigningMode(trezorTxData);

--- a/packages/hardware-trezor/src/types.ts
+++ b/packages/hardware-trezor/src/types.ts
@@ -13,6 +13,8 @@ export type TrezorTxTransformerContext = {
   accountIndex: number;
   /** Whether sets should be encoded as tagged set in CBOR */
   tagCborSets: boolean;
+  /** Whether to use Babbage output format or not. */
+  useBabbageOutputs: boolean;
 } & SignTransactionContext;
 
 export type TrezorTxOutputDestination =

--- a/packages/hardware-trezor/test/testData.ts
+++ b/packages/hardware-trezor/test/testData.ts
@@ -171,7 +171,8 @@ export const contextWithKnownAddresses: TrezorTxTransformerContext = {
   },
   knownAddresses: [knownAddress],
   tagCborSets: false,
-  txInKeyPathMap: {}
+  txInKeyPathMap: {},
+  useBabbageOutputs: false
 };
 
 export const contextWithKnownAddressesWithoutStakingCredentials: TrezorTxTransformerContext = {
@@ -182,7 +183,8 @@ export const contextWithKnownAddressesWithoutStakingCredentials: TrezorTxTransfo
   },
   knownAddresses: [knownAddressWithoutStakingPath],
   tagCborSets: false,
-  txInKeyPathMap: {}
+  txInKeyPathMap: {},
+  useBabbageOutputs: false
 };
 
 export const contextWithoutKnownAddresses: TrezorTxTransformerContext = {
@@ -193,7 +195,8 @@ export const contextWithoutKnownAddresses: TrezorTxTransformerContext = {
   },
   knownAddresses: [],
   tagCborSets: false,
-  txInKeyPathMap: {}
+  txInKeyPathMap: {},
+  useBabbageOutputs: false
 };
 
 export const coreWithdrawalWithKeyHashCredential = {

--- a/packages/hardware-trezor/test/transformers/tx.test.ts
+++ b/packages/hardware-trezor/test/transformers/tx.test.ts
@@ -204,7 +204,8 @@ describe('tx', () => {
           ...contextWithKnownAddresses,
           txInKeyPathMap: {
             [TxInId(babbageTxBodyWithScripts.inputs[0])]: knownAddressPaymentKeyPath
-          }
+          },
+          useBabbageOutputs: true
         })
       ).toEqual({
         additionalWitnessRequests: [
@@ -327,7 +328,8 @@ describe('tx', () => {
           txInKeyPathMap: {
             [TxInId(plutusTxWithBabbage.inputs[0])]: knownAddressPaymentKeyPath,
             [TxInId(plutusTxWithBabbage.collaterals[0])]: knownAddressPaymentKeyPath
-          }
+          },
+          useBabbageOutputs: true
         })
       ).toEqual({
         additionalWitnessRequests: [
@@ -361,7 +363,7 @@ describe('tx', () => {
           address:
             'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp',
           amount: '10',
-          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
+          format: Trezor.PROTO.CardanoTxOutputSerializationFormat.MAP_BABBAGE
         },
         fee: '10',
         inputs: [

--- a/packages/hardware-trezor/test/transformers/txOut.test.ts
+++ b/packages/hardware-trezor/test/transformers/txOut.test.ts
@@ -156,14 +156,16 @@ describe('txOut', () => {
     });
 
     it('can map a set of transaction outputs with both output formats', async () => {
-      const txOuts = mapTxOuts(
-        [txOutWithDatumHashAndOwnedAddress, txOutWithReferenceScriptAndDatumHash],
-        contextWithKnownAddresses
-      );
+      const legacyTxOuts = mapTxOuts([txOutWithDatumHashAndOwnedAddress], contextWithKnownAddresses);
 
-      expect(txOuts.length).toEqual(2);
+      const babbageTxOuts = mapTxOuts([txOutWithReferenceScriptAndDatumHash], {
+        ...contextWithKnownAddresses,
+        useBabbageOutputs: true
+      });
 
-      expect(txOuts).toEqual([
+      expect(legacyTxOuts.length).toEqual(1);
+
+      expect(legacyTxOuts).toEqual([
         {
           addressParameters: {
             addressType: Trezor.PROTO.CardanoAddressType.BASE,
@@ -173,7 +175,12 @@ describe('txOut', () => {
           amount: '10',
           datumHash: '0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5',
           format: Trezor.PROTO.CardanoTxOutputSerializationFormat.ARRAY_LEGACY
-        },
+        }
+      ]);
+
+      expect(babbageTxOuts.length).toEqual(1);
+
+      expect(babbageTxOuts).toEqual([
         {
           addressParameters: {
             addressType: Trezor.PROTO.CardanoAddressType.BASE,
@@ -332,7 +339,7 @@ describe('txOut', () => {
     });
 
     it('can map simple transaction with inline datum', async () => {
-      const out = toTxOut(txOutWithInlineDatum, contextWithKnownAddresses);
+      const out = toTxOut(txOutWithInlineDatum, { ...contextWithKnownAddresses, useBabbageOutputs: true });
 
       expect(out).toEqual({
         address:
@@ -344,7 +351,10 @@ describe('txOut', () => {
     });
 
     it('can map simple transaction with inline datum to owned address', async () => {
-      const out = toTxOut(txOutWithInlineDatumAndOwnedAddress, contextWithKnownAddresses);
+      const out = toTxOut(txOutWithInlineDatumAndOwnedAddress, {
+        ...contextWithKnownAddresses,
+        useBabbageOutputs: true
+      });
 
       expect(out).toEqual({
         addressParameters: {
@@ -359,7 +369,10 @@ describe('txOut', () => {
     });
 
     it('can map a simple transaction output with reference script and datum hash', async () => {
-      const out = toTxOut(txOutWithReferenceScriptAndDatumHash, contextWithKnownAddresses);
+      const out = toTxOut(txOutWithReferenceScriptAndDatumHash, {
+        ...contextWithKnownAddresses,
+        useBabbageOutputs: true
+      });
       expect(out).toEqual({
         addressParameters: {
           addressType: Trezor.PROTO.CardanoAddressType.BASE,
@@ -374,7 +387,10 @@ describe('txOut', () => {
     });
 
     it('can map a simple transaction output with reference script and inline datum', async () => {
-      const out = toTxOut(txOutWithReferenceScriptAndInlineDatum, contextWithKnownAddresses);
+      const out = toTxOut(txOutWithReferenceScriptAndInlineDatum, {
+        ...contextWithKnownAddresses,
+        useBabbageOutputs: true
+      });
       expect(out).toEqual({
         addressParameters: {
           addressType: Trezor.PROTO.CardanoAddressType.BASE,

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -230,6 +230,15 @@ describe('LedgerKeyAgent', () => {
         expect(signatures.size).toBe(2);
       });
 
+      it('successfully signs ADA handle mint transaction', async () => {
+        const cbor =
+          '84a500818258207aa1264bcd0c06f34a49ed1dd7307a2bdec5a97bdeb546498759ad5b8ed42fd5010182a200583930195bde3deacb613b7e9eb6280b14db4e353e475e96d19f3f7a5e2d66195bde3deacb613b7e9eb6280b14db4e353e475e96d19f3f7a5e2d66011a00e4e1c0a2005839003d3246dc0c50ab3c74a8ffdd8068313ff99d341c461a8fe31f416d0a8fba06d60d71edc077cc5ebcb8ff82137afbce68df98271909332348011b000000025106a838021a00029309031a04a07bc6081a04a07a40a0f5f6';
+        const {
+          witness: { signatures }
+        } = await wallet.finalizeTx({ tx: cbor as any });
+        expect(signatures.size).toBe(1);
+      });
+
       it('throws if signed transaction hash doesnt match hash computed by the wallet', async () => {
         const originalHashFn = Serialization.TransactionBody.prototype.hash;
         jest


### PR DESCRIPTION
# Context

We had a round-trip issue in our hardware wallet output mappings. This PR introduces a change to check for the actual format on the raw CBOR and passes as as context to the type mappers

# Proposed Solution

Analyze the raw CBOR to detect the output format and pass it as part of the transformation context.
