### PR TITLE
feat: Dijkstra batch groundwork - hydrated sub transactions and batch-aware inspection

### DIFF
--- a/packages/cardano-services-client/src/ChainHistoryProvider/BlockfrostChainHistoryProvider.ts
+++ b/packages/cardano-services-client/src/ChainHistoryProvider/BlockfrostChainHistoryProvider.ts
@@ -442,10 +442,13 @@ export class BlockfrostChainHistoryProvider extends BlockfrostProvider implement
 
     const body: Cardano.HydratedTxBody = this.mapTxBody(
       {
+        accountBalanceIntervals: txFromCBOR.body.accountBalanceIntervals,
         certificates: await this.processCertificates(txContent, txFromCBOR.body.certificates),
         collateralReturn: txFromCBOR.body.collateralReturn,
         collaterals,
+        directDeposits: txFromCBOR.body.directDeposits,
         fee: txFromCBOR.body.fee,
+        guards: txFromCBOR.body.guards,
         inputs,
         mint: txFromCBOR.body.mint ? new Map([...txFromCBOR.body.mint].sort()) : undefined,
         outputs,
@@ -737,9 +740,12 @@ export class BlockfrostChainHistoryProvider extends BlockfrostProvider implement
 
   private mapTxBody(
     {
+      accountBalanceIntervals,
       collateralReturn,
       collaterals,
+      directDeposits,
       fee,
+      guards,
       inputs,
       outputs,
       mint,
@@ -768,7 +774,10 @@ export class BlockfrostChainHistoryProvider extends BlockfrostProvider implement
             inputs,
             outputs
           }),
+      accountBalanceIntervals,
       certificates,
+      directDeposits,
+      guards,
       mint,
       proposalProcedures,
       validityInterval,

--- a/packages/cardano-services-client/test/ChainHistoryProvider/BlockfrostChainHistoryProvider.test.ts
+++ b/packages/cardano-services-client/test/ChainHistoryProvider/BlockfrostChainHistoryProvider.test.ts
@@ -1,7 +1,7 @@
 import { BlockfrostChainHistoryProvider, BlockfrostClient } from '../../src';
 import { Cardano, NetworkInfoProvider } from '@cardano-sdk/core';
 import { Responses } from '@blockfrost/blockfrost-js';
-import { cip19TestVectors } from '@cardano-sdk/util-dev';
+import { cip19TestVectors, createDijkstraBatchFixture } from '@cardano-sdk/util-dev';
 import { dummyLogger as logger } from 'ts-log';
 import { mockResponses } from '../util';
 import type { Cache } from '@cardano-sdk/util';
@@ -705,6 +705,86 @@ describe('blockfrostChainHistoryProvider', () => {
         expect(secondResponse).toHaveLength(1);
         expect(secondResponse[0]).toEqual(expectedHydratedTxCBOR);
         expect(request).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Dijkstra transactions (CBOR)', () => {
+      const fixture = createDijkstraBatchFixture();
+      const dijkstraTxId = fixture.tx.id.toString();
+
+      const dijkstraTxContentResponse = {
+        asset_mint_or_burn_count: 0,
+        block: '356b7d7dbb696ccd12775c016941057a9dc70898d87a63fc752271bb46856940',
+        block_height: 123_456,
+        delegation_count: 0,
+        fees: '300000',
+        hash: dijkstraTxId,
+        index: 0,
+        invalid_before: null,
+        invalid_hereafter: null,
+        mir_cert_count: 0,
+        output_amount: [{ quantity: '5700000', unit: 'lovelace' }],
+        pool_retire_count: 0,
+        pool_update_count: 0,
+        redeemer_count: 0,
+        size: fixture.cbor.length / 2,
+        slot: 42_000_000,
+        stake_cert_count: 0,
+        utxo_count: 2,
+        valid_contract: true,
+        withdrawal_count: 0
+      };
+
+      const dijkstraUtxosResponse = {
+        hash: dijkstraTxId,
+        inputs: [
+          {
+            address: fixture.actors.walletAddress.toString(),
+            amount: [{ quantity: '5000000', unit: 'lovelace' }],
+            collateral: false,
+            output_index: 0,
+            reference: false,
+            tx_hash: '3000000000000000000000000000000000000000000000000000000000000003'
+          }
+        ],
+        outputs: [
+          {
+            address: fixture.actors.walletAddress.toString(),
+            amount: [{ quantity: '5700000', unit: 'lovelace' }],
+            collateral: false,
+            output_index: 0
+          }
+        ]
+      };
+
+      beforeEach(() => {
+        mockResponses(request, [
+          [`txs/${dijkstraTxId}`, dijkstraTxContentResponse],
+          [`txs/${dijkstraTxId}/utxos`, dijkstraUtxosResponse],
+          [`txs/${dijkstraTxId}/cbor`, { cbor: fixture.cbor }]
+        ]);
+      });
+
+      test('passes guards, direct deposits and account balance intervals through to the hydrated tx', async () => {
+        const [hydrated] = await provider.transactionsByHashes({ ids: [fixture.tx.id] });
+
+        expect(hydrated.body.guards).toEqual(fixture.tx.body.guards);
+        expect(hydrated.body.directDeposits).toEqual(fixture.tx.body.directDeposits);
+        expect(hydrated.body.accountBalanceIntervals).toEqual(fixture.tx.body.accountBalanceIntervals);
+      });
+
+      test('hydrates the top level input and preserves fee and outputs from the cbor', async () => {
+        const [hydrated] = await provider.transactionsByHashes({ ids: [fixture.tx.id] });
+
+        expect(hydrated.body.fee).toEqual(fixture.tx.body.fee);
+        expect(hydrated.body.inputs).toEqual([
+          {
+            address: fixture.actors.walletAddress,
+            index: 0,
+            txId: Cardano.TransactionId('3000000000000000000000000000000000000000000000000000000000000003')
+          }
+        ]);
+        expect(hydrated.body.outputs).toEqual(fixture.tx.body.outputs);
       });
     });
   });

--- a/packages/core/src/Cardano/types/Transaction.ts
+++ b/packages/core/src/Cardano/types/Transaction.ts
@@ -110,9 +110,17 @@ export interface HydratedTxBody {
    * balance lies in a half-open range at validation time. Non-empty when present.
    */
   accountBalanceIntervals?: AccountBalanceIntervalEntry[];
+
+  /**
+   * Sub transactions (Dijkstra body key 23, CIP-0118 nested transactions) in batch order, each
+   * hydrated and carrying its own id. Non-empty when present.
+   */
+  // eslint-disable-next-line no-use-before-define
+  subTransactions?: HydratedSubTransaction[];
 }
 
