### PR TITLE
feat: [LW-13150] narrow down type for protocol parameters in summary inspector

### DIFF
--- a/packages/core/src/util/transactionSummaryInspector.ts
+++ b/packages/core/src/util/transactionSummaryInspector.ts
@@ -28,7 +28,7 @@ interface TransactionSummaryInspectorArgs {
   addresses: Cardano.PaymentAddress[];
   rewardAccounts: Cardano.RewardAccount[];
   inputResolver: Cardano.InputResolver;
-  protocolParameters: Cardano.ProtocolParameters;
+  protocolParameters: Pick<Cardano.ProtocolParameters, 'poolDeposit' | 'stakeKeyDeposit'>;
   assetProvider: AssetProvider;
   dRepKeyHash?: Crypto.Ed25519KeyHashHex;
   timeout: Milliseconds;


### PR DESCRIPTION
# Context

`TransactionSummaryInspector` expects `protocolParameters` param typed as `Cardano.ProtocolParameters`.
`protocolParameters` then used (only occurrence) in `computeImplicitCoin` util, where it is typed as `Pick<Cardano.ProtocolParameters, 'stakeKeyDeposit' | 'poolDeposit'>`.

# Proposed Solution
Narrow down `protocolParameters` type in `TransactionSummaryInspector` to be aligned with `computeImplicitCoin`.

# Important Changes Introduced
