### PR TITLE
test(key-management): add tests for accountKeyDerivationPathToBip32Path

### DIFF
--- a/packages/key-management/src/util/key.ts
+++ b/packages/key-management/src/util/key.ts
@@ -49,7 +49,6 @@ export const deriveAccountPrivateKey = async ({
     harden(accountIndex)
   ]);
 
-// TODO: test
 /**
  * Constructs the hardened derivation path for the specified
  * account key of an HD wallet as specified in CIP 1852

--- a/packages/key-management/test/util/key.test.ts
+++ b/packages/key-management/test/util/key.test.ts
@@ -1,6 +1,10 @@
 import { AddressType, GroupedAddress, KeyRole } from '../../src';
 import { Cardano } from '@cardano-sdk/core';
-import { paymentKeyPathFromGroupedAddress, stakeKeyPathFromGroupedAddress } from '../../src/util';
+import {
+  accountKeyDerivationPathToBip32Path,
+  paymentKeyPathFromGroupedAddress,
+  stakeKeyPathFromGroupedAddress
+} from '../../src/util';
 
 export const paymentAddress = Cardano.PaymentAddress(
   'addr1qxdtr6wjx3kr7jlrvrfzhrh8w44qx9krcxhvu3e79zr7497tpmpxjfyhk3vwg6qjezjmlg5nr5dzm9j6nxyns28vsy8stu5lh6'
@@ -42,6 +46,37 @@ describe('key utils', () => {
     });
     it('returns a hardened BIP32 stake key path', () => {
       expect(stakeKeyPathFromGroupedAddress(knownAddress)).toEqual(knownAddressStakeKeyPath);
+    });
+  });
+  describe('accountKeyDerivationPathToBip32Path', () => {
+    it('returns correct path with default purpose', () => {
+      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.External, index: 0 });
+      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 0, 0]);
+    });
+
+    it('returns correct path for internal key role', () => {
+      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.Internal, index: 0 });
+      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 1, 0]);
+    });
+
+    it('returns correct path for stake key role', () => {
+      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.Stake, index: 0 });
+      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0]);
+    });
+
+    it('returns correct path for DRep key role', () => {
+      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.DRep, index: 0 });
+      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 3, 0]);
+    });
+
+    it('returns correct path with custom account index', () => {
+      const path = accountKeyDerivationPathToBip32Path(5, { role: KeyRole.External, index: 3 });
+      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_653, 0, 3]);
+    });
+
+    it('returns correct path with custom purpose', () => {
+      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.External, index: 0 }, 1854);
+      expect(path).toEqual([2_147_485_502, 2_147_485_463, 2_147_483_648, 0, 0]);
     });
   });
 });

--- a/packages/key-management/test/util/key.test.ts
+++ b/packages/key-management/test/util/key.test.ts
@@ -1,4 +1,4 @@
-import { AddressType, GroupedAddress, KeyRole } from '../../src';
+import { AddressType, GroupedAddress, KeyPurpose, KeyRole } from '../../src';
 import { Cardano } from '@cardano-sdk/core';
 import {
   accountKeyDerivationPathToBip32Path,
@@ -29,8 +29,15 @@ const knownAddress: GroupedAddress = {
   type: AddressType.Internal
 };
 
-const knownAddressKeyPath = [2_147_485_500, 2_147_485_463, 2_147_483_648, 1, 0];
-const knownAddressStakeKeyPath = [2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0];
+// CIP-1852: m / 1852' / 1815' / account' / role / index  (hardened = n + 0x8000_0000)
+const HARDENED_PURPOSE_1852 = 2_147_485_500;
+const HARDENED_PURPOSE_1854 = 2_147_485_502;
+const HARDENED_COINTYPE_1815 = 2_147_485_463;
+const HARDENED_ACCOUNT_0 = 2_147_483_648;
+const HARDENED_ACCOUNT_5 = 2_147_483_653;
+
+const knownAddressKeyPath = [HARDENED_PURPOSE_1852, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_0, KeyRole.Internal, 0];
+const knownAddressStakeKeyPath = [HARDENED_PURPOSE_1852, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_0, KeyRole.Stake, 0];
 
 describe('key utils', () => {
   describe('paymentKeyPathFromGroupedAddress', () => {
@@ -50,33 +57,33 @@ describe('key utils', () => {
   });
   describe('accountKeyDerivationPathToBip32Path', () => {
     it('returns correct path with default purpose', () => {
-      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.External, index: 0 });
-      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 0, 0]);
+      const path = accountKeyDerivationPathToBip32Path(0, { index: 0, role: KeyRole.External });
+      expect(path).toEqual([HARDENED_PURPOSE_1852, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_0, KeyRole.External, 0]);
     });
 
     it('returns correct path for internal key role', () => {
-      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.Internal, index: 0 });
-      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 1, 0]);
+      const path = accountKeyDerivationPathToBip32Path(0, { index: 0, role: KeyRole.Internal });
+      expect(path).toEqual([HARDENED_PURPOSE_1852, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_0, KeyRole.Internal, 0]);
     });
 
     it('returns correct path for stake key role', () => {
-      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.Stake, index: 0 });
-      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 2, 0]);
+      const path = accountKeyDerivationPathToBip32Path(0, { index: 0, role: KeyRole.Stake });
+      expect(path).toEqual([HARDENED_PURPOSE_1852, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_0, KeyRole.Stake, 0]);
     });
 
     it('returns correct path for DRep key role', () => {
-      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.DRep, index: 0 });
-      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_648, 3, 0]);
+      const path = accountKeyDerivationPathToBip32Path(0, { index: 0, role: KeyRole.DRep });
+      expect(path).toEqual([HARDENED_PURPOSE_1852, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_0, KeyRole.DRep, 0]);
     });
 
     it('returns correct path with custom account index', () => {
-      const path = accountKeyDerivationPathToBip32Path(5, { role: KeyRole.External, index: 3 });
-      expect(path).toEqual([2_147_485_500, 2_147_485_463, 2_147_483_653, 0, 3]);
+      const path = accountKeyDerivationPathToBip32Path(5, { index: 3, role: KeyRole.External });
+      expect(path).toEqual([HARDENED_PURPOSE_1852, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_5, KeyRole.External, 3]);
     });
 
     it('returns correct path with custom purpose', () => {
-      const path = accountKeyDerivationPathToBip32Path(0, { role: KeyRole.External, index: 0 }, 1854);
-      expect(path).toEqual([2_147_485_502, 2_147_485_463, 2_147_483_648, 0, 0]);
+      const path = accountKeyDerivationPathToBip32Path(0, { index: 0, role: KeyRole.External }, KeyPurpose.MULTI_SIG);
+      expect(path).toEqual([HARDENED_PURPOSE_1854, HARDENED_COINTYPE_1815, HARDENED_ACCOUNT_0, KeyRole.External, 0]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add test coverage for the `accountKeyDerivationPathToBip32Path` function which constructs BIP32 derivation paths following CIP-1852
- Remove the `// TODO: test` comment from `key.ts` since tests are now in place

## Test Cases

- Default purpose (1852) with external key role
- Stake key role derivation
- Custom account index
- Custom purpose (1854 for multi-sig)

## Test Plan

- [x] All new tests pass locally
- [x] Existing tests continue to pass