-export interface TxBody extends Omit<HydratedTxBody, 'certificates' | 'inputs' | 'collaterals' | 'referenceInputs'> {
+export interface TxBody
+  extends Omit<HydratedTxBody, 'certificates' | 'inputs' | 'collaterals' | 'referenceInputs' | 'subTransactions'> {
   certificates?: Certificate[];
   collaterals?: TxIn[];
   inputs: TxIn[];
@@ -162,6 +170,26 @@ export interface SubTransaction {
   // eslint-disable-next-line no-use-before-define
   witness: Witness;
   auxiliaryData?: AuxiliaryData;
+}
+
+/**
+ * A SubTransactionBody with its inputs resolved to hydrated inputs, so consumers can read the
+ * address of each spent output without an input resolver. Intra-batch inputs (spending a sibling
+ * sub transaction's output) hydrate from the batch itself.
+ */
+export interface HydratedSubTransactionBody extends Omit<SubTransactionBody, 'inputs' | 'referenceInputs'> {
+  inputs: HydratedTxIn[];
+  referenceInputs?: HydratedTxIn[];
+}
+
+/**
+ * A hydrated Dijkstra sub transaction. Carries the sub transaction id (the blake2b-256 hash of
+ * the sub transaction body bytes) explicitly: a hydrated body cannot be re-serialized to derive
+ * it, and intra-batch inputs of sibling sub transactions reference it.
+ */
+export interface HydratedSubTransaction extends Omit<SubTransaction, 'body'> {
+  id: TransactionId;
+  body: HydratedSubTransactionBody;
 }
 
 export enum InputSource {

--- a/packages/core/src/util/dijkstraBatchUtil.ts
+++ b/packages/core/src/util/dijkstraBatchUtil.ts
@@ -1,0 +1,86 @@
+import { BigIntMath } from '@cardano-sdk/util';
+import { coalesceTokenMaps } from '../Asset/util';
+import type { Credential, InputResolver, RewardAccount } from '../Cardano/Address';
+import type { Inspector } from './txInspector';
+import type { Lovelace, TransactionId, Tx } from '../Cardano/types';
+
+const nonEmpty = <T>(items: T[]): T[] | undefined => (items.length > 0 ? items : undefined);
+
+/**
+ * Creates an InputResolver that resolves inputs against the outputs produced within the given
+ * transaction's own batch (CIP-0118): the top level outputs and the outputs of every sub
+ * transaction that carries an id (hydrated sub transactions do; serialization-side ones do not
+ * and are skipped). Inputs produced outside the batch are delegated to fallbackResolver, or
+ * resolve to null without one.
+ */
+export const createBatchInputResolver = (tx: Tx, fallbackResolver?: InputResolver): InputResolver => {
+  const producers = [
+    { id: tx.id as TransactionId | undefined, outputs: tx.body.outputs },
+    ...(tx.body.subTransactions ?? []).map((subTx) => ({
+      id: (subTx as { id?: TransactionId }).id,
+      outputs: subTx.body.outputs
+    }))
+  ];
+
+  return {
+    resolveInput: async (txIn, options) => {
+      const producer = producers.find(({ id }) => id !== undefined && id === txIn.txId);
+      if (producer) return producer.outputs[txIn.index] ?? null;
+      return fallbackResolver ? fallbackResolver.resolveInput(txIn, options) : null;
+    }
+  };
+};
+
+/**
+ * Merges a CIP-0118 batch into a single flat transaction view for value arithmetic: inputs,
+ * outputs, mint, certificates, withdrawals and direct deposits are concatenated across the top
+ * level and every sub transaction, witness scripts are pooled, and subTransactions is cleared.
+ * Intra-batch spends cancel naturally because both their producing output and their consuming
+ * input remain in the view.
+ *
+ * All other fields (fee, validity interval, guards, governance procedures, auxiliary data) stay
+ * as the top level transaction defined them. The view keeps the id of the top level transaction
+ * and is meant for inspection only - it does not re-serialize to a valid transaction.
+ *
+ * Returns the input unchanged when the transaction carries no sub transactions. The cast to the
+ * input type is sound because merging only combines arrays of the input's own hydration level.
+ */
+export const toMergedBatchView = <T extends Tx>(tx: T): T => {
+  const subTransactions = tx.body.subTransactions;
+  if (!subTransactions || subTransactions.length === 0) return tx;
+
+  const bodies = [tx.body, ...subTransactions.map(({ body }) => body)];
+  const scripts = [...(tx.witness.scripts ?? []), ...subTransactions.flatMap(({ witness }) => witness.scripts ?? [])];
+
+  return {
+    ...tx,
+    body: {
+      ...tx.body,
+      certificates: nonEmpty(bodies.flatMap(({ certificates }) => certificates ?? [])),
+      directDeposits: nonEmpty(bodies.flatMap(({ directDeposits }) => directDeposits ?? [])),
+      inputs: bodies.flatMap(({ inputs }) => inputs),
+      mint: coalesceTokenMaps(bodies.map(({ mint }) => mint)),
+      outputs: bodies.flatMap(({ outputs }) => outputs),
+      subTransactions: undefined,
+      withdrawals: nonEmpty(bodies.flatMap(({ withdrawals }) => withdrawals ?? []))
+    },
+    witness: { ...tx.witness, scripts: nonEmpty(scripts) }
+  } as T;
+};
+
+/**
+ * Inspects a transaction for direct deposits (Dijkstra body key 25) and returns their total.
+ * When reward accounts are given only deposits into those accounts are counted; otherwise all
+ * direct deposits of the transaction are.
+ */
+export const directDepositsInspector =
+  (rewardAccounts?: RewardAccount[]): Inspector<Lovelace> =>
+  async (tx) =>
+    BigIntMath.sum(
+      (tx.body.directDeposits ?? [])
+        .filter(({ stakeAddress }) => !rewardAccounts || rewardAccounts.includes(stakeAddress))
+        .map(({ quantity }) => quantity)
+    );
+
+/** Inspects a transaction for its guard credentials (Dijkstra body key 14). */
+export const guardsInspector: Inspector<Credential[]> = async (tx) => tx.body.guards ?? [];

--- a/packages/core/src/util/index.ts
+++ b/packages/core/src/util/index.ts
@@ -2,6 +2,7 @@ export * as util from './misc';
 export * from './conwayEra';
 export * from './slotCalc';
 export * from './txInspector';
+export * from './dijkstraBatchUtil';
 export * from './tokenTransferInspector';
 export * from './transactionSummaryInspector';
 export * from './utxo';

--- a/packages/core/src/util/transactionSummaryInspector.ts
+++ b/packages/core/src/util/transactionSummaryInspector.ts
@@ -15,6 +15,7 @@ import { TimeoutError } from '../errors';
 import { coalesceTokenMaps, subtractTokenMaps } from '../Asset/util';
 import { coalesceValueQuantities } from './coalesceValueQuantities';
 import { computeImplicitCoin } from '../Cardano/util';
+import { createBatchInputResolver, directDepositsInspector, toMergedBatchView } from './dijkstraBatchUtil';
 import { promiseTimeout } from './promiseTimeout';
 import { subtractValueQuantities } from './subtractValueQuantities';
 import { tryGetAssetInfos } from './tryGetAssetInfos';
@@ -38,8 +39,11 @@ interface TransactionSummaryInspectorArgs {
 export type TransactionSummaryInspection = {
   assets: Map<Cardano.AssetId, AssetInfoWithAmount>;
   /**
-   * Spent amount from the wallet's perspective, computed as `own outputs - (own inputs + withdrawals)`.
+   * Spent amount from the wallet's perspective, computed as
+   * `own outputs + own direct deposits - (own inputs + withdrawals)`.
    * Withdrawals are a type of "own input", and are accounted for when computing the wallet spent amount.
+   * Direct deposits into own reward accounts are a type of "own output" (Dijkstra).
+   * For a CIP-0118 batch the computation spans the top level and all sub transactions.
    * Positive when the wallet is receiving funds, negative when the wallet is sending funds.
    */
   coins: Cardano.Lovelace;
@@ -119,22 +123,35 @@ const getImplicitAssets = async (tx: Cardano.Tx) => {
   return coalesceTokenMaps([mintedAssets, burnedAssets]);
 };
 
-const getUnaccountedFunds = async (
-  tx: Cardano.Tx,
-  resolvedInputs: ResolutionResult,
-  implicitCoin: Cardano.Lovelace,
-  fee: Cardano.Lovelace,
-  implicitAssets: Cardano.TokenMap = new Map()
-): Promise<Cardano.Value> => {
+const getUnaccountedFunds = async ({
+  tx,
+  resolvedInputs,
+  implicitCoin,
+  fee,
+  implicitAssets = new Map(),
+  directDepositTotal = 0n
+}: {
+  tx: Cardano.Tx;
+  resolvedInputs: ResolutionResult;
+  implicitCoin: Cardano.Lovelace;
+  fee: Cardano.Lovelace;
+  implicitAssets?: Cardano.TokenMap;
+  directDepositTotal?: Cardano.Lovelace;
+}): Promise<Cardano.Value> => {
   const totalInputs = totalInputsValue(resolvedInputs);
   const totalOutputs = totalOutputsValue(tx.body.outputs);
 
   totalInputs.assets = coalesceTokenMaps([totalInputs.assets, implicitAssets]);
   totalInputs.coins += implicitCoin;
-  totalOutputs.coins += fee;
+  totalOutputs.coins += fee + directDepositTotal;
 
   return subtractValueQuantities([totalOutputs, totalInputs]);
 };
+
+const getBatchContext = (tx: Cardano.Tx, inputResolver: Cardano.InputResolver) => ({
+  resolver: tx.body.subTransactions?.length ? createBatchInputResolver(tx, inputResolver) : inputResolver,
+  view: toMergedBatchView(tx)
+});
 
 const intoAssetInfoWithAmount = async ({
   assetProvider,
@@ -181,10 +198,14 @@ export const transactionSummaryInspector: TransactionSummaryInspector =
     logger
   }: TransactionSummaryInspectorArgs) =>
   async (tx) => {
+    // A CIP-0118 batch is inspected as one flat transaction: value flows span the top level and
+    // all sub transactions, and intra-batch inputs resolve from the batch before the caller's resolver.
+    const { view, resolver } = getBatchContext(tx, inputResolver);
+
     let resolvedInputs: ResolutionResult;
 
     try {
-      resolvedInputs = await promiseTimeout(resolveInputs(tx.body.inputs, inputResolver), timeout);
+      resolvedInputs = await promiseTimeout(resolveInputs(view.body.inputs, resolver), timeout);
     } catch (error) {
       if (error instanceof TimeoutError) {
         logger.error('Error: Inputs resolution timed out');
@@ -192,34 +213,38 @@ export const transactionSummaryInspector: TransactionSummaryInspector =
 
       resolvedInputs = {
         resolvedInputs: [],
-        unresolvedInputs: tx.body.inputs
+        unresolvedInputs: view.body.inputs
       };
     }
 
-    const fee = tx.body.fee;
+    const fee = view.body.fee;
 
     const implicit = computeImplicitCoin(
       protocolParameters,
-      { certificates: tx.body.certificates, withdrawals: tx.body.withdrawals },
+      { certificates: view.body.certificates, withdrawals: view.body.withdrawals },
       rewardAccounts || [],
       dRepKeyHash
     );
 
-    const collateral = await getCollateral(tx, inputResolver, addresses);
+    const collateral = await getCollateral(view, resolver, addresses);
 
     const withdrawals = implicit.withdrawals || 0n;
-    const totalOutputValue = await totalAddressOutputsValueInspector(addresses)(tx);
-    const totalInputValue = await totalAddressInputsValueInspector(addresses, inputResolver)(tx);
+    const ownDirectDeposits = await directDepositsInspector(rewardAccounts || [])(view);
+    const directDepositTotal = await directDepositsInspector()(view);
+    const totalOutputValue = await totalAddressOutputsValueInspector(addresses)(view);
+    const totalInputValue = await totalAddressInputsValueInspector(addresses, resolver)(view);
     const implicitCoin = withdrawals + (implicit.reclaimDeposit || 0n) - (implicit.deposit || 0n);
-    const implicitAssets = await getImplicitAssets(tx);
+    const implicitAssets = await getImplicitAssets(view);
 
     const diff = {
       assets: subtractTokenMaps([totalOutputValue.assets, totalInputValue.assets]),
-      // Withdrawals are a type of "own input", which must be accounted for when computing the wallet spent amount.
-      // `coins` represents the actual spent coins from the wallets perspective, using the formula `ownOutputs - ownInputs`.
+      // Withdrawals are a type of "own input" and direct deposits into own reward accounts a type
+      // of "own output", which must be accounted for when computing the wallet spent amount.
+      // `coins` represents the actual spent coins from the wallets perspective, using the formula
+      // `ownOutputs + ownDirectDeposits - (ownInputs + withdrawals)`.
       // deposit is like a foreign output, and reclaimDeposit is like a foreignInput,
       // so they do not need to be included in the computation.
-      coins: totalOutputValue.coins - (totalInputValue.coins + withdrawals)
+      coins: totalOutputValue.coins + ownDirectDeposits - (totalInputValue.coins + withdrawals)
     };
 
     return {
@@ -237,7 +262,14 @@ export const transactionSummaryInspector: TransactionSummaryInspector =
       returnedDeposit: implicit.reclaimDeposit || 0n,
       unresolved: {
         inputs: resolvedInputs.unresolvedInputs,
-        value: await getUnaccountedFunds(tx, resolvedInputs, implicitCoin, fee, implicitAssets)
+        value: await getUnaccountedFunds({
+          directDepositTotal,
+          fee,
+          implicitAssets,
+          implicitCoin,
+          resolvedInputs,
+          tx: view
+        })
       }
     };
   };

--- a/packages/core/test/util/dijkstraBatchUtil.test.ts
+++ b/packages/core/test/util/dijkstraBatchUtil.test.ts
@@ -1,0 +1,222 @@
+import * as Cardano from '../../src/Cardano';
+import { Hash28ByteBase16 } from '@cardano-sdk/crypto';
+import { createBatchInputResolver, directDepositsInspector, guardsInspector, toMergedBatchView } from '../../src';
+
+const topId = Cardano.TransactionId('1000000000000000000000000000000000000000000000000000000000000001');
+const subTx1Id = Cardano.TransactionId('2000000000000000000000000000000000000000000000000000000000000002');
+const subTx2Id = Cardano.TransactionId('3000000000000000000000000000000000000000000000000000000000000003');
+const externalTxId = Cardano.TransactionId('4000000000000000000000000000000000000000000000000000000000000004');
+
+const address1 = Cardano.PaymentAddress(
+  'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+);
+const address2 = Cardano.PaymentAddress(
+  'addr_test1qpfhhfy2qgls50r9u4yh0l7z67xpg0a5rrhkmvzcuqrd0znuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q9gw0lz'
+);
+const ownRewardAccount = Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27');
+const foreignRewardAccount = Cardano.RewardAccount('stake_test1up7pvfq8zn4quy45r2g572290p9vf99mr9tn7r9xrgy2l2qdsf58d');
+
+const assetA = Cardano.AssetId('2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740');
+const assetB = Cardano.AssetId('659f2917fb63f12b33667463ee575eeac1845bbc736b9c0bbc40ba8254534c41');
+
+const keyGuard: Cardano.Credential = {
+  hash: Hash28ByteBase16('00112233445566778899aabbccddeeff00112233445566778899aabb'),
+  type: Cardano.CredentialType.KeyHash
+};
+const scriptGuard: Cardano.Credential = {
+  hash: Hash28ByteBase16('aabbccddeeff00112233445566778899aabbccddeeff001122334455'),
+  type: Cardano.CredentialType.ScriptHash
+};
+
+const certificate1 = {
+  __typename: Cardano.CertificateType.StakeRegistration,
+  stakeCredential: keyGuard
+} as Cardano.Certificate;
+const certificate2 = {
+  __typename: Cardano.CertificateType.StakeDeregistration,
+  stakeCredential: keyGuard
+} as Cardano.Certificate;
+
+const topOutput: Cardano.TxOut = { address: address1, value: { coins: 1_000_000n } };
+const subTx1Output0: Cardano.TxOut = { address: address1, value: { coins: 2_000_000n } };
+const subTx1Output1: Cardano.TxOut = { address: address2, value: { coins: 3_000_000n } };
+const subTx2Output: Cardano.TxOut = { address: address2, value: { coins: 4_000_000n } };
+
+const emptyWitness: Cardano.Witness = { signatures: new Map() };
+const mockScript = {
+  __type: Cardano.ScriptType.Native,
+  keyHash: keyGuard.hash,
+  kind: Cardano.NativeScriptKind.RequireSignature
+} as Cardano.Script;
+
+const buildBatchTx = (): Cardano.Tx =>
+  ({
+    body: {
+      certificates: [certificate1],
+      directDeposits: [
+        { quantity: 2_000_000n, stakeAddress: ownRewardAccount },
+        { quantity: 3_000_000n, stakeAddress: foreignRewardAccount }
+      ],
+      fee: 300_000n,
+      guards: [keyGuard, scriptGuard],
+      inputs: [{ index: 0, txId: externalTxId }],
+      mint: new Map([[assetA, 5n]]),
+      outputs: [topOutput],
+      subTransactions: [
+        {
+          body: {
+            certificates: [certificate2],
+            directDeposits: [{ quantity: 5_000_000n, stakeAddress: foreignRewardAccount }],
+            inputs: [{ index: 1, txId: externalTxId }],
+            mint: new Map([
+              [assetA, -2n],
+              [assetB, 7n]
+            ]),
+            outputs: [subTx1Output0, subTx1Output1],
+            withdrawals: [{ quantity: 100n, stakeAddress: ownRewardAccount }]
+          },
+          id: subTx1Id,
+          witness: { scripts: [mockScript], signatures: new Map() }
+        },
+        {
+          body: {
+            inputs: [{ index: 1, txId: subTx1Id }],
+            outputs: [subTx2Output]
+          },
+          id: subTx2Id,
+          witness: emptyWitness
+        }
+      ],
+      withdrawals: [{ quantity: 200n, stakeAddress: foreignRewardAccount }]
+    },
+    id: topId,
+    witness: emptyWitness
+  } as unknown as Cardano.Tx);
+
+describe('createBatchInputResolver', () => {
+  const tx = buildBatchTx();
+
+  it('resolves inputs produced by the top level transaction', async () => {
+    const resolver = createBatchInputResolver(tx);
+
+    expect(await resolver.resolveInput({ index: 0, txId: topId })).toEqual(topOutput);
+  });
+
+  it('resolves inputs produced by sub transactions', async () => {
+    const resolver = createBatchInputResolver(tx);
+
+    expect(await resolver.resolveInput({ index: 1, txId: subTx1Id })).toEqual(subTx1Output1);
+    expect(await resolver.resolveInput({ index: 0, txId: subTx2Id })).toEqual(subTx2Output);
+  });
+
+  it('resolves to null for an out of range index of a batch producer', async () => {
+    const resolver = createBatchInputResolver(tx);
+
+    expect(await resolver.resolveInput({ index: 5, txId: subTx1Id })).toBeNull();
+  });
+
+  it('delegates batch-external inputs to the fallback resolver', async () => {
+    const externalOutput: Cardano.TxOut = { address: address2, value: { coins: 9_000_000n } };
+    const fallback: Cardano.InputResolver = { resolveInput: jest.fn().mockResolvedValue(externalOutput) };
+    const resolver = createBatchInputResolver(tx, fallback);
+    const externalInput = { index: 0, txId: externalTxId };
+
+    expect(await resolver.resolveInput(externalInput)).toEqual(externalOutput);
+    expect(fallback.resolveInput).toHaveBeenCalledWith(externalInput, undefined);
+  });
+
+  it('resolves batch-external inputs to null without a fallback resolver', async () => {
+    const resolver = createBatchInputResolver(tx);
+
+    expect(await resolver.resolveInput({ index: 0, txId: externalTxId })).toBeNull();
+  });
+
+  it('skips sub transactions that do not carry an id', async () => {
+    const withoutIds = buildBatchTx();
+    for (const subTx of withoutIds.body.subTransactions!) delete (subTx as { id?: Cardano.TransactionId }).id;
+    const resolver = createBatchInputResolver(withoutIds);
+
+    expect(await resolver.resolveInput({ index: 1, txId: subTx1Id })).toBeNull();
+  });
+});
+
+describe('toMergedBatchView', () => {
+  it('returns the input unchanged when there are no sub transactions', () => {
+    const tx = buildBatchTx();
+    tx.body.subTransactions = undefined;
+
+    expect(toMergedBatchView(tx)).toBe(tx);
+  });
+
+  it('concatenates inputs and outputs across the batch and clears subTransactions', () => {
+    const view = toMergedBatchView(buildBatchTx());
+
+    expect(view.body.inputs).toEqual([
+      { index: 0, txId: externalTxId },
+      { index: 1, txId: externalTxId },
+      { index: 1, txId: subTx1Id }
+    ]);
+    expect(view.body.outputs).toEqual([topOutput, subTx1Output0, subTx1Output1, subTx2Output]);
+    expect(view.body.subTransactions).toBeUndefined();
+  });
+
+  it('merges mint maps, certificates, withdrawals and direct deposits', () => {
+    const view = toMergedBatchView(buildBatchTx());
+
+    expect(view.body.mint).toEqual(
+      new Map([
+        [assetA, 3n],
+        [assetB, 7n]
+      ])
+    );
+    expect(view.body.certificates).toEqual([certificate1, certificate2]);
+    expect(view.body.withdrawals).toEqual([
+      { quantity: 200n, stakeAddress: foreignRewardAccount },
+      { quantity: 100n, stakeAddress: ownRewardAccount }
+    ]);
+    expect(view.body.directDeposits).toEqual([
+      { quantity: 2_000_000n, stakeAddress: ownRewardAccount },
+      { quantity: 3_000_000n, stakeAddress: foreignRewardAccount },
+      { quantity: 5_000_000n, stakeAddress: foreignRewardAccount }
+    ]);
+  });
+
+  it('pools witness scripts and keeps top level only fields', () => {
+    const view = toMergedBatchView(buildBatchTx());
+
+    expect(view.witness.scripts).toEqual([mockScript]);
+    expect(view.body.fee).toEqual(300_000n);
+    expect(view.body.guards).toEqual([keyGuard, scriptGuard]);
+    expect(view.id).toEqual(topId);
+  });
+});
+
+describe('directDepositsInspector', () => {
+  it('totals direct deposits into the given reward accounts', async () => {
+    expect(await directDepositsInspector([ownRewardAccount])(buildBatchTx())).toEqual(2_000_000n);
+    expect(await directDepositsInspector([ownRewardAccount])(toMergedBatchView(buildBatchTx()))).toEqual(2_000_000n);
+    expect(await directDepositsInspector([foreignRewardAccount])(toMergedBatchView(buildBatchTx()))).toEqual(
+      8_000_000n
+    );
+  });
+
+  it('returns zero when the transaction has no direct deposits into the given accounts', async () => {
+    const tx = buildBatchTx();
+    tx.body.directDeposits = undefined;
+
+    expect(await directDepositsInspector([ownRewardAccount])(tx)).toEqual(0n);
+  });
+});
+
+describe('guardsInspector', () => {
+  it('returns the guard credentials of the transaction', async () => {
+    expect(await guardsInspector(buildBatchTx())).toEqual([keyGuard, scriptGuard]);
+  });
+
+  it('returns an empty array when the transaction has no guards', async () => {
+    const tx = buildBatchTx();
+    tx.body.guards = undefined;
+
+    expect(await guardsInspector(tx)).toEqual([]);
+  });
+});

--- a/packages/core/test/util/transactionSummaryInspector.test.ts
+++ b/packages/core/test/util/transactionSummaryInspector.test.ts
@@ -119,6 +119,8 @@ const buildMockTx = (
     collaterals?: Cardano.HydratedTxIn[];
     totalCollateral?: Cardano.Lovelace;
     collateralReturn?: Cardano.TxOut;
+    directDeposits?: Cardano.Withdrawal[];
+    subTransactions?: Cardano.HydratedSubTransaction[];
   } = {}
 ): Cardano.HydratedTx =>
   ({
@@ -132,6 +134,7 @@ const buildMockTx = (
       certificates: args.certificates,
       collateralReturn: args.collateralReturn ?? undefined,
       collaterals: args.collaterals ?? undefined,
+      directDeposits: args.directDeposits,
       fee,
       inputs: args.inputs ?? [
         {
@@ -171,6 +174,7 @@ const buildMockTx = (
           }
         }
       ],
+      subTransactions: args.subTransactions,
       totalCollateral: args.totalCollateral ?? undefined,
       validityInterval: {},
       withdrawals: args.withdrawals
@@ -1286,5 +1290,80 @@ describe('Transaction Summary Inspector', () => {
         },
       }
     `);
+  });
+
+  it('inspects a Dijkstra batch as one flat transaction', async () => {
+    const externalTxAId = Cardano.TransactionId('a00000000000000000000000000000000000000000000000000000000000000a');
+    const externalTxBId = Cardano.TransactionId('b00000000000000000000000000000000000000000000000000000000000000b');
+    const externalTxWId = Cardano.TransactionId('c00000000000000000000000000000000000000000000000000000000000000c');
+    const subTx1Id = Cardano.TransactionId('d00000000000000000000000000000000000000000000000000000000000000d');
+    const subTx2Id = Cardano.TransactionId('e00000000000000000000000000000000000000000000000000000000000000e');
+
+    const tx = buildMockTx({
+      directDeposits: [{ quantity: 2_000_000n, stakeAddress: rewardAccounts[0] }],
+      inputs: [{ address: addresses[0], index: 0, txId: externalTxWId }],
+      outputs: [{ address: addresses[0], value: { coins: 5_830_000n } }],
+      subTransactions: [
+        {
+          body: {
+            inputs: [{ address: externalAddress1, index: 0, txId: externalTxAId }],
+            mint: new Map([[AssetId.A, 100n]]),
+            outputs: [
+              { address: addresses[0], value: { assets: new Map([[AssetId.A, 100n]]), coins: 12_000_000n } },
+              { address: externalAddress2, value: { coins: 3_000_000n } }
+            ]
+          },
+          id: subTx1Id,
+          witness: { signatures: new Map() }
+        },
+        {
+          body: {
+            inputs: [
+              { address: externalAddress2, index: 0, txId: externalTxBId },
+              { address: externalAddress2, index: 1, txId: subTx1Id }
+            ],
+            outputs: [{ address: externalAddress1, value: { coins: 1_000_000n } }]
+          },
+          id: subTx2Id,
+          witness: { signatures: new Map() }
+        }
+      ] as Cardano.HydratedSubTransaction[]
+    });
+
+    const histTxs = [
+      { body: { outputs: [{ address: addresses[0], value: { coins: 5_000_000n } }] }, id: externalTxWId },
+      { body: { outputs: [{ address: externalAddress1, value: { coins: 10_000_000n } }] }, id: externalTxAId },
+      { body: { outputs: [{ address: externalAddress2, value: { coins: 6_000_000n } }] }, id: externalTxBId }
+    ] as unknown as Cardano.HydratedTx[];
+
+    const inspectTx = createTxInspector({
+      summary: transactionSummaryInspector({
+        addresses,
+        assetProvider,
+        inputResolver: createMockInputResolver(histTxs),
+        logger,
+        protocolParameters,
+        rewardAccounts,
+        timeout
+      })
+    });
+
+    const { summary } = await inspectTx(tx);
+
+    expect(summary).toEqual<TransactionSummaryInspection>({
+      assets: buildAssetInfoWithAmount([[assetInfos[AssetInfoIdx.A], 100n]]),
+      coins: 14_830_000n,
+      collateral: 0n,
+      deposit: 0n,
+      fee,
+      resolvedInputs: [
+        { address: addresses[0], index: 0, txId: externalTxWId, value: { coins: 5_000_000n } },
+        { address: externalAddress1, index: 0, txId: externalTxAId, value: { coins: 10_000_000n } },
+        { address: externalAddress2, index: 0, txId: externalTxBId, value: { coins: 6_000_000n } },
+        { address: externalAddress2, index: 1, txId: subTx1Id, value: { coins: 3_000_000n } }
+      ],
+      returnedDeposit: 0n,
+      unresolved: { inputs: [], value: { assets: new Map(), coins: 0n } }
+    });
   });
 });

--- a/packages/util-dev/src/dijkstraBatchFixture.ts
+++ b/packages/util-dev/src/dijkstraBatchFixture.ts
@@ -24,6 +24,11 @@ export interface DijkstraBatchFixture {
    * source sibling-produced outputs from the batch itself.
    */
   externalUtxos: Cardano.Utxo[];
+  /**
+   * The chain-history view of {@link tx}: every input hydrated with the address of the output it
+   * spends and each sub transaction carrying its id, under a synthetic block header.
+   */
+  hydratedTx: Cardano.HydratedTx;
   /** The sibling-produced utxo: sub transaction 1 output #1, spent by sub transaction 2. */
   intraBatchUtxo: Cardano.Utxo;
   /** Asset minted by sub transaction 1 into its wallet-bound output. */
@@ -181,13 +186,46 @@ export const createDijkstraBatchFixture = (): DijkstraBatchFixture => {
     { address: actors.counterparty2Address, value: { coins: INTERMEDIATE_OUTPUT_COINS } }
   ];
 
+  const allUtxos = [...externalUtxos, intraBatchUtxo];
+  const hydrateInput = (txIn: Cardano.TxIn): Cardano.HydratedTxIn => {
+    const utxo = allUtxos.find(([produced]) => produced.txId === txIn.txId && produced.index === txIn.index);
+    if (!utxo) throw new Error(`No utxo for input: ${txIn.txId}#${txIn.index}`);
+    return { address: utxo[0].address, index: txIn.index, txId: txIn.txId };
+  };
+
+  const subTxIds: [Cardano.TransactionId, Cardano.TransactionId] = [subTx1Id, subTx2Id];
+  const hydratedTx: Cardano.HydratedTx = {
+    blockHeader: {
+      blockNo: Cardano.BlockNo(1_000_000),
+      hash: Cardano.BlockId('9999999999999999999999999999999999999999999999999999999999999999'),
+      slot: Cardano.Slot(50_000_000)
+    },
+    body: {
+      ...tx.body,
+      collaterals: undefined,
+      inputs: tx.body.inputs.map(hydrateInput),
+      referenceInputs: undefined,
+      subTransactions: tx.body.subTransactions!.map((subTx, subTxIndex) => ({
+        ...subTx,
+        body: { ...subTx.body, inputs: subTx.body.inputs.map(hydrateInput), referenceInputs: undefined },
+        id: subTxIds[subTxIndex]
+      }))
+    },
+    id: tx.id,
+    index: 0,
+    inputSource: Cardano.InputSource.inputs,
+    txSize: cbor.length / 2,
+    witness: tx.witness
+  };
+
   return {
     actors,
     cbor,
     externalUtxos,
+    hydratedTx,
     intraBatchUtxo,
     mintedAssetId,
-    subTxIds: [subTx1Id, subTx2Id],
+    subTxIds,
     tx
   };
 };

--- a/packages/util-dev/src/dijkstraBatchFixture.ts
+++ b/packages/util-dev/src/dijkstraBatchFixture.ts
@@ -1,0 +1,193 @@
+import * as Crypto from '@cardano-sdk/crypto';
+import { Cardano, Serialization } from '@cardano-sdk/core';
+
+/** The parties participating in the batch, from the perspective of a wallet under test. */
+export interface DijkstraBatchActors {
+  /** Funds sub transaction 1 and receives the sub transaction 2 output. */
+  counterparty1Address: Cardano.PaymentAddress;
+  /** Funds sub transaction 2 and owns the intermediate output it also spends. */
+  counterparty2Address: Cardano.PaymentAddress;
+  /** Receives outputs from sub transaction 1 and the top level, funds the top level input. */
+  walletAddress: Cardano.PaymentAddress;
+  /** Receives the direct deposit and is the subject of the account balance interval. */
+  walletRewardAccount: Cardano.RewardAccount;
+}
+
+/** A semantically coherent Dijkstra batch transaction plus the companion data needed to resolve and inspect it. */
+export interface DijkstraBatchFixture {
+  actors: DijkstraBatchActors;
+  /** Mempool-frame CBOR of {@link tx}, byte-exact under round trip. */
+  cbor: Serialization.TxCBOR;
+  /**
+   * Every batch-external input of the transaction (top level and sub transactions) with the
+   * output it spends. Deliberately excludes {@link intraBatchUtxo}: resolvers under test must
+   * source sibling-produced outputs from the batch itself.
+   */
+  externalUtxos: Cardano.Utxo[];
+  /** The sibling-produced utxo: sub transaction 1 output #1, spent by sub transaction 2. */
+  intraBatchUtxo: Cardano.Utxo;
+  /** Asset minted by sub transaction 1 into its wallet-bound output. */
+  mintedAssetId: Cardano.AssetId;
+  /** Sub transaction ids in batch order, derived from each sub transaction body hash. */
+  subTxIds: [Cardano.TransactionId, Cardano.TransactionId];
+  tx: Cardano.Tx;
+}
+
+const COUNTERPARTY_1_UTXO_TX_ID = Cardano.TransactionId(
+  '1000000000000000000000000000000000000000000000000000000000000001'
+);
+const COUNTERPARTY_2_UTXO_TX_ID = Cardano.TransactionId(
+  '2000000000000000000000000000000000000000000000000000000000000002'
+);
+const WALLET_UTXO_TX_ID = Cardano.TransactionId('3000000000000000000000000000000000000000000000000000000000000003');
+
+const COUNTERPARTY_1_INPUT_COINS = 10_000_000n;
+const COUNTERPARTY_2_INPUT_COINS = 6_000_000n;
+const WALLET_INPUT_COINS = 5_000_000n;
+
+const SUB_TX_1_WALLET_OUTPUT_COINS = 12_000_000n;
+const INTERMEDIATE_OUTPUT_COINS = 3_000_000n;
+const SUB_TX_2_OUTPUT_COINS = 1_000_000n;
+const TOP_LEVEL_WALLET_OUTPUT_COINS = 5_700_000n;
+
+const BATCH_FEE = 300_000n;
+const DIRECT_DEPOSIT_COINS = 2_000_000n;
+const ACCOUNT_BALANCE_LOWER_BOUND = 2_000_000n;
+const ACCOUNT_BALANCE_UPPER_BOUND = 100_000_000n;
+
+const MINTED_TOKEN_QUANTITY = 100n;
+
+const GUARD_KEY_HASH = Crypto.Hash28ByteBase16('00112233445566778899aabbccddeeff00112233445566778899aabb');
+const GUARD_SCRIPT_HASH = Crypto.Hash28ByteBase16('aabbccddeeff00112233445566778899aabbccddeeff001122334455');
+
+const actors: DijkstraBatchActors = {
+  counterparty1Address: Cardano.PaymentAddress(
+    'addr_test1qzs0umu0s2ammmpw0hea0w2crtcymdjvvlqngpgqy76gpfnuzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475qp3y3vz'
+  ),
+  counterparty2Address: Cardano.PaymentAddress(
+    'addr_test1qq585l3hyxgj3nas2v3xymd23vvartfhceme6gv98aaeg9muzcjqw982pcftgx53fu5527z2cj2tkx2h8ux2vxsg475q2g7k3g'
+  ),
+  walletAddress: Cardano.PaymentAddress(
+    'addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp'
+  ),
+  walletRewardAccount: Cardano.RewardAccount('stake_test1uqfu74w3wh4gfzu8m6e7j987h4lq9r3t7ef5gaw497uu85qsqfy27')
+};
+
+const mintedAssetId = Cardano.AssetId('2a286ad895d091f2b3d168a6091ad2627d30a72761a5bc36eef00740');
+
+const emptyWitness = (): Cardano.Witness => ({ signatures: new Map() });
+
+/**
+ * Builds a deterministic Dijkstra-era (CIP-0118) batch transaction whose economics are coherent:
+ * the batch as a whole balances while no level balances on its own, so any code that treats a
+ * sub transaction as a self-contained transaction produces detectably wrong numbers.
+ *
+ * Value flow, in lovelace:
+ *
+ * - Sub transaction 1 spends counterparty 1's 10.0 utxo and produces 12.0 (plus 100 minted
+ *   tokens) to the wallet and a 3.0 intermediate output to counterparty 2. Deficit: 5.0.
+ * - Sub transaction 2 spends counterparty 2's 6.0 utxo and the 3.0 intermediate output of its
+ *   sibling (the intra-batch input), producing 1.0 to counterparty 1. Surplus: 8.0.
+ * - The top level spends the wallet's 5.0 utxo, produces 5.7 back to the wallet, pays the 0.3
+ *   batch fee and direct-deposits 2.0 into the wallet reward account. Deficit: 3.0.
+ *
+ * Batch invariant: external inputs (21.0) = new outputs (18.7) + fee (0.3) + direct deposits (2.0).
+ *
+ * Dijkstra decorations: the top level carries guards (one key hash, one script hash) and an
+ * account balance interval on the wallet reward credential; sub transaction 2 requires the
+ * script guard at the top level (datum-less); sub transaction 1 mints {@link DijkstraBatchFixture.mintedAssetId}.
+ */
+export const createDijkstraBatchFixture = (): DijkstraBatchFixture => {
+  const subTx1Body: Cardano.SubTransactionBody = {
+    inputs: [{ index: 0, txId: COUNTERPARTY_1_UTXO_TX_ID }],
+    mint: new Map([[mintedAssetId, MINTED_TOKEN_QUANTITY]]),
+    outputs: [
+      {
+        address: actors.walletAddress,
+        value: {
+          assets: new Map([[mintedAssetId, MINTED_TOKEN_QUANTITY]]),
+          coins: SUB_TX_1_WALLET_OUTPUT_COINS
+        }
+      },
+      { address: actors.counterparty2Address, value: { coins: INTERMEDIATE_OUTPUT_COINS } }
+    ]
+  };
+
+  const subTx1: Cardano.SubTransaction = { body: subTx1Body, witness: emptyWitness() };
+  const subTx1Id = Serialization.SubTransaction.fromCore(subTx1).getId();
+
+  const subTx2Body: Cardano.SubTransactionBody = {
+    inputs: [
+      { index: 0, txId: COUNTERPARTY_2_UTXO_TX_ID },
+      { index: 1, txId: subTx1Id }
+    ],
+    outputs: [{ address: actors.counterparty1Address, value: { coins: SUB_TX_2_OUTPUT_COINS } }],
+    requiredTopLevelGuards: [
+      { credential: { hash: GUARD_SCRIPT_HASH, type: Cardano.CredentialType.ScriptHash }, datum: null }
+    ]
+  };
+
+  const subTx2: Cardano.SubTransaction = { body: subTx2Body, witness: emptyWitness() };
+  const subTx2Id = Serialization.SubTransaction.fromCore(subTx2).getId();
+
+  const body: Cardano.TxBody = {
+    accountBalanceIntervals: [
+      {
+        credential: {
+          hash: Cardano.RewardAccount.toHash(actors.walletRewardAccount),
+          type: Cardano.CredentialType.KeyHash
+        },
+        interval: {
+          exclusiveUpperBound: ACCOUNT_BALANCE_UPPER_BOUND,
+          inclusiveLowerBound: ACCOUNT_BALANCE_LOWER_BOUND
+        }
+      }
+    ],
+    directDeposits: [{ quantity: DIRECT_DEPOSIT_COINS, stakeAddress: actors.walletRewardAccount }],
+    fee: BATCH_FEE,
+    guards: [
+      { hash: GUARD_KEY_HASH, type: Cardano.CredentialType.KeyHash },
+      { hash: GUARD_SCRIPT_HASH, type: Cardano.CredentialType.ScriptHash }
+    ],
+    inputs: [{ index: 0, txId: WALLET_UTXO_TX_ID }],
+    outputs: [{ address: actors.walletAddress, value: { coins: TOP_LEVEL_WALLET_OUTPUT_COINS } }],
+    subTransactions: [subTx1, subTx2]
+  };
+
+  const serialized = new Serialization.Transaction(
+    Serialization.TransactionBody.fromCore(body),
+    Serialization.TransactionWitnessSet.fromCore(emptyWitness())
+  );
+  const cbor = Serialization.TxCBOR(serialized.toCbor());
+  const tx = Serialization.Transaction.fromCbor(cbor).toCore();
+
+  const externalUtxos: Cardano.Utxo[] = [
+    [
+      { address: actors.counterparty1Address, index: 0, txId: COUNTERPARTY_1_UTXO_TX_ID },
+      { address: actors.counterparty1Address, value: { coins: COUNTERPARTY_1_INPUT_COINS } }
+    ],
+    [
+      { address: actors.counterparty2Address, index: 0, txId: COUNTERPARTY_2_UTXO_TX_ID },
+      { address: actors.counterparty2Address, value: { coins: COUNTERPARTY_2_INPUT_COINS } }
+    ],
+    [
+      { address: actors.walletAddress, index: 0, txId: WALLET_UTXO_TX_ID },
+      { address: actors.walletAddress, value: { coins: WALLET_INPUT_COINS } }
+    ]
+  ];
+
+  const intraBatchUtxo: Cardano.Utxo = [
+    { address: actors.counterparty2Address, index: 1, txId: subTx1Id },
+    { address: actors.counterparty2Address, value: { coins: INTERMEDIATE_OUTPUT_COINS } }
+  ];
+
+  return {
+    actors,
+    cbor,
+    externalUtxos,
+    intraBatchUtxo,
+    mintedAssetId,
+    subTxIds: [subTx1Id, subTx2Id],
+    tx
+  };
+};

--- a/packages/util-dev/src/index.ts
+++ b/packages/util-dev/src/index.ts
@@ -11,6 +11,7 @@ export * from './createStubUtxoProvider';
 export * from './createStubObservable';
 export * from './createGenericMockServer';
 export * from './dataGeneration';
+export * from './dijkstraBatchFixture';
 export * from './eraSummaries';
 export * as mockProviders from './mockProviders';
 export * as handleProviderMocks from './handleProvider';

--- a/packages/util-dev/test/dijkstraBatchFixture.test.ts
+++ b/packages/util-dev/test/dijkstraBatchFixture.test.ts
@@ -91,6 +91,47 @@ describe('createDijkstraBatchFixture', () => {
     });
   });
 
+  describe('hydrated view', () => {
+    const hydratedBody = fixture.hydratedTx.body;
+
+    it('mirrors the id, witness and non-input body fields of the core transaction', () => {
+      expect(fixture.hydratedTx.id).toEqual(fixture.tx.id);
+      expect(fixture.hydratedTx.witness).toEqual(fixture.tx.witness);
+      expect(hydratedBody.fee).toEqual(topLevelBody.fee);
+      expect(hydratedBody.guards).toEqual(topLevelBody.guards);
+      expect(hydratedBody.directDeposits).toEqual(topLevelBody.directDeposits);
+      expect(hydratedBody.accountBalanceIntervals).toEqual(topLevelBody.accountBalanceIntervals);
+      expect(hydratedBody.outputs).toEqual(topLevelBody.outputs);
+    });
+
+    it('carries each sub transaction with its id', () => {
+      expect(hydratedBody.subTransactions!.map(({ id }) => id)).toEqual(fixture.subTxIds);
+      expect(hydratedBody.subTransactions!.map(({ body }) => body.outputs)).toEqual([
+        subTx1Body.outputs,
+        subTx2Body.outputs
+      ]);
+    });
+
+    it('hydrates every input with the address of the utxo it spends', () => {
+      const hydratedInputs = [
+        ...hydratedBody.inputs,
+        ...hydratedBody.subTransactions!.flatMap(({ body }) => body.inputs)
+      ];
+
+      expect(hydratedInputs.map(({ address }) => address)).toEqual(
+        hydratedInputs.map((txIn) => resolveOrThrow(allUtxos, txIn).address)
+      );
+    });
+
+    it('hydrates the intra-batch input from the sibling sub transaction output', () => {
+      const [, hydratedSubTx2] = hydratedBody.subTransactions!;
+      const intraBatchInput = hydratedSubTx2.body.inputs.find(({ txId }) => txId === fixture.subTxIds[0]);
+
+      expect(intraBatchInput).toBeDefined();
+      expect(intraBatchInput!.address).toEqual(fixture.actors.counterparty2Address);
+    });
+  });
+
   describe('dijkstra decorations', () => {
     it('carries one key hash guard and one script hash guard at the top level', () => {
       expect(topLevelBody.guards!.map(({ type }) => type)).toEqual([

--- a/packages/util-dev/test/dijkstraBatchFixture.test.ts
+++ b/packages/util-dev/test/dijkstraBatchFixture.test.ts
@@ -1,0 +1,130 @@
+import { Cardano, Serialization } from '@cardano-sdk/core';
+import { createDijkstraBatchFixture } from '../src';
+
+const resolveOrThrow = (utxos: Cardano.Utxo[], txIn: Cardano.TxIn): Cardano.TxOut => {
+  const utxo = utxos.find(([produced]) => produced.txId === txIn.txId && produced.index === txIn.index);
+  if (!utxo) throw new Error(`Unresolvable input: ${txIn.txId}#${txIn.index}`);
+  return utxo[1];
+};
+
+const totalCoins = (utxos: Cardano.Utxo[], txIns: Cardano.TxIn[]): Cardano.Lovelace =>
+  txIns.reduce((total, txIn) => total + resolveOrThrow(utxos, txIn).value.coins, 0n);
+
+const totalOutputCoins = (outputs: Cardano.TxOut[]): Cardano.Lovelace =>
+  outputs.reduce((total, { value }) => total + value.coins, 0n);
+
+describe('createDijkstraBatchFixture', () => {
+  const fixture = createDijkstraBatchFixture();
+  const topLevelBody = fixture.tx.body;
+  const [subTx1Body, subTx2Body] = topLevelBody.subTransactions!.map(({ body }) => body);
+  const allUtxos = [...fixture.externalUtxos, fixture.intraBatchUtxo];
+  const directDepositTotal = topLevelBody.directDeposits!.reduce((total, { quantity }) => total + quantity, 0n);
+
+  it('is deterministic', () => {
+    expect(createDijkstraBatchFixture().cbor).toEqual(fixture.cbor);
+  });
+
+  describe('serialization', () => {
+    it('round trips the cbor byte-exactly', () => {
+      expect(Serialization.Transaction.fromCbor(fixture.cbor).toCbor()).toEqual(fixture.cbor);
+    });
+
+    it('re-encodes byte-exactly from core', () => {
+      expect(Serialization.Transaction.fromCore(fixture.tx).toCbor()).toEqual(fixture.cbor);
+    });
+
+    it('decodes cleanly in strict mode', () => {
+      expect(() => Serialization.Transaction.fromCbor(fixture.cbor, { strict: true })).not.toThrow();
+    });
+
+    it('exposes the id of the top level transaction and of each sub transaction', () => {
+      expect(Serialization.Transaction.fromCbor(fixture.cbor).getId()).toEqual(fixture.tx.id);
+      expect(
+        topLevelBody.subTransactions!.map((subTx) => Serialization.SubTransaction.fromCore(subTx).getId())
+      ).toEqual(fixture.subTxIds);
+    });
+  });
+
+  describe('batch economics', () => {
+    it('balances across the whole batch: all inputs equal all outputs plus fee plus direct deposits', () => {
+      const allInputs = [...topLevelBody.inputs, ...subTx1Body.inputs, ...subTx2Body.inputs];
+      const allOutputs = [...topLevelBody.outputs, ...subTx1Body.outputs, ...subTx2Body.outputs];
+
+      expect(totalCoins(allUtxos, allInputs)).toEqual(
+        totalOutputCoins(allOutputs) + topLevelBody.fee + directDepositTotal
+      );
+    });
+
+    it('does not balance at the top level alone', () => {
+      expect(totalCoins(allUtxos, topLevelBody.inputs)).not.toEqual(
+        totalOutputCoins(topLevelBody.outputs) + topLevelBody.fee + directDepositTotal
+      );
+    });
+
+    it('does not balance in either sub transaction alone', () => {
+      expect(totalCoins(allUtxos, subTx1Body.inputs)).not.toEqual(totalOutputCoins(subTx1Body.outputs));
+      expect(totalCoins(allUtxos, subTx2Body.inputs)).not.toEqual(totalOutputCoins(subTx2Body.outputs));
+    });
+  });
+
+  describe('intra-batch input', () => {
+    it('is spent by sub transaction 2 and produced by sub transaction 1', () => {
+      const [intraBatchTxIn] = fixture.intraBatchUtxo;
+
+      expect(subTx2Body.inputs).toContainEqual({ index: intraBatchTxIn.index, txId: intraBatchTxIn.txId });
+      expect(intraBatchTxIn.txId).toEqual(fixture.subTxIds[0]);
+      expect(subTx1Body.outputs[intraBatchTxIn.index]).toEqual(fixture.intraBatchUtxo[1]);
+    });
+
+    it('is not resolvable from the external utxos', () => {
+      const [intraBatchTxIn] = fixture.intraBatchUtxo;
+
+      expect(() => resolveOrThrow(fixture.externalUtxos, intraBatchTxIn)).toThrow('Unresolvable input');
+    });
+
+    it('external utxos resolve every batch input except the intra-batch one', () => {
+      const allInputs = [...topLevelBody.inputs, ...subTx1Body.inputs, ...subTx2Body.inputs];
+      const externallyResolvable = allInputs.filter((txIn) => txIn.txId !== fixture.subTxIds[0]);
+
+      expect(externallyResolvable).toHaveLength(fixture.externalUtxos.length);
+      for (const txIn of externallyResolvable) expect(() => resolveOrThrow(fixture.externalUtxos, txIn)).not.toThrow();
+    });
+  });
+
+  describe('dijkstra decorations', () => {
+    it('carries one key hash guard and one script hash guard at the top level', () => {
+      expect(topLevelBody.guards!.map(({ type }) => type)).toEqual([
+        Cardano.CredentialType.KeyHash,
+        Cardano.CredentialType.ScriptHash
+      ]);
+    });
+
+    it('asserts an account balance interval on the wallet reward credential', () => {
+      expect(topLevelBody.accountBalanceIntervals).toEqual([
+        {
+          credential: {
+            hash: Cardano.RewardAccount.toHash(fixture.actors.walletRewardAccount),
+            type: Cardano.CredentialType.KeyHash
+          },
+          interval: { exclusiveUpperBound: 100_000_000n, inclusiveLowerBound: 2_000_000n }
+        }
+      ]);
+    });
+
+    it('direct-deposits into the wallet reward account', () => {
+      expect(topLevelBody.directDeposits).toEqual([
+        { quantity: 2_000_000n, stakeAddress: fixture.actors.walletRewardAccount }
+      ]);
+    });
+
+    it('sub transaction 2 requires the top level script guard without a datum', () => {
+      expect(subTx2Body.requiredTopLevelGuards).toEqual([{ credential: topLevelBody.guards![1], datum: null }]);
+    });
+
+    it('sub transaction 1 mints the fixture asset into its wallet-bound output', () => {
+      expect(subTx1Body.mint!.get(fixture.mintedAssetId)).toEqual(100n);
+      expect(subTx1Body.outputs[0].address).toEqual(fixture.actors.walletAddress);
+      expect(subTx1Body.outputs[0].value.assets!.get(fixture.mintedAssetId)).toEqual(100n);
+    });
+  });
+});


### PR DESCRIPTION
# Context

Follow-up to the Dijkstra serialization work (LW-15103). Serialization round-trips CIP-0118 batches, guards, direct deposits and account balance intervals, but nothing above that layer surfaces them: the hydrated representation cannot carry sub transactions, the Blockfrost CBOR path silently drops the new body fields, and the tx inspectors compute wrong wallet amounts for a batch (no single level of a batch is balanced on its own). Wallets need this stack ready before the era activates on preview.

# Proposed Solution

Five commits, each independently reviewable:

1. **feat(util-dev): add Dijkstra batch transaction fixture** - deterministic CIP-0118 batch built through the real serialization layer with coherent economics: the batch balances while the top level and both sub transactions are individually unbalanced. Covers an intra-batch input (sub tx 2 spends a sub tx 1 output), guards (key + script), a direct deposit, an account balance interval and a sub tx mint. Ships resolved-input companions for wiring input resolvers in tests.
2. **feat(core): add hydrated Dijkstra sub transaction types** - `HydratedTxBody.subTransactions`, `HydratedSubTransaction` with an explicit `id` (a hydrated body cannot be re-serialized to derive it, and sibling intra-batch inputs reference it).
3. **feat(util-dev): add hydrated view to Dijkstra batch fixture** - the same batch as a `Cardano.HydratedTx`, the exact shape chain-history consumers and inspector tests work with.
4. **fix(cardano-services-client): surface Dijkstra body fields from the Blockfrost CBOR path** - `guards`, `directDeposits` and `accountBalanceIntervals` were deserialized and then dropped by `mapTxBody`; now passed through. Tested against the fixture CBOR through the real deserialize-and-map pipeline.
5. **feat(core): make transactionSummaryInspector Dijkstra batch aware** - `toMergedBatchView` flattens a batch for value arithmetic (intra-batch spends cancel naturally), `createBatchInputResolver` resolves inputs from the batch's own outputs before the caller's resolver, and the summary formula becomes `own outputs + own direct deposits - (own inputs + withdrawals)` with the direct deposit total joining the fee in the unaccounted-funds check. Adds `directDepositsInspector` and `guardsInspector` primitives.

# Important Changes Introduced

- All changes are additive; no breaking API changes. Existing (non-batch) transactions take the exact same code path as before (`toMergedBatchView` is an identity without sub transactions).
- Sub transaction hydration in `BlockfrostChainHistoryProvider` is deliberately out of scope: it depends on how Blockfrost will represent batch utxos (`txs/{id}/utxos`) for Dijkstra, which is not published yet. The seam is ready once that lands.
- The util-dev fixture doubles as the shared test vector set for downstream work (wallet, Lace rendering).