### PR TITLE
feat(tx-construction): expose tx-builder utils and add fluent minting

### DIFF
--- a/packages/e2e/test/wallet_epoch_0/PersonalWallet/mint.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/PersonalWallet/mint.test.ts
@@ -1,6 +1,5 @@
-import { BaseWallet, FinalizeTxProps } from '@cardano-sdk/wallet';
+import { BaseWallet } from '@cardano-sdk/wallet';
 import { Cardano, nativeScriptPolicyId } from '@cardano-sdk/core';
-import { InitializeTxProps } from '@cardano-sdk/tx-construction';
 import { KeyRole, util } from '@cardano-sdk/key-management';
 import {
   bip32Ed25519Factory,
@@ -66,38 +65,16 @@ describe('PersonalWallet/mint', () => {
 
     const policyId = nativeScriptPolicyId(policyScript);
     const assetId = Cardano.AssetId(`${policyId}`); // skip asset name
-    const tokens = new Map([[assetId, 1n]]);
 
-    const walletAddress = (await firstValueFrom(wallet.addresses$))[0].address;
+    // Mint through the fluent transaction builder. The minted asset is balanced into the wallet's
+    // change; the policy requires Alice's signature, supplied as an extra signer.
+    const { tx: signedTx } = await wallet
+      .createTxBuilder()
+      .addMint({ assets: new Map([[Cardano.AssetName(''), 1n]]), policy: policyScript })
+      .extraSigners([alicePolicySigner])
+      .build()
+      .sign();
 
-    const txProps: InitializeTxProps = {
-      mint: tokens,
-      outputs: new Set([
-        {
-          address: walletAddress,
-          value: {
-            assets: tokens,
-            coins
-          }
-        }
-      ]),
-      signingOptions: {
-        extraSigners: [alicePolicySigner]
-      },
-      witness: { scripts: [policyScript] }
-    };
-
-    const unsignedTx = await wallet.initializeTx(txProps);
-
-    const finalizeProps: FinalizeTxProps = {
-      signingOptions: {
-        extraSigners: [alicePolicySigner]
-      },
-      tx: unsignedTx,
-      witness: { scripts: [policyScript] }
-    };
-
-    const signedTx = await wallet.finalizeTx(finalizeProps);
     const [, txFoundInHistory] = await submitAndConfirm(wallet, signedTx, 1);
 
     expect(txFoundInHistory.id).toEqual(signedTx.id);

--- a/packages/e2e/test/wallet_epoch_0/PersonalWallet/phase2validation.test.ts
+++ b/packages/e2e/test/wallet_epoch_0/PersonalWallet/phase2validation.test.ts
@@ -128,7 +128,7 @@ describe('PersonalWallet/phase2validation', () => {
           }
         }
       ]),
-      redeemersByType: { [Cardano.RedeemerPurpose.mint]: [scriptRedeemer] },
+      redeemersByType: { mint: new Map([[policyId, scriptRedeemer]]) },
       scriptIntegrityHash: scriptDataHash,
       witness: { redeemers: [scriptRedeemer], scripts: [alwaysFailScript] }
     };

--- a/packages/tx-construction/src/input-selection/selectionConstraints.ts
+++ b/packages/tx-construction/src/input-selection/selectionConstraints.ts
@@ -17,13 +17,26 @@ export const MAX_U64 = 18_446_744_073_709_551_615n;
 
 export type BuildTx = (selection: SelectionSkeleton) => Promise<Cardano.Tx>;
 
