### PR TITLE
feat: add native cip8 serialization to ledger package

### DIFF
--- a/packages/hardware-ledger/package.json
+++ b/packages/hardware-ledger/package.json
@@ -55,7 +55,6 @@
     "@cardano-sdk/key-management": "workspace:~",
     "@cardano-sdk/tx-construction": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
-    "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
     "@ledgerhq/hw-transport": "^6.31.4",
     "@ledgerhq/hw-transport-node-hid-noevents": "^6.30.5",
     "@ledgerhq/hw-transport-webusb": "^6.29.4",

--- a/packages/hardware-ledger/src/LedgerKeyAgent.ts
+++ b/packages/hardware-ledger/src/LedgerKeyAgent.ts
@@ -1,15 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Crypto from '@cardano-sdk/crypto';
 import * as Ledger from '@cardano-foundation/ledgerjs-hw-app-cardano';
-import {
-  AlgorithmId,
-  CBORValue,
-  COSESign1Builder,
-  HeaderMap,
-  Headers,
-  Label,
-  ProtectedHeaderMap
-} from '@emurgo/cardano-message-signing-nodejs';
 import { Cardano, NotImplementedError, Serialization, util as coreUtils } from '@cardano-sdk/core';
 import {
   CardanoKeyConst,
@@ -73,33 +64,6 @@ const CIP08_SIGN_HASH_THRESHOLD = 198;
 
 const isUsbDevice = (device: any): device is USBDevice =>
   typeof USBDevice !== 'undefined' && device instanceof USBDevice;
-
-/* Sets the hashed entry in the COSESign1 CBOR structure */
-const setCOSESignHashed = (COSESignCbor: string, isHashed: boolean) => {
-  const reader = new Serialization.CborReader(HexBlob(COSESignCbor));
-  reader.readStartArray();
-
-  const headers = reader.readEncodedValue();
-  // Skip hashed entry
-  reader.readEncodedValue();
-  const payload = reader.readEncodedValue();
-  const signature = reader.readEncodedValue();
-
-  reader.readEndArray();
-
-  const writer = new Serialization.CborWriter();
-
-  writer.writeStartArray(4);
-  writer.writeEncodedValue(headers);
-  writer.writeStartMap(1);
-  writer.writeTextString('hashed');
-  writer.writeBoolean(isHashed);
-
-  writer.writeEncodedValue(payload);
-  writer.writeEncodedValue(signature);
-
-  return writer.encodeAsHex();
-};
 
 const isDeviceAlreadyOpenError = (error: unknown) => {
   if (typeof error !== 'object') return false;
@@ -865,24 +829,21 @@ export class LedgerKeyAgent extends KeyAgentBase {
       // will not verify.
       const addressBytes = coreUtils.hexToBytes(HexBlob(result.addressFieldHex));
 
-      const protectedHeaders = HeaderMap.new();
-      protectedHeaders.set_algorithm_id(Label.from_algorithm_id(AlgorithmId.EdDSA));
-      protectedHeaders.set_header(cip8.CoseLabel.address, CBORValue.new_bytes(addressBytes));
-
+      const protectedHeadersBytes = cip8.createProtectedHeadersCbor(addressBytes);
       const sigPayload = coreUtils.hexToBytes(hashPayload ? blake2b.hash(request.payload, 28) : request.payload);
-      const builder = COSESign1Builder.new(
-        Headers.new(ProtectedHeaderMap.new(protectedHeaders), HeaderMap.new()),
+
+      const coseSign1 = cip8.createCoseSign1Cbor(
+        protectedHeadersBytes,
         sigPayload,
-        false
+        Buffer.from(result.signatureHex, 'hex'),
+        hashPayload
       );
 
-      const coseSign1 = builder.build(Buffer.from(result.signatureHex, 'hex'));
-      const coseKey = cip8.createCoseKey(addressBytes, Crypto.Ed25519PublicKeyHex(result.signingPublicKeyHex));
+      const coseKey = cip8.createCoseKeyCbor(addressBytes, result.signingPublicKeyHex);
 
-      const coseSigHex = coreUtils.bytesToHex(coseSign1.to_bytes());
       return {
-        key: coreUtils.bytesToHex(coseKey.to_bytes()),
-        signature: hashPayload ? setCOSESignHashed(coseSigHex, true) : coseSigHex
+        key: coreUtils.bytesToHex(coseKey),
+        signature: coreUtils.bytesToHex(coseSign1)
       };
     } catch (error: any) {
       if (error.code === 28_169) {

--- a/packages/key-management/src/cip8/coseUtils.ts
+++ b/packages/key-management/src/cip8/coseUtils.ts
@@ -1,0 +1,62 @@
+import { Serialization } from '@cardano-sdk/core';
+
+// COSE algorithm identifiers
+export const ALGORITHM_EDDSA = -8;
+export const KEY_TYPE_OKP = 1;
+export const CURVE_ED25519 = 6;
+
+// COSE key map labels (RFC 8152)
+export const COSE_KEY_KTY = 1;
+export const COSE_KEY_KID = 2;
+export const COSE_KEY_ALG = 3;
+export const COSE_KEY_CRV = -1;
+export const COSE_KEY_X = -2;
+
+// COSE header labels
+export const COSE_HEADER_ALG = 1;
+
+/** Creates CBOR-encoded protected headers for CIP-8 signing (alg + address). */
+export const createProtectedHeadersCbor = (addressBytes: Uint8Array): Uint8Array => {
+  const writer = new Serialization.CborWriter();
+  writer.writeStartMap(2);
+  writer.writeInt(COSE_HEADER_ALG);
+  writer.writeInt(ALGORITHM_EDDSA);
+  writer.writeTextString('address');
+  writer.writeByteString(addressBytes);
+  return writer.encode();
+};
+
+/** Creates a CBOR-encoded COSE_Sign1 structure. */
+export const createCoseSign1Cbor = (
+  protectedHeadersBytes: Uint8Array,
+  payloadBytes: Uint8Array,
+  signatureBytes: Uint8Array,
+  isHashed: boolean
+): Uint8Array => {
+  const writer = new Serialization.CborWriter();
+  writer.writeStartArray(4);
+  writer.writeByteString(protectedHeadersBytes);
+  writer.writeStartMap(1);
+  writer.writeTextString('hashed');
+  writer.writeBoolean(isHashed);
+  writer.writeByteString(payloadBytes);
+  writer.writeByteString(signatureBytes);
+  return writer.encode();
+};
+
+/** Creates a CBOR-encoded COSE_Key structure for Ed25519. */
+export const createCoseKeyCbor = (addressBytes: Uint8Array, publicKeyHex: string): Uint8Array => {
+  const writer = new Serialization.CborWriter();
+  writer.writeStartMap(5);
+  writer.writeInt(COSE_KEY_KTY);
+  writer.writeInt(KEY_TYPE_OKP);
+  writer.writeInt(COSE_KEY_KID);
+  writer.writeByteString(addressBytes);
+  writer.writeInt(COSE_KEY_ALG);
+  writer.writeInt(ALGORITHM_EDDSA);
+  writer.writeInt(COSE_KEY_CRV);
+  writer.writeInt(CURVE_ED25519);
+  writer.writeInt(COSE_KEY_X);
+  writer.writeByteString(Buffer.from(publicKeyHex, 'hex'));
+  return writer.encode();
+};

--- a/packages/key-management/src/cip8/index.ts
+++ b/packages/key-management/src/cip8/index.ts
@@ -1,3 +1,4 @@
 export * from './cip30signData';
+export * from './coseUtils';
 export * from './types';
 export * from './util';

--- a/packages/key-management/test/cip8/coseUtils.test.ts
+++ b/packages/key-management/test/cip8/coseUtils.test.ts
@@ -1,0 +1,112 @@
+import { HexBlob } from '@cardano-sdk/util';
+import { createCoseKeyCbor, createCoseSign1Cbor, createProtectedHeadersCbor } from '../../src/cip8/coseUtils';
+
+// Test vectors generated with @emurgo/cardano-message-signing-nodejs WASM library
+// to ensure our pure TypeScript implementation produces identical CBOR output.
+
+const CBOR_MATCHING_WASM_OUTPUT = 'produces CBOR matching WASM output';
+
+const vectors = {
+  // Enterprise address (short, 29 bytes)
+  vector1: {
+    addressHex: '6199eb65b21702e0872e41b90ff1bfe237b64f23c53bee9074ef38ca5c',
+    expected: {
+      coseKey:
+        'a5010102581d6199eb65b21702e0872e41b90ff1bfe237b64f23c53bee9074ef38ca5c03272006215820deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      coseSign1:
+        '84582aa201276761646472657373581d6199eb65b21702e0872e41b90ff1bfe237b64f23c53bee9074ef38ca5ca166686173686564f44548656c6c6f5840bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      protectedHeaders: 'a201276761646472657373581d6199eb65b21702e0872e41b90ff1bfe237b64f23c53bee9074ef38ca5c'
+    },
+    payloadHex: '48656c6c6f',
+    publicKeyHex: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    signatureHex:
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+  },
+  // Base address (longer, 57 bytes)
+  vector2: {
+    addressHex:
+      '00d73b4d5548f4d00a1947e9284ccdcdc565dd4b85b36e88533c54ed9bfa2e192363674c755f5efe81c620f18bddf8cf63f181d1366fffef34',
+    expected: {
+      coseKey:
+        'a5010102583900d73b4d5548f4d00a1947e9284ccdcdc565dd4b85b36e88533c54ed9bfa2e192363674c755f5efe81c620f18bddf8cf63f181d1366fffef34032720062158203fe822fca223192577130a288b766fcac5b2b8972d89fc229bbc00af60aeaf67',
+      coseSign1:
+        '845846a201276761646472657373583900d73b4d5548f4d00a1947e9284ccdcdc565dd4b85b36e88533c54ed9bfa2e192363674c755f5efe81c620f18bddf8cf63f181d1366fffef34a166686173686564f443abc1235840aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      coseSign1Hashed:
+        '845846a201276761646472657373583900d73b4d5548f4d00a1947e9284ccdcdc565dd4b85b36e88533c54ed9bfa2e192363674c755f5efe81c620f18bddf8cf63f181d1366fffef34a166686173686564f543abc1235840aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      protectedHeaders:
+        'a201276761646472657373583900d73b4d5548f4d00a1947e9284ccdcdc565dd4b85b36e88533c54ed9bfa2e192363674c755f5efe81c620f18bddf8cf63f181d1366fffef34'
+    },
+    payloadHex: 'abc123',
+    publicKeyHex: '3fe822fca223192577130a288b766fcac5b2b8972d89fc229bbc00af60aeaf67',
+    signatureHex:
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  }
+};
+
+describe('coseUtils', () => {
+  describe('createProtectedHeadersCbor', () => {
+    it(`${CBOR_MATCHING_WASM_OUTPUT} for enterprise address`, () => {
+      const { addressHex, expected } = vectors.vector1;
+      const result = createProtectedHeadersCbor(Buffer.from(addressHex, 'hex'));
+      expect(HexBlob.fromBytes(result)).toBe(expected.protectedHeaders);
+    });
+
+    it(`${CBOR_MATCHING_WASM_OUTPUT} for base address`, () => {
+      const { addressHex, expected } = vectors.vector2;
+      const result = createProtectedHeadersCbor(Buffer.from(addressHex, 'hex'));
+      expect(HexBlob.fromBytes(result)).toBe(expected.protectedHeaders);
+    });
+  });
+
+  describe('createCoseSign1Cbor', () => {
+    it(`${CBOR_MATCHING_WASM_OUTPUT} (hashed=false)`, () => {
+      const { addressHex, payloadHex, signatureHex, expected } = vectors.vector2;
+      const protectedHeaders = createProtectedHeadersCbor(Buffer.from(addressHex, 'hex'));
+      const result = createCoseSign1Cbor(
+        protectedHeaders,
+        Buffer.from(payloadHex, 'hex'),
+        Buffer.from(signatureHex, 'hex'),
+        false
+      );
+      expect(HexBlob.fromBytes(result)).toBe(expected.coseSign1);
+    });
+
+    it(`${CBOR_MATCHING_WASM_OUTPUT} (hashed=true)`, () => {
+      const { addressHex, payloadHex, signatureHex, expected } = vectors.vector2;
+      const protectedHeaders = createProtectedHeadersCbor(Buffer.from(addressHex, 'hex'));
+      const result = createCoseSign1Cbor(
+        protectedHeaders,
+        Buffer.from(payloadHex, 'hex'),
+        Buffer.from(signatureHex, 'hex'),
+        true
+      );
+      expect(HexBlob.fromBytes(result)).toBe(expected.coseSign1Hashed);
+    });
+
+    it(`${CBOR_MATCHING_WASM_OUTPUT} for enterprise address`, () => {
+      const { addressHex, payloadHex, signatureHex, expected } = vectors.vector1;
+      const protectedHeaders = createProtectedHeadersCbor(Buffer.from(addressHex, 'hex'));
+      const result = createCoseSign1Cbor(
+        protectedHeaders,
+        Buffer.from(payloadHex, 'hex'),
+        Buffer.from(signatureHex, 'hex'),
+        false
+      );
+      expect(HexBlob.fromBytes(result)).toBe(expected.coseSign1);
+    });
+  });
+
+  describe('createCoseKeyCbor', () => {
+    it(`${CBOR_MATCHING_WASM_OUTPUT} for enterprise address`, () => {
+      const { addressHex, publicKeyHex, expected } = vectors.vector1;
+      const result = createCoseKeyCbor(Buffer.from(addressHex, 'hex'), publicKeyHex);
+      expect(HexBlob.fromBytes(result)).toBe(expected.coseKey);
+    });
+
+    it(`${CBOR_MATCHING_WASM_OUTPUT} for base address`, () => {
+      const { addressHex, publicKeyHex, expected } = vectors.vector2;
+      const result = createCoseKeyCbor(Buffer.from(addressHex, 'hex'), publicKeyHex);
+      expect(HexBlob.fromBytes(result)).toBe(expected.coseKey);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2562,7 +2562,6 @@ __metadata:
     "@cardano-sdk/tx-construction": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
     "@cardano-sdk/util-dev": "workspace:~"
-    "@emurgo/cardano-message-signing-nodejs": ^1.0.1
     "@ledgerhq/hw-transport": ^6.31.4
     "@ledgerhq/hw-transport-node-hid-noevents": ^6.30.5
     "@ledgerhq/hw-transport-webusb": ^6.29.4


### PR DESCRIPTION
# Context

This PR removes the wasm dependency of `@emurgo/cardano-message-signing-nodejs` from hardware wallet ledger package as this was breaking cip8 signing on mobile.

# Proposed Solution

Implement the cip8 header serialization natively in typescript

