### PR TITLE
fix: handle ConwayCertsFailure error while building delegation portfolio

### DIFF
--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -633,7 +633,10 @@ export class GenericTxBuilder implements TxBuilder {
       const { id: newPoolId, weight } = newPools.pop()!;
       const rewardAccount = availableRewardAccounts.pop()!;
       this.#logger.debug(`Building delegation certificate for ${newPoolId} ${rewardAccount}`);
-      if (rewardAccount.credentialStatus !== Cardano.StakeCredentialStatus.Registered) {
+      if (
+        rewardAccount.credentialStatus !== Cardano.StakeCredentialStatus.Registered &&
+        rewardAccount.credentialStatus !== Cardano.StakeCredentialStatus.Registering
+      ) {
         certificates.push(Cardano.createStakeRegistrationCert(rewardAccount.address));
       }
       certificates.push(Cardano.createDelegationCert(rewardAccount.address, newPoolId));


### PR DESCRIPTION
# Context

Lace should not try to register a stake key that is currently "registering".

# Proposed Solution
Check for `Cardano.StakeCredentialStatus.Registering` status explicitly  while building delegation certificates for given portfolio.

# Important Changes Introduced
