### PR TITLE
refactor(core): narrow down assetProvider type in summary inspector

### DIFF
--- a/packages/core/src/util/transactionSummaryInspector.ts
+++ b/packages/core/src/util/transactionSummaryInspector.ts
@@ -29,7 +29,7 @@ interface TransactionSummaryInspectorArgs {
   rewardAccounts: Cardano.RewardAccount[];
   inputResolver: Cardano.InputResolver;
   protocolParameters: Pick<Cardano.ProtocolParameters, 'poolDeposit' | 'stakeKeyDeposit'>;
-  assetProvider: AssetProvider;
+  assetProvider: Pick<AssetProvider, 'getAssets'>;
   dRepKeyHash?: Crypto.Ed25519KeyHashHex;
   timeout: Milliseconds;
   logger: Logger;
@@ -59,7 +59,7 @@ export type TransactionSummaryInspector = (
 ) => Inspector<TransactionSummaryInspection>;
 
 type IntoTokenTransferValueProps = {
-  assetProvider: AssetProvider;
+  assetProvider: Pick<AssetProvider, 'getAssets'>;
   logger: Logger;
   timeout: Milliseconds;
   tokenMap?: TokenMap;

--- a/packages/core/src/util/tryGetAssetInfos.ts
+++ b/packages/core/src/util/tryGetAssetInfos.ts
@@ -8,7 +8,7 @@ import type { Milliseconds } from './time';
 
 type TryGetAssetInfosProps = {
   assetIds: Cardano.AssetId[];
-  assetProvider: AssetProvider;
+  assetProvider: Pick<AssetProvider, 'getAssets'>;
   timeout: Milliseconds;
   logger: Logger;
 };


### PR DESCRIPTION
Summary inspector needs only `getAssets` method from the AssetsProvider.
Narrow down the required type