+/**
+ * Redeemers grouped by purpose. Each purpose is keyed by the on-chain identifier its redeemer
+ * points at, so the canonical (ledger) redeemer index can be derived from the transaction body
+ * during {@link computeMinimumCost}:
+ *
+ * - `spend` by `txId#index`
+ * - `mint` by minting `PolicyId`
+ * - `withdrawal` by script `RewardAccount`
+ * - `vote` by `Voter`
+ *
+ * `certificate` and `propose` redeemers are sequence-indexed in transaction-body order, which is
+ * what the ledger expects for those purposes, so they remain ordered lists.
+ */
 export interface RedeemersByType {
   spend?: Map<TxIdWithIndex, Cardano.Redeemer>;
-  mint?: Array<Cardano.Redeemer>;
+  mint?: Map<Cardano.PolicyId, Cardano.Redeemer>;
+  withdrawal?: Map<Cardano.RewardAccount, Cardano.Redeemer>;
+  vote?: Array<{ voter: Cardano.Voter; redeemer: Cardano.Redeemer }>;
   certificate?: Array<Cardano.Redeemer>;
-  withdrawal?: Array<Cardano.Redeemer>;
   propose?: Array<Cardano.Redeemer>;
-  vote?: Array<Cardano.Redeemer>;
 }
 
 export interface DefaultSelectionConstraintsProps {
@@ -33,75 +46,135 @@ export interface DefaultSelectionConstraintsProps {
   txEvaluator: TxEvaluator;
 }
 
-const updateRedeemers = (
-  evaluation: TxEvaluationResult,
+/** Lexicographic comparison of hex-encoded byte strings. */
+const compareHex = (a: string, b: string): number => (a === b ? 0 : a < b ? -1 : 1);
+
+const rewardAccountCredential = (rewardAccount: Cardano.RewardAccount): Cardano.Credential =>
+  Cardano.Address.fromBech32(rewardAccount).asReward()!.getPaymentCredential();
+
+/** Ledger ordering group for a voter constructor: ConstitutionalCommittee < DRep < StakePool. */
+const voterGroup = (voter: Cardano.Voter): number => {
+  switch (voter.__typename) {
+    case Cardano.VoterType.ccHotKeyHash:
+    case Cardano.VoterType.ccHotScriptHash:
+      return 0;
+    case Cardano.VoterType.dRepKeyHash:
+    case Cardano.VoterType.dRepScriptHash:
+      return 1;
+    default:
+      return 2;
+  }
+};
+
+// Within a constructor the ledger Credential Ord places ScriptHash before KeyHash.
+const credentialScriptFirstRank = (type: Cardano.CredentialType): number =>
+  type === Cardano.CredentialType.ScriptHash ? 0 : 1;
+
+const compareVoters = (a: Cardano.Voter, b: Cardano.Voter): number =>
+  voterGroup(a) - voterGroup(b) ||
+  credentialScriptFirstRank(a.credential.type) - credentialScriptFirstRank(b.credential.type) ||
+  compareHex(a.credential.hash, b.credential.hash);
+
+const votersEqual = (a: Cardano.Voter, b: Cardano.Voter): boolean =>
+  a.__typename === b.__typename && a.credential.hash === b.credential.hash;
+
+const reindexed = (
+  redeemer: Cardano.Redeemer,
+  purpose: Cardano.RedeemerPurpose,
+  index: number,
+  executionUnits: Cardano.ExUnits
+): Cardano.Redeemer => ({ data: redeemer.data, executionUnits, index, purpose });
+
+const spendRedeemers = (
   redeemersByType: RedeemersByType,
-  txInputs: Array<Cardano.TxIn>
-): Array<Cardano.Redeemer> => {
-  const result: Array<Cardano.Redeemer> = [];
+  sortedInputs: Array<Cardano.TxIn>,
+  executionUnits: Cardano.ExUnits
+): Cardano.Redeemer[] =>
+  [...(redeemersByType.spend ?? [])].map(([key, redeemer]) => {
+    const index = sortedInputs.findIndex((input) => key === `${input.txId}#${input.index}`);
+    if (index < 0) throw new Error(`Spend redeemer input not found in transaction: ${key}`);
+    return reindexed(redeemer, Cardano.RedeemerPurpose.spend, index, executionUnits);
+  });
 
-  // Mapping between purpose and redeemersByType
-  const redeemersMap: { [key in Cardano.RedeemerPurpose]?: Map<string, Cardano.Redeemer> | Cardano.Redeemer[] } = {
-    [Cardano.RedeemerPurpose.spend]: redeemersByType.spend,
-    [Cardano.RedeemerPurpose.mint]: redeemersByType.mint,
-    [Cardano.RedeemerPurpose.certificate]: redeemersByType.certificate,
-    [Cardano.RedeemerPurpose.withdrawal]: redeemersByType.withdrawal,
-    [Cardano.RedeemerPurpose.propose]: redeemersByType.propose,
-    [Cardano.RedeemerPurpose.vote]: redeemersByType.vote
-  };
-
-  for (const txEval of evaluation) {
-    const redeemers = redeemersMap[txEval.purpose];
-    if (!redeemers) throw new Error(`No redeemers found for ${txEval.purpose} purpose`);
-
-    let knownRedeemer;
-    if (txEval.purpose === Cardano.RedeemerPurpose.spend) {
-      const input = txInputs[txEval.index];
-
-      knownRedeemer = (redeemers as Map<string, Cardano.Redeemer>).get(`${input.txId}#${input.index}`);
-
-      if (!knownRedeemer) throw new Error(`Known Redeemer not found for tx id ${input.txId} and index ${input.index}`);
-    } else {
-      const redeemerList = redeemers as Cardano.Redeemer[];
-
-      knownRedeemer = redeemerList.find((redeemer) => redeemer.index === txEval.index);
-
-      if (!knownRedeemer) throw new Error(`Known Redeemer not found for index ${txEval.index}`);
-    }
-
-    result.push({ ...knownRedeemer, executionUnits: txEval.budget });
-  }
-
-  return result;
-};
-
-const reorgRedeemers = (
-  redeemerByType: RedeemersByType,
-  witness: Cardano.Witness,
-  txInputs: Array<Cardano.TxIn>
+const mintRedeemers = (
+  redeemersByType: RedeemersByType,
+  body: Cardano.TxBody,
+  executionUnits: Cardano.ExUnits
 ): Cardano.Redeemer[] => {
-  let redeemers: Cardano.Redeemer[] = [];
-
-  if (witness.redeemers) {
-    // Lets remove all spend redeemers if any.
-    redeemers = witness.redeemers.filter((redeemer) => redeemer.purpose !== Cardano.RedeemerPurpose.spend);
-
-    // Add them back with the correct redeemer index.
-    if (redeemerByType.spend) {
-      for (const [key, value] of redeemerByType.spend) {
-        const index = txInputs.findIndex((input) => key === `${input.txId}#${input.index}`);
-
-        if (index < 0) throw new Error(`Redeemer not found for tx id ${key}`);
-
-        value.index = index;
-
-        redeemers.push({ ...value });
-      }
-    }
-  }
-
-  return redeemers;
+  const policyIds = [...new Set([...(body.mint?.keys() ?? [])].map(Cardano.AssetId.getPolicyId))].sort(compareHex);
+  return [...(redeemersByType.mint ?? [])].map(([policyId, redeemer]) => {
+    const index = policyIds.indexOf(policyId);
+    if (index < 0) throw new Error(`Mint redeemer policy not present in transaction mint: ${policyId}`);
+    return reindexed(redeemer, Cardano.RedeemerPurpose.mint, index, executionUnits);
+  });
 };
+
+const withdrawalRedeemers = (
+  redeemersByType: RedeemersByType,
+  body: Cardano.TxBody,
+  executionUnits: Cardano.ExUnits
+): Cardano.Redeemer[] => {
+  // Node quirk: withdrawal script credentials are processed before key-hash ones, so key-hash
+  // withdrawals carry no redeemer and don't shift the index. Index = rank among script reward
+  // accounts, sorted by credential hash.
+  const scriptRewardAccounts = (body.withdrawals ?? [])
+    .map((withdrawal) => withdrawal.stakeAddress)
+    .filter((rewardAccount) => rewardAccountCredential(rewardAccount).type === Cardano.CredentialType.ScriptHash)
+    .sort((a, b) => compareHex(rewardAccountCredential(a).hash, rewardAccountCredential(b).hash));
+  return [...(redeemersByType.withdrawal ?? [])].map(([rewardAccount, redeemer]) => {
+    const index = scriptRewardAccounts.indexOf(rewardAccount);
+    if (index < 0) throw new Error(`Withdrawal redeemer is not a script withdrawal in transaction: ${rewardAccount}`);
+    return reindexed(redeemer, Cardano.RedeemerPurpose.withdrawal, index, executionUnits);
+  });
+};
+
+const voteRedeemers = (
+  redeemersByType: RedeemersByType,
+  body: Cardano.TxBody,
+  executionUnits: Cardano.ExUnits
+): Cardano.Redeemer[] => {
+  const sortedVoters = (body.votingProcedures ?? []).map(({ voter }) => voter).sort(compareVoters);
+  return (redeemersByType.vote ?? []).map(({ voter, redeemer }) => {
+    const index = sortedVoters.findIndex((candidate) => votersEqual(candidate, voter));
+    if (index < 0) throw new Error('Vote redeemer voter not present in transaction voting procedures');
+    return reindexed(redeemer, Cardano.RedeemerPurpose.vote, index, executionUnits);
+  });
+};
+
+/**
+ * Assigns each redeemer its canonical ledger index, derived from the position of the item it
+ * unlocks within the transaction body's canonically-ordered collections (mirroring the node's
+ * `getAlonzoScriptsNeeded`). Certificate/proposal redeemers keep the caller-provided index, which
+ * is the item's position in transaction-body order. `executionUnits` are seeded from the (already
+ * max-budgeted) builder redeemers so evaluation has headroom; concrete units are merged back in
+ * via {@link mergeExecutionUnits}.
+ */
+const assignCanonicalIndices = (
+  redeemersByType: RedeemersByType,
+  body: Cardano.TxBody,
+  sortedInputs: Array<Cardano.TxIn>,
+  executionUnits: Cardano.ExUnits
+): Cardano.Redeemer[] => [
+  ...spendRedeemers(redeemersByType, sortedInputs, executionUnits),
+  ...mintRedeemers(redeemersByType, body, executionUnits),
+  ...withdrawalRedeemers(redeemersByType, body, executionUnits),
+  ...voteRedeemers(redeemersByType, body, executionUnits),
+  ...(redeemersByType.certificate ?? []).map((redeemer) =>
+    reindexed(redeemer, Cardano.RedeemerPurpose.certificate, redeemer.index, executionUnits)
+  ),
+  ...(redeemersByType.propose ?? []).map((redeemer) =>
+    reindexed(redeemer, Cardano.RedeemerPurpose.propose, redeemer.index, executionUnits)
+  )
+];
+
+/** Merges evaluated execution units back onto the canonically-indexed redeemers by (purpose, index). */
+const mergeExecutionUnits = (redeemers: Cardano.Redeemer[], evaluation: TxEvaluationResult): Cardano.Redeemer[] =>
+  redeemers.map((redeemer) => {
+    const evaluated = evaluation.find(
+      (txEval) => txEval.purpose === redeemer.purpose && txEval.index === redeemer.index
+    );
+    return evaluated ? { ...redeemer, executionUnits: evaluated.budget } : redeemer;
+  });
 
 export const computeMinimumCost =
   (
@@ -116,9 +189,12 @@ export const computeMinimumCost =
     const txIns = utxos.map((utxo) => utxo[0]).sort(sortTxIn);
 
     if (tx.witness && tx.witness.redeemers && tx.witness.redeemers.length > 0) {
-      // before the evaluation can happen, we need to point every redeemer to its corresponding inputs.
-      tx.witness.redeemers = reorgRedeemers(redeemersByType, tx.witness, txIns);
-      tx.witness.redeemers = updateRedeemers(await txEvaluator.evaluate(tx, utxos), redeemersByType, txIns);
+      // The builder redeemers carry a sentinel index and a max-budget; reassign canonical indices
+      // from the transaction body, evaluate, then merge the concrete execution units back in.
+      const maxBudget = tx.witness.redeemers[0].executionUnits;
+      const indexed = assignCanonicalIndices(redeemersByType, tx.body, txIns, maxBudget);
+      tx.witness.redeemers = indexed;
+      tx.witness.redeemers = mergeExecutionUnits(indexed, await txEvaluator.evaluate(tx, utxos));
     }
 
     return {

--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -12,6 +12,7 @@ import { Cardano, HandleProvider, HandleResolution, Serialization, inConwayEra, 
 import {
   CustomizeCb,
   InsufficientRewardAccounts,
+  MintProps,
   OutOfSyncRewardAccounts,
   OutputBuilderTxOut,
   PartialTx,
@@ -142,11 +143,11 @@ export class GenericTxBuilder implements TxBuilder {
   #knownInlineDatums = new Set<Cardano.DatumHash>();
   #knownRedeemers: RedeemersByType = {
     certificate: new Array<Cardano.Redeemer>(),
-    mint: new Array<Cardano.Redeemer>(),
+    mint: new Map<Cardano.PolicyId, Cardano.Redeemer>(),
     propose: new Array<Cardano.Redeemer>(),
     spend: new Map<TxIdWithIndex, Cardano.Redeemer>(),
-    vote: new Array<Cardano.Redeemer>(),
-    withdrawal: new Array<Cardano.Redeemer>()
+    vote: new Array<{ voter: Cardano.Voter; redeemer: Cardano.Redeemer }>(),
+    withdrawal: new Map<Cardano.RewardAccount, Cardano.Redeemer>()
   };
 
   #unresolvedInputs = new Array<Cardano.TxIn>();
@@ -215,6 +216,31 @@ export class GenericTxBuilder implements TxBuilder {
       )
     )
       this.#unresolvedInputs.push(input);
+
+    return this;
+  }
+
+  addMint({ policy, assets, redeemer }: MintProps): TxBuilder {
+    const policyHash = Serialization.Script.fromCore(policy).hash();
+    this.#knownScripts.set(policyHash, policy);
+
+    const policyId = Cardano.PolicyId(policyHash);
+    const mint = new Map(this.partialTxBody.mint);
+    for (const [assetName, quantity] of assets) {
+      mint.set(Cardano.AssetId.fromParts(policyId, assetName), quantity);
+    }
+    this.partialTxBody = { ...this.partialTxBody, mint };
+
+    if (redeemer) {
+      // Keyed by policy id; the canonical redeemer index is derived from the sorted minting
+      // policies of the transaction body during input selection.
+      this.#knownRedeemers.mint?.set(policyId, {
+        data: redeemer,
+        executionUnits: { memory: 0, steps: 0 },
+        index: 0,
+        purpose: Cardano.RedeemerPurpose.mint
+      });
+    }
 
     return this;
   }
@@ -412,6 +438,7 @@ export class GenericTxBuilder implements TxBuilder {
               customizeCb: this.#customizeCb,
               handleResolutions: this.#handleResolutions,
               inputs: new Set(this.#preSelectedInputs.values()),
+              mint: this.partialTxBody.mint,
               options: {
                 validityInterval: this.partialTxBody.validityInterval
               },

--- a/packages/tx-construction/src/tx-builder/TxBuilder.ts
+++ b/packages/tx-construction/src/tx-builder/TxBuilder.ts
@@ -363,7 +363,11 @@ export class GenericTxBuilder implements TxBuilder {
             );
             const auxiliaryData = this.partialAuxiliaryData && { ...this.partialAuxiliaryData };
             const extraSigners = this.partialExtraSigners && [...this.partialExtraSigners];
-            const partialSigningOptions = this.partialSigningOptions && { ...this.partialSigningOptions, extraSigners };
+            // Include extra signers in the signing options used for fee estimation, even when no
+            // other signing options were set — otherwise their witnesses are added at sign() but
+            // not accounted for in the fee, producing an insufficient-fee transaction.
+            const partialSigningOptions =
+              this.partialSigningOptions || extraSigners ? { ...this.partialSigningOptions, extraSigners } : undefined;
 
             if (this.partialAuxiliaryData) {
               this.partialTxBody.auxiliaryDataHash = Cardano.computeAuxiliaryDataHash(this.partialAuxiliaryData);

--- a/packages/tx-construction/src/tx-builder/index.ts
+++ b/packages/tx-construction/src/tx-builder/index.ts
@@ -3,3 +3,4 @@ export * from './initializeTx';
 export * from './types';
 export * from './TxBuilder';
 export * from './GreedyTxEvaluator';
+export * from './utils';

--- a/packages/tx-construction/src/tx-builder/types.ts
+++ b/packages/tx-construction/src/tx-builder/types.ts
@@ -266,6 +266,15 @@ export type ScriptUnlockProps = {
   datum?: Cardano.PlutusData;
 };
 
+export type MintProps = {
+  /** The minting policy script. The policy id is derived from its hash. */
+  policy: Cardano.Script;
+  /** Asset names mapped to the quantity to mint (positive) or burn (negative), under the policy. */
+  assets: Map<Cardano.AssetName, bigint>;
+  /** Redeemer for Plutus minting policies; omit for native scripts. */
+  redeemer?: Cardano.PlutusData;
+};
+
 export interface TxBuilder {
   /**
    * @returns a partial transaction that has properties set by calling other TxBuilder methods. Does not validate the transaction.
@@ -288,6 +297,16 @@ export interface TxBuilder {
    * @returns {TxBuilder} The current TxBuilder instance for chaining.
    */
   addInput(input: Cardano.TxIn | Cardano.Utxo, scriptUnlockProps?: ScriptUnlockProps): TxBuilder;
+
+  /**
+   * Mints (or burns) assets under a minting policy. The policy script is attached to the witness
+   * set and, for Plutus policies, the redeemer is included and its execution units are evaluated
+   * during `build()`. Call multiple times to mint under several policies.
+   *
+   * @param props - The minting policy, the assets (by name) to mint/burn, and an optional redeemer.
+   * @returns {TxBuilder} The current TxBuilder instance for chaining.
+   */
+  addMint(props: MintProps): TxBuilder;
 
   /**
    * Adds a datum to the transaction.

--- a/packages/tx-construction/src/tx-builder/utils.ts
+++ b/packages/tx-construction/src/tx-builder/utils.ts
@@ -103,11 +103,11 @@ export const buildRedeemers = (redeemersData: RedeemersByType, maxExecutionUnits
   const redeemers = [];
 
   const knownRedeemers = [
-    ...(redeemersData.mint ?? []),
-    ...(redeemersData.vote ?? []),
+    ...(redeemersData.mint ? [...redeemersData.mint.values()] : []),
+    ...(redeemersData.vote?.map(({ redeemer }) => redeemer) ?? []),
     ...(redeemersData.propose ?? []),
     ...(redeemersData.certificate ?? []),
-    ...(redeemersData.withdrawal ?? []),
+    ...(redeemersData.withdrawal ? [...redeemersData.withdrawal.values()] : []),
     ...(redeemersData.spend ? [...redeemersData.spend.values()] : [])
   ];
 

--- a/packages/tx-construction/test/input-selection/selectionConstraints.test.ts
+++ b/packages/tx-construction/test/input-selection/selectionConstraints.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-loop-func */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable unicorn/consistent-function-scoping */
+import * as Crypto from '@cardano-sdk/crypto';
 import { AssetId } from '@cardano-sdk/util-dev';
 import { Cardano, InvalidProtocolParametersError, Serialization } from '@cardano-sdk/core';
 import { DefaultSelectionConstraintsProps, defaultSelectionConstraints } from '../../src';
@@ -49,17 +50,21 @@ describe('defaultSelectionConstraints', () => {
             purpose: Cardano.RedeemerPurpose.certificate
           }
         ],
-        mint: [
-          {
-            data: Serialization.PlutusData.fromCbor(HexBlob('d86682008101')).toCore(),
-            executionUnits: {
-              memory: 0,
-              steps: 0
-            },
-            index: 0,
-            purpose: Cardano.RedeemerPurpose.mint
-          }
-        ]
+        // Keyed by a policy id present in babbageTx's mint; it sorts first canonically -> index 0.
+        mint: new Map([
+          [
+            Cardano.PolicyId('2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740'),
+            {
+              data: Serialization.PlutusData.fromCbor(HexBlob('d86682008101')).toCore(),
+              executionUnits: {
+                memory: 0,
+                steps: 0
+              },
+              index: 0,
+              purpose: Cardano.RedeemerPurpose.mint
+            }
+          ]
+        ])
       },
       txEvaluator: mockTxEvaluator
     });
@@ -159,6 +164,71 @@ describe('defaultSelectionConstraints', () => {
         protocolParameters: { ...protocolParameters, maxValueSize: 1 }
       } as DefaultSelectionConstraintsProps);
       expect(constraints.tokenBundleSizeExceedsLimit(new Map())).toBe(true);
+    });
+  });
+
+  describe('canonical redeemer indices', () => {
+    const selection = { inputs: [] } as unknown as SelectionSkeleton;
+    const maxBudget = { memory: 100, steps: 200 };
+    const dataA = Serialization.PlutusData.fromCbor(HexBlob('d87980')).toCore();
+    const dataB = Serialization.PlutusData.fromCbor(HexBlob('d87a80')).toCore();
+
+    const scriptRewardAccount = (hashByte: string) =>
+      Cardano.RewardAccount.fromCredential(
+        { hash: Crypto.Hash28ByteBase16(hashByte.repeat(28)), type: Cardano.CredentialType.ScriptHash },
+        Cardano.NetworkId.Testnet
+      );
+    const keyRewardAccount = (hashByte: string) =>
+      Cardano.RewardAccount.fromCredential(
+        { hash: Crypto.Hash28ByteBase16(hashByte.repeat(28)), type: Cardano.CredentialType.KeyHash },
+        Cardano.NetworkId.Testnet
+      );
+
+    it('withdrawal redeemers are indexed among script reward accounts by hash, excluding key-hash withdrawals', async () => {
+      const scriptA = scriptRewardAccount('aa');
+      const scriptB = scriptRewardAccount('bb');
+      const keyC = keyRewardAccount('cc');
+
+      const redeemer = (data: Cardano.PlutusData): Cardano.Redeemer => ({
+        data,
+        executionUnits: { memory: 0, steps: 0 },
+        index: Number.MAX_SAFE_INTEGER,
+        purpose: Cardano.RedeemerPurpose.withdrawal
+      });
+
+      // Body lists them out of canonical order, and a key-hash withdrawal is interleaved.
+      const tx = {
+        ...babbageTx,
+        body: {
+          ...babbageTx.body,
+          mint: undefined,
+          withdrawals: [
+            { quantity: 1n, stakeAddress: keyC },
+            { quantity: 1n, stakeAddress: scriptB },
+            { quantity: 1n, stakeAddress: scriptA }
+          ]
+        },
+        witness: { ...babbageTx.witness, redeemers: [redeemer(dataA), redeemer(dataB)] }
+      } as Cardano.Tx;
+
+      const constraints = defaultSelectionConstraints({
+        buildTx: async () => tx,
+        protocolParameters,
+        redeemersByType: {
+          withdrawal: new Map([
+            [scriptB, redeemer(dataB)],
+            [scriptA, redeemer(dataA)]
+          ])
+        },
+        txEvaluator: mockTxEvaluator
+      } as DefaultSelectionConstraintsProps);
+
+      const { redeemers } = await constraints.computeMinimumCost(selection);
+
+      // scriptA (aa) sorts before scriptB (bb); the key-hash withdrawal carries no redeemer.
+      expect(redeemers!.find((r) => r.data === dataA)!.index).toBe(0);
+      expect(redeemers!.find((r) => r.data === dataB)!.index).toBe(1);
+      expect(redeemers!.every((r) => r.executionUnits.steps === maxBudget.steps)).toBe(true);
     });
   });
 });

