### PR TITLE
[LW-12690] fix: ledger hardware wallets can now create byron era outputs

### DIFF
--- a/packages/core/src/Cardano/util/isScriptAddress.ts
+++ b/packages/core/src/Cardano/util/isScriptAddress.ts
@@ -1,6 +1,10 @@
 import { Address, CredentialType, PaymentAddress } from '../Address';
 
 export const isScriptAddress = (address: PaymentAddress): boolean => {
+  if (!Address.isValidBech32(address)) {
+    return false;
+  }
+
   const baseAddress = Address.fromBech32(address).asBase();
   const paymentCredential = baseAddress?.getPaymentCredential();
   const stakeCredential = baseAddress?.getStakeCredential();

--- a/packages/hardware-ledger/src/transformers/txOut.ts
+++ b/packages/hardware-ledger/src/transformers/txOut.ts
@@ -40,9 +40,15 @@ const toDestination: Transform<Cardano.TxOut, Ledger.TxOutputDestination, Ledger
     };
   }
 
+  const address = Cardano.Address.fromString(txOut.address);
+
+  if (!address) {
+    throw new InvalidArgumentError('txOut', 'Invalid address format.');
+  }
+
   return {
     params: {
-      addressHex: Cardano.Address.fromBech32(txOut.address).toBytes()
+      addressHex: address.toBytes()
     },
     type: Ledger.TxOutputDestinationType.THIRD_PARTY
   };

--- a/packages/hardware-ledger/test/testData.ts
+++ b/packages/hardware-ledger/test/testData.ts
@@ -126,6 +126,13 @@ export const txOut: Cardano.TxOut = {
   value: valueWithAssets
 };
 
+export const byronEraTxOut: Cardano.TxOut = {
+  address: Cardano.PaymentAddress('Ae2tdPwUPEZ5DW1am2FnANGLW2qReao5xXX7dcC86x2JAg39oo7oanFNbrd'),
+  value: {
+    coins: 20_000_000n
+  }
+};
+
 export const txOutToOwnedAddress: Cardano.TxOut = {
   address: paymentAddress,
   datumHash: Crypto.Hash32ByteBase16('0f3abbc8fc19c2e61bab6059bf8a466e6e754833a08a62a6c56fe0e78f19d9d5'),

--- a/packages/hardware-ledger/test/transformers/txOut.test.ts
+++ b/packages/hardware-ledger/test/transformers/txOut.test.ts
@@ -1,6 +1,8 @@
 import * as Ledger from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import {
+  CONTEXT_WITHOUT_KNOWN_ADDRESSES,
   CONTEXT_WITH_KNOWN_ADDRESSES,
+  byronEraTxOut,
   txOut,
   txOutToOwnedAddress,
   txOutWithReferenceScript,
@@ -117,6 +119,23 @@ describe('txOut', () => {
             ]
           }
         ]
+      });
+    });
+
+    it('can map a simple txOut to Byron era address', async () => {
+      const out = toTxOut({ index: 0, isCollateral: false, txOut: byronEraTxOut }, CONTEXT_WITHOUT_KNOWN_ADDRESSES);
+
+      expect(out).toEqual({
+        amount: 20_000_000n,
+        datumHashHex: null,
+        destination: {
+          params: {
+            addressHex: '82d818582183581c54473376651c3d50b7a85055bb2395751e2db78bcb65410e1624989ca0001a73156e8e'
+          },
+          type: Ledger.TxOutputDestinationType.THIRD_PARTY
+        },
+        format: Ledger.TxOutputFormat.ARRAY_LEGACY,
+        tokenBundle: null
       });
     });
 

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -183,6 +183,24 @@ describe('LedgerKeyAgent', () => {
           }
         }
       ];
+
+      const byronOutputs = [
+        {
+          address: Cardano.PaymentAddress('FHnt4NL7yPXtsWVUqTv1Tr1ZSarFUYHS2DFLRUJwtqx8RnpZ8s8JefSYTekFcSF'),
+          value: { coins: 11_111_111n }
+        }
+      ];
+
+      const byronProps: InitializeTxProps = {
+        options: {
+          validityInterval: {
+            invalidBefore: Cardano.Slot(1),
+            invalidHereafter: Cardano.Slot(999_999_999)
+          }
+        },
+        outputs: new Set<Cardano.TxOut>(byronOutputs)
+      };
+
       const props: InitializeTxProps = {
         options: {
           validityInterval: {
@@ -230,6 +248,13 @@ describe('LedgerKeyAgent', () => {
         const {
           witness: { signatures }
         } = await wallet.finalizeTx({ tx: txInternals });
+        expect(signatures.size).toBe(2);
+      });
+
+      it('successfully signs a transaction with byron address output', async () => {
+        const {
+          witness: { signatures }
+        } = await wallet.finalizeTx({ tx: await wallet.initializeTx(byronProps) });
         expect(signatures.size).toBe(2);
       });
 


### PR DESCRIPTION
# Context

Currently hardware-ledger has a bug that prevents Byron era addresses to be used as destination. This PR fixes this bug.

# Proposed Solution

- Fix address parsing so support all Cardano address formats

