### PR TITLE
LW-12668 Add a debug parameter to handle resolution call

### DIFF
--- a/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
+++ b/packages/cardano-services-client/src/HandleProvider/handleHttpProvider.ts
@@ -11,6 +11,9 @@ export const handleHttpProvider = (config: CreateHttpProviderConfig<HandleProvid
   createHttpProvider<HandleProvider>({
     ...config,
     apiVersion: config.apiVersion || apiVersion.handle,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    modifyData: (method: string | number | symbol, data: any) =>
+      method === 'resolveHandles' ? { ...data, check_handle: true } : { ...data },
     paths: handleProviderPaths,
     serviceSlug: 'handle'
   });

--- a/packages/cardano-services-client/test/HandleProvider/handleHttpProvider.test.ts
+++ b/packages/cardano-services-client/test/HandleProvider/handleHttpProvider.test.ts
@@ -24,4 +24,15 @@ describe('handleHttpProvider', () => {
     axiosMock.onPost().replyOnce(200, []);
     await expect(provider.resolveHandles({ handles: [] })).resolves.toEqual([]);
   });
+
+  test('resolve handles has one more parameter', async () => {
+    const provider = handleHttpProvider(config);
+
+    axiosMock.onPost().reply((cfg) => [200, cfg.data]);
+
+    await expect(provider.resolveHandles({ handles: ['test'] })).resolves.toEqual({
+      check_handle: true,
+      handles: ['test']
+    });
+  });
 });


### PR DESCRIPTION
# Context

In order to investigate the high resolution calls rate we want to add a debug parameter to calls performed by Lace.

# Proposed Solution

Added an unused `check_handle` parameter to resolution calls.
