### PR TITLE
feat(core): opt-in strict CBOR deserialization mode

### DIFF
--- a/packages/core/src/Serialization/Certificates/AuthCommitteeHot.ts
+++ b/packages/core/src/Serialization/Certificates/AuthCommitteeHot.ts
@@ -3,6 +3,7 @@ import { CborReader, CborWriter } from '../CBOR';
 import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -86,7 +87,7 @@ export class AuthCommitteeHot {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const coldType = Number(reader.readInt()) as Cardano.CredentialType;
+    const coldType = readCredentialType(reader);
     const coldHash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();
@@ -99,7 +100,7 @@ export class AuthCommitteeHot {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const hotType = Number(reader.readInt()) as Cardano.CredentialType;
+    const hotType = readCredentialType(reader);
     const hotHash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/DRep/DRep.ts
+++ b/packages/core/src/Serialization/Certificates/DRep/DRep.ts
@@ -2,7 +2,7 @@ import * as Crypto from '@cardano-sdk/crypto';
 import { CborReader, CborWriter } from '../../CBOR';
 import { CredentialType } from '../../../Cardano/Address/Address';
 import { DRepKind } from './DRepKind';
-import { HexBlob } from '@cardano-sdk/util';
+import { HexBlob, InvalidStateError } from '@cardano-sdk/util';
 import { isDRepAlwaysAbstain, isDRepAlwaysNoConfidence } from '../../../Cardano/types/Governance';
 import type * as Cardano from '../../../Cardano';
 
@@ -91,8 +91,9 @@ export class DRep {
     reader.readEndArray();
 
     if (kind === DRepKind.Abstain) return DRep.newAlwaysAbstain();
+    if (kind === DRepKind.NoConfidence) return DRep.newAlwaysNoConfidence();
 
-    return DRep.newAlwaysNoConfidence();
+    throw new InvalidStateError(`Unexpected kind value: ${kind}`);
   }
 
   /**

--- a/packages/core/src/Serialization/Certificates/RegisterDelegateRepresentative.ts
+++ b/packages/core/src/Serialization/Certificates/RegisterDelegateRepresentative.ts
@@ -5,6 +5,7 @@ import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { hexToBytes } from '../../util/misc';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -100,7 +101,7 @@ export class RegisterDelegateRepresentative {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/Registration.ts
+++ b/packages/core/src/Serialization/Certificates/Registration.ts
@@ -3,6 +3,7 @@ import { CborReader, CborWriter } from '../CBOR';
 import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -95,7 +96,7 @@ export class Registration {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/ResignCommitteeCold.ts
+++ b/packages/core/src/Serialization/Certificates/ResignCommitteeCold.ts
@@ -5,6 +5,7 @@ import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { hexToBytes } from '../../util/misc';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -90,7 +91,7 @@ export class ResignCommitteeCold {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const coldType = Number(reader.readInt()) as Cardano.CredentialType;
+    const coldType = readCredentialType(reader);
     const coldHash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
     reader.readEndArray();
 

--- a/packages/core/src/Serialization/Certificates/StakeDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeDelegation.ts
@@ -4,6 +4,7 @@ import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { PoolId } from '../../Cardano/types/StakePool';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 3;
@@ -92,7 +93,7 @@ export class StakeDelegation {
         `Expected an array of ${CREDENTIAL_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/StakeDeregistration.ts
+++ b/packages/core/src/Serialization/Certificates/StakeDeregistration.ts
@@ -3,6 +3,7 @@ import { CborReader, CborWriter } from '../CBOR';
 import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -86,7 +87,7 @@ export class StakeDeregistration {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/StakeRegistration.ts
+++ b/packages/core/src/Serialization/Certificates/StakeRegistration.ts
@@ -3,6 +3,7 @@ import { CborReader, CborWriter } from '../CBOR';
 import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -86,7 +87,7 @@ export class StakeRegistration {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/StakeRegistrationDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeRegistrationDelegation.ts
@@ -4,6 +4,7 @@ import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { PoolId } from '../../Cardano/types/StakePool';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -90,7 +91,7 @@ export class StakeRegistrationDelegation {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/StakeVoteDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeVoteDelegation.ts
@@ -6,6 +6,7 @@ import { DRep } from './DRep';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { PoolId } from '../../Cardano/types/StakePool';
 import { hexToBytes } from '../../util/misc';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -95,7 +96,7 @@ export class StakeVoteDelegation {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/StakeVoteRegistrationDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/StakeVoteRegistrationDelegation.ts
@@ -6,6 +6,7 @@ import { DRep } from './DRep';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { PoolId } from '../../Cardano/types/StakePool';
 import { hexToBytes } from '../../util/misc';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -105,7 +106,7 @@ export class StakeVoteRegistrationDelegation {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/UnregisterDelegateRepresentative.ts
+++ b/packages/core/src/Serialization/Certificates/UnregisterDelegateRepresentative.ts
@@ -3,6 +3,7 @@ import { CborReader, CborWriter } from '../CBOR';
 import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -90,7 +91,7 @@ export class UnregisterDelegateRepresentative {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/Unregistration.ts
+++ b/packages/core/src/Serialization/Certificates/Unregistration.ts
@@ -3,6 +3,7 @@ import { CborReader, CborWriter } from '../CBOR';
 import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -93,7 +94,7 @@ export class Unregistration {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/UpdateDelegateRepresentative.ts
+++ b/packages/core/src/Serialization/Certificates/UpdateDelegateRepresentative.ts
@@ -5,6 +5,7 @@ import { CertificateKind } from './CertificateKind';
 import { CertificateType } from '../../Cardano/types/Certificate';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { hexToBytes } from '../../util/misc';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -93,7 +94,7 @@ export class UpdateDelegateRepresentative {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/VoteDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/VoteDelegation.ts
@@ -5,6 +5,7 @@ import { CertificateType } from '../../Cardano/types/Certificate';
 import { DRep } from './DRep';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { hexToBytes } from '../../util/misc';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -86,7 +87,7 @@ export class VoteDelegation {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Certificates/VoteRegistrationDelegation.ts
+++ b/packages/core/src/Serialization/Certificates/VoteRegistrationDelegation.ts
@@ -5,6 +5,7 @@ import { CertificateType } from '../../Cardano/types/Certificate';
 import { DRep } from './DRep';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { hexToBytes } from '../../util/misc';
+import { readCredentialType } from '../Common/Credential';
 import type * as Cardano from '../../Cardano';
 
 const EMBEDDED_GROUP_SIZE = 2;
@@ -91,7 +92,7 @@ export class VoteRegistrationDelegation {
         `Expected an array of ${EMBEDDED_GROUP_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readInt()) as Cardano.CredentialType;
+    const type = readCredentialType(reader);
     const hash = Crypto.Hash28ByteBase16(HexBlob.fromBytes(reader.readByteString()));
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Common/Credential.ts
+++ b/packages/core/src/Serialization/Common/Credential.ts
@@ -1,10 +1,26 @@
-import { Cardano } from '../..';
 import { CborReader, CborWriter } from '../CBOR';
+import { CredentialType } from '../../Cardano/Address/Address';
 import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
-import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
+import { HexBlob, InvalidArgumentError, InvalidStateError } from '@cardano-sdk/util';
 import { hexToBytes } from '../../util/misc';
+import type { Cardano } from '../..';
 
 const CREDENTIAL_ARRAY_SIZE = 2;
+
+/**
+ * Reads a credential type discriminant from the reader, throwing if it is not a known credential type.
+ *
+ * @param reader The CBOR reader positioned at the credential type value.
+ * @returns The credential type.
+ */
+export const readCredentialType = (reader: CborReader): CredentialType => {
+  const type = Number(reader.readInt());
+
+  if (type !== CredentialType.KeyHash && type !== CredentialType.ScriptHash)
+    throw new InvalidStateError(`Unexpected credential type value: ${type}`);
+
+  return type;
+};
 
 export class Credential {
   #value: Cardano.Credential;
@@ -29,7 +45,7 @@ export class Credential {
         `Expected an array of ${CREDENTIAL_ARRAY_SIZE} elements, but got an array of ${length} elements`
       );
 
-    const type = Number(reader.readUInt());
+    const type = readCredentialType(reader);
     const hash = HexBlob.fromBytes(reader.readByteString()) as unknown as Hash28ByteBase16;
 
     reader.readEndArray();

--- a/packages/core/src/Serialization/Common/DeserializationOptions.ts
+++ b/packages/core/src/Serialization/Common/DeserializationOptions.ts
@@ -1,0 +1,9 @@
+/** Options controlling CBOR deserialization behavior. */
+export interface DeserializationOptions {
+  /**
+   * When true, deserialization throws on unknown map keys instead of silently skipping them, so that
+   * constructs from a newer era than this build understands are detected rather than under-rendered.
+   * Defaults to false (unknown keys are skipped).
+   */
+  strict?: boolean;
+}

--- a/packages/core/src/Serialization/Common/index.ts
+++ b/packages/core/src/Serialization/Common/index.ts
@@ -1,3 +1,4 @@
+export * from './DeserializationOptions';
 export * from './UnitInterval';
 export * from './ExUnits';
 export * from './ProtocolVersion';

--- a/packages/core/src/Serialization/Transaction.ts
+++ b/packages/core/src/Serialization/Transaction.ts
@@ -1,5 +1,6 @@
 import { AuxiliaryData } from './AuxiliaryData';
 import { CborReader, CborReaderState, CborWriter } from './CBOR';
+import { DeserializationOptions } from './Common';
 import { HexBlob, OpaqueString } from '@cardano-sdk/util';
 import { TransactionBody } from './TransactionBody';
 import { TransactionWitnessSet } from './TransactionWitnessSet';
@@ -86,17 +87,19 @@ export class Transaction {
    * Deserializes the transaction from a CBOR byte array.
    *
    * @param cbor The CBOR encoded transaction object.
+   * @param options Deserialization options. When `strict` is true, throws on unknown map keys
+   * instead of skipping them.
    * @returns The new transaction instance.
    */
-  static fromCbor(cbor: TxCBOR): Transaction {
+  static fromCbor(cbor: TxCBOR, options?: DeserializationOptions): Transaction {
     const reader = new CborReader(cbor as unknown as HexBlob);
 
     const length = reader.readStartArray();
 
     const bodyBytes = reader.readEncodedValue();
-    const body = TransactionBody.fromCbor(HexBlob.fromBytes(bodyBytes));
+    const body = TransactionBody.fromCbor(HexBlob.fromBytes(bodyBytes), options);
 
-    const witnessSet = TransactionWitnessSet.fromCbor(HexBlob.fromBytes(reader.readEncodedValue()));
+    const witnessSet = TransactionWitnessSet.fromCbor(HexBlob.fromBytes(reader.readEncodedValue()), options);
     let isValid = true;
 
     // The isValid flag was added in Alonzo era (onwards), mary era transactions only have three fields.

--- a/packages/core/src/Serialization/TransactionBody/ProposalProcedure/Committee.ts
+++ b/packages/core/src/Serialization/TransactionBody/ProposalProcedure/Committee.ts
@@ -1,7 +1,7 @@
 import { CborReader, CborReaderState, CborWriter } from '../../CBOR';
 import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
 import { HexBlob, InvalidArgumentError, InvalidStateError } from '@cardano-sdk/util';
-import { UnitInterval } from '../../Common';
+import { UnitInterval, readCredentialType } from '../../Common';
 import { hexToBytes } from '../../../util/misc';
 import type * as Cardano from '../../../Cardano';
 
@@ -90,7 +90,7 @@ export class Committee {
           `Expected an array of ${CREDENTIAL_ARRAY_SIZE} elements, but got an array of ${length} elements`
         );
 
-      const type = Number(reader.readUInt());
+      const type = readCredentialType(reader);
       const hash = HexBlob.fromBytes(reader.readByteString()) as unknown as Hash28ByteBase16;
 
       reader.readEndArray();

--- a/packages/core/src/Serialization/TransactionBody/TransactionBody.ts
+++ b/packages/core/src/Serialization/TransactionBody/TransactionBody.ts
@@ -2,7 +2,7 @@
 import * as Crypto from '@cardano-sdk/crypto';
 import { Address, RewardAddress } from '../../Cardano/Address';
 import { CborReader, CborReaderState, CborTag, CborWriter } from '../CBOR';
-import { CborSet, Hash } from '../Common';
+import { CborSet, DeserializationOptions, Hash } from '../Common';
 import { Certificate } from '../Certificates';
 import { HexBlob } from '@cardano-sdk/util';
 import { ProposalProcedure } from './ProposalProcedure';
@@ -253,9 +253,11 @@ export class TransactionBody {
    * Deserializes the TransactionBody from a CBOR byte array.
    *
    * @param cbor The CBOR encoded TransactionBody object.
+   * @param options Deserialization options. When `strict` is true, throws on unknown map keys
+   * instead of skipping them.
    * @returns The new TransactionBody instance.
    */
-  static fromCbor(cbor: HexBlob): TransactionBody {
+  static fromCbor(cbor: HexBlob, options?: DeserializationOptions): TransactionBody {
     const reader = new CborReader(cbor);
 
     const inputs = CborSet.fromCore([], TransactionInput.fromCore);
@@ -278,7 +280,7 @@ export class TransactionBody {
           reader.readStartArray();
 
           while (reader.peekState() !== CborReaderState.EndArray) {
-            body.outputs().push(TransactionOutput.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+            body.outputs().push(TransactionOutput.fromCbor(HexBlob.fromBytes(reader.readEncodedValue()), options));
           }
 
           reader.readEndArray();
@@ -362,7 +364,7 @@ export class TransactionBody {
           body.setNetworkId(Number(reader.readInt()) as Cardano.NetworkId);
           break;
         case 16n:
-          body.setCollateralReturn(TransactionOutput.fromCbor(HexBlob.fromBytes(reader.readEncodedValue())));
+          body.setCollateralReturn(TransactionOutput.fromCbor(HexBlob.fromBytes(reader.readEncodedValue()), options));
           break;
         case 17n:
           body.setTotalCollateral(reader.readInt());
@@ -386,6 +388,11 @@ export class TransactionBody {
         case 22n:
           body.setDonation(reader.readInt());
           break;
+        default:
+          if (options?.strict)
+            throw new SerializationError(SerializationFailure.UnknownField, `Unknown transaction body map key: ${key}`);
+
+          reader.skipValue();
       }
     }
 

--- a/packages/core/src/Serialization/TransactionBody/TransactionOutput.ts
+++ b/packages/core/src/Serialization/TransactionBody/TransactionOutput.ts
@@ -3,9 +3,11 @@ import * as Crypto from '@cardano-sdk/crypto';
 import { Address } from '../../Cardano/Address';
 import { CborReader, CborReaderState, CborTag, CborWriter } from '../CBOR';
 import { Datum, DatumKind } from '../Common/Datum';
+import { DeserializationOptions } from '../Common/DeserializationOptions';
 import { HexBlob, InvalidArgumentError } from '@cardano-sdk/util';
 import { PlutusData } from '../PlutusData';
 import { Script } from '../Scripts';
+import { SerializationError, SerializationFailure } from '../../errors';
 import { Value } from './Value';
 import type * as Cardano from '../../Cardano';
 
@@ -99,9 +101,11 @@ export class TransactionOutput {
    * Deserializes the TransactionOutput from a CBOR byte array.
    *
    * @param cbor The CBOR encoded TransactionOutput object.
+   * @param options Deserialization options. When `strict` is true, throws on unknown map keys
+   * instead of skipping them.
    * @returns The new TransactionOutput instance.
    */
-  static fromCbor(cbor: HexBlob): TransactionOutput {
+  static fromCbor(cbor: HexBlob, options?: DeserializationOptions): TransactionOutput {
     const reader = new CborReader(cbor);
 
     let address;
@@ -171,6 +175,14 @@ export class TransactionOutput {
             scriptRef = Script.fromCbor(HexBlob.fromBytes(encodedDatum));
             break;
           }
+          default:
+            if (options?.strict)
+              throw new SerializationError(
+                SerializationFailure.UnknownField,
+                `Unknown transaction output map key: ${key}`
+              );
+
+            reader.skipValue();
         }
       }
 

--- a/packages/core/src/Serialization/TransactionBody/TransactionOutput.ts
+++ b/packages/core/src/Serialization/TransactionBody/TransactionOutput.ts
@@ -136,6 +136,9 @@ export class TransactionOutput {
 
             const datumKind = Number(datumReader.readInt());
 
+            if (datumKind !== DatumKind.DataHash && datumKind !== DatumKind.InlineData)
+              throw new InvalidArgumentError('cbor', `Unexpected datum kind ${datumKind}`);
+
             if (datumKind === DatumKind.InlineData) {
               const tag = datumReader.readTag();
 

--- a/packages/core/src/Serialization/TransactionBody/VotingProcedures/VotingProcedure.ts
+++ b/packages/core/src/Serialization/TransactionBody/VotingProcedures/VotingProcedure.ts
@@ -1,6 +1,7 @@
 import { Anchor } from '../../Common/Anchor';
 import { CborReader, CborReaderState, CborWriter } from '../../CBOR';
-import { HexBlob } from '@cardano-sdk/util';
+import { HexBlob, InvalidStateError } from '@cardano-sdk/util';
+import { Vote } from '../../../Cardano/types/Governance';
 import { hexToBytes } from '../../../util/misc';
 import type * as Cardano from '../../../Cardano';
 
@@ -61,6 +62,10 @@ export class VotingProcedure {
 
     reader.readStartArray();
     const vote = Number(reader.readInt());
+
+    if (vote !== Vote.no && vote !== Vote.yes && vote !== Vote.abstain)
+      throw new InvalidStateError(`Unexpected vote value: ${vote}`);
+
     let anchor;
 
     if (reader.peekState() === CborReaderState.Null) {

--- a/packages/core/src/Serialization/TransactionWitnessSet/TransactionWitnessSet.ts
+++ b/packages/core/src/Serialization/TransactionWitnessSet/TransactionWitnessSet.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/cognitive-complexity, complexity, max-statements, unicorn/prefer-switch */
 import { BootstrapWitness } from './BootstrapWitness';
 import { CborReader, CborReaderState, CborWriter } from '../CBOR';
-import { CborSet } from '../Common';
+import { CborSet, DeserializationOptions } from '../Common';
 import { HexBlob } from '@cardano-sdk/util';
 import { NativeScript, PlutusV1Script, PlutusV2Script, PlutusV3Script } from '../Scripts';
 import { PlutusData } from '../PlutusData/PlutusData';
@@ -119,9 +119,11 @@ export class TransactionWitnessSet {
    * Deserializes the TransactionWitnessSet from a CBOR byte array.
    *
    * @param cbor The CBOR encoded TransactionWitnessSet object.
+   * @param options Deserialization options. When `strict` is true, throws on unknown map keys
+   * instead of skipping them.
    * @returns The new TransactionWitnessSet instance.
    */
-  static fromCbor(cbor: HexBlob): TransactionWitnessSet {
+  static fromCbor(cbor: HexBlob, options?: DeserializationOptions): TransactionWitnessSet {
     const reader = new CborReader(cbor);
 
     const witness = new TransactionWitnessSet();
@@ -167,6 +169,14 @@ export class TransactionWitnessSet {
             CborSet.fromCbor(HexBlob.fromBytes(reader.readEncodedValue()), PlutusV3Script.fromCbor)
           );
           break;
+        default:
+          if (options?.strict)
+            throw new SerializationError(
+              SerializationFailure.UnknownField,
+              `Unknown transaction witness set map key: ${key}`
+            );
+
+          reader.skipValue();
       }
     }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -62,7 +62,8 @@ export enum SerializationFailure {
   InvalidScript = 'INVALID_SCRIPT',
   InvalidNativeScriptKind = 'INVALID_NATIVE_SCRIPT_KIND',
   InvalidScriptType = 'INVALID_SCRIPT_TYPE',
-  InvalidDatum = 'INVALID_DATUM'
+  InvalidDatum = 'INVALID_DATUM',
+  UnknownField = 'UNKNOWN_FIELD'
 }
 
 export class SerializationError<InnerError = unknown> extends ComposableError<InnerError> {

--- a/packages/core/test/Serialization/Certificates/DRep.test.ts
+++ b/packages/core/test/Serialization/Certificates/DRep.test.ts
@@ -38,3 +38,9 @@ testDRep('Always Abstain', HexBlob('8102'), {
 testDRep('Always No Confidence', HexBlob('8103'), {
   __typename: 'AlwaysNoConfidence'
 });
+
+describe('DRep unknown kind', () => {
+  it('fromCbor throws', () => {
+    expect(() => DRep.fromCbor(HexBlob('8104'))).toThrow('Unexpected kind value: 4');
+  });
+});

--- a/packages/core/test/Serialization/Certificates/StakeRegistration.test.ts
+++ b/packages/core/test/Serialization/Certificates/StakeRegistration.test.ts
@@ -6,6 +6,12 @@ import { StakeRegistration } from '../../../src/Serialization';
 
 // Test data used in the following tests was generated with the cardano-serialization-lib
 describe('StakeRegistration', () => {
+  it('throws when decoding StakeRegistration with an unknown credential type', () => {
+    const cbor = HexBlob('82008202581ccb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f');
+
+    expect(() => StakeRegistration.fromCbor(cbor)).toThrow('Unexpected credential type value: 2');
+  });
+
   it('can decode StakeRegistration from CBOR', () => {
     const cbor = HexBlob('82008200581ccb0ec2692497b458e46812c8a5bfa2931d1a2d965a99893828ec810f');
 

--- a/packages/core/test/Serialization/Common/Credential.test.ts
+++ b/packages/core/test/Serialization/Common/Credential.test.ts
@@ -25,4 +25,10 @@ describe('Credential', () => {
   it('politely refuses an invalid credential cbor', () => {
     expect(() => Credential.fromCbor(cborArraySize3)).toThrow();
   });
+
+  it('politely refuses an unknown credential type', () => {
+    expect(() =>
+      Credential.fromCbor(HexBlob('8202581c30000000000000000000000000000000000000000000000000000000'))
+    ).toThrow('Unexpected credential type value: 2');
+  });
 });

--- a/packages/core/test/Serialization/Transaction.test.ts
+++ b/packages/core/test/Serialization/Transaction.test.ts
@@ -153,3 +153,28 @@ describe('Transaction', () => {
     expect(Transaction.fromCore(tx).toCbor()).toBe(cbor);
   });
 });
+
+describe('Transaction strict deserialization', () => {
+  // [{0: [], 1: [], 2: 0, 23: [1, 2]}, {}, true, null] - body has unknown key 23
+  const txWithUnknownBodyKey = '84a400800180020017820102a0f5f6';
+  // [{0: [], 1: [], 2: 0}, {0: [], 8: [1, 2]}, true, null] - witness set has unknown key 8
+  const txWithUnknownWitnessSetKey = '84a3008001800200a2008008820102f5f6';
+
+  it('deserializes transactions with unknown body keys by default', () => {
+    const tx = Transaction.fromCbor(TxCBOR(txWithUnknownBodyKey));
+
+    expect(tx.body().fee()).toEqual(0n);
+  });
+
+  it('throws on unknown body keys when strict', () => {
+    expect(() => Transaction.fromCbor(TxCBOR(txWithUnknownBodyKey), { strict: true })).toThrow(
+      'Unknown transaction body map key: 23'
+    );
+  });
+
+  it('throws on unknown witness set keys when strict', () => {
+    expect(() => Transaction.fromCbor(TxCBOR(txWithUnknownWitnessSetKey), { strict: true })).toThrow(
+      'Unknown transaction witness set map key: 8'
+    );
+  });
+});

--- a/packages/core/test/Serialization/TransactionBody/TransactionBody.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/TransactionBody.test.ts
@@ -2,6 +2,7 @@
 import * as Cardano from '../../../src/Cardano';
 import * as Crypto from '@cardano-sdk/crypto';
 import { HexBlob } from '@cardano-sdk/util';
+import { SerializationError } from '../../../src/errors';
 import { Transaction, TransactionBody, TxBodyCBOR, TxCBOR } from '../../../src/Serialization';
 import { babbageTx } from '../testData';
 import { mintTokenMap, params, txIn, txOut } from './testData';
@@ -341,5 +342,29 @@ describe('TransactionBody', () => {
       withdrawals: canonicallySortedWithdrawals
     };
     expect(body.toCore()).toEqual(numericFieldsSetToZeroCanonicalWithdrawals);
+  });
+});
+
+describe('TransactionBody unknown map keys', () => {
+  // {0: [], 1: [], 2: 0, 23: [1, 2]} - key 23 is not part of the transaction_body CDDL
+  const cborWithUnknownKey = HexBlob('a400800180020017820102');
+  // {0: [], 1: [], 23: [1, 2], 2: 10}
+  const cborWithUnknownKeyBeforeFee = HexBlob('a40080018017820102020a');
+
+  it('skips unknown keys and keeps reading subsequent fields by default', () => {
+    const body = TransactionBody.fromCbor(cborWithUnknownKeyBeforeFee);
+
+    expect(body.fee()).toEqual(10n);
+  });
+
+  it('preserves the original bytes when re-serializing a body with unknown keys', () => {
+    expect(TransactionBody.fromCbor(cborWithUnknownKey).toCbor()).toEqual(cborWithUnknownKey);
+  });
+
+  it('throws on unknown keys when strict', () => {
+    expect(() => TransactionBody.fromCbor(cborWithUnknownKey, { strict: true })).toThrowError(SerializationError);
+    expect(() => TransactionBody.fromCbor(cborWithUnknownKey, { strict: true })).toThrow(
+      'Unknown transaction body map key: 23'
+    );
   });
 });

--- a/packages/core/test/Serialization/TransactionBody/TransactionOutput.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/TransactionOutput.test.ts
@@ -408,6 +408,25 @@ describe('TransactionOutput', () => {
   });
 });
 
+describe('TransactionOutput unknown map keys', () => {
+  // {0: address, 1: 10, 4: [1, 2]} - key 4 is not part of the post-alonzo output CDDL
+  const cborWithUnknownKey = HexBlob(
+    'a300583900537ba48a023f0a3c65e54977ffc2d78c143fb418ef6db058e006d78a7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8010a04820102'
+  );
+
+  it('skips unknown keys by default', () => {
+    const output = TransactionOutput.fromCbor(cborWithUnknownKey);
+
+    expect(output.amount().coin()).toEqual(10n);
+  });
+
+  it('throws on unknown keys when strict', () => {
+    expect(() => TransactionOutput.fromCbor(cborWithUnknownKey, { strict: true })).toThrow(
+      'Unknown transaction output map key: 4'
+    );
+  });
+});
+
 describe('TransactionOutput unknown datum kind', () => {
   it('fromCbor throws', () => {
     // {0: address, 1: 10, 2: [2, h'00']} - datum_option kind 2 is unknown

--- a/packages/core/test/Serialization/TransactionBody/TransactionOutput.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/TransactionOutput.test.ts
@@ -407,3 +407,14 @@ describe('TransactionOutput', () => {
     });
   });
 });
+
+describe('TransactionOutput unknown datum kind', () => {
+  it('fromCbor throws', () => {
+    // {0: address, 1: 10, 2: [2, h'00']} - datum_option kind 2 is unknown
+    const cborWithUnknownDatumKind = HexBlob(
+      'a300583900537ba48a023f0a3c65e54977ffc2d78c143fb418ef6db058e006d78a7c16240714ea0e12b41a914f2945784ac494bb19573f0ca61a08afa8010a0282024100'
+    );
+
+    expect(() => TransactionOutput.fromCbor(cborWithUnknownDatumKind)).toThrow('Unexpected datum kind 2');
+  });
+});

--- a/packages/core/test/Serialization/TransactionBody/VotingProcedures/VotingProcedure.test.ts
+++ b/packages/core/test/Serialization/TransactionBody/VotingProcedures/VotingProcedure.test.ts
@@ -66,3 +66,9 @@ testVotingProcedure(
     vote: Cardano.Vote.abstain
   }
 );
+
+describe('VotingProcedure unknown vote', () => {
+  it('fromCbor throws', () => {
+    expect(() => VotingProcedure.fromCbor(HexBlob('8203f6'))).toThrow('Unexpected vote value: 3');
+  });
+});

--- a/packages/core/test/Serialization/TransactionWitnessSet/TransactionWitnessSet.test.ts
+++ b/packages/core/test/Serialization/TransactionWitnessSet/TransactionWitnessSet.test.ts
@@ -214,3 +214,20 @@ describe('TransactionWitnessSet', () => {
     expect(witness.toCore()).toEqual(simpleCore);
   });
 });
+
+describe('TransactionWitnessSet unknown map keys', () => {
+  // {0: [], 8: [1, 2]} - key 8 is not part of the transaction_witness_set CDDL
+  const cborWithUnknownKey = HexBlob('a2008008820102');
+
+  it('skips unknown keys by default', () => {
+    const witnessSet = TransactionWitnessSet.fromCbor(cborWithUnknownKey);
+
+    expect(witnessSet.vkeys()?.size()).toEqual(0);
+  });
+
+  it('throws on unknown keys when strict', () => {
+    expect(() => TransactionWitnessSet.fromCbor(cborWithUnknownKey, { strict: true })).toThrow(
+      'Unknown transaction witness set map key: 8'
+    );
+  });
+});


### PR DESCRIPTION
# Context

Closes #1684

`Serialization.TransactionBody.fromCbor` switches on known map keys with no `default` branch, so a transaction containing constructs from a newer era than the client understands is under-rendered with no signal that anything was skipped. Wallet UIs rendering a summary before signing would prefer to detect this and refuse/warn, since the signature covers the full body bytes. Re-encode round-trips don't catch it either because `originalBytes` is cached.

# Proposed Solution

Two parts:

**Always-on discriminant validation (fix).** Unknown discriminants cannot be parsed leniently — the old code misinterpreted them rather than skipping them:
- `DRep.fromCbor` silently decoded any unknown kind as `AlwaysNoConfidence`
- credential types and votes were accepted as-is via numeric casts
- an unknown `datum_option` kind produced an empty datum

These now throw unconditionally, consistent with `Certificate`, `Voter` and `ProposalProcedure` which already throw on unknown kinds. Credential type validation is centralized in a new `readCredentialType` helper (`Common/Credential.ts`) used by all certificate types, `Committee` and `Credential`.

**Opt-in strict mode for extensible maps (feat).** `Transaction`, `TransactionBody`, `TransactionOutput` and `TransactionWitnessSet` `fromCbor` accept an optional `{ strict?: boolean }`. When strict, an unknown map key throws `SerializationError` with the new `SerializationFailure.UnknownField` reason. Default behavior stays lenient for existing consumers.

# Important Changes Introduced

- Lenient mode now skips unknown map keys correctly: previously the unknown key's value was left unconsumed, so the reader misaligned and parsed garbage (or threw a confusing error) on the next field.
- Known follow-up gaps (unchanged in this PR): `ProtocolParamUpdate`, `Update` and `AuxiliaryData` maps still have no `default` branch, so they retain the misalignment behavior and no strict support.