### PR TITLE
refactor: relax CIP-8 signing threshold from 100 to 190

### DIFF
--- a/packages/hardware-ledger/src/LedgerKeyAgent.ts
+++ b/packages/hardware-ledger/src/LedgerKeyAgent.ts
@@ -67,7 +67,7 @@ const LedgerConnection = (_LedgerConnection as any).default
   : _LedgerConnection;
 type LedgerConnection = _LedgerConnection;
 
-const CIP08_SIGN_HASH_THRESHOLD = 100;
+const CIP08_SIGN_HASH_THRESHOLD = 190;
 
 const isUsbDevice = (device: any): device is USBDevice =>
   typeof USBDevice !== 'undefined' && device instanceof USBDevice;


### PR DESCRIPTION
This change increases the threshold for when payloads are hashed during CIP-8 signing from 100 to 190 bytes. This allows larger payloads to be signed directly without hashing, which can be useful for certain use cases where the full payload needs to be preserved.