### PR TITLE
chore(core): remove unused dependencies (rxjs, ogmios)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,18 +47,8 @@
     "tsc-alias": "^1.8.10",
     "typescript": "^4.7.4"
   },
-  "peerDependencies": {
-    "rxjs": "^7.4.0"
-  },
-  "peerDependenciesMeta": {
-    "rxjs": {
-      "optional": true
-    }
-  },
   "dependencies": {
     "@biglup/is-cid": "^1.0.3",
-    "@cardano-ogmios/client": "6.9.0",
-    "@cardano-ogmios/schema": "6.9.0",
     "@cardano-sdk/crypto": "workspace:~",
     "@cardano-sdk/util": "workspace:~",
     "@foxglove/crc": "^0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,8 +2296,6 @@ __metadata:
   resolution: "@cardano-sdk/core@workspace:packages/core"
   dependencies:
     "@biglup/is-cid": ^1.0.3
-    "@cardano-ogmios/client": 6.9.0
-    "@cardano-ogmios/schema": 6.9.0
     "@cardano-sdk/crypto": "workspace:~"
     "@cardano-sdk/util": "workspace:~"
     "@foxglove/crc": ^0.0.3
@@ -2317,11 +2315,6 @@ __metadata:
     tsc-alias: ^1.8.10
     typescript: ^4.7.4
     web-encoding: ^1.1.5
-  peerDependencies:
-    rxjs: ^7.4.0
-  peerDependenciesMeta:
-    rxjs:
-      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Context

Closes the residue of #1001 ("core: rxjs is not optional"). The original ESM `ERR_MODULE_NOT_FOUND: rxjs` was caused by a runtime `rxjs` import in `CardanoNode/util/bufferChainSyncEvent.js`, which was since hoisted out of `core` (fixed in 0.40.0).

## Change

Full dependency audit of `@cardano-sdk/core` against actual `src`/`test` imports. Removes declarations that have **zero references** anywhere in the package:

- `rxjs` — `peerDependencies` + `peerDependenciesMeta` (dead since `bufferChainSyncEvent` was hoisted)
- `@cardano-ogmios/client` — unused
- `@cardano-ogmios/schema` — unused

### Audit result (all other deps verified in use)

| Dependency | src usage | Verdict |
|---|---|---|
| `rxjs` (peer) | 0 | removed |
| `@cardano-ogmios/client` | 0 | removed |
| `@cardano-ogmios/schema` | 0 | removed |
| `@biglup/is-cid`, `@foxglove/crc`, `@scure/base`, `fraction.js`, `ip-address`, `lodash`, `ts-custom-error`, `ts-log`, `web-encoding`, `@cardano-sdk/crypto`, `@cardano-sdk/util` | ≥1 | kept |

`yarn.lock` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)