### PR TITLE
feat(key-management): allow injecting custom root private key encryption in InMemoryKeyAgent

### DIFF
--- a/packages/key-management/src/InMemoryKeyAgent.ts
+++ b/packages/key-management/src/InMemoryKeyAgent.ts
@@ -8,6 +8,7 @@ import {
   KeyAgentType,
   KeyPair,
   KeyPurpose,
+  PassphraseEncryption,
   SerializableInMemoryKeyAgentData,
   SignBlobResult,
   SignTransactionContext,
@@ -29,6 +30,8 @@ import { HexBlob } from '@cardano-sdk/util';
 import { KeyAgentBase } from './KeyAgentBase';
 import { emip3decrypt, emip3encrypt } from './emip3';
 import uniqBy from 'lodash/uniqBy.js';
+
+const defaultRootPrivateKeyEncryption: PassphraseEncryption = { decrypt: emip3decrypt, encrypt: emip3encrypt };
 
 export interface InMemoryKeyAgentProps extends Omit<SerializableInMemoryKeyAgentData, '__typename'> {
   getPassphrase: GetPassphrase;
@@ -53,10 +56,12 @@ const getPassphraseRethrowTypedError = async (getPassphrase: GetPassphrase) => {
 
 export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
   readonly #getPassphrase: GetPassphrase;
+  readonly #rootPrivateKeyEncryption: PassphraseEncryption;
 
   constructor({ getPassphrase, ...serializableData }: InMemoryKeyAgentProps, dependencies: KeyAgentDependencies) {
     super({ ...serializableData, __typename: KeyAgentType.InMemory }, dependencies);
     this.#getPassphrase = getPassphrase;
+    this.#rootPrivateKeyEncryption = dependencies.rootPrivateKeyEncryption ?? defaultRootPrivateKeyEncryption;
   }
 
   async signBlob({ index, role: type }: AccountKeyDerivationPath, blob: HexBlob): Promise<SignBlobResult> {
@@ -109,7 +114,11 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
     const entropy = Buffer.from(mnemonicWordsToEntropy(mnemonicWords), 'hex');
     const rootPrivateKey = dependencies.bip32Ed25519.fromBip39Entropy(entropy, mnemonic2ndFactorPassphrase);
     const passphrase = await getPassphraseRethrowTypedError(getPassphrase);
-    const encryptedRootPrivateKey = await emip3encrypt(Buffer.from(rootPrivateKey, 'hex'), passphrase);
+    const rootPrivateKeyEncryption = dependencies.rootPrivateKeyEncryption ?? defaultRootPrivateKeyEncryption;
+    const encryptedRootPrivateKey = await rootPrivateKeyEncryption.encrypt(
+      Buffer.from(rootPrivateKey, 'hex'),
+      passphrase
+    );
     const accountPrivateKey = await deriveAccountPrivateKey({
       accountIndex,
       bip32Ed25519: dependencies.bip32Ed25519,
@@ -176,7 +185,7 @@ export class InMemoryKeyAgent extends KeyAgentBase implements KeyAgent {
     let decryptedRootKeyBytes: Uint8Array;
 
     try {
-      decryptedRootKeyBytes = await emip3decrypt(
+      decryptedRootKeyBytes = await this.#rootPrivateKeyEncryption.decrypt(
         new Uint8Array((this.serializableData as SerializableInMemoryKeyAgentData).encryptedRootPrivateKeyBytes),
         passphrase
       );

--- a/packages/key-management/src/types.ts
+++ b/packages/key-management/src/types.ts
@@ -68,9 +68,21 @@ export enum CommunicationType {
   Node = 'node'
 }
 
+/**
+ * Pluggable passphrase-based encryption for secrets at rest (e.g. the root
+ * private key). `encrypt` and `decrypt` are inverses for a given passphrase.
+ * Defaults to EMIP-003 when not provided to a key agent.
+ */
+export interface PassphraseEncryption {
+  encrypt: (data: Uint8Array, passphrase: Uint8Array) => Promise<Uint8Array>;
+  decrypt: (encrypted: Uint8Array, passphrase: Uint8Array) => Promise<Uint8Array>;
+}
+
 export interface KeyAgentDependencies {
   logger: Logger;
   bip32Ed25519: Crypto.Bip32Ed25519;
+  /** Overrides root private key encryption at rest. Defaults to EMIP-003. */
+  rootPrivateKeyEncryption?: PassphraseEncryption;
 }
 
 export interface AccountAddressDerivationPath {

--- a/packages/key-management/test/InMemoryKeyAgent.test.ts
+++ b/packages/key-management/test/InMemoryKeyAgent.test.ts
@@ -6,6 +6,7 @@ import {
   KeyPurpose,
   KeyRole,
   SerializableInMemoryKeyAgentData,
+  emip3decrypt,
   util
 } from '../src';
 import { Bip32Ed25519 } from '@cardano-sdk/crypto';
@@ -15,6 +16,11 @@ import { dummyLogger } from 'ts-log';
 
 jest.mock('../src/util/ownSignatureKeyPaths');
 const { ownSignatureKeyPaths } = jest.requireMock('../src/util/ownSignatureKeyPaths');
+
+const makeEncryption = () => ({
+  decrypt: jest.fn(async (encrypted: Uint8Array) => encrypted.slice(1)),
+  encrypt: jest.fn(async (data: Uint8Array) => Uint8Array.from([170, ...data]))
+});
 
 describe('InMemoryKeyAgent', () => {
   let keyAgent: InMemoryKeyAgent;
@@ -64,6 +70,38 @@ describe('InMemoryKeyAgent', () => {
       { bip32Ed25519, logger: dummyLogger }
     );
     expect(await saferKeyAgent.exportRootPrivateKey()).not.toEqual(await keyAgent.exportRootPrivateKey());
+  });
+
+  describe('rootPrivateKeyEncryption injection', () => {
+    it('uses the injected encryption to encrypt the root private key', async () => {
+      const encryption = makeEncryption();
+      const agent = await InMemoryKeyAgent.fromBip39MnemonicWords(
+        { chainId: Cardano.ChainIds.Preview, getPassphrase, mnemonicWords },
+        { bip32Ed25519, logger: dummyLogger, rootPrivateKeyEncryption: encryption }
+      );
+
+      expect(encryption.encrypt).toHaveBeenCalledTimes(1);
+      const { encryptedRootPrivateKeyBytes } = agent.serializableData as SerializableInMemoryKeyAgentData;
+      expect(encryptedRootPrivateKeyBytes[0]).toBe(170);
+    });
+
+    it('uses the injected encryption to decrypt, recovering the same root key as the default', async () => {
+      const encryption = makeEncryption();
+      const agent = await InMemoryKeyAgent.fromBip39MnemonicWords(
+        { chainId: Cardano.ChainIds.Preview, getPassphrase, mnemonicWords },
+        { bip32Ed25519, logger: dummyLogger, rootPrivateKeyEncryption: encryption }
+      );
+
+      const rootPrivateKey = await agent.exportRootPrivateKey();
+      expect(encryption.decrypt).toHaveBeenCalled();
+      expect(rootPrivateKey).toEqual(await keyAgent.exportRootPrivateKey());
+    });
+
+    it('defaults to EMIP-003 when no encryption is injected', async () => {
+      const { encryptedRootPrivateKeyBytes } = keyAgent.serializableData as SerializableInMemoryKeyAgentData;
+      const decrypted = await emip3decrypt(new Uint8Array(encryptedRootPrivateKeyBytes), Buffer.from('password'));
+      expect(Buffer.from(decrypted).toString('hex')).toEqual(await keyAgent.exportRootPrivateKey());
+    });
   });
 
   describe('serializableData', () => {


### PR DESCRIPTION
# Context

`InMemoryKeyAgent` currently hard-codes EMIP-003 for the root private key, both when creating the agent and when decrypting it to sign, so there's no way to change the KDF without forking the agent or rewriting the signing path.

# Proposed Solution

Add an optional `rootPrivateKeyEncryption` to `KeyAgentDependencies`. When provided, the agent uses its `encrypt`/`decrypt` for the root private key; when omitted it falls back to EMIP-003, so existing callers are unaffected.

# Important Changes Introduced

- New `PassphraseEncryption` interface (`encrypt` / `decrypt`).
- `InMemoryKeyAgent` uses the injected encryption at creation and at sign/export, defaulting to emip3.
- Tests cover both injected directions and the emip3 default; existing Yoroi/Daedalus compatibility tests still pass.