--- a/packages/tx-construction/test/tx-builder/TxBuilderPlutusScripts.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderPlutusScripts.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
 import { AddressType, Bip32Account, InMemoryKeyAgent, util } from '@cardano-sdk/key-management';
-import { Cardano, coalesceValueQuantities } from '@cardano-sdk/core';
+import { Cardano, Serialization, coalesceValueQuantities } from '@cardano-sdk/core';
 import {
   DatumResolver,
   GenericTxBuilder,
@@ -280,6 +280,120 @@ describe('TxBuilder/plutusScripts', () => {
     expect(tx.witness?.scripts?.some((s) => s === script)).toBeTruthy();
     expect(tx.body.scriptIntegrityHash).toEqual('6f33e6b98194924c306d686a35ed5560eb25be58fc72b721a50fc895a7d3f304');
     expect(roundRobinRandomImprove).toHaveBeenCalled();
+  });
+
+  it('can mint assets under a plutus policy with a redeemer', async () => {
+    const assetName = Cardano.AssetName('4d794e4654'); // "MyNFT"
+    const tx = await txBuilder
+      .addMint({ assets: new Map([[assetName, 1n]]), policy: script, redeemer: 1n })
+      .build()
+      .inspect();
+
+    const policyId = Cardano.PolicyId(Serialization.Script.fromCore(script).hash());
+    const assetId = Cardano.AssetId.fromParts(policyId, assetName);
+
+    expect(tx.body.mint?.get(assetId)).toEqual(1n);
+    expect(tx.witness?.scripts?.some((s) => s === script)).toBeTruthy();
+    expect(
+      tx.witness?.redeemers?.some(
+        (redeemer) => redeemer.purpose === Cardano.RedeemerPurpose.mint && redeemer.data === 1n
+      )
+    ).toBeTruthy();
+    expect(tx.body.scriptIntegrityHash).toBeDefined();
+  });
+
+  it('can burn assets under a plutus policy (negative quantity)', async () => {
+    const assetName = Cardano.AssetName('4d794e4654');
+    const policyId = Cardano.PolicyId(Serialization.Script.fromCore(script).hash());
+    const assetId = Cardano.AssetId.fromParts(policyId, assetName);
+
+    // The asset being burned must be available on an input.
+    const assetHolderAddress = Cardano.PaymentAddress(
+      'addr_test1qqt9c69kjqf0wsnlp7hs8xees5l6pm4yxdqa3hknqr0kfe0htmj4e5t8n885zxm4qzpfzwruqx3ey3f5q8kpkr0gt9ms8dcsz6'
+    );
+    const inputWithAsset: Cardano.Utxo = [
+      {
+        address: assetHolderAddress,
+        index: 0,
+        txId: Cardano.TransactionId('aa21ffbaff60ff0cff8cff55ffa6ff6dff78ff78ffaeffceff36ff3fffc5ffe0')
+      },
+      {
+        address: assetHolderAddress,
+        value: { assets: new Map([[assetId, 1n]]), coins: 10_000_000n }
+      }
+    ];
+
+    const tx = await txBuilder
+      .addInput(inputWithAsset)
+      .addMint({ assets: new Map([[assetName, -1n]]), policy: script, redeemer: 1n })
+      .build()
+      .inspect();
+
+    expect(tx.body.mint?.get(assetId)).toEqual(-1n);
+    expect(tx.body.scriptIntegrityHash).toBeDefined();
+  });
+
+  it('can mint under a native policy without a redeemer', async () => {
+    const nativePolicy: Cardano.NativeScript = {
+      __type: Cardano.ScriptType.Native,
+      kind: Cardano.NativeScriptKind.RequireAllOf,
+      scripts: []
+    };
+    const assetName = Cardano.AssetName('4e6174697665'); // "Native"
+    const policyId = Cardano.PolicyId(Serialization.Script.fromCore(nativePolicy).hash());
+    const assetId = Cardano.AssetId.fromParts(policyId, assetName);
+
+    const tx = await txBuilder
+      .addMint({ assets: new Map([[assetName, 5n]]), policy: nativePolicy })
+      .build()
+      .inspect();
+
+    expect(tx.body.mint?.get(assetId)).toEqual(5n);
+    expect(tx.witness?.scripts?.some((s) => s === nativePolicy)).toBeTruthy();
+    // Native minting has no redeemer and therefore no script-data-hash.
+    expect(tx.witness?.redeemers?.some((r) => r.purpose === Cardano.RedeemerPurpose.mint)).toBeFalsy();
+    expect(tx.body.scriptIntegrityHash).toBeUndefined();
+  });
+
+  it('indexes mint redeemers by canonical policy-id order, not insertion order', async () => {
+    const policyA = script;
+    const policyB: Cardano.PlutusScript = {
+      __type: Cardano.ScriptType.Plutus,
+      bytes: HexBlob('4d01000033222220051200120011'),
+      version: Cardano.PlutusLanguageVersion.V2
+    };
+
+    const policyIdA = Cardano.PolicyId(Serialization.Script.fromCore(policyA).hash());
+    const policyIdB = Cardano.PolicyId(Serialization.Script.fromCore(policyB).hash());
+    // Redeemer data identifies the policy: 1n -> A, 2n -> B.
+    const firstPolicySortsAsA = policyIdA < policyIdB;
+    const firstPolicyData = firstPolicySortsAsA ? 1n : 2n;
+    const secondPolicyData = firstPolicySortsAsA ? 2n : 1n;
+
+    const mintA = () =>
+      txBuilder.addMint({ assets: new Map([[Cardano.AssetName('41'), 1n]]), policy: policyA, redeemer: 1n });
+    const mintB = () =>
+      txBuilder.addMint({ assets: new Map([[Cardano.AssetName('42'), 1n]]), policy: policyB, redeemer: 2n });
+
+    // Add the policies in reverse canonical order; a plain insertion-order impl would mis-index.
+    if (firstPolicySortsAsA) {
+      mintB();
+      mintA();
+    } else {
+      mintA();
+      mintB();
+    }
+
+    const tx = await txBuilder.build().inspect();
+
+    const mintRedeemers = (tx.witness?.redeemers ?? []).filter((r) => r.purpose === Cardano.RedeemerPurpose.mint);
+    const indexOf = (data: bigint) => mintRedeemers.find((r) => r.data === data)?.index;
+
+    expect(mintRedeemers).toHaveLength(2);
+    // The policy whose id sorts first gets index 0, regardless of the order they were added.
+    expect(indexOf(firstPolicyData)).toBe(0);
+    expect(indexOf(secondPolicyData)).toBe(1);
+    expect(mintRedeemers.every((r) => r.executionUnits.steps > 0)).toBeTruthy();
   });
 
   it('can point the redeemer to the right input', async () => {

--- a/packages/tx-construction/test/tx-builder/TxBuilderPlutusScripts.test.ts
+++ b/packages/tx-construction/test/tx-builder/TxBuilderPlutusScripts.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import * as Crypto from '@cardano-sdk/crypto';
-import { AddressType, Bip32Account, InMemoryKeyAgent, util } from '@cardano-sdk/key-management';
+import { AddressType, Bip32Account, InMemoryKeyAgent, KeyRole, util } from '@cardano-sdk/key-management';
 import { Cardano, Serialization, coalesceValueQuantities } from '@cardano-sdk/core';
 import {
   DatumResolver,
@@ -394,6 +394,27 @@ describe('TxBuilder/plutusScripts', () => {
     expect(indexOf(firstPolicyData)).toBe(0);
     expect(indexOf(secondPolicyData)).toBe(1);
     expect(mintRedeemers.every((r) => r.executionUnits.steps > 0)).toBeTruthy();
+  });
+
+  it('accounts for extra signers in the fee', async () => {
+    const recipient = Cardano.PaymentAddress(
+      'addr_test1qqt9c69kjqf0wsnlp7hs8xees5l6pm4yxdqa3hknqr0kfe0htmj4e5t8n885zxm4qzpfzwruqx3ey3f5q8kpkr0gt9ms8dcsz6'
+    );
+    const feeFor = async (withExtraSigner: boolean) => {
+      const { txBuilder: builder } = await createTxBuilder({
+        keyAgent,
+        stakeDelegations: [{ credentialStatus: Cardano.StakeCredentialStatus.Unregistered }]
+      });
+      builder.addOutput(await builder.buildOutput().address(recipient).coin(1_000_000n).build());
+      if (withExtraSigner) {
+        // A distinct derivation path so its witness isn't deduped against the input-signing key.
+        builder.extraSigners([new util.KeyAgentTransactionSigner(keyAgent, { index: 5, role: KeyRole.External })]);
+      }
+      return (await builder.build().inspect()).body.fee;
+    };
+
+    // The extra signer's witness must be paid for, even without explicit signingOptions.
+    expect(await feeFor(true)).toBeGreaterThan(await feeFor(false));
   });
 
   it('can point the redeemer to the right input', async () => {

--- a/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
+++ b/packages/wallet/test/hardware/ledger/LedgerKeyAgent.test.ts
@@ -347,7 +347,7 @@ describe('LedgerKeyAgent', () => {
             }
           ]),
           redeemersByType: {
-            mint: [scriptRedeemer]
+            mint: new Map([[policyId, scriptRedeemer]])
           },
           scriptIntegrityHash: scriptDataHash,
           witness: { redeemers: [scriptRedeemer], scripts: [script] }

--- a/packages/web-extension/src/observableWallet/util.ts
+++ b/packages/web-extension/src/observableWallet/util.ts
@@ -47,6 +47,10 @@ export const txBuilderProperties: RemoteApiProperties<Omit<TxBuilder, 'customize
     getApiProperties: () => txBuilderProperties,
     propType: RemoteApiPropertyType.ApiFactory
   },
+  addMint: {
+    getApiProperties: () => txBuilderProperties,
+    propType: RemoteApiPropertyType.ApiFactory
+  },
   addOutput: {
     getApiProperties: () => txBuilderProperties,
     propType: RemoteApiPropertyType.ApiFactory


### PR DESCRIPTION
Closes gaps in `@cardano-sdk/tx-construction` that forced consumers (e.g. Lace's full-domain Cardano transaction builder) to reimplement SDK internals or drop to lower-level APIs.

## 1. Export tx-builder utils

`buildRedeemers`, `buildWitness` and `computeCollateral` are defined in [`tx-builder/utils.ts`](packages/tx-construction/src/tx-builder/utils.ts) but the barrel never re-exported `./utils`, so they were absent from the public API. Fixed with `export * from './utils'` (pure addition, no collisions).

## 2. Fluent minting on the transaction builder

Add `TxBuilder.addMint({ policy, assets, redeemer })`. The policy script is attached to the witness set, the asset quantities are added to the body, and for Plutus policies the redeemer is included and its execution units evaluated during `build()`. Previously `GenericTxBuilder` had **no minting support** — `mint` was never forwarded to `initializeTx`.

## 3. Canonical redeemer indexing (review follow-up)

Redeemer pointers must reference an item's position in the **canonically-sorted transaction-body collection**, not insertion order. `RedeemersByType` now keys redeemers by on-chain identifier (mint → `PolicyId`, withdrawal → `RewardAccount`, vote → `Voter`), and `computeMinimumCost` derives each index from the body:

- **mint**: rank of the policy id in the sorted minting policies.
- **withdrawal**: rank among script-credential reward accounts sorted by hash; key-hash withdrawals carry no redeemer and don't shift the index (node quirk).
- **vote**: position in the canonically-sorted voters (voter group, then script-before-keyhash credential, then hash).
- **certificate / propose**: caller-provided index (item position in body order).

The `@cardano-sdk/web-extension` remote-api property map gains the new `addMint` method.

## Tests

- Unit (`TxBuilderPlutusScripts.test.ts`): plutus mint with redeemer, **burn** (negative quantity), **native-script mint without a redeemer**, and **multi-policy** redeemer indexing.
- Canonical-index vector (`selectionConstraints.test.ts`): withdrawal indices computed among script reward accounts by hash, with a key-hash withdrawal interleaved and the body out of canonical order. Full `@cardano-sdk/tx-construction` suite green (221).
- E2E (`PersonalWallet/mint.test.ts`): the mint scenario now builds through `createTxBuilder().addMint(...).build().sign()` instead of `initializeTx`, validated on-chain by the e2e workflow (`wallet_epoch_0`, runs on PR).

## Open

Vote redeemer ordering is derived from the ledger Voter Ord (the cardano-c reference for votes was past the readable excerpt) and lacks a dedicated vector — flagged in-thread for confirmation against the reviewer's vote vectors. Withdrawal-with-redeemer is otherwise reachable via the documented `customize` hook; a first-class "build unsigned tx for external signers" path remains a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)