### PR TITLE
chore(deps): bump uuid to ^11.1.1 (minimal node-16-safe fix)

### DIFF
--- a/packages/cardano-services/package.json
+++ b/packages/cardano-services/package.json
@@ -69,7 +69,6 @@
     "@types/express-prometheus-middleware": "^1.2.1",
     "@types/lodash": "^4.14.182",
     "@types/pg": "^8.6.5",
-    "@types/uuid": "^8.3.4",
     "@types/wait-on": "^5.3.1",
     "@types/ws": "^8.5.10",
     "axios-mock-adapter": "^2.0.0",
@@ -132,7 +131,7 @@
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.4",
     "typeorm": "^0.3.15",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.1",
     "ws": "^8.17.1"
   },
   "files": [

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -112,7 +112,7 @@
     "ts-log": "^2.2.4",
     "ts-node": "^10.8.1",
     "ts-stopwatch": "0.0.4",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "webextension-polyfill": "^0.8.0",
     "ws": "^8.5.0"
   },
@@ -135,7 +135,6 @@
     "@types/k6": "^0.53.1",
     "@types/lodash": "^4.14.182",
     "@types/ora": "^3.2.0",
-    "@types/uuid": "^8.3.4",
     "@types/webextension-polyfill": "^0.8.0",
     "@wdio/cli": "^7.19.5",
     "@wdio/local-runner": "^7.19.5",

--- a/packages/projection-typeorm/package.json
+++ b/packages/projection-typeorm/package.json
@@ -51,7 +51,7 @@
     "ts-log": "^2.2.4",
     "tsc-alias": "^1.8.10",
     "typeorm": "^0.3.15",
-    "uuid": "^9.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@cardano-sdk/util-dev": "workspace:~",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -81,7 +81,7 @@
     "rxjs": "^7.4.0",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.3",
-    "uuid": "^8.3.2"
+    "uuid": "^11.1.1"
   },
   "files": [
     "dist/*",

--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@cardano-sdk/util-dev": "workspace:~",
     "@types/lodash": "^4.14.182",
-    "@types/uuid": "^8.3.4",
     "@types/webextension-polyfill": "^0.8.0",
     "eslint": "^7.32.0",
     "jest": "^28.1.3",
@@ -67,7 +66,7 @@
     "rxjs": "^7.4.0",
     "ts-custom-error": "^3.2.0",
     "ts-log": "^2.2.3",
-    "uuid": "^8.3.2",
+    "uuid": "^11.1.1",
     "webextension-polyfill": "^0.8.0"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,7 +2623,6 @@ __metadata:
     "@types/express-prometheus-middleware": ^1.2.1
     "@types/lodash": ^4.14.182
     "@types/pg": ^8.6.5
-    "@types/uuid": ^8.3.4
     "@types/wait-on": ^5.3.1
     "@types/ws": ^8.5.10
     axios: ^1.7.4
@@ -2673,7 +2672,7 @@ __metadata:
     typeorm: ^0.3.15
     typeorm-extension: ^2.7.0
     typescript: ^4.7.4
-    uuid: ^10.0.0
+    uuid: ^11.1.1
     wait-on: ^6.0.1
     ws: ^8.17.1
   bin:
@@ -2810,7 +2809,6 @@ __metadata:
     "@types/k6": ^0.53.1
     "@types/lodash": ^4.14.182
     "@types/ora": ^3.2.0
-    "@types/uuid": ^8.3.4
     "@types/webextension-polyfill": ^0.8.0
     "@wdio/cli": ^7.19.5
     "@wdio/local-runner": ^7.19.5
@@ -2864,7 +2862,7 @@ __metadata:
     typescript: ^4.7.4
     url: ^0.11.4
     util: ^0.12.4
-    uuid: ^8.3.2
+    uuid: ^11.1.1
     wdio-chromedriver-service: ^7.3.2
     webassembly-loader-sw: ^1.1.0
     webdriverio: ^7.20.5
@@ -3097,7 +3095,7 @@ __metadata:
     tsc-alias: ^1.8.10
     typeorm: ^0.3.15
     typescript: ^4.7.4
-    uuid: ^9.0.0
+    uuid: ^11.1.1
   languageName: unknown
   linkType: soft
 
@@ -3267,7 +3265,7 @@ __metadata:
     ts-log: ^2.2.3
     tsc-alias: ^1.8.10
     typescript: ^4.7.4
-    uuid: ^8.3.2
+    uuid: ^11.1.1
     wait-on: ^6.0.1
     webextension-polyfill: ^0.9.0
   languageName: unknown
@@ -3289,7 +3287,6 @@ __metadata:
     "@cardano-sdk/util-rxjs": "workspace:~"
     "@cardano-sdk/wallet": "workspace:~"
     "@types/lodash": ^4.14.182
-    "@types/uuid": ^8.3.4
     "@types/webextension-polyfill": ^0.8.0
     backoff-rxjs: ^7.0.0
     eslint: ^7.32.0
@@ -3305,7 +3302,7 @@ __metadata:
     tsc-alias: ^1.8.10
     typescript: ^4.7.4
     util: ^0.12.4
-    uuid: ^8.3.2
+    uuid: ^11.1.1
     webextension-polyfill: ^0.8.0
   languageName: unknown
   linkType: soft
@@ -24348,15 +24345,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "uuid@npm:10.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 4b81611ade2885d2313ddd8dc865d93d8dccc13ddf901745edca8f86d99bc46d7a330d678e7532e7ebf93ce616679fb19b2e3568873ac0c14c999032acb25869
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the direct `uuid` dependency from `^8`/`^9`/`^10` to **`^11.1.1`** in `cardano-services`, `e2e`, `projection-typeorm`, `wallet`, and `web-extension`.

This is the **minimal** version that clears the advisory (uuid `< 11.1.1`), chosen deliberately over Dependabot's `uuid@14` (PR #1710, closed) which **requires Node 20+** and conflicts with this repo's `engines: >=16.20.2`. `uuid@11` has no `engines` constraint and is Node-16-safe.

Part of #1707.

## Why it's safe
- We only use named imports (`import { v4 } from 'uuid'`) across all 5 packages — no removed deep imports (`uuid/v4`) — so v11 is API-compatible.
- `uuid@11` ships its own TypeScript types, so the now-redundant `@types/uuid@^8` is removed from the 3 packages that declared it.

## Scope / remaining
Closes the **5 direct-manifest** uuid alerts. The transitive copies (`uuid@8.3.2`/`9.0.0` via `pg-boss`, `pouchdb`, `jayson`, `rpc-websockets`, `@lerna-lite/version`, `devtools`) remain — clearing them would need a global `uuid` resolution that risks those packages, so it stays deferred under #1707.

## Test plan
- [x] full `yarn build` green
- [x] `wallet` 440/440 (uses `uuid.v4` in PouchDbCollectionStore)
- [x] `web-extension` build green; uuid-using messaging tests pass (the 3 `NonBackgroundMessenger` reconnect-timing failures are **pre-existing on master** in this environment and unrelated to uuid)
- [ ] CI: confirm `build_and_test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)