### PR TITLE
chore(release): add `yarn release:refs` helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "version:stable": "lerna version --conventional-graduate --allow-branch master --create-release github -m \"ci: publish packages [skip actions]\" --sign-git-commit",
     "publish:rc": "lerna publish from-package --dist-tag rc --yes",
     "publish:stable": "lerna publish from-package --yes",
+    "release:refs": "node release-refs.mjs",
     "test": "yarn workspaces foreach -v run test",
     "test:build:verify": "yarn workspaces foreach -v run test:build:verify",
     "test:e2e": "yarn workspaces foreach -v run test:e2e",

--- a/release-refs.mjs
+++ b/release-refs.mjs
@@ -1,0 +1,37 @@
+// Lists recent release (version) commits with the @cardano-sdk/core version each carries,
+// so a maintainer can nominate a real release ref (and its versions) for the `release`
+// workflow's `ref` input. workflow_dispatch dropdowns can't be populated from git history,
+// so this is the discovery aid. See .github/workflows/release.yaml.
+import { execFileSync } from 'node:child_process';
+
+// Invoke git directly (no shell) — portable and free of quoting pitfalls.
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' });
+
+// Authoritative match is on the commit SUBJECT (stable + rc). `git log --grep` matches the
+// whole message (subject + body), so it's only a coarse pre-filter to keep the walk cheap;
+// this regex then drops anything (reverts, merges) that merely mentions the subject in its body.
+const SUBJECT_RE = /^ci: publish (rc )?packages \[skip actions\]$/;
+const limit = Number.parseInt(process.argv[2], 10) || 20;
+const US = '\x1f'; // unit separator — a field delimiter that can't appear in the log fields
+
+const rows = git('log', '-F', '--grep=ci: publish', `--format=%h${US}%H${US}%ci${US}%s`, '-n', String(limit * 3))
+  .split('\n')
+  .filter(Boolean)
+  .map((line) => line.split(US))
+  .filter(([, , , subject]) => SUBJECT_RE.test(subject))
+  .slice(0, limit);
+
+if (rows.length === 0) {
+  console.log('No release commits found.');
+  process.exit(0);
+}
+
+for (const [short, full, date] of rows) {
+  let version = '?';
+  try {
+    version = JSON.parse(git('show', `${full}:packages/core/package.json`)).version;
+  } catch {
+    // packages/core/package.json may not exist at very old commits — leave as '?'
+  }
+  console.log(`${short}  core@${version.padEnd(11)}${date}`);
+}


### PR DESCRIPTION
Follow-up to #1733. `workflow_dispatch` dropdowns can't be dynamically populated from git history, so this adds a `yarn release:refs` helper (implemented as `release-refs.mjs`, matching `collectCoverage.mjs`) that lists the recent release (version) commits — the refs you'd nominate for the release workflow's `ref` input.

It:
- invokes **git via `execFileSync`** (no shell — portable, no quoting pitfalls);
- **filters on the commit subject** (stable `ci: publish packages [skip actions]` + rc `ci: publish rc packages [skip actions]`) with an authoritative regex in JS, so reverts and merge commits that merely mention the subject in their body don't leak in (`--grep` is only a coarse pre-filter, since it matches the whole message);
- **annotates each ref with the `@cardano-sdk/core` version** it carries, as a quick anchor to confirm a ref's versions before nominating it.

Accepts an optional count (default 20): `yarn release:refs 5`.

### Example output

```
$ yarn release:refs
8c50d0296a8  core@0.46.15    2026-06-30 08:34:50 +0000
a018c19d539  core@0.46.15    2026-06-22 14:29:59 +0000
c750551944b  core@0.46.14    2026-06-19 15:38:28 +0000
3cbc64f8417  core@0.46.13    2026-05-27 10:25:50 +0000
5fd89b1a0c1  core@0.46.12    2026-04-15 12:21:23 +0000
5d5d089d5ae  core@0.46.12    2026-04-13 13:01:25 +0000
977604a138e  core@0.46.12    2026-03-12 10:50:10 +0000
cf8a9643892  core@0.46.12    2026-02-27 11:55:22 +0000
aa425da0164  core@0.46.12    2026-01-30 18:13:36 +0000
ba816c6c9a8  core@0.46.12    2026-01-15 08:41:28 +0000
d705b98d2af  core@0.46.11    2025-11-07 16:22:09 +0000
636b0fea746  core@0.46.11    2025-11-06 16:16:13 +0000
```

Copy a SHA, then dispatch `release` with `ref=<sha>` (+ `publish_only=true`). The workflow's tag-alignment guard still validates the ref is a faithful release state before publishing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)