### PR TITLE
fix(wallet): resolve only the own signed portions of the witness set

### DIFF
--- a/packages/wallet/src/cip30.ts
+++ b/packages/wallet/src/cip30.ts
@@ -469,7 +469,10 @@ const baseCip30WalletApi = (
           );
         }
 
-        const cbor = Serialization.TransactionWitnessSet.fromCore({ signatures }).toCbor();
+        const ownSignatures = new Map(
+          [...signatures.entries()].filter(([pubKey]) => !coreTx.witness.signatures.has(pubKey))
+        );
+        const cbor = Serialization.TransactionWitnessSet.fromCore({ signatures: ownSignatures }).toCbor();
         return Promise.resolve(cbor);
       } catch (error) {
         if (error instanceof TxSignError) {


### PR DESCRIPTION
# Context

Fixes #1631 

![image](https://github.com/user-attachments/assets/749336e1-3a61-40b7-be5e-8f3a95f025ab)

# Proposed Solution

See commit

# Important Changes Introduced
