### PR TITLE
fix(core): fix canonical serialization when outputs are empty

### DIFF
--- a/packages/core/src/Serialization/TransactionBody/TransactionBody.ts
+++ b/packages/core/src/Serialization/TransactionBody/TransactionBody.ts
@@ -107,7 +107,7 @@ export class TransactionBody {
       writer.writeEncodedValue(hexToBytes(this.#inputs.toCbor()));
     }
 
-    if (this.#outputs !== undefined && this.#outputs.length > 0) {
+    if (this.#outputs !== undefined) {
       writer.writeInt(1n);
       writer.writeStartArray(this.#outputs.length);
 
@@ -421,7 +421,7 @@ export class TransactionBody {
       treasuryValue: this.#currentTreasuryValue,
       update: this.#update ? this.#update.toCore() : undefined,
       validityInterval:
-        this.#ttl || this.#validityStartInterval !== undefined
+        this.#ttl !== undefined || this.#validityStartInterval !== undefined
           ? {
               invalidBefore: this.#validityStartInterval,
               invalidHereafter: this.#ttl
@@ -968,7 +968,7 @@ export class TransactionBody {
     let mapSize = 0;
 
     if (this.#inputs !== undefined && this.#inputs.size() > 0) ++mapSize;
-    if (this.#outputs !== undefined && this.#outputs.length > 0) ++mapSize;
+    if (this.#outputs !== undefined) ++mapSize;
     if (this.#fee !== undefined) ++mapSize;
     if (this.#ttl !== undefined) ++mapSize;
     if (this.#certs !== undefined && this.#certs.size() > 0) ++mapSize;

--- a/packages/core/test/Serialization/Transaction.test.ts
+++ b/packages/core/test/Serialization/Transaction.test.ts
@@ -143,4 +143,13 @@ describe('Transaction', () => {
       '2d7f290c815e061fb7c27e91d2a898bd7b454a71c9b7a26660e2257ac31ebe32'
     );
   });
+
+  it('can roundtrip tx with ttl 0 and no outputs', () => {
+    const cbor = TxCBOR(
+      '84a700818258200000000000000000000000000000000000000000000000000000000000000000000180020003000758203f5c96d4e519a27e7e62d3e19c05aa352431fccc60fc2255e7d479a2bf1a01110e81581cf120862e979a660a8a068485a930e78de8a5804aff7612895b1f77250f01a0f5a10075544f444f3a2046494c4c20494e204d455353414745'
+    );
+    const tx = Transaction.fromCbor(cbor).toCore();
+
+    expect(Transaction.fromCore(tx).toCbor()).toBe(cbor);
+  });
 });


### PR DESCRIPTION
# Context

The Conway-era [CDDL specification](https://github.com/intersectmbo/cardano-ledger/tree/master/eras/conway/impl/cddl-files) mandates that optional maps and arrays must be either non-empty or omitted entirely.

However, this rule does not apply to required fields. The transaction outputs array is a required field and must always be present, even if it contains no outputs. The SDK was incorrectly omitting this array when it was empty, leading to invalid transactions. This fix ensures the outputs array is always serialized to maintain compliance.

Additionally, an incorrect falsy check on the TTL value was preventing ttl: 0 from being serialized into core types. Because 0 is a valid TTL, the check has been corrected to properly handle this value.

