### PR TITLE
fix(crypto): remove setImmediate from async calls

### DIFF
--- a/packages/crypto/src/blake2b-hash.ts
+++ b/packages/crypto/src/blake2b-hash.ts
@@ -35,10 +35,6 @@ export const blake2b: Blake2b = {
     return hash(outputLengthBytes).update(hexStringToBuffer(message)).digest('hex') as T;
   },
   async hashAsync<T extends HexBlob>(message: HexBlob, outputLengthBytes: number): Promise<T> {
-    return new Promise((resolve) => {
-      setImmediate(() => {
-        resolve(blake2b.hash<T>(message, outputLengthBytes));
-      });
-    });
+    return blake2b.hash<T>(message, outputLengthBytes);
   }
 };

--- a/packages/crypto/src/strategies/CmlBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/CmlBip32Ed25519.ts
@@ -104,11 +104,7 @@ export class CmlBip32Ed25519 implements Bip32Ed25519 {
     parentKey: Bip32PublicKeyHex,
     derivationIndices: BIP32Path
   ): Promise<Bip32PublicKeyHex> {
-    return new Promise((resolve) => {
-      setImmediate(() => {
-        resolve(this.derivePublicKey(parentKey, derivationIndices));
-      });
-    });
+    return this.derivePublicKey(parentKey, derivationIndices);
   }
 
   public sign(

--- a/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
+++ b/packages/crypto/src/strategies/SodiumBip32Ed25519.ts
@@ -74,11 +74,7 @@ export class SodiumBip32Ed25519 implements Bip32Ed25519 {
     parentKey: Bip32PublicKeyHex,
     derivationIndices: BIP32Path
   ): Promise<Bip32PublicKeyHex> {
-    return new Promise((resolve) => {
-      setImmediate(() => {
-        resolve(this.derivePublicKey(parentKey, derivationIndices));
-      });
-    });
+    return this.derivePublicKey(parentKey, derivationIndices);
   }
 
   public sign(


### PR DESCRIPTION
# Context

setImmediate is not available in browser environments, and we dont really need it.

# Proposed Solution

Remove calls to setImmediate

