### PR TITLE
LW-12622 Remove useless dependency

### DIFF
--- a/packages/ogmios/package.json
+++ b/packages/ogmios/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@cardano-ogmios/schema": "6.9.0",
-    "@cardano-sdk/cardano-services-client": "workspace:~",
     "@cardano-sdk/util-dev": "workspace:~",
     "@cardano-sdk/util-rxjs": "workspace:~",
     "@types/lodash": "^4.14.182",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3873,7 +3873,6 @@ __metadata:
   dependencies:
     "@cardano-ogmios/client": 6.9.0
     "@cardano-ogmios/schema": 6.9.0
-    "@cardano-sdk/cardano-services-client": "workspace:~"
     "@cardano-sdk/core": "workspace:~"
     "@cardano-sdk/crypto": "workspace:~"
     "@cardano-sdk/projection": "workspace:~"


### PR DESCRIPTION
# Context

We have this dependency cycle issue.

```
lerna-lite WARN ECYCLE Dependency cycles detected, you should fix these!
lerna-lite WARN ECYCLE @cardano-sdk/cardano-services-client -> @cardano-sdk/util-dev -> @cardano-sdk/projection -> @cardano-sdk/ogmios -> @cardano-sdk/cardano-services-client
lerna-lite WARN ECYCLE @cardano-sdk/util-rxjs -> (nested cycle: @cardano-sdk/cardano-services-client -> @cardano-sdk/util-dev -> @cardano-sdk/projection -> @cardano-sdk/ogmios -> @cardano-sdk/cardano-services-client) -> @cardano-sdk/util-rxjs
```

# Proposed Solution

Removed useless dependency from `ogmios` package.