### PR TITLE
fix: remove redundant Trezor device connection check in getXpub

### DIFF
--- a/packages/hardware-trezor/src/TrezorKeyAgent.ts
+++ b/packages/hardware-trezor/src/TrezorKeyAgent.ts
@@ -191,7 +191,6 @@ export class TrezorKeyAgent extends KeyAgentBase {
     derivationType
   }: GetTrezorXpubProps): Promise<Crypto.Bip32PublicKeyHex> {
     try {
-      await TrezorKeyAgent.checkDeviceConnection(communicationType);
       const derivationPath = `m/${purpose}'/${CardanoKeyConst.COIN_TYPE}'/${accountIndex}'`;
       const trezorConnect = getTrezorConnect(communicationType);
       const trezorDerivationType = derivationType ? mapDerivationType(derivationType) : undefined;


### PR DESCRIPTION
# Context

it was causing duplicate connection prompt in Lace v1 and causing an error in v2 integration

# Proposed Solution

# Important Changes Introduced